### PR TITLE
agent-tasks: add health helpers and stable json

### DIFF
--- a/cmd/agent-tasks/exit.go
+++ b/cmd/agent-tasks/exit.go
@@ -23,6 +23,7 @@ func toExitCode(err error) int {
 	case errors.Is(err, tasks.ErrValueTooLarge):
 		return 9
 	}
+	// Coupled to workspace.ExitCode's invariant that unknown errors map to 1.
 	if code := workspace.ExitCode(err); code != 1 {
 		return code
 	}

--- a/cmd/agent-tasks/format_test.go
+++ b/cmd/agent-tasks/format_test.go
@@ -21,6 +21,7 @@ func TestToExitCode(t *testing.T) {
 		{"generic", errors.New("boom"), 1},
 		{"workspace_already_init", workspace.ErrAlreadyInitialized, 2},
 		{"workspace_no_workspace", workspace.ErrNoWorkspace, 3},
+		{"wrapped_workspace_no_workspace", fmtWrap(workspace.ErrNoWorkspace), 3},
 		{"workspace_leaf_unreachable", workspace.ErrLeafUnreachable, 4},
 		{"workspace_leaf_timeout", workspace.ErrLeafStartTimeout, 5},
 		{"tasks_not_found", tasks.ErrNotFound, 6},
@@ -116,6 +117,14 @@ func TestFormatShowBlock(t *testing.T) {
 		if !strings.Contains(got, sub) {
 			t.Errorf("formatShowBlock missing %q; got:\n%s", sub, got)
 		}
+	}
+	idxID := strings.Index(got, "id=abc123")
+	idxTitle := strings.Index(got, "title=hello")
+	idxStatus := strings.Index(got, "status=open")
+	idxCtx1 := strings.Index(got, "context.k1=v1")
+	idxCtx2 := strings.Index(got, "context.k2=v2")
+	if idxID >= idxTitle || idxTitle >= idxStatus || idxCtx1 >= idxCtx2 {
+		t.Errorf("formatShowBlock ordering regression; got:\n%s", got)
 	}
 	mustNotContain := []string{
 		"claimed_by=",

--- a/cmd/agent-tasks/health.go
+++ b/cmd/agent-tasks/health.go
@@ -1,0 +1,181 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"sort"
+	"time"
+
+	"github.com/danmestas/agent-infra/coord"
+	"github.com/danmestas/agent-infra/internal/tasks"
+	"github.com/danmestas/agent-infra/internal/workspace"
+)
+
+type preflightResult struct {
+	Stale   []tasks.Task `json:"stale"`
+	Orphans []tasks.Task `json:"orphans"`
+}
+
+func init() {
+	handlers["stale"] = staleCmd
+	handlers["orphans"] = orphansCmd
+	handlers["preflight"] = preflightCmd
+}
+
+func staleCmd(ctx context.Context, info workspace.Info, args []string) error {
+	return runOp(ctx, "stale", func(ctx context.Context) error {
+		fs := flag.NewFlagSet("stale", flag.ContinueOnError)
+		fs.SetOutput(os.Stderr)
+		days := fs.Int("days", 7, "minimum age in days")
+		asJSON := fs.Bool("json", false, "emit JSON")
+		if err := fs.Parse(args); err != nil {
+			return err
+		}
+		mgr, err := openManager(ctx, info)
+		if err != nil {
+			return fmt.Errorf("open manager: %w", err)
+		}
+		defer func() { _ = mgr.Close() }()
+		allTasks, err := mgr.List(ctx)
+		if err != nil {
+			return err
+		}
+		cutoff := time.Now().UTC().Add(-time.Duration(*days) * 24 * time.Hour)
+		stale := findStaleTasks(allTasks, cutoff)
+		if *asJSON {
+			return emitJSON(os.Stdout, stale)
+		}
+		for _, t := range stale {
+			fmt.Println(formatListLine(t))
+		}
+		return nil
+	})
+}
+
+func orphansCmd(ctx context.Context, info workspace.Info, args []string) error {
+	return runOp(ctx, "orphans", func(ctx context.Context) error {
+		fs := flag.NewFlagSet("orphans", flag.ContinueOnError)
+		fs.SetOutput(os.Stderr)
+		asJSON := fs.Bool("json", false, "emit JSON")
+		if err := fs.Parse(args); err != nil {
+			return err
+		}
+		orphans, err := loadOrphans(ctx, info)
+		if err != nil {
+			return err
+		}
+		if *asJSON {
+			return emitJSON(os.Stdout, orphans)
+		}
+		for _, t := range orphans {
+			fmt.Println(formatListLine(t))
+		}
+		return nil
+	})
+}
+
+func preflightCmd(ctx context.Context, info workspace.Info, args []string) error {
+	return runOp(ctx, "preflight", func(ctx context.Context) error {
+		fs := flag.NewFlagSet("preflight", flag.ContinueOnError)
+		fs.SetOutput(os.Stderr)
+		days := fs.Int("days", 7, "minimum stale age in days")
+		asJSON := fs.Bool("json", false, "emit JSON")
+		if err := fs.Parse(args); err != nil {
+			return err
+		}
+		mgr, err := openManager(ctx, info)
+		if err != nil {
+			return fmt.Errorf("open manager: %w", err)
+		}
+		defer func() { _ = mgr.Close() }()
+		allTasks, err := mgr.List(ctx)
+		if err != nil {
+			return err
+		}
+		cutoff := time.Now().UTC().Add(-time.Duration(*days) * 24 * time.Hour)
+		result := preflightResult{Stale: findStaleTasks(allTasks, cutoff)}
+		result.Orphans, err = loadOrphans(ctx, info)
+		if err != nil {
+			return err
+		}
+		if *asJSON {
+			return emitJSON(os.Stdout, result)
+		}
+		for _, t := range result.Stale {
+			fmt.Printf("stale %s\n", formatListLine(t))
+		}
+		for _, t := range result.Orphans {
+			fmt.Printf("orphan %s\n", formatListLine(t))
+		}
+		return nil
+	})
+}
+
+func loadOrphans(ctx context.Context, info workspace.Info) ([]tasks.Task, error) {
+	mgr, err := openManager(ctx, info)
+	if err != nil {
+		return nil, fmt.Errorf("open manager: %w", err)
+	}
+	defer func() { _ = mgr.Close() }()
+	allTasks, err := mgr.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	c, err := coord.Open(ctx, newCoordConfig(info))
+	if err != nil {
+		return nil, fmt.Errorf("open coord: %w", err)
+	}
+	defer func() { _ = c.Close() }()
+	peers, err := c.Who(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return findOrphanTasks(allTasks, liveAgentSet(peers)), nil
+}
+
+func liveAgentSet(peers []coord.Presence) map[string]struct{} {
+	out := make(map[string]struct{}, len(peers))
+	for _, p := range peers {
+		out[p.AgentID()] = struct{}{}
+	}
+	return out
+}
+
+func findStaleTasks(allTasks []tasks.Task, cutoff time.Time) []tasks.Task {
+	out := make([]tasks.Task, 0, len(allTasks))
+	for _, t := range allTasks {
+		if t.Status == tasks.StatusClosed {
+			continue
+		}
+		if t.UpdatedAt.After(cutoff) {
+			continue
+		}
+		out = append(out, t)
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		return out[i].UpdatedAt.Before(out[j].UpdatedAt)
+	})
+	return out
+}
+
+func findOrphanTasks(
+	allTasks []tasks.Task,
+	liveAgents map[string]struct{},
+) []tasks.Task {
+	out := make([]tasks.Task, 0, len(allTasks))
+	for _, t := range allTasks {
+		if t.Status != tasks.StatusClaimed || t.ClaimedBy == "" {
+			continue
+		}
+		if _, ok := liveAgents[t.ClaimedBy]; ok {
+			continue
+		}
+		out = append(out, t)
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		return out[i].UpdatedAt.Before(out[j].UpdatedAt)
+	})
+	return out
+}

--- a/cmd/agent-tasks/health_test.go
+++ b/cmd/agent-tasks/health_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/danmestas/agent-infra/internal/tasks"
+)
+
+func TestFindStaleTasks(t *testing.T) {
+	base := time.Date(2026, 4, 22, 12, 0, 0, 0, time.UTC)
+	cutoff := base.Add(-24 * time.Hour)
+	all := []tasks.Task{
+		{ID: "old-open", Status: tasks.StatusOpen, UpdatedAt: cutoff.Add(-time.Hour)},
+		{ID: "recent-open", Status: tasks.StatusOpen, UpdatedAt: cutoff.Add(time.Hour)},
+		{ID: "old-claimed", Status: tasks.StatusClaimed, UpdatedAt: cutoff.Add(-2 * time.Hour)},
+		{ID: "old-closed", Status: tasks.StatusClosed, UpdatedAt: cutoff.Add(-3 * time.Hour)},
+	}
+	got := findStaleTasks(all, cutoff)
+	if len(got) != 2 {
+		t.Fatalf("len=%d, want 2", len(got))
+	}
+	if got[0].ID != "old-claimed" || got[1].ID != "old-open" {
+		t.Fatalf("order=%q,%q", got[0].ID, got[1].ID)
+	}
+}
+
+func TestFindOrphanTasks(t *testing.T) {
+	all := []tasks.Task{
+		{ID: "live", Status: tasks.StatusClaimed, ClaimedBy: "agent-live"},
+		{ID: "orphan", Status: tasks.StatusClaimed, ClaimedBy: "agent-dead"},
+		{ID: "open", Status: tasks.StatusOpen},
+	}
+	live := map[string]struct{}{"agent-live": {}}
+	got := findOrphanTasks(all, live)
+	if len(got) != 1 {
+		t.Fatalf("len=%d, want 1", len(got))
+	}
+	if got[0].ID != "orphan" {
+		t.Fatalf("ID=%q, want orphan", got[0].ID)
+	}
+}

--- a/cmd/agent-tasks/integration_test.go
+++ b/cmd/agent-tasks/integration_test.go
@@ -750,6 +750,30 @@ func TestCLI_Dispatch(t *testing.T) {
 	})
 }
 
+func TestCLI_Prime(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip in -short: integration test")
+	}
+	dir := newWorkspace(t)
+
+	out, _, code := runCmd(t, binPath, dir, "create", "prime task")
+	if code != 0 {
+		t.Fatalf("seed create failed code=%d", code)
+	}
+	id := firstLine(out)
+
+	t.Run("json", func(t *testing.T) {
+		stdout, stderr, code := runCmd(t, binPath, dir, "prime", "--json")
+		if code != 0 {
+			t.Fatalf("prime --json exit=%d stderr=%s", code, stderr)
+		}
+		if !strings.Contains(stdout, `"open_tasks"`) ||
+			!strings.Contains(stdout, `"id":"`+id+`"`) {
+			t.Errorf("prime json missing expected task: %q", stdout)
+		}
+	})
+}
+
 func TestCLI_Link(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skip in -short: integration test")

--- a/cmd/agent-tasks/json.go
+++ b/cmd/agent-tasks/json.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"time"
+
+	"github.com/danmestas/agent-infra/coord"
+)
+
+type coordTaskJSON struct {
+	ID        string    `json:"id"`
+	Title     string    `json:"title"`
+	Files     []string  `json:"files,omitempty"`
+	ClaimedBy string    `json:"claimed_by,omitempty"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+type chatThreadJSON struct {
+	ThreadShort  string    `json:"thread_short"`
+	LastActivity time.Time `json:"last_activity"`
+	MessageCount int       `json:"message_count"`
+	LastBody     string    `json:"last_body"`
+}
+
+type presenceJSON struct {
+	AgentID   string    `json:"agent_id"`
+	Project   string    `json:"project"`
+	StartedAt time.Time `json:"started_at"`
+	LastSeen  time.Time `json:"last_seen"`
+}
+
+type primeResultJSON struct {
+	OpenTasks    []coordTaskJSON  `json:"open_tasks"`
+	ReadyTasks   []coordTaskJSON  `json:"ready_tasks"`
+	ClaimedTasks []coordTaskJSON  `json:"claimed_tasks"`
+	Threads      []chatThreadJSON `json:"threads"`
+	Peers        []presenceJSON   `json:"peers"`
+}
+
+func coordTaskToJSON(t coord.Task) coordTaskJSON {
+	return coordTaskJSON{
+		ID:        string(t.ID()),
+		Title:     t.Title(),
+		Files:     t.Files(),
+		ClaimedBy: t.ClaimedBy(),
+		CreatedAt: t.CreatedAt(),
+		UpdatedAt: t.UpdatedAt(),
+	}
+}
+
+func coordTasksToJSON(ts []coord.Task) []coordTaskJSON {
+	out := make([]coordTaskJSON, 0, len(ts))
+	for _, t := range ts {
+		out = append(out, coordTaskToJSON(t))
+	}
+	return out
+}
+
+func primeToJSON(r coord.PrimeResult) primeResultJSON {
+	out := primeResultJSON{
+		OpenTasks:    coordTasksToJSON(r.OpenTasks),
+		ReadyTasks:   coordTasksToJSON(r.ReadyTasks),
+		ClaimedTasks: coordTasksToJSON(r.ClaimedTasks),
+		Threads:      make([]chatThreadJSON, 0, len(r.Threads)),
+		Peers:        make([]presenceJSON, 0, len(r.Peers)),
+	}
+	for _, t := range r.Threads {
+		out.Threads = append(out.Threads, chatThreadJSON{
+			ThreadShort:  t.ThreadShort(),
+			LastActivity: t.LastActivity(),
+			MessageCount: t.MessageCount(),
+			LastBody:     t.LastBody(),
+		})
+	}
+	for _, p := range r.Peers {
+		out.Peers = append(out.Peers, presenceJSON{
+			AgentID:   p.AgentID(),
+			Project:   p.Project(),
+			StartedAt: p.StartedAt(),
+			LastSeen:  p.LastSeen(),
+		})
+	}
+	return out
+}

--- a/cmd/agent-tasks/link_ready.go
+++ b/cmd/agent-tasks/link_ready.go
@@ -68,7 +68,7 @@ func readyCmd(ctx context.Context, info workspace.Info, args []string) error {
 		}
 
 		if asJSON {
-			return emitJSON(os.Stdout, tasks)
+			return emitJSON(os.Stdout, coordTasksToJSON(tasks))
 		}
 		for _, t := range tasks {
 			fmt.Println(formatReadyLine(t))

--- a/cmd/agent-tasks/main.go
+++ b/cmd/agent-tasks/main.go
@@ -11,6 +11,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -35,6 +36,9 @@ const usage = `Usage:
   agent-tasks link   <from-id> <to-id> --type=blocks|supersedes|duplicates|discovered-from
                      [--json]
   agent-tasks prime  [--json]
+  agent-tasks stale [--days=N] [--json]
+  agent-tasks orphans [--json]
+  agent-tasks preflight [--days=N] [--json]
   agent-tasks autoclaim [--enabled=true|false] [--idle=true|false] [--claim-ttl=1m]
   agent-tasks dispatch parent --task-id=<id> [--worker-bin=<path>]
   agent-tasks dispatch worker --task-id=<id> --task-thread=<thread> --worker-agent-id=<id>
@@ -72,7 +76,7 @@ func run(args []string) int {
 
 	info, err := workspace.Join(ctx, cwd)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "agent-tasks: join: %v\n", err)
+		reportJoinError(err)
 		return workspace.ExitCode(err)
 	}
 
@@ -101,9 +105,30 @@ func setupTelemetry(ctx context.Context) func(context.Context) error {
 	shutdown, err := telemetry.Setup(ctx, tcfg)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "agent-tasks: telemetry setup: %v\n", err)
+		// Intentional no-op shutdown: task execution should continue even
+		// when telemetry bootstrap fails.
 		return func(context.Context) error { return nil }
 	}
 	return shutdown
+}
+
+func reportJoinError(err error) {
+	switch {
+	case errors.Is(err, workspace.ErrAlreadyInitialized):
+		fmt.Fprintln(os.Stderr,
+			"agent-tasks: workspace already initialized; run `agent-init join` instead")
+	case errors.Is(err, workspace.ErrNoWorkspace):
+		fmt.Fprintln(os.Stderr,
+			"agent-tasks: no agent-infra workspace found; run `agent-init init` first")
+	case errors.Is(err, workspace.ErrLeafUnreachable):
+		fmt.Fprintln(os.Stderr,
+			"agent-tasks: leaf daemon not reachable; its PID file may be stale")
+	case errors.Is(err, workspace.ErrLeafStartTimeout):
+		fmt.Fprintln(os.Stderr,
+			"agent-tasks: leaf failed to start within timeout")
+	default:
+		fmt.Fprintf(os.Stderr, "agent-tasks: join: %v\n", err)
+	}
 }
 
 func parseOTelHeaders(s string) map[string]string {

--- a/cmd/agent-tasks/prime.go
+++ b/cmd/agent-tasks/prime.go
@@ -37,7 +37,7 @@ func primeCmd(ctx context.Context, info workspace.Info, args []string) error {
 		}
 
 		if asJSON {
-			return emitJSON(os.Stdout, result)
+			return emitJSON(os.Stdout, primeToJSON(result))
 		}
 		fmt.Print(formatPrime(result))
 		return nil


### PR DESCRIPTION
## Summary
- add `agent-tasks stale`, `orphans`, and `preflight` helper subcommands
- fix stable JSON output for coord-backed CLI commands by introducing explicit DTOs for `ready` and `prime`
- land remaining `cmd/agent-tasks` polish from `ju2` (friendly workspace join errors, telemetry note, exit-code coverage, and show-format ordering checks)

## Test Plan
- [x] `go test ./...`
- [x] `make check`
- [x] `go test ./cmd/agent-tasks -run 'Test(ToExitCode|FormatShowBlock|Find(Stale|Orphan)|CLI_Prime)' -v`
