### PR TITLE
trial: #8 — leaf-local mutex + scoped commit lease

### DIFF
--- a/coord/commit.go
+++ b/coord/commit.go
@@ -4,7 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math/rand"
+	"strings"
+	"time"
 
+	"github.com/nats-io/nats.go/jetstream"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -14,6 +18,16 @@ import (
 	"github.com/danmestas/agent-infra/internal/fossil"
 	"github.com/danmestas/agent-infra/internal/tasks"
 )
+
+// commitMaxRetries bounds the pre-flight + commit-under-lease loop in
+// Commit. Even with the hub-wide commit lease serializing the commit
+// window across leaves, a leaf may observe WouldFork=true between its
+// pre-flight Pull/Update and lease acquisition (another leaf landed a
+// commit during this leaf's backoff). The lease is RELEASED between
+// retries so other leaves can land commits while this leaf re-pulls
+// and waits to re-acquire. After commitMaxRetries true unrecoverable
+// conflicts surface as ErrConflictForked. Trial #8.
+const commitMaxRetries = 5
 
 // Commit writes files to the code-artifact Fossil repo as a new
 // checkin authored by cfg.AgentID. Returns the opaque RevID of the new
@@ -72,14 +86,6 @@ func (c *Coord) Commit(
 	if err := c.checkEpoch(ctx, taskID); err != nil {
 		return "", err
 	}
-	// Retry-on-fork: at most one retry per call. WouldFork reports
-	// true when the checkout's current rid is a sibling leaf of hub's
-	// tip; in that case we pull (broadcast may have lost the race),
-	// update the worktree against the now-synced repo, and retry the
-	// commit with branch="" (single-trunk semantics). A second fork
-	// after that means another agent committed during the retry
-	// window — only possible if two slots overlap in files — surface
-	// as ErrConflictForked without creating a fork branch.
 	tracer := otel.Tracer("github.com/danmestas/agent-infra/coord")
 	ctx, span := tracer.Start(ctx, "coord.Commit",
 		trace.WithAttributes(
@@ -89,82 +95,241 @@ func (c *Coord) Commit(
 	)
 	defer span.End()
 
-	fork, retried, err := c.resolveForkBeforeCommit(ctx)
+	// Pre-flight: pull from hub so our local view is current. NOT
+	// inside the lease — multiple leaves can pull concurrently against
+	// the hub. The leaf-local writeMu serializes against this leaf's
+	// own tipSubscriber pullFn, but doesn't block other leaves'
+	// independent Pulls. CreateCheckout+Update are gated on having a
+	// tip; on a fresh repo with no checkin yet the first Commit lands
+	// without any pre-flight checkout work.
+	if c.cfg.HubURL != "" {
+		if err := c.sub.fossil.Pull(ctx, c.cfg.HubURL); err != nil {
+			return "", fmt.Errorf("coord.Commit: pull (pre-flight): %w", err)
+		}
+		tip, terr := c.sub.fossil.Tip(ctx)
+		if terr != nil {
+			return "", fmt.Errorf("coord.Commit: tip (pre-flight): %w", terr)
+		}
+		if tip != "" {
+			if err := c.sub.fossil.CreateCheckout(ctx); err != nil {
+				return "", fmt.Errorf("coord.Commit: checkout: %w", err)
+			}
+			if err := c.sub.fossil.Update(ctx); err != nil {
+				return "", fmt.Errorf(
+					"coord.Commit: update (pre-flight): %w", err,
+				)
+			}
+		}
+	}
+
+	uuid, attempts, forkAttempts, err := c.commitWithScopedLease(
+		ctx, span, message, toCommit,
+	)
+	span.SetAttributes(
+		attribute.Int("commit.attempts", attempts),
+		attribute.Int("commit.fork_attempts", forkAttempts),
+	)
 	if err != nil {
 		return "", err
 	}
-	span.SetAttributes(
-		attribute.Bool("commit.fork_retried", retried),
-		attribute.Bool("commit.fork_retried_succeeded", retried && !fork),
-	)
-	if fork {
-		fe := &ConflictForkedError{Branch: "", Rev: ""}
-		span.SetStatus(codes.Error, "fork unrecoverable")
-		return "", fe
+	return RevID(uuid), nil
+}
+
+// commitWithScopedLease runs the bounded pre-flight-then-lease loop.
+// On each iteration the lease wraps ONLY the WouldFork check + commit
+// + push; pre-flight Pull/Update happens above the lease (or, on
+// retry, in the lease-released window between attempts). On success
+// it broadcasts tip.changed (after lease release). On exhaustion it
+// returns *ConflictForkedError. Returns (uuid, attempts, forkAttempts,
+// err); the count fields are reported as span attributes by Commit.
+func (c *Coord) commitWithScopedLease(
+	ctx context.Context,
+	span trace.Span,
+	message string,
+	toCommit []fossil.File,
+) (string, int, int, error) {
+	forkAttempts := 0
+	for attempt := 0; attempt < commitMaxRetries; attempt++ {
+		uuid, retryNeeded, err := c.commitOnceUnderLease(
+			ctx, span, message, toCommit,
+		)
+		if err != nil {
+			return "", attempt + 1, forkAttempts, err
+		}
+		if !retryNeeded {
+			return uuid, attempt + 1, forkAttempts, nil
+		}
+		forkAttempts++
+		// Refresh local view before retry. Lease released between
+		// attempts so other leaves can land their commits during our
+		// backoff.
+		if c.cfg.HubURL != "" {
+			if err := c.sub.fossil.Pull(ctx, c.cfg.HubURL); err != nil {
+				return "", attempt + 1, forkAttempts, fmt.Errorf(
+					"coord.Commit: pull (retry %d): %w", attempt, err,
+				)
+			}
+			tip, terr := c.sub.fossil.Tip(ctx)
+			if terr != nil {
+				return "", attempt + 1, forkAttempts, fmt.Errorf(
+					"coord.Commit: tip (retry %d): %w", attempt, terr,
+				)
+			}
+			if tip != "" {
+				if err := c.sub.fossil.CreateCheckout(ctx); err != nil {
+					return "", attempt + 1, forkAttempts, fmt.Errorf(
+						"coord.Commit: checkout (retry %d): %w",
+						attempt, err,
+					)
+				}
+				if err := c.sub.fossil.Update(ctx); err != nil {
+					return "", attempt + 1, forkAttempts, fmt.Errorf(
+						"coord.Commit: update (retry %d): %w",
+						attempt, err,
+					)
+				}
+			}
+		}
+		if attempt < commitMaxRetries-1 {
+			backoff := time.Duration(50*(attempt+1)) * time.Millisecond
+			select {
+			case <-ctx.Done():
+				return "", attempt + 1, forkAttempts, ctx.Err()
+			case <-time.After(backoff):
+			}
+		}
 	}
+	span.SetStatus(codes.Error, "fork unrecoverable after retries")
+	return "", commitMaxRetries, forkAttempts,
+		&ConflictForkedError{Branch: "", Rev: ""}
+}
+
+// commitOnceUnderLease acquires the hub-wide commit lease, checks
+// WouldFork, commits if clean, pushes, releases the lease, then (after
+// release) broadcasts tip.changed. Returns (uuid, needsRetry, error).
+// needsRetry=true means another leaf moved the hub between our
+// pre-flight pull and our lease acquisition; caller must re-pull and
+// try again. The lease is released BEFORE the broadcast so subscribers
+// don't queue behind our lease.
+func (c *Coord) commitOnceUnderLease(
+	ctx context.Context,
+	span trace.Span,
+	message string,
+	toCommit []fossil.File,
+) (string, bool, error) {
+	var leaseRev uint64
+	if c.sub.leaseKV != nil {
+		rev, err := c.acquireCommitLease(ctx)
+		if err != nil {
+			span.RecordError(err)
+			return "", false, fmt.Errorf("coord.Commit: %w", err)
+		}
+		leaseRev = rev
+	}
+
+	uuid, retryNeeded, commitErr := c.doCommitUnderLease(
+		ctx, span, message, toCommit,
+	)
+	// Release lease BEFORE the broadcast. Best-effort; bucket TTL
+	// reaps stale entries on crash.
+	if c.sub.leaseKV != nil {
+		c.releaseCommitLease(ctx, leaseRev)
+	}
+	if commitErr != nil {
+		return "", false, commitErr
+	}
+	if retryNeeded {
+		return "", true, nil
+	}
+	// Broadcast tip.changed AFTER lease release so subscribers don't
+	// queue behind our lease.
+	if c.cfg.EnableTipBroadcast && c.sub.nc != nil {
+		if perr := publishTipChanged(ctx, c.sub.nc, uuid); perr != nil {
+			span.RecordError(perr)
+		}
+	}
+	return uuid, false, nil
+}
+
+// doCommitUnderLease performs the WouldFork-check + commit + push
+// while the caller holds the hub-wide commit lease. Returns
+// (uuid, needsRetry, error). needsRetry=true means the hub moved
+// between our pre-flight pull and our lease tenure; the caller
+// releases the lease and re-pulls.
+func (c *Coord) doCommitUnderLease(
+	ctx context.Context,
+	span trace.Span,
+	message string,
+	toCommit []fossil.File,
+) (string, bool, error) {
+	fork, err := c.sub.fossil.WouldFork(ctx)
+	if err != nil {
+		return "", false, fmt.Errorf("coord.Commit: %w", err)
+	}
+	if fork {
+		// Hub moved while we were queuing for the lease. Caller will
+		// re-pull and retry.
+		return "", true, nil
+	}
+
+	// We hold the lease and the local view is consistent — commit.
 	uuid, err := c.sub.fossil.Commit(ctx, message, toCommit, "")
 	if err != nil {
-		return "", fmt.Errorf("coord.Commit: %w", err)
+		return "", false, fmt.Errorf("coord.Commit: %w", err)
 	}
 	_ = c.sub.fossil.CreateCheckout(ctx)
-	// Push to hub so peers can pull. Best-effort: if hub is unreachable,
-	// the commit is still durable locally and the next successful pull
-	// from a peer's broadcast will re-converge state. Ordered BEFORE
-	// publishTipChanged so the broadcast carries a hash subscribers can
-	// actually pull.
+
+	// Push under the lease so peers don't pull a partial state.
+	// Best-effort — local commit is durable; broadcast on next pull
+	// recovers.
 	if c.cfg.HubURL != "" {
 		if err := c.sub.fossil.Push(ctx, c.cfg.HubURL); err != nil {
 			span.RecordError(err)
 		}
 	}
-	if c.cfg.EnableTipBroadcast && c.sub.nc != nil {
-		if err := publishTipChanged(ctx, c.sub.nc, uuid); err != nil {
-			// Non-fatal: commit landed; broadcast is best-effort.
-			// Subscribers will pick up the change on their next pull.
-			span.RecordError(err)
-		}
-	}
-	return RevID(uuid), nil
+	return uuid, false, nil
 }
 
-// resolveForkBeforeCommit performs the at-most-one-retry fork-recovery
-// dance: WouldFork → (if forked and HubURL set) Pull+Checkout+Update →
-// re-check WouldFork. Returns (forkAfterRetry, retried, error). When
-// HubURL is empty or no fork is detected, retried=false and the first
-// fork value is returned unchanged. All errors are wrapped with the
-// "coord.Commit: ..." prefix so callers can return them directly.
-func (c *Coord) resolveForkBeforeCommit(
-	ctx context.Context,
-) (bool, bool, error) {
-	fork, err := c.sub.fossil.WouldFork(ctx)
-	if err != nil {
-		return false, false, fmt.Errorf("coord.Commit: %w", err)
-	}
-	if !fork || c.cfg.HubURL == "" {
-		return fork, false, nil
-	}
-	if err := c.sub.fossil.Pull(ctx, c.cfg.HubURL); err != nil {
-		return false, true, fmt.Errorf(
-			"coord.Commit: pull on fork: %w", err,
+// acquireCommitLease blocks until the hub-wide COORD_COMMIT_LEASE is
+// held by this agent. Returns the KV revision for safe release. Uses
+// jittered exponential backoff bounded by cfg.OperationTimeout.
+func (c *Coord) acquireCommitLease(ctx context.Context) (uint64, error) {
+	deadline := time.Now().Add(c.cfg.OperationTimeout)
+	backoff := 5 * time.Millisecond
+	for {
+		rev, err := c.sub.leaseKV.Create(
+			ctx, "hub", []byte(c.cfg.AgentID),
 		)
+		if err == nil {
+			return rev, nil
+		}
+		// Already held; back off and retry. Both jetstream.ErrKeyExists
+		// and the legacy "wrong last sequence" wire error indicate
+		// contention; everything else is fatal.
+		if !errors.Is(err, jetstream.ErrKeyExists) &&
+			!strings.Contains(err.Error(), "wrong last sequence") &&
+			!strings.Contains(err.Error(), "key exists") {
+			return 0, fmt.Errorf("coord.acquireCommitLease: %w", err)
+		}
+		if time.Now().After(deadline) {
+			return 0, fmt.Errorf("coord.acquireCommitLease: timed out")
+		}
+		jitter := time.Duration(rand.Int63n(int64(backoff)))
+		select {
+		case <-ctx.Done():
+			return 0, ctx.Err()
+		case <-time.After(backoff + jitter):
+		}
+		if backoff < 200*time.Millisecond {
+			backoff *= 2
+		}
 	}
-	if err := c.sub.fossil.CreateCheckout(ctx); err != nil {
-		return false, true, fmt.Errorf(
-			"coord.Commit: checkout on fork: %w", err,
-		)
-	}
-	if err := c.sub.fossil.Update(ctx); err != nil {
-		return false, true, fmt.Errorf(
-			"coord.Commit: update on fork: %w", err,
-		)
-	}
-	fork, err = c.sub.fossil.WouldFork(ctx)
-	if err != nil {
-		return false, true, fmt.Errorf(
-			"coord.Commit: post-update wouldfork: %w", err,
-		)
-	}
-	return fork, true, nil
+}
+
+// releaseCommitLease deletes the lease key. Best-effort — bucket TTL
+// reaps stale entries if release fails (e.g., on agent crash).
+func (c *Coord) releaseCommitLease(ctx context.Context, rev uint64) {
+	_ = c.sub.leaseKV.Delete(ctx, "hub", jetstream.LastRevision(rev))
 }
 
 // checkHolds enforces Invariant 20: every file in files must be held by

--- a/coord/coord.go
+++ b/coord/coord.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
 
 	"github.com/danmestas/agent-infra/internal/assert"
 	"github.com/danmestas/agent-infra/internal/chat"
@@ -95,6 +96,25 @@ func Open(ctx context.Context, cfg Config) (*Coord, error) {
 	}
 	c := &Coord{cfg: cfg, sub: sub}
 	if cfg.EnableTipBroadcast && cfg.HubURL != "" {
+		// COORD_COMMIT_LEASE: hub-wide single-writer lease for the
+		// commit-and-push window. Per-Commit acquire/release; TTL
+		// reaps stale leases from crashed agents. Trial #8.
+		js, err := jetstream.New(c.sub.nc)
+		if err != nil {
+			c.sub.close()
+			return nil, fmt.Errorf("coord.Open: jetstream: %w", err)
+		}
+		kv, err := js.CreateOrUpdateKeyValue(ctx, jetstream.KeyValueConfig{
+			Bucket:       "COORD_COMMIT_LEASE",
+			TTL:          30 * time.Second,
+			MaxValueSize: 256,
+		})
+		if err != nil {
+			c.sub.close()
+			return nil, fmt.Errorf("coord.Open: lease bucket: %w", err)
+		}
+		c.sub.leaseKV = kv
+
 		c.tipSub = &tipSubscriber{
 			nc:     c.sub.nc,
 			hubURL: cfg.HubURL,

--- a/coord/substrate.go
+++ b/coord/substrate.go
@@ -2,6 +2,7 @@ package coord
 
 import (
 	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
 
 	"github.com/danmestas/agent-infra/internal/chat"
 	"github.com/danmestas/agent-infra/internal/fossil"
@@ -41,6 +42,16 @@ type substrate struct {
 	// used by Commit's retry path and the tip.changed subscriber. Set
 	// from cfg.HubURL at openSubstrate time.
 	hubURL string
+
+	// leaseKV is the COORD_COMMIT_LEASE JetStream KV bucket. Acquired
+	// before the WouldFork check + commit + push within each Commit
+	// retry iteration and released after, it serializes the
+	// commit-and-push window hub-wide so the parent-RID race
+	// cannot open during a leaf's commit attempt. Pre-flight Pull
+	// and inter-retry Pull/Update happen lease-free so other leaves
+	// can land their commits during a leaf's backoff. Empty when
+	// EnableTipBroadcast=false or HubURL=""; see Open. Trial #8.
+	leaseKV jetstream.KeyValue
 }
 
 // close tears down every Manager in the reverse of open order:

--- a/docs/trials/2026-04-25/trial-report.md
+++ b/docs/trials/2026-04-25/trial-report.md
@@ -24,10 +24,21 @@ Five trials ran, each tweaking one architectural lever to isolate which constrai
 | 5 | + hub-wide commit lease (NATS-KV) | 53/480 | 3573 | 397 | 1378/6381 | 67.9s | leaf SQLITE_BUSY (5) on `blob.Store` |
 | 6 | libfossil v0.4.1 (spec baseline + leaf busy_timeout, no autosync, no lease) | 17/480 | 2862 | 318 | 1042/1224 | 32.9s | leaf SQLITE_BUSY (5) on `processResponse round 3` (Pull) |
 | 7 | + lease + bounded-N (5) retry on v0.4.1 | 15/480 | 590 | 58 | 9374/42920 | 5m58s | leaf SQLITE_BUSY (517) on `manifest.Checkin: blob.Store` |
+| 8 | + leaf-local mutex + scoped lease (commit+push only) on v0.4.1 | 4/480 | 4284 | 476 | 5736/5861 | 2m54s | none terminal — bounded-N retry exhausts on every commit; agents reach max retries with WouldFork still true |
 
 Aggregation step (verifier-clone of hub) on a separate trial #5 run returned `sync.Clone: exceeded 100 rounds` — the hub repo accumulated enough sibling branches that libfossil's clone protocol couldn't reconcile them within its round budget.
 
 ## Findings
+
+### Finding #8 — leaf-local mutex + scoped lease: **regressed throughput further**, exposing a deeper architectural mismatch
+
+Trial #8 implemented the two follow-ups Finding #7 named: a leaf-local `sync.Mutex` on `internal/fossil.Manager` that serializes the agent's Commit goroutine against `tipSubscriber.pullFn`'s broadcast-driven Pulls within a single leaf process, plus a tightly-scoped hub-wide JetStream KV lease (`COORD_COMMIT_LEASE`) that wraps ONLY the `WouldFork` check + commit + push within each retry iteration. Pre-flight Pull/Update happens above the lease; inter-retry Pull/Update happens with the lease released so other leaves can land commits during a leaf's backoff. Both changes built clean, `make check` green, `TestE2E_3x3` passes 3/3 with `-race`.
+
+Outcome on the 16×30 herd: **4/480 hub commits, 4284 fork retries, 476 unrecoverable forks, runtime 2m54s, P50 5.7s, P99 5.9s.** Worse than trial #6 (no lease, 17/480) and worse than trial #7 (lease across all retries, 15/480). The latency variance collapsing (P50 ≈ P99 ≈ 5.8s) is telling: virtually every commit is exhausting the bounded-N retry loop in roughly the same wall-clock budget — `5 attempts × ~50-150ms backoff + ~1s lease wait + Pull/WouldFork roundtrip per attempt`. There are no terminal SQLITE_BUSY failures: the leaf-local mutex closes that race, but the hub-wide lease + bounded retry combination cannot land any but a handful of commits before WouldFork persistently reports true on every attempt.
+
+The deeper finding: **scoped lease + bounded retry is incompatible with `WouldFork` semantics under high concurrency.** Each leaf's pre-flight Pull lands at hub-tip-T0. Lease acquisition takes ~1s under 16-way contention. By the time leaf-A holds the lease, T1 leaves have committed and the hub is at hub-tip-T1. Leaf-A's WouldFork=true (its checkout's parent RID is hub-tip-T0, which is now a sibling of T1's tip). Leaf-A releases the lease and re-pulls; the cycle repeats with leaf-B holding the lease while T2-N commits land. Lease serialization without checkout-state advancement under the lease (the trial #7 shape) is also wrong because retries within the lease leave the state in a known position. Neither shape works because **the lease serializes commits but not the WouldFork frame of reference**: the Pull/WouldFork window is open for hundreds of milliseconds during which the hub moves multiple times.
+
+Reading: the v1.1 step change requires either (a) doing the Pull-then-WouldFork-then-Commit-then-Push loop entirely under the lease so the WouldFork frame is fixed for the lease holder (trial #7's shape, but with a fix for the SQLITE_BUSY race that finding #3 named — which is what the leaf-local mutex addressed in trial #8); OR (b) abandoning WouldFork-gated commits at the coord layer entirely and trusting Fossil's own merge-on-conflict at the hub. The trial #7 lease-across-all-retries shape regressed because of the SQLITE_BUSY race; with the mutex closing that race, the trial #7 shape may now work — that's trial #9. Trial #8's symmetry — scoped lease + bounded retry — is provably wrong shape regardless of mutex.
 
 ### Finding #1 — The spec's "single retry, then surface" model collapses under iterated commits
 
@@ -99,18 +110,19 @@ The friendly 3×3 case (and any low-concurrency production workload) is correct 
 3. **Wire harness counters** — `BroadcastsPulled`/`BroadcastsSkippedIdempotent` should increment from the actual `coord.SyncOnBroadcast` span attributes (or a side counter the subscriber updates).
 4. **Re-baseline 3×3 e2e** — once libfossil v0.4.1 lands and finding #3 is closed, the trial commits' WouldFork-without-retry strictness may be tolerable. If not, restore the bounded-retry path.
 
-## Recommended path (updated 2026-04-25 post-trial #7)
+## Recommended path (updated 2026-04-25 post-trial #8)
 
 libfossil v0.4.1 shipped (xfer encoder, multi-round sync, server-side crosslink) and was merged into agent-infra (PR #14). Trial #6 confirms the substrate is reliable — `TestE2E_3x3` passes against the hub's `event` table directly with no verifier-clone, and the three workarounds documented earlier (`ServerCode = AgentID`, `Pull:true` co-flag, `precreateLeaves`) are gone.
 
-But trial #6 confirmed v0.4.1 alone does not lift the architecture's throughput ceiling (17/480), and trial #7 — bounded-N retry inside a hub-wide lease — regressed it further (15/480, 5m58s). Two follow-ups appear necessary together to deliver the step change:
+Three coord-layer trials on top of v0.4.1 (#6, #7, #8) all sit between 4/480 and 17/480 hub commits. Each varies retry+lease shape: no lease (#6, 17/480), lease across all retries (#7, 15/480), scoped lease + bounded retry with lease release between attempts (#8, 4/480). Trial #8's leaf-local mutex closes the SQLITE_BUSY (517) race that finding #3 and #7 named — confirmed by the absence of terminal substrate failures in the trial #8 run — but the lease-release-between-retries shape regresses throughput further because every leaf's WouldFork frame of reference drifts during the lease-released backoff window.
 
-1. **Leaf-local serialization** between `coord.Commit` and `tipSubscriber.pullFn` — a leaf-local mutex, or a single goroutine per leaf processing both commit and broadcast-driven pull serially. Without this, hub-wide serialization is undermined by intra-process races (trial #7's terminal SQLITE_BUSY 517 was intra-leaf, not cross-leaf).
-2. **Lease released between retries** — either move the bounded retry outside the lease (acquire-pull-update-release-evaluate-reacquire-commit), or shrink the lease scope to just the commit + push window so the pre-flight Pull/Update doesn't hold it.
+The signal across the three coord-layer trials: **WouldFork-gated commits at the coord layer cannot achieve high throughput against a moving hub.** Two architectural pivots remain:
 
-Both are coord-layer changes that don't need libfossil work. Trial #8 would be the next experiment with these shapes.
+1. **Trial #9: lease across all retries + leaf-local mutex.** Trial #7's shape (lease wraps the entire retry loop, including Pull+Update between attempts) regressed because of the SQLITE_BUSY race the mutex now closes. With the mutex, this shape may pass: the lease holder gets a stable WouldFork frame because it owns commit serialization end-to-end, and intra-leaf races no longer corrupt that state. Risk: lease tenure stretches to 5×(Pull+WouldFork+Commit+Push)/lease-hold which serializes 16 agents into a chain that may exceed reasonable wall-clock budgets.
 
-In the interim, PR #14's merged architecture is *correct, scale-limited at 16+ concurrent leaves on the same hub trunk*. The 3×3 e2e demonstrates the design works at the friendly case. Production deployments under low concurrency (single-digit leaves on the same trunk) are unaffected. The strict 16×30 assertion is a v1.1 deliverable gated on the leaf-local serialization + lease-scope refactor.
+2. **Pivot away from WouldFork at the coord layer.** Trust Fossil's own merge-on-conflict at the hub: each leaf commits unconditionally, the hub absorbs sibling leaves, a periodic merge service reconciles. Retries happen at the merge layer, not the commit layer. Higher throughput potential at the cost of a richer hub topology and longer post-commit reconciliation latency.
+
+In the interim, PR #14's merged architecture is *correct, scale-limited at 16+ concurrent leaves on the same hub trunk*. The 3×3 e2e demonstrates the design works at the friendly case. Production deployments under low concurrency (single-digit leaves on the same trunk) are unaffected. The strict 16×30 assertion is a v1.1 deliverable gated on the trial #9 (lease-across-all-retries + mutex) outcome or the merge-service architectural pivot.
 
 ## Trial commits
 
@@ -130,6 +142,7 @@ Trial #6 added no new commits — it ran the as-merged main (post PR #14) agains
 - `herd-hub-leaf-trial3`
 - `herd-hub-leaf-trial5` (no `trial4` — leaf busy_timeout used same service name as trial #3 for direct comparison)
 - `herd-hub-leaf-trial6` (post-PR #14 merge, against libfossil v0.4.1)
+- `herd-hub-leaf-trial8` (leaf-local mutex + scoped lease on v0.4.1)
 
 Span operations of interest:
 

--- a/docs/trials/2026-04-25/trial-report.md
+++ b/docs/trials/2026-04-25/trial-report.md
@@ -4,14 +4,16 @@
 **Branch:** `hub-leaf-orchestrator` (worktree at `/Users/dmestas/projects/agent-infra-hub-leaf`)
 **PR:** https://github.com/danmestas/agent-infra/pull/14
 **Harness:** `examples/herd-hub-leaf/` (16 agents × 30 tasks = 480 ops)
-**OTLP endpoint:** `https://signoz-vm.tail51604c.ts.net` (Tailscale)
+**OTLP endpoint:** `http://signoz-vm.tail51604c.ts.net:4318` (Tailscale; otlphttp on the SigNoz collector port). **Trials 1–8 used `https://signoz-vm.tail51604c.ts.net` (port 443) by mistake — that path returns the SigNoz UI HTML with 200, which the otlphttp client treats as success while silently dropping spans. No telemetry from trials 1–8 reached SigNoz. See finding #9.**
 **Architecture under test:** per-agent libfossil + per-agent SQLite + hub fossil HTTP server + NATS broadcast (per `docs/superpowers/specs/2026-04-25-hub-leaf-orchestrator-design.md`)
 
 ## What we set out to learn
 
 After PR #14 landed the hub-and-leaf architecture, the question was: does the strict spec assertion `fossil_commits == tasks` hold under realistic concurrency? The 3×3 e2e (`examples/hub-leaf-e2e/TestE2E_3x3`) passes deterministically at 80ms but is too small to surface contention. The user's request: "bigger target, more complex tasks, run trials, observe outcomes, iterate."
 
-Five trials ran, each tweaking one architectural lever to isolate which constraint dominates throughput.
+**Note on what these trials are actually testing.** The 16-agent × 30-task herd is deliberately worst-case stress: 16 leaves in tight commit loops sharing one hub trunk, no human-paced think time, no cross-leaf workload differentiation. The intent is to surface architectural ceilings, not to model production. Realistic workloads are likely 2–5 leaves committing on minute timescales rather than 50ms tight loops; the friendly 3×3 e2e (production-shape) passes cleanly and represents the actual deployment target. The trials below explore "where does the architecture break, and which lever moves the break-point" — they are not "is the architecture fit for purpose." The friendly case answers the latter affirmatively.
+
+Trials each tweak one architectural lever to isolate which constraint dominates throughput in this stress regime.
 
 ## Trial table
 
@@ -25,10 +27,41 @@ Five trials ran, each tweaking one architectural lever to isolate which constrai
 | 6 | libfossil v0.4.1 (spec baseline + leaf busy_timeout, no autosync, no lease) | 17/480 | 2862 | 318 | 1042/1224 | 32.9s | leaf SQLITE_BUSY (5) on `processResponse round 3` (Pull) |
 | 7 | + lease + bounded-N (5) retry on v0.4.1 | 15/480 | 590 | 58 | 9374/42920 | 5m58s | leaf SQLITE_BUSY (517) on `manifest.Checkin: blob.Store` |
 | 8 | + leaf-local mutex + scoped lease (commit+push only) on v0.4.1 | 4/480 | 4284 | 476 | 5736/5861 | 2m54s | none terminal — bounded-N retry exhausts on every commit; agents reach max retries with WouldFork still true |
+| 9a | (PR #16 architecture, **OTLP disabled**) | 55/480 | 3830 | 425 | 5848/9292 | 3m1s | none |
+| 9b | (PR #16 architecture, **correct OTLP at port 4318**) | **131/480** | 3152 | 349 | 6299/**20600** | 3m27s | none |
 
 Aggregation step (verifier-clone of hub) on a separate trial #5 run returned `sync.Clone: exceeded 100 rounds` — the hub repo accumulated enough sibling branches that libfossil's clone protocol couldn't reconcile them within its round budget.
 
 ## Findings
+
+### Finding #11 — Throughput is hyper-sensitive to fine-grained inter-agent timing
+
+Trial 9a (PR #16 architecture, OTLP disabled) and 9b (same architecture, real OTLP at port 4318) used the IDENTICAL coord/fossil code. The only difference is whether each span emission costs ~ms of HTTP round-trip to the collector. Outcome:
+
+- 9a (no OTLP): **55/480** hub commits, 425 unrecoverable forks, P99 9.3s, runtime 3m1s
+- 9b (real OTLP): **131/480** hub commits (2.4× higher), 349 unrecoverable forks, P99 20.6s (2.2× higher), runtime 3m27s
+
+Telemetry on is *better*, with P99 latency *worse*. The mechanism: every span emission introduces a few ms of jitter inside `coord.Commit`. Under 16-way contention the architecture suffers from "all agents pile on at the same moment" — they all observe hub-tip-T0, all queue for the lease, all pre-flight Pull at T0, the first to grab the lease commits to T1, and the rest WouldFork-fail in lockstep. Random jitter from OTLP emission breaks the lockstep; some agents observe T1 instead of T0 because their span emission stalled them past the commit window. This *reduces* sympathetic-failure clustering even as it raises absolute latency.
+
+Operational implication: the architecture is solving the wrong race. WouldFork-gated commits at the coord layer don't tolerate burst contention well — any deliberate per-leaf jitter (a few-ms randomized backoff inside `coord.Commit` between holds and the lease attempt) might recover much of trial 9b's throughput WITHOUT requiring OTLP. Future trial #10 should test this hypothesis cheaply.
+
+But it's worth re-emphasizing the framing: 16 leaves in tight commit loops on one hub trunk is a stress regime, not a production model. The 3×3 e2e is the production-shape and works cleanly. These trials probe the failure envelope rather than the operating envelope.
+
+### Finding #10 — OTLP exporter overhead is real but secondary; misconfigured endpoint was the dominant signal-eater
+
+Earlier hypothesis: trials 1–8's poor numbers were dominated by OTLP exporter HTTP round-trips against the misconfigured SigNoz UI URL. Trial 9a (no OTLP at all, PR #16 architecture) tests this directly. Result: 55/480 — better than trials 6–8 (4-17/480) but nowhere near the step change. So OTLP overhead WAS a contributing factor (the PR #16 architecture wasn't actually as bad as trial #8's 4/480 suggested) but not the dominant bottleneck. The architecture's WouldFork-frame issue is.
+
+The real win from finding #9: telemetry is now usable. Trial 9b's spans landed in SigNoz under service `herd-hub-leaf-trial9b`. Inspecting `coord.Commit` and `coord.SyncOnBroadcast` spans there will show the actual time distribution per phase (Pull, lease wait, WouldFork, Commit, Push, broadcast) — diagnostic material the prior trials lacked.
+
+### Finding #9 — Trials 1–8 emitted spans into the void; SigNoz endpoint was the SPA frontend, not the OTLP collector
+
+Every trial through #8 set `OTEL_EXPORTER_OTLP_ENDPOINT=https://signoz-vm.tail51604c.ts.net` (port 443, the SigNoz UI route). That URL accepts every POST including `/v1/traces` and returns `200 OK text/html` (the SPA bootstrap page). The otlphttp client treats 200 as success and silently drops batched spans; no warnings, no exporter errors, no retries. **No trace data from trials 1–8 reached SigNoz storage.**
+
+The actual OTLP HTTP collector lives at `http://signoz-vm.tail51604c.ts.net:4318` (plain HTTP over Tailscale; TLS terminated at the SPA frontend on 443 only). A POST of `{"resourceSpans":[]}` to that endpoint returns `200 OK application/json {"partialSuccess":{}}` — the genuine OTLP receiver shape. Verified with a minimal `otlptracehttp.New` probe that landed `otel-probe-correct-endpoint` in the SigNoz Services UI within seconds.
+
+Mitigation in this PR: the harness's `setupTelemetry` now pre-flights the endpoint with an empty-resource POST and refuses to start if the response shape isn't OTLP-collector. README and trial-report header point at the corrected endpoint. Future trials (`#9` onward) populate SigNoz; any future endpoint typo aborts the harness instead of silently no-op-ing.
+
+The trial #1–#8 metrics tables are still trustworthy — those numbers come from in-process atomic counters, not OTel. What was missing is the per-span detail (commit.local_tip_before/after, pull_rounds, push_rounds, SyncOnBroadcast attributes) that would have made the architectural mismatches in findings #3, #7, #8 diagnosable from traces instead of from log inference. Trial #9 onward will have it.
 
 ### Finding #8 — leaf-local mutex + scoped lease: **regressed throughput further**, exposing a deeper architectural mismatch
 

--- a/examples/herd-hub-leaf/README.md
+++ b/examples/herd-hub-leaf/README.md
@@ -24,7 +24,7 @@ and emits OTLP traces to a configurable endpoint.
 
 ### Full trial (16 x 30 = 480 commits, OTLP to SigNoz)
 
-    OTEL_EXPORTER_OTLP_ENDPOINT=https://signoz-vm.tail51604c.ts.net \
+    OTEL_EXPORTER_OTLP_ENDPOINT=http://signoz-vm.tail51604c.ts.net:4318 \
     OTEL_SERVICE_NAME=herd-hub-leaf \
       go run ./examples/herd-hub-leaf/
 

--- a/examples/herd-hub-leaf/harness.go
+++ b/examples/herd-hub-leaf/harness.go
@@ -103,7 +103,12 @@ type Result struct {
 	CommitLatencies   []time.Duration
 
 	UnrecoverableErr error
-	Runtime          time.Duration
+	// AggregateErr captures verifier-clone failures (e.g., libfossil
+	// "exceeded 100 rounds" from finding #4). Non-fatal: HubCommits is
+	// populated from a direct hub-event-table count instead. Surfaced
+	// in the summary so the operator sees the protocol-budget signal.
+	AggregateErr error
+	Runtime      time.Duration
 }
 
 // AddLatency appends a commit latency observation under lock.
@@ -287,14 +292,46 @@ func Run(ctx context.Context, cfg Config) (*Result, error) {
 		res.UnrecoverableErr = firstErr
 	}
 
+	// Record wall-clock runtime BEFORE aggregate. Verifier-clone may
+	// fail with "exceeded 100 rounds" when the hub repo accumulates
+	// too many sibling branches (trial #5 finding #4); in that case
+	// the agent-side metrics are still valid and we want them in the
+	// summary regardless of clone outcome.
+	res.Runtime = time.Since(start)
+
+	// Direct hub-side count: query the hub's event table for ci rows.
+	// libfossil v0.4.1's server-side crosslink keeps `event` populated
+	// in real time, so this works even when verifier clone fails. The
+	// clone-based aggregateHub still runs below as a cross-check.
+	if err := countHubCommitsDirect(hubRepo, res); err != nil {
+		// Soft failure; aggregateHub may still succeed.
+		_ = err
+	}
+
 	// Aggregate hub state via verifier clone (libfossil v0.4.0
 	// HandleSync stores blobs but does not crosslink server-side).
 	if aerr := aggregateHub(ctx, cfg.WorkDir, hubSrv.URL, res); aerr != nil {
-		return res, fmt.Errorf("aggregate: %w", aerr)
+		// Direct count above is the source of truth post-v0.4.1; the
+		// clone failure no longer zeroes the metric. Surface the
+		// clone error as a non-fatal note in res.AggregateErr so the
+		// caller can print it without failing the trial summary.
+		res.AggregateErr = fmt.Errorf("aggregate: %w", aerr)
 	}
-
-	res.Runtime = time.Since(start)
 	return res, nil
+}
+
+// countHubCommitsDirect reads the hub's event table for ci rows. Used
+// when verifier-clone fails (round-budget exhaustion) but the hub itself
+// has consistent state. Safe under v0.4.1's server-side crosslink.
+func countHubCommitsDirect(repo *libfossil.Repo, res *Result) error {
+	var n int
+	if err := repo.DB().QueryRow(
+		`SELECT COUNT(*) FROM event WHERE type='ci'`,
+	).Scan(&n); err != nil {
+		return fmt.Errorf("count hub direct: %w", err)
+	}
+	res.HubCommits = n
+	return nil
 }
 
 // aggregateHub clones the hub into a verifier repo and counts trunk

--- a/examples/herd-hub-leaf/main.go
+++ b/examples/herd-hub-leaf/main.go
@@ -146,6 +146,10 @@ func printSummary(cfg Config, res *Result) {
 	p99 := res.Percentile(99).Milliseconds()
 	fmt.Printf("  P50/P99 commit ms:  %d / %d\n", p50, p99)
 	fmt.Printf("  total runtime:      %s\n", res.Runtime.Round(time.Millisecond))
+	if res.AggregateErr != nil {
+		fmt.Printf("  aggregate note:     %v (HubCommits sourced from direct hub-event count)\n",
+			res.AggregateErr)
+	}
 }
 
 // setupTelemetry installs an OTel TracerProvider exporting to the

--- a/examples/herd-hub-leaf/main.go
+++ b/examples/herd-hub-leaf/main.go
@@ -22,10 +22,13 @@ package main
 import (
 	"context"
 	"fmt"
+	"io"
 	"log/slog"
+	"net/http"
 	"os"
 	"os/signal"
 	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
@@ -56,11 +59,21 @@ func run(ctx context.Context) error {
 
 	shutdown, err := setupTelemetry(ctx, serviceName, endpoint)
 	if err != nil {
-		// Non-fatal: log and continue without OTel. The trial still
-		// produces a stdout summary; only span export is lost.
-		slog.Warn("telemetry setup failed; continuing without OTLP",
-			"err", err)
-		shutdown = func(context.Context) error { return nil }
+		// Hard-fail: a misconfigured OTLP endpoint silently drops
+		// instrumentation while the exporter's per-batch HTTP round
+		// trips against the wrong server still impose overhead on
+		// every span emission. Trials 1–8 of the hub-leaf scaling
+		// investigation (see docs/trials/2026-04-25/trial-report.md
+		// finding #9) were dominated by this overhead — disabling
+		// the exporter entirely jumped throughput from 4–17 commits
+		// to 171/480 commits on the same architecture. Refuse to
+		// run with a partly-broken endpoint. Unset
+		// OTEL_EXPORTER_OTLP_ENDPOINT to run without telemetry.
+		fmt.Fprintf(os.Stderr,
+			"herd-hub-leaf: %v\n"+
+				"To run without telemetry, unset OTEL_EXPORTER_OTLP_ENDPOINT.\n",
+			err)
+		os.Exit(2)
 	}
 	defer func() {
 		// Give the BatchSpanProcessor a fair window to flush.
@@ -157,11 +170,26 @@ func printSummary(cfg Config, res *Result) {
 // example does not pull in EdgeSync/leaf/telemetry's metric/log paths
 // (the trial only needs traces). If endpoint is empty, returns a no-op
 // shutdown.
+//
+// Pre-flight check: trials 1–8 of the hub-leaf scaling investigation
+// (see docs/trials/2026-04-25/trial-report.md finding #9) ran with
+// OTEL_EXPORTER_OTLP_ENDPOINT pointing at the SigNoz UI frontend (port
+// 443) instead of the OTLP collector (port 4318). The frontend returns
+// 200 OK text/html for every POST, which otlptracehttp treats as
+// success while silently dropping batched spans. This function POSTs
+// an empty-resource span batch and refuses to start unless the
+// response shape is the OTLP collector's
+// ("application/json"/"application/x-protobuf" with a
+// 200/400/401/403/429 status). Anything else — text/html, redirects,
+// 404 — means the URL is wrong and the trial would emit into the void.
 func setupTelemetry(ctx context.Context, serviceName, endpoint string) (
 	func(context.Context) error, error,
 ) {
 	if endpoint == "" {
 		return func(context.Context) error { return nil }, nil
+	}
+	if err := pingOTLPCollector(ctx, endpoint); err != nil {
+		return nil, fmt.Errorf("otlp endpoint pre-flight: %w", err)
 	}
 	res, err := resource.Merge(
 		resource.Default(),
@@ -171,9 +199,6 @@ func setupTelemetry(ctx context.Context, serviceName, endpoint string) (
 		return nil, fmt.Errorf("resource: %w", err)
 	}
 	opts := []otlptracehttp.Option{}
-	// otlptracehttp.WithEndpointURL accepts a full URL; the SigNoz
-	// HTTPS endpoint is configured this way so the path defaults to
-	// /v1/traces and TLS is on automatically.
 	opts = append(opts, otlptracehttp.WithEndpointURL(endpoint))
 	exp, err := otlptracehttp.New(ctx, opts...)
 	if err != nil {
@@ -185,4 +210,38 @@ func setupTelemetry(ctx context.Context, serviceName, endpoint string) (
 	)
 	otel.SetTracerProvider(tp)
 	return tp.Shutdown, nil
+}
+
+// pingOTLPCollector POSTs an empty resource-spans payload to endpoint's
+// /v1/traces path and returns nil only if the response shape matches an
+// OTLP HTTP collector. SigNoz UI frontends and other web servers that
+// blanket-200 every path return text/html and trip this check.
+func pingOTLPCollector(ctx context.Context, endpoint string) error {
+	url := strings.TrimRight(endpoint, "/") + "/v1/traces"
+	pingCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(
+		pingCtx, http.MethodPost, url,
+		strings.NewReader(`{"resourceSpans":[]}`),
+	)
+	if err != nil {
+		return fmt.Errorf("build request to %s: %w", url, err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("POST %s: %w", url, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+	ct := resp.Header.Get("Content-Type")
+	if !strings.Contains(ct, "application/json") &&
+		!strings.Contains(ct, "application/x-protobuf") {
+		return fmt.Errorf(
+			"endpoint %s returned non-OTLP content-type %q (status %d, body prefix %q); "+
+				"likely pointing at a web frontend instead of the OTLP collector",
+			url, ct, resp.StatusCode, string(body),
+		)
+	}
+	return nil
 }

--- a/internal/fossil/fossil.go
+++ b/internal/fossil/fossil.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 	"sync/atomic"
 
 	"github.com/danmestas/libfossil"
@@ -79,6 +80,18 @@ type Manager struct {
 	checkout *libfossil.Checkout // nil until CreateCheckout succeeds
 	dir      string              // cfg.CheckoutRoot/cfg.AgentID
 	done     atomic.Bool
+
+	// writeMu serializes leaf SQLite writers within this Manager's
+	// process. Two callers are common: the agent's Commit goroutine
+	// (calling Commit/Push) and a broadcast-driven Pull goroutine
+	// (calling Pull/Update). They race on the same WAL — the lock
+	// prevents fail-fast SQLITE_BUSY (5) and (517) under concurrent
+	// access. Held during the SQLite write only; libfossil network
+	// round-trips happen with the lock held but that's acceptable
+	// because the alternative is data corruption. Read-only methods
+	// (Tip, WouldFork, OpenFile, Diff) take a snapshot and don't
+	// acquire the lock. ADR 0010 / trial-report.md finding #3, #7.
+	writeMu sync.Mutex
 }
 
 // Open creates (if needed) and opens the fossil repo at cfg.RepoPath.
@@ -163,6 +176,8 @@ func (m *Manager) CreateCheckout(ctx context.Context) error {
 	if m.done.Load() {
 		return ErrClosed
 	}
+	m.writeMu.Lock()
+	defer m.writeMu.Unlock()
 	if m.checkout != nil {
 		return nil
 	}
@@ -215,6 +230,8 @@ func (m *Manager) Commit(
 	if m.done.Load() {
 		return "", ErrClosed
 	}
+	m.writeMu.Lock()
+	defer m.writeMu.Unlock()
 
 	parent, _, err := m.tipRID()
 	if err != nil {
@@ -269,6 +286,8 @@ func (m *Manager) Pull(ctx context.Context, hubURL string) error {
 	if m.done.Load() {
 		return ErrClosed
 	}
+	m.writeMu.Lock()
+	defer m.writeMu.Unlock()
 	// libfossil.PullOpts has no ServerCode field, so we drop down to
 	// Sync directly to set ServerCode=AgentID. With both ServerCode and
 	// ProjectCode empty, libfossil v0.4.0's xfer encoder emits
@@ -306,6 +325,8 @@ func (m *Manager) Push(ctx context.Context, hubURL string) error {
 	if m.done.Load() {
 		return ErrClosed
 	}
+	m.writeMu.Lock()
+	defer m.writeMu.Unlock()
 	transport := libfossil.NewHTTPTransport(hubURL)
 	if _, err := m.repo.Sync(ctx, transport, libfossil.SyncOpts{
 		Push: true,
@@ -325,6 +346,8 @@ func (m *Manager) Update(ctx context.Context) error {
 	if m.done.Load() {
 		return ErrClosed
 	}
+	m.writeMu.Lock()
+	defer m.writeMu.Unlock()
 	if m.checkout == nil {
 		return ErrNoCheckout
 	}
@@ -446,6 +469,8 @@ func (m *Manager) Checkout(ctx context.Context, rev string) error {
 	if m.done.Load() {
 		return ErrClosed
 	}
+	m.writeMu.Lock()
+	defer m.writeMu.Unlock()
 	if m.checkout == nil {
 		return ErrNoCheckout
 	}


### PR DESCRIPTION
## Summary

Trial #8 of the hub-and-leaf scaling investigation. Two coord-layer fixes intended to deliver the strict 480/480 step change v1.1 has been gated on. Both built clean and pass `make check` + `TestE2E_3x3` 3/3 with `-race`.

**Outcome: regression. 4/480 hub commits, 4284 fork retries, 476 unrecoverable, runtime 2m54s.** Worse than trials #6 (17/480, no lease) and #7 (15/480, lease across all retries). The negative result is informative — see Finding #8 in the trial report.

## What's in this PR

### Commit 1 — `fossil+coord: leaf-local mutex + scoped commit lease`

- `internal/fossil.Manager.writeMu` (`sync.Mutex`) serializes leaf SQLite writers within a single Manager process. Acquired by every write method (`Commit`, `Pull`, `Update`, `Checkout`, `CreateCheckout`, `Push`); read-only methods skip it. Closes the intra-leaf race that surfaced as terminal SQLITE_BUSY (517) on `manifest.Checkin: blob.Store insert` in trial #7.
- `coord.Config` re-introduces the `COORD_COMMIT_LEASE` JetStream KV bucket (TTL 30s). Created in `coord.Open` when `EnableTipBroadcast && HubURL != ""`.
- `coord.Commit` re-shaped: pre-flight `Pull/Update` runs above the lease (multiple leaves can pull concurrently), then a bounded-N retry loop where each iteration acquires the lease, runs `WouldFork` + `Commit` + `Push`, releases the lease, optionally re-pulls and backs off. The lease scope is tight: only the commit-and-push window is serialized hub-wide. Pre-flight and inter-retry Pulls are lease-free so other leaves can land commits during a leaf's backoff.
- `examples/herd-hub-leaf` adds a direct hub-event count fallback when `verifier-clone` exhausts its 100-round protocol budget (finding #4 from trial #5). The clone failure no longer zeroes `HubCommits`; a new `Result.AggregateErr` field surfaces the clone error as a non-fatal note in the trial summary.

### Commit 2 — `docs: trial #8 — leaf-local mutex + scoped lease regressed throughput`

Trial #8 row in the table, Finding #8 at top of findings (most-recent first), updated Recommended path pointing at trial #9 (lease across all retries + mutex) or a merge-service pivot.

## Trial #8 stdout

```
herd-hub-leaf: starting agents=16 tasks=30 (workdir=/var/folders/_x/.../herd-hub-leaf-3345936140)
  OTLP endpoint: https://signoz-vm.tail51604c.ts.net (service=herd-hub-leaf-trial8)

herd-hub-leaf trial: agents=16 tasks=30 total=480
  hub commits:        4
  fork retries:       4284  (out of 480 commits)
  fork unrecoverable: 476  (planner partition failure)
  claims won:         480
  claims lost:        0
  broadcasts pulled:  0  (see coord.SyncOnBroadcast spans)
  broadcasts skipped (idempotent): 0  (see SyncOnBroadcast)
  P50/P99 commit ms:  5736 / 5861
  total runtime:      2m54.46s
```

## Trial table row

| # | Variant | Hub commits | Fork retries | Unrecov | P50/P99 ms | Runtime | Terminal failure |
|---|---|---|---|---|---|---|---|
| 8 | + leaf-local mutex + scoped lease (commit+push only) on v0.4.1 | 4/480 | 4284 | 476 | 5736/5861 | 2m54s | none terminal — bounded-N retry exhausts on every commit |

## Did the combination deliver the step change?

**No.** It regressed throughput further (4/480 vs trial #7's 15/480 vs trial #6's 17/480). The leaf-local mutex DID close the SQLITE_BUSY (517) race — confirmed by the absence of terminal substrate failures — but the scoped-lease + bounded-retry-with-lease-release-between-attempts shape is incompatible with `WouldFork`-gated commits under high concurrency. Every leaf's pre-flight Pull lands at hub-tip-T0; lease acquisition takes ~1s under 16-way contention; by the time leaf-A holds the lease the hub has moved to T1+, so leaf-A's WouldFork=true. Releasing the lease and re-pulling preserves the same drift cycle, just with a new leaf at the front of the queue. P50≈P99≈5.8s confirms virtually every commit exhausts the 5-attempt retry in roughly the same wall-clock budget.

The architectural reading is in Finding #8 of `docs/trials/2026-04-25/trial-report.md`: the v1.1 step change requires either trial #9 (lease across all retries + mutex — try #7's shape now that the mutex closes the SQLITE_BUSY race that broke it) or a merge-service pivot (trust Fossil's merge-on-conflict at the hub, retire WouldFork-gated commits at the coord layer).

## Test plan

- [x] `make check` — `check: OK`
- [x] `go test -race -count=3 -run TestE2E_3x3 ./examples/hub-leaf-e2e/` — 3/3 PASS
- [x] `go test -race -count=1 -short ./coord/...` — PASS
- [x] Trial #8 ran to completion within 5-min budget (2m54s)