### PR TITLE
ADR 0024: orchestrator Fossil checkout = git working tree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 
 # Built binaries
 bin/
+/agent-init
 /agent-tasks
 # examples/* leave these in cwd when run without -o or from the repo root.
 /two-agents
@@ -29,3 +30,7 @@ go.work.sum
 .fslckout
 .fossil-settings/
 .orchestrator/
+
+# Local scratch — code reviews and implementation plans (ephemeral, per-session)
+docs/code-review/
+docs/plans/

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,8 @@ go.work.sum
 
 # Claude Code / scheduled_tasks runtime state (local-only).
 .claude/
+
+# Orchestrator runtime + Fossil checkout-at-root (ADR 0024)
+.fslckout
+.fossil-settings/
+.orchestrator/

--- a/cmd/agent-init/gitignore.go
+++ b/cmd/agent-init/gitignore.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ensureGitignoreEntries appends Fossil + orchestrator entries to the
+// project's root .gitignore if they're not already present. Per ADR
+// 0024: the orchestrator opens a Fossil checkout at the project root,
+// so .fslckout and .fossil-settings/ must be gitignored, and
+// .orchestrator/ holds runtime state that should never be committed.
+//
+// Idempotent: skips entries already present (whole-line match).
+// Creates .gitignore if missing.
+func ensureGitignoreEntries(dir string) error {
+	path := filepath.Join(dir, ".gitignore")
+	wantEntries := []string{
+		".fslckout",
+		".fossil-settings/",
+		".orchestrator/",
+	}
+
+	existing := map[string]bool{}
+	if f, err := os.Open(path); err == nil {
+		sc := bufio.NewScanner(f)
+		for sc.Scan() {
+			existing[strings.TrimSpace(sc.Text())] = true
+		}
+		_ = f.Close()
+	}
+
+	var missing []string
+	for _, e := range wantEntries {
+		if !existing[e] {
+			missing = append(missing, e)
+		}
+	}
+	if len(missing) == 0 {
+		return nil
+	}
+
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return fmt.Errorf("open .gitignore: %w", err)
+	}
+	defer f.Close()
+
+	header := "\n# Orchestrator runtime + Fossil checkout-at-root (ADR 0024)\n"
+	if _, err := f.WriteString(header); err != nil {
+		return fmt.Errorf("write .gitignore: %w", err)
+	}
+	for _, e := range missing {
+		if _, err := f.WriteString(e + "\n"); err != nil {
+			return fmt.Errorf("write .gitignore: %w", err)
+		}
+	}
+	return nil
+}

--- a/cmd/agent-init/gitignore.go
+++ b/cmd/agent-init/gitignore.go
@@ -47,7 +47,7 @@ func ensureGitignoreEntries(dir string) error {
 	if err != nil {
 		return fmt.Errorf("open .gitignore: %w", err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	header := "\n# Orchestrator runtime + Fossil checkout-at-root (ADR 0024)\n"
 	if _, err := f.WriteString(header); err != nil {

--- a/cmd/agent-init/gitignore_test.go
+++ b/cmd/agent-init/gitignore_test.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestEnsureGitignoreEntries_FreshFile(t *testing.T) {
+	dir := t.TempDir()
+	if err := ensureGitignoreEntries(dir); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, ".gitignore"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{".fslckout", ".fossil-settings/", ".orchestrator/"} {
+		if !strings.Contains(string(data), want) {
+			t.Errorf("missing %q\n%s", want, data)
+		}
+	}
+}
+
+func TestEnsureGitignoreEntries_Idempotent(t *testing.T) {
+	dir := t.TempDir()
+	if err := ensureGitignoreEntries(dir); err != nil {
+		t.Fatal(err)
+	}
+	first, err := os.ReadFile(filepath.Join(dir, ".gitignore"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := ensureGitignoreEntries(dir); err != nil {
+		t.Fatal(err)
+	}
+	second, err := os.ReadFile(filepath.Join(dir, ".gitignore"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(first) != string(second) {
+		t.Fatalf(".gitignore changed on second run\nfirst:\n%s\nsecond:\n%s", first, second)
+	}
+}
+
+func TestEnsureGitignoreEntries_PreservesExisting(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".gitignore")
+	preexisting := "node_modules/\n*.log\n"
+	if err := os.WriteFile(path, []byte(preexisting), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := ensureGitignoreEntries(dir); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "node_modules/") {
+		t.Errorf("preexisting entry lost:\n%s", data)
+	}
+	if !strings.Contains(string(data), ".fslckout") {
+		t.Errorf("new entry missing:\n%s", data)
+	}
+}
+
+func TestEnsureGitignoreEntries_PartialOverlap(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".gitignore")
+	// File already has .fslckout but not the other two.
+	preexisting := ".fslckout\nnode_modules/\n"
+	if err := os.WriteFile(path, []byte(preexisting), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := ensureGitignoreEntries(dir); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := string(data)
+	// .fslckout must appear exactly once (no duplicate added).
+	if strings.Count(body, ".fslckout\n") != 1 {
+		t.Errorf(".fslckout duplicated\n%s", body)
+	}
+	// The other two entries must now be present.
+	for _, want := range []string{".fossil-settings/", ".orchestrator/"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("missing %q\n%s", want, body)
+		}
+	}
+	// Preexisting unrelated entry must survive.
+	if !strings.Contains(body, "node_modules/") {
+		t.Errorf("preexisting entry lost\n%s", body)
+	}
+}

--- a/cmd/agent-init/orchestrator.go
+++ b/cmd/agent-init/orchestrator.go
@@ -35,6 +35,10 @@ func runOrchestrator(root string) error {
 	if err := mergeSettings(filepath.Join(root, ".claude", "settings.json")); err != nil {
 		return fmt.Errorf("settings: %w", err)
 	}
+	// 5) Ensure root .gitignore carries Fossil + orchestrator entries (ADR 0024).
+	if err := ensureGitignoreEntries(root); err != nil {
+		return fmt.Errorf("root gitignore: %w", err)
+	}
 	return nil
 }
 

--- a/cmd/agent-init/orchestrator_test.go
+++ b/cmd/agent-init/orchestrator_test.go
@@ -120,3 +120,46 @@ func verifyHooks(t *testing.T, path string) {
 		t.Errorf("Stop hub-shutdown missing:\n%s", out)
 	}
 }
+
+func TestRunOrchestrator_HubBootstrapHasADR0024Seed(t *testing.T) {
+	dir := t.TempDir()
+	if err := runOrchestrator(dir); err != nil {
+		t.Fatalf("runOrchestrator: %v", err)
+	}
+	bootstrap, err := os.ReadFile(
+		filepath.Join(dir, ".orchestrator", "scripts", "hub-bootstrap.sh"),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"git ls-files",        // seeds hub from git-tracked files (ADR 0024 §3)
+		"fossil open --force", // opens checkout at project root (ADR 0024 §1)
+		`$ROOT/.fslckout`,     // wipes checkout metadata on fresh start (ADR 0024 §2)
+	} {
+		if !strings.Contains(string(bootstrap), want) {
+			t.Errorf("hub-bootstrap.sh missing %q (ADR 0024)", want)
+		}
+	}
+}
+
+func TestRunOrchestrator_SkillHasADR0024Completion(t *testing.T) {
+	dir := t.TempDir()
+	if err := runOrchestrator(dir); err != nil {
+		t.Fatalf("runOrchestrator: %v", err)
+	}
+	skill, err := os.ReadFile(
+		filepath.Join(dir, ".claude", "skills", "orchestrator", "SKILL.md"),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"fossil pull",   // pulls merged tip (ADR 0024 §4)
+		"fossil update", // materializes into worktree (ADR 0024 §4)
+	} {
+		if !strings.Contains(string(skill), want) {
+			t.Errorf("orchestrator SKILL.md missing %q (ADR 0024)", want)
+		}
+	}
+}

--- a/cmd/agent-init/orchestrator_test.go
+++ b/cmd/agent-init/orchestrator_test.go
@@ -155,8 +155,7 @@ func TestRunOrchestrator_SkillHasADR0024Completion(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, want := range []string{
-		"fossil pull",   // pulls merged tip (ADR 0024 §4)
-		"fossil update", // materializes into worktree (ADR 0024 §4)
+		"fossil update", // materializes merged tip into worktree (ADR 0024 §4)
 	} {
 		if !strings.Contains(string(skill), want) {
 			t.Errorf("orchestrator SKILL.md missing %q (ADR 0024)", want)

--- a/cmd/agent-init/templates/orchestrator/scripts/hub-bootstrap.sh
+++ b/cmd/agent-init/templates/orchestrator/scripts/hub-bootstrap.sh
@@ -40,7 +40,8 @@ if [[ ! -f "$HUB_REPO" ]]; then
             exit 1
         fi
         git ls-files -z | xargs -0 fossil add >/dev/null
-        fossil commit -m "session base: $(git rev-parse --short HEAD)" >/dev/null
+        fossil commit --user orchestrator \
+            -m "session base: $(git rev-parse --short HEAD)" >/dev/null
     )
 fi
 

--- a/cmd/agent-init/templates/orchestrator/scripts/hub-bootstrap.sh
+++ b/cmd/agent-init/templates/orchestrator/scripts/hub-bootstrap.sh
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
 # hub-bootstrap.sh — idempotent.
-# Boots the orchestrator's hub fossil HTTP server and NATS server.
+# Per ADR 0024: opens a Fossil checkout at the project root and seeds
+# the hub from git-tracked files. Files Fossil writes (.fslckout,
+# .fossil-settings/, .orchestrator/) must be gitignored.
 # Writes server PIDs to .orchestrator/pids for hub-shutdown.sh.
-# No-op if both servers are already up.
+# No-op if servers are already up.
 #
-# Prerequisites: `fossil` and `nats-server` must be in $PATH.
+# Prerequisites: `fossil`, `nats-server`, and `git` must be in $PATH.
 set -euo pipefail
 
 ROOT="$(git rev-parse --show-toplevel)"
@@ -13,22 +15,49 @@ HUB_REPO="$ORCH_DIR/hub.fossil"
 PID_DIR="$ORCH_DIR/pids"
 mkdir -p "$PID_DIR"
 
-# 1) Hub fossil repo
+# Fresh-start detection: if no fossil PID is alive, wipe stale state
+# (hub repo, checkout metadata, settings dir) so each session starts
+# from a clean substrate. Working-tree files are untouched. Per ADR
+# 0024 §2.
+fossil_alive=false
+if [[ -f "$PID_DIR/fossil.pid" ]] && \
+   kill -0 "$(cat "$PID_DIR/fossil.pid")" 2>/dev/null; then
+    fossil_alive=true
+fi
+
+if [[ "$fossil_alive" == "false" ]]; then
+    rm -rf "$HUB_REPO" "$ROOT/.fslckout" "$ROOT/.fossil-settings"
+fi
+
+# 1) Hub fossil repo + checkout-at-root + git-tracked seed (ADR 0024 §1, §3)
 if [[ ! -f "$HUB_REPO" ]]; then
     fossil new "$HUB_REPO" --admin-user orchestrator >/dev/null
+    (
+        cd "$ROOT"
+        fossil open --force "$HUB_REPO" >/dev/null
+        if [[ "$(git ls-files | wc -l | tr -d ' ')" -eq 0 ]]; then
+            echo "hub-bootstrap: error: no git-tracked files to seed from" >&2
+            exit 1
+        fi
+        git ls-files -z | xargs -0 fossil add >/dev/null
+        fossil commit -m "session base: $(git rev-parse --short HEAD)" >/dev/null
+    )
 fi
 
 # 2) Fossil HTTP server
-if [[ -f "$PID_DIR/fossil.pid" ]] && kill -0 "$(cat "$PID_DIR/fossil.pid")" 2>/dev/null; then
+if [[ -f "$PID_DIR/fossil.pid" ]] && \
+   kill -0 "$(cat "$PID_DIR/fossil.pid")" 2>/dev/null; then
     echo "fossil server already running (pid=$(cat "$PID_DIR/fossil.pid"))"
 else
-    fossil server "$HUB_REPO" --localhost --port 8765 >"$ORCH_DIR/fossil.log" 2>&1 &
+    fossil server "$HUB_REPO" --localhost --port 8765 \
+        >"$ORCH_DIR/fossil.log" 2>&1 &
     echo $! >"$PID_DIR/fossil.pid"
     sleep 0.3
 fi
 
 # 3) NATS server with JetStream
-if [[ -f "$PID_DIR/nats.pid" ]] && kill -0 "$(cat "$PID_DIR/nats.pid")" 2>/dev/null; then
+if [[ -f "$PID_DIR/nats.pid" ]] && \
+   kill -0 "$(cat "$PID_DIR/nats.pid")" 2>/dev/null; then
     echo "nats-server already running (pid=$(cat "$PID_DIR/nats.pid"))"
 else
     nats-server -js -p 4222 >"$ORCH_DIR/nats.log" 2>&1 &

--- a/cmd/agent-init/templates/orchestrator/skills/orchestrator/SKILL.md
+++ b/cmd/agent-init/templates/orchestrator/skills/orchestrator/SKILL.md
@@ -90,10 +90,23 @@ When all subagents return:
    fossil timeline --type ci -R .orchestrator/hub.fossil --limit <N>
    ```
 
-2. Print a summary: slots completed, tasks per slot, fork retries (from
+2. Materialize the merged tip into the host project's working tree
+   (per ADR 0024). The orchestrator's Fossil checkout is opened at the
+   project root by `hub-bootstrap.sh`; pulling and updating writes the
+   swarm's commits onto disk as ordinary file changes. Run from the
+   project root (where `.fslckout` lives):
+
+   ```
+   ROOT="$(git rev-parse --show-toplevel)"
+   (cd "$ROOT" && fossil pull && fossil update && git status)
+   ```
+
+3. Print a summary: slots completed, tasks per slot, fork retries (from
    span data if available), unrecoverable conflicts.
 
-3. (v2 stub for now) Log "PR generation skipped — implement in v2".
+4. Tell the user: "Swarm complete. Review with `git diff`. Stage the
+   files you want with `git add -u` (modified) or `git add <paths>`
+   (specific), then `git commit -m '...' && git push`."
 
 The hub itself stays running across the session — Stop hook will tear it
 down.
@@ -108,7 +121,8 @@ down.
 
 ## What this skill does NOT do (v2 work)
 
-- GitHub PR creation
+- Auto git-add/commit/push (user runs these after Step 6)
+- GitHub PR creation (user runs `gh pr create` after committing)
 - Remote-harness subagents (multi-cloud)
 - Auto-replan on conflict
 - Multi-session hub coordination beyond persistence

--- a/cmd/agent-init/templates/orchestrator/skills/orchestrator/SKILL.md
+++ b/cmd/agent-init/templates/orchestrator/skills/orchestrator/SKILL.md
@@ -91,14 +91,14 @@ When all subagents return:
    ```
 
 2. Materialize the merged tip into the host project's working tree
-   (per ADR 0024). The orchestrator's Fossil checkout is opened at the
-   project root by `hub-bootstrap.sh`; pulling and updating writes the
-   swarm's commits onto disk as ordinary file changes. Run from the
-   project root (where `.fslckout` lives):
+   (per ADR 0024). The orchestrator's Fossil checkout shares the hub
+   repo file directly (opened by `hub-bootstrap.sh`), so `fossil update`
+   reads the autosynced tip and rewrites the working tree as ordinary
+   file changes. Run from the project root (where `.fslckout` lives):
 
    ```
    ROOT="$(git rev-parse --show-toplevel)"
-   (cd "$ROOT" && fossil pull && fossil update && git status)
+   (cd "$ROOT" && fossil update && git status)
    ```
 
 3. Print a summary: slots completed, tasks per slot, fork retries (from

--- a/docs/adr/0024-orchestrator-fossil-checkout-as-git-worktree.md
+++ b/docs/adr/0024-orchestrator-fossil-checkout-as-git-worktree.md
@@ -1,0 +1,160 @@
+# ADR 0024: Orchestrator Fossil checkout = git working tree
+
+## Status
+
+Accepted 2026-04-27. Closes the v1 stub in ADR 0023 §"Orchestrator skill
+responsibilities" step 5 (PR generation skipped — implement in v2).
+Implements the swarm→git bridge.
+
+## Context
+
+ADR 0023 ships a hub-and-leaf orchestration model: a bare Fossil repo at
+`.orchestrator/hub.fossil`, leaves cloned from the hub, agents committing
+into their leaf checkouts, Fossil autosync replicating to the hub. The
+merged tip lives in the hub Fossil repo.
+
+ADR 0023 step 5 (Completion) explicitly stubs the bridge from this Fossil
+DAG to the host project's git working tree: *"Kill servers; stub
+PR-creation log line for v1."* Today, code agents produce never lands in
+git — the human extracts files from a Fossil checkout manually.
+
+The narrowest fix: open the orchestrator's Fossil checkout *at the host
+project root* itself, with Fossil metadata gitignored. After all
+subagents complete, `fossil pull && fossil update` materializes the
+merged hub tip into the working tree as ordinary file contents. From
+there `git add/commit/push` is the standard flow.
+
+The alternative — a `coord.Export(ctx, rev) ([]File, error)` primitive
+that materializes bytes into the git tree without any Fossil metadata
+leaking — is cleaner long-term but requires a new substrate-hiding API.
+This ADR picks the simpler path; a successor ADR can revisit if
+Fossil-in-tree friction shows up.
+
+## Decision
+
+### 1. Orchestrator's Fossil checkout opens at the host project root
+
+`hub-bootstrap.sh` runs `fossil open --force "$HUB_REPO"` from
+`git rev-parse --show-toplevel`. This creates `.fslckout` and
+`.fossil-settings/` in the project root. Both are gitignored. The host's
+git working tree remains the authoritative on-disk source; Fossil tracks
+the same files for coordination purposes only.
+
+### 2. Wipe stale Fossil state on fresh-start bootstrap
+
+When the bootstrap detects no live fossil PID (i.e. fresh-start), it
+removes:
+
+- `.orchestrator/hub.fossil` — the bare hub repo
+- `<root>/.fslckout` — the checkout metadata
+- `<root>/.fossil-settings/` — the per-checkout settings
+
+Wipe runs *before* `fossil new` so each session starts from a clean
+substrate. Files in the working tree are untouched — only Fossil metadata
+is removed. Git-committed work is in `.git/`, not Fossil; uncommitted
+work in the working tree also survives.
+
+### 3. Seed hub from `git ls-files`
+
+After `fossil new` and `fossil open`, the bootstrap walks
+`git ls-files -z` (NUL-delimited for paths with spaces), runs
+`fossil add` on each, then
+`fossil commit -m "session base: <git-short-sha>"`. The commit message
+embeds `git rev-parse --short HEAD` so the seed is traceable to a git
+ref.
+
+Leaves clone from a hub already populated with the host project's
+tracked files. Agents see and modify the existing codebase, not a
+greenfield repo.
+
+`git ls-files` returns tracked files only; untracked files are not
+seeded. Users with mid-flight uncommitted work either commit/stash first
+or accept that the swarm sees only the tracked state.
+
+### 4. Completion materializes merged tip into the working tree
+
+The orchestrator skill's Step 6 (Completion) gains two new commands
+before the summary:
+
+```
+fossil pull
+fossil update
+```
+
+`fossil pull` fetches the merged hub tip into the local checkout.
+`fossil update` applies it to the working tree. Files committed by
+subagents now appear as ordinary file changes.
+
+Followed by `git status` (informational) so the user sees exactly what
+changed. PR creation remains caller-driven — the skill prints a one-line
+"ready to commit" message; humans (or v2 tooling) run git/gh.
+
+### 5. `.gitignore` carries the Fossil and orchestrator entries
+
+The host project's root `.gitignore` adds:
+
+```
+.fslckout
+.fossil-settings/
+.orchestrator/
+```
+
+`agent-init` appends these idempotently when scaffolding the orchestrator
+into a new project, so users don't have to discover the requirement.
+
+## Consequences
+
+**Locks in.** Orchestrator-as-checkout-at-project-root is the v1 bridge.
+Tooling that scans the working tree (linters, IDEs) sees `.fslckout`.
+Most tools ignore unknown dotfiles; the few that don't are the friction
+signal that would justify graduating to a `coord.Export` primitive (open
+question §1).
+
+**Forecloses.** Running multiple concurrent orchestrator sessions on the
+same host project is incoherent — the wipe step would clobber an
+in-flight session's hub. Single-session-per-project matches ADR 0023's
+single-host leaf-daemon assumption. Multi-worktree usage (one
+orchestrator per git worktree) is the supported parallel pattern.
+
+**Enables.** The swarm produces git diffs the user can review and commit
+normally — no manual file extraction, no Fossil-aware tooling on the user
+side. PR creation becomes "what you'd do for any feature".
+
+**Invariants.** No new coord invariants. The bootstrap script gains
+discipline (wipe-before-init); ADR 0023's slot-disjointness invariant and
+ADR 0010's invariant 22 are unchanged.
+
+**Substrate.** Coord is unchanged; this is an orchestrator-skill /
+bootstrap-script concern only. No new public surface, no new error
+sentinels.
+
+## Open questions
+
+**Tooling friction with `.fslckout` in tree.** Some tools may surface
+`.fslckout` as noise. Mitigation: editorconfig, tool-level ignore
+patterns. If friction is persistent, graduate to a successor ADR
+introducing `coord.Export(ctx, rev) ([]File, error)` and writing to a
+separate temp dir then `cp` into the working tree.
+
+**Seeding untracked-but-staged files.** v1 uses `git ls-files`
+(tracked-and-committed only). If swarm runs need to see staged-but-
+uncommitted files, switch to
+`git ls-files --modified --others --cached --exclude-standard`. Deferred
+until a user reports it.
+
+**Multi-session concurrency.** Two orchestrators in the same project
+collide on `.orchestrator/hub.fossil`. The git-worktree pattern handles
+this since `git rev-parse --show-toplevel` returns the worktree root,
+not the canonical repo path — each worktree gets its own
+`.orchestrator/`. Untested.
+
+## Cross-links
+
+- **ADR 0010** — Per-leaf checkouts, hold-gated commits. The orchestrator's
+  checkout at project root follows the same per-checkout discipline at a
+  different role.
+- **ADR 0018** — EdgeSync refactor. Bootstrap delegates to EdgeSync's
+  leaf agent for fossil server + NATS; the wipe/seed/checkout-at-root
+  layer sits above that.
+- **ADR 0023** — Hub-leaf orchestrator topology. This ADR fills the v1
+  stub in step 5 (Completion).

--- a/docs/adr/0024-orchestrator-fossil-checkout-as-git-worktree.md
+++ b/docs/adr/0024-orchestrator-fossil-checkout-as-git-worktree.md
@@ -19,9 +19,10 @@ PR-creation log line for v1."* Today, code agents produce never lands in
 git — the human extracts files from a Fossil checkout manually.
 
 The narrowest fix: open the orchestrator's Fossil checkout *at the host
-project root* itself, with Fossil metadata gitignored. After all
-subagents complete, `fossil pull && fossil update` materializes the
-merged hub tip into the working tree as ordinary file contents. From
+project root* itself, with Fossil metadata gitignored. The checkout
+shares the hub repo file directly, so when leaves autosync their
+commits to the hub, `fossil update` alone reads the new tip and
+materializes it into the working tree as ordinary file contents. From
 there `git add/commit/push` is the standard flow.
 
 The alternative — a `coord.Export(ctx, rev) ([]File, error)` primitive
@@ -73,16 +74,17 @@ or accept that the swarm sees only the tracked state.
 
 ### 4. Completion materializes merged tip into the working tree
 
-The orchestrator skill's Step 6 (Completion) gains two new commands
+The orchestrator skill's Step 6 (Completion) gains a new command
 before the summary:
 
 ```
-fossil pull
 fossil update
 ```
 
-`fossil pull` fetches the merged hub tip into the local checkout.
-`fossil update` applies it to the working tree. Files committed by
+Because the orchestrator's checkout shares the hub repo file directly
+(opened locally by `hub-bootstrap.sh` rather than cloned), no `pull` is
+required — `fossil update` reads the autosynced tip from the shared
+`.fossil` file and applies it to the working tree. Files committed by
 subagents now appear as ordinary file changes.
 
 Followed by `git status` (informational) so the user sees exactly what


### PR DESCRIPTION
## Summary
- Closes the swarm→git loop stubbed in ADR 0023 §"Orchestrator skill responsibilities" step 5 (was *"PR generation skipped — implement in v2"*).
- Orchestrator opens a Fossil checkout at the host project root with Fossil metadata (`.fslckout`, `.fossil-settings/`) gitignored. Bootstrap wipes stale state, seeds the hub from `git ls-files`, and starts servers as before.
- Skill Step 6 runs `fossil update` (no `pull` — checkout shares the hub repo file directly) to materialize the merged tip into the working tree, then `git status` so the user can review and `git add -u` / `git add <paths>` + commit + push.
- `agent-init` auto-appends `.fslckout`, `.fossil-settings/`, `.orchestrator/` to the host `.gitignore` for new projects so users don't have to discover the requirement.

## Test plan
- [x] `make check` clean (fmt-check, vet, lint, race, todo-check)
- [x] 12 `cmd/agent-init` tests pass — 4 new gitignore-helper tests (TDD: fresh / idempotent / preserves-existing / partial-overlap), 2 new regression tests guarding ADR 0024 markers in scaffolded `hub-bootstrap.sh` and `orchestrator/SKILL.md`, plus existing tests
- [x] Manual e2e: run an orchestrator session against a real project, confirm `git status` after Step 6 surfaces the swarm's commits as ordinary file changes ready for `git add/commit/push`

## Design

See [ADR 0024](https://github.com/danmestas/agent-infra/blob/adr-0024-fossil-checkout-as-git-worktree/docs/adr/0024-orchestrator-fossil-checkout-as-git-worktree.md) for the full decision and tradeoffs (chose simpler "checkout-at-root" over a `coord.Export` primitive; deferred multi-session concurrency and untracked-but-staged seeding).