### PR TITLE
docs: sweep references to old binary names → bones

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -159,7 +159,7 @@ guard against:
 
 - `coord/` — the single public Go package agents import
 - `internal/holds/`, `internal/tasks/` — implementation detail
-- `cmd/agent-init/`, `cmd/agent-tasks/` — CLI binaries
+- `cmd/bones/` — unified CLI binary (init/up/orchestrator + tasks subcommands)
 - Tasks stored as files under `tasks/` in the fossil repo (Phase 2
   decision — subject to revisit)
 - Pre-commit hook that blocks imports from `EdgeSync/internal/` or

--- a/README.md
+++ b/README.md
@@ -21,22 +21,22 @@ cd .. && git clone https://github.com/danmestas/EdgeSync && cd agent-infra
 # Build agent-infra binaries:
 make
 # One-command bootstrap: workspace + scaffold + bin/leaf + hub:
-bin/agent-init up
+bin/bones up
 # Add and inspect tasks:
-bin/agent-tasks add "my first task" --files src/foo.go
-bin/agent-tasks open
-bin/agent-tasks status
+bin/bones tasks add "my first task" --files src/foo.go
+bin/bones tasks open
+bin/bones tasks status
 ```
 
-Or use fine-grained control (`agent-init up` is equivalent to):
+Or use fine-grained control (`bones up` is equivalent to):
 
 ```bash
-bin/agent-init init
-bin/agent-init orchestrator
+bin/bones init
+bin/bones orchestrator
 bash .orchestrator/scripts/hub-bootstrap.sh
 ```
 
-See `bin/agent-tasks --help` for the full subcommand list (`add`, `claim`,
+See `bin/bones --help` for the full subcommand list (`add`, `claim`,
 `close`, `watch`, `status`, and more).
 
 ---
@@ -245,9 +245,9 @@ NATS carries:
 
 ### Phase 4 — auto-init + CLI
 
-- `cmd/agent-init/` — walk up to find `.agent-infra/` marker or create one at
-  the invocation directory; start (or join) a local leaf daemon
-- `cmd/agent-tasks/` — human-facing CLI (`list`, `claim`, `update`, `done`)
+- `cmd/bones/` — walk up to find `.agent-infra/` marker or create one at
+  the invocation directory; start (or join) a local leaf daemon; human-facing
+  tasks subcommands (`list`, `claim`, `update`, `close`)
 - Decide: explicit `agent-infra init` command vs silent walk-up
 
 ### Phase 5 — smoke + chaos tests
@@ -289,8 +289,7 @@ NATS carries:
 agent-infra/
   coord/              # Public Go API — the surface agents import
   cmd/
-    agent-init/       # Project auto-init wrapper
-    agent-tasks/      # Human-facing tasks CLI
+    bones/            # Unified CLI: init/up/orchestrator + tasks subcommands
   internal/
     holds/            # NATS KV hold protocol
     tasks/            # tasks-as-files helpers
@@ -337,24 +336,24 @@ go test ./...
 you find yourself editing inside `reference/` that's a sign something's
 miswired.
 
-### Getting started with `agent-init`
+### Getting started with `bones`
 
-`agent-init` creates an `.agent-infra/` workspace and starts a local
+`bones init` creates an `.agent-infra/` workspace and starts a local
 `leaf` daemon, or rejoins an existing workspace from any subdir.
 
 ```bash
-# Build the binary (leaves it at ./bin/agent-init):
-make agent-init
+# Build the binary (leaves it at ./bin/bones):
+make bones
 
 # First time in a fresh directory — starts a leaf, writes .agent-infra/:
-$ ./bin/agent-init init
+$ ./bin/bones init
 workspace=/path/to/dir
 agent_id=7c3d…
 nats_url=nats://127.0.0.1:4222
 leaf_http_url=http://127.0.0.1:51234
 
 # From any descendant directory — walks up to find the marker:
-$ ./bin/agent-init join
+$ ./bin/bones join
 workspace=/path/to/dir
 …
 ```
@@ -363,7 +362,7 @@ The `leaf` binary must be on `PATH` (or `LEAF_BIN` set to its absolute
 path). Build it from EdgeSync with `cd ../EdgeSync && make leaf`. Leaf
 stdout/stderr lands in `.agent-infra/leaf.log`; the PID sits at
 `.agent-infra/leaf.pid`. Set `AGENT_INFRA_LOG=json` to switch
-`agent-init`'s own logs to JSON.
+`bones`'s own logs to JSON.
 
 Release-time: each of the three repos (`agent-infra`, `EdgeSync`,
 `libfossil`) is tagged and published independently. `agent-infra`

--- a/docs/adr/0018-edgesync-refactor.md
+++ b/docs/adr/0018-edgesync-refactor.md
@@ -132,7 +132,7 @@ EdgeSync upstream changes required:
 
 agent-infra's chat and workspace continue to import libfossil
 directly — explicit scope limit, not an oversight. Other callers
-(`coord/`, both example harnesses, `cmd/orchestrator-validate-plan/`)
+(`coord/`, both example harnesses, `cmd/bones/`)
 flow through `coord.Hub`/`coord.Leaf`.
 
 `.orchestrator/scripts/hub-bootstrap.sh` now spawns

--- a/docs/adr/0019-cli-binaries.md
+++ b/docs/adr/0019-cli-binaries.md
@@ -8,6 +8,12 @@ NATS KV) and ADR 0007 (claim semantics) by giving operators a verb
 vocabulary to drive both. Compressed from three plan/spec pairs
 (`cmd/agent-init`, `cmd/agent-tasks`, `examples/two-agents`).
 
+Superseded by the bones consolidation — the `agent-init`,
+`agent-tasks`, and `orchestrator-validate-plan` binaries were merged
+into a single `bones` CLI in 2026-04 (PR #20). The split rationale
+below is preserved for historical context; current behavior, verb
+list, and packaging live under `cmd/bones/`.
+
 ## Context
 
 After ADRs 0005–0010 the coord package had a complete primitive surface

--- a/docs/adr/0020-defer-until-ready.md
+++ b/docs/adr/0020-defer-until-ready.md
@@ -67,8 +67,8 @@ the gate opens, it stays open.
 
 ### CLI surface
 
-`agent-tasks create` and `agent-tasks update` accept `--defer-until=<rfc3339>`.
-`agent-tasks show` formats `defer_until=<rfc3339>` when set. No
+`bones tasks create` and `bones tasks update` accept `--defer-until=<rfc3339>`.
+`bones tasks show` formats `defer_until=<rfc3339>` when set. No
 dedicated `defer` verb — the field is a property, not a verb. Callers
 who want to "un-defer" use `update --defer-until=` (empty string) which
 clears the pointer.

--- a/docs/adr/0021-dispatch-and-autoclaim.md
+++ b/docs/adr/0021-dispatch-and-autoclaim.md
@@ -84,7 +84,7 @@ unclaimed" is the contract.
 **Opt-out.** Env var `AGENT_INFRA_AUTOCLAIM=0|false|no` disables the
 tick at the CLI layer; CLI flag `--autoclaim=false` overrides env.
 
-**Hook wiring.** `.claude/settings.json` runs `agent-tasks autoclaim`
+**Hook wiring.** `.claude/settings.json` runs `bones tasks autoclaim`
 on Stop and PreCompact hooks (so a session-idle moment becomes a
 claim-tick opportunity).
 
@@ -107,7 +107,7 @@ files, parent id, edges, thread id, parent agent id, worker agent id,
 workspace dir. Encoded as JSON on stdin so the worker doesn't have to
 re-Get the task record.
 
-**Worker command contract.** Parent launches `agent-tasks dispatch worker
+**Worker command contract.** Parent launches `bones tasks dispatch worker
 ...`. Worker mode is a self-exec branch of the same binary, not a hidden
 internal function. Operator-introspectable.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -5,19 +5,19 @@ Listed alphabetically by prefix.
 
 ## AGENT_INFRA_*
 
-- `AGENT_INFRA_AUTOCLAIM` — enable/disable the `agent-tasks autoclaim` tick.
+- `AGENT_INFRA_AUTOCLAIM` — enable/disable the `bones tasks autoclaim` tick.
   Accepted values: `1`, `true`, `yes` (enable); `0`, `false`, `no` (disable).
-  Used by: `bin/agent-tasks` (`autoclaim` subcommand).
+  Used by: `bin/bones tasks autoclaim`.
 
 - `AGENT_INFRA_LOG=json` — switch slog handler to JSON output on stderr.
   Default: human-readable text.
-  Used by: `bin/agent-init`, `bin/agent-tasks`.
+  Used by: `bin/bones`.
 
 ## EDGESYNC_*
 
 - `EDGESYNC_DIR` — path to the EdgeSync sibling repository.
   Default: `$ROOT/../EdgeSync` (where `$ROOT` is the agent-infra workspace root).
-  Used by: `.orchestrator/scripts/hub-bootstrap.sh`, `agent-init up`.
+  Used by: `.orchestrator/scripts/hub-bootstrap.sh`, `bones up`.
 
 ## HERD_*
 
@@ -42,7 +42,7 @@ that `hub-bootstrap.sh` and agent-infra's workspace package use:
   If unset, `hub-bootstrap.sh` resolves the binary in priority order:
   `$ROOT/bin/leaf` → `$EDGESYNC_DIR/bin/leaf` → `leaf` on `$PATH` →
   build from `$EDGESYNC_DIR/leaf/cmd/leaf`.
-  Used by: `.orchestrator/scripts/hub-bootstrap.sh`, `agent-init up`,
+  Used by: `.orchestrator/scripts/hub-bootstrap.sh`, `bones up`,
   `internal/workspace`, `examples/two-agents`.
 
 - `LEAF_NATS_CLIENT_PORT` — TCP port for the embedded NATS server started by
@@ -75,16 +75,16 @@ disabled (no-op) and the binary runs normally.
 
 - `OTEL_EXPORTER_OTLP_ENDPOINT` — OTLP collector endpoint
   (e.g. `https://api.honeycomb.io`).
-  Used by: `bin/agent-init`, `bin/agent-tasks`, `examples/herd-hub-leaf`.
+  Used by: `bin/bones`, `examples/herd-hub-leaf`.
   Note: `hub-bootstrap.sh` **unsets** this var in the hub process env to
   prevent the hub from blocking on a slow or unreachable collector.
 
 - `OTEL_EXPORTER_OTLP_HEADERS` — key=value pairs passed to the OTLP exporter,
   comma-separated (e.g. `x-honeycomb-team=abc123`).
-  Used by: `bin/agent-init`, `bin/agent-tasks`.
+  Used by: `bin/bones`.
 
 - `OTEL_SERVICE_NAME` — service name tag for traces and metrics.
-  Defaults: `agent-init` (bin/agent-init), `agent-tasks` (bin/agent-tasks),
+  Defaults: `bones` (bin/bones),
   `herd-hub-leaf` (examples/herd-hub-leaf), `edgesync-leaf` (bin/leaf).
   Used by: `examples/herd-hub-leaf` (reads directly); other binaries pass the
   default via `telemetry.TelemetryConfig.ServiceName`.

--- a/docs/harness-integration.md
+++ b/docs/harness-integration.md
@@ -49,7 +49,7 @@ plugin; Claude Code's skill runner drives the lifecycle.
    `.claude/skills/orchestrator/SKILL.md` in this repo.
 2. Invoke the orchestrator skill with a slot-annotated plan: the skill
    expects a plan doc that identifies which files go to which slot.
-3. The skill calls `agent-tasks` subcommands internally and coordinates
+3. The skill calls `bones tasks` subcommands internally and coordinates
    leaf commit/close.
 
 See `.claude/skills/orchestrator/SKILL.md` for the full invocation
@@ -172,11 +172,11 @@ required in agent-infra.
 
 ## 4. Result Aggregation
 
-After a run, use `agent-tasks aggregate` to get a one-shot summary of
+After a run, use `bones tasks aggregate` to get a one-shot summary of
 what every slot committed:
 
 ```
-$ bin/agent-tasks aggregate --since 1h
+$ bin/bones tasks aggregate --since 1h
 Run summary (last 1h0m0s)
 ─────────────────────────────────────────────────────
 slot-A               3 task(s)  files: foo.go, bar.go            status: closed
@@ -202,7 +202,7 @@ slot-C               1 task(s)  files: baz.go                    status: active
 ```
 
 The command requires a running hub workspace (NATS + tasks bucket). If no
-hub is running, `agent-tasks aggregate` exits with an error about the
+hub is running, `bones tasks aggregate` exits with an error about the
 missing workspace.
 
 ---
@@ -242,7 +242,7 @@ if err != nil {
 |---|---|---|
 | `examples/herd-hub-leaf/` | Shape B (library) | N-leaf thundering-herd trial: 16 slots × 30 tasks, OTLP telemetry |
 | `cmd/space-invaders-orchestrate/` | Shape B (library) | 4–5 slot minimal harness; commits files produced by parallel Task subagents |
-| `.claude/skills/orchestrator/SKILL.md` | Shape A (skill) | Claude Code orchestrator skill; drives slots via `agent-tasks` CLI |
+| `.claude/skills/orchestrator/SKILL.md` | Shape A (skill) | Claude Code orchestrator skill; drives slots via `bones tasks` CLI |
 
 ### Anatomy of `examples/herd-hub-leaf/`
 

--- a/reference/CAPABILITIES.md
+++ b/reference/CAPABILITIES.md
@@ -63,7 +63,7 @@ conflict resolution is one round trip with a deterministic winner
 | `bd blocked` | `coord.Blocked()` | planned | Same DAG, filtered inversely. Phase 6 (tickets `dcd` → `0sr`). |
 | `bd list --status=X` | `coord.List(filter struct)` | planned | Struct filter, not a query-string DSL. |
 | `bd defer --until` | `defer_until:` field + Ready filter | planned | Phase 6 (ticket `8m9`). Not yet on the task record. |
-| `bd stale` / `bd orphans` / `bd preflight` | Helpers under `cmd/agent-tasks/` | planned | Lint-style checks fit the CLI better than the library. `cmd/agent-tasks` ships with `create`/`list`/`show`/`claim`/`update`/`close`; the stale/orphans/preflight helpers are Phase 6 (ticket `kue`). |
+| `bd stale` / `bd orphans` / `bd preflight` | Helpers under `cmd/bones/` | planned | Lint-style checks fit the CLI better than the library. `bones tasks` ships with `create`/`list`/`show`/`claim`/`update`/`close`; the stale/orphans/preflight helpers are Phase 6 (ticket `kue`). |
 | Priority 0–4 (0=critical) | Same integer scheme | planned | Additive extension to the Phase 2 record. |
 
 ## 2. Dependency graph
@@ -94,11 +94,11 @@ conflict resolution is one round trip with a deterministic winner
 
 | Beads | agent-infra plan | Status | Notes |
 |---|---|---|---|
-| `bd prime` — canonical context recovery | `coord.Prime(ctx)` + `agent-tasks prime` CLI wrapper — outputs project state, ready work, claimed work, thread summaries | planned | Phase 6 (ticket `rbu`). Borrow the single-source-of-truth pattern directly. |
-| SessionStart + PreCompact hooks auto-inject `bd prime` | Claude plugin with the same two hooks calling `agent-tasks prime` | planned | Phase 6 (ticket `rbu`). |
+| `bd prime` — canonical context recovery | `coord.Prime(ctx)` + `bones tasks prime` CLI wrapper — outputs project state, ready work, claimed work, thread summaries | planned | Phase 6 (ticket `rbu`). Borrow the single-source-of-truth pattern directly. |
+| SessionStart + PreCompact hooks auto-inject `bd prime` | Claude plugin with the same two hooks calling `bones tasks prime` | planned | Phase 6 (ticket `rbu`). |
 | "Landing the plane" session close (close issues, run QA, push, verify up-to-date) | Same ceremony, adapted: verify fossil timeline is synced, no outstanding txns | planned | Conceptual win to keep: agents are accountable for finalization, not "ready when you are." |
 | `bd edit` is prohibited (opens `$EDITOR`, blocks agents) | Never ship an equivalent; all mutations via flags or stdin | planned | Pre-learned lesson. |
-| `--json` everywhere | Every CLI subcommand supports `--json`; programmatic contract | partially implemented | `agent-tasks` subcommands accept `--json` per `cmd/agent-tasks/main.go`; schema stability audit is Phase 6 (ticket `ayy`). |
+| `--json` everywhere | Every CLI subcommand supports `--json`; programmatic contract | partially implemented | `bones tasks` subcommands accept `--json` per `cmd/bones/`; schema stability audit is Phase 6 (ticket `ayy`). |
 | `discovered-from` linking for context recovery | Same edge type; `agent-infra task discover <new> --from <parent>` | planned | Phase 6 (ticket `dcd`). Cheap to implement once typed edges land, large payoff for multi-session continuity. |
 | `bd remember` / `bd memories` — memory as first-class, in Dolt not MEMORY.md | Memory is either an issue-type (`type: memory`) or a dedicated `memories/` dir | TBD | Open: memory as a task-type or a separate primitive? |
 
@@ -127,7 +127,7 @@ conflict resolution is one round trip with a deterministic winner
 
 | Beads | agent-infra plan | Status | Notes |
 |---|---|---|---|
-| Multi-tier AI compaction (summarize old closed issues via Haiku) | `coord.Compact(ctx, opts)` does on-demand batch compaction of eligible closed tasks via a caller-supplied summarizer, writes summaries to deterministic Fossil artifacts, can archive compacted closed tasks into a cold KV bucket, and can prune them from the hot tasks bucket; `agent-tasks compact` binds a default Anthropic-backed summarizer and optional `--every` cadence wrapper | implemented | ADR 0016 keeps provider choice outside `coord`; the shipped default binding lives in the CLI layer. |
+| Multi-tier AI compaction (summarize old closed issues via Haiku) | `coord.Compact(ctx, opts)` does on-demand batch compaction of eligible closed tasks via a caller-supplied summarizer, writes summaries to deterministic Fossil artifacts, can archive compacted closed tasks into a cold KV bucket, and can prune them from the hot tasks bucket; `bones tasks compact` binds a default Anthropic-backed summarizer and optional `--every` cadence wrapper | implemented | ADR 0016 keeps provider choice outside `coord`; the shipped default binding lives in the CLI layer. |
 | `original_size`, `compact_level`, `compacted_at` metadata | Same scheme on the task record | implemented | Landed with ADR 0016 / ticket `znr`. |
 | Compaction audit trail | Fossil timeline *is* the audit trail — no separate log needed | implemented | Summary artifacts are Fossil commits; task metadata updates are KV revisions. |
 
@@ -151,13 +151,13 @@ build one on top of `coord`.
 | Content hash on Issue (SHA256 of canonical fields) | Fossil artifact hash on code artifacts (Phase 5 per ADR 0010); task records carry a schema_version but no content hash | implemented for code / planned for tasks | Free on the code side: every `coord.Commit` returns a content-addressed `RevID` (see `coord/commit.go`). Task records still carry only `schema_version`. |
 | `events` table + `EventKind` namespacing (`patrol.muted`, `agent.started`, ...) | In-process `coord.Event` interface carrying `ChatMessage`, `Reaction`, `PresenceChange` (ADR 0008 / 0009) | implemented (live-only) / TBD (durable) | `coord.Event` interface is shipped with three concrete types — see `coord/events.go`. Current events are live-only on Subscribe channels; whether a durable event store is worth building is still open. |
 | Append-only `interactions.jsonl` (LLM calls, tool calls, labeling) | Out of scope — consumers track their own LLM audit | non-goal | Not a substrate concern. |
-| Lint / orphan / stale checks | Helpers in `cmd/agent-tasks/` | planned | Phase 6 (ticket `kue`). Base CLI ships; these three helpers are additive. |
+| Lint / orphan / stale checks | Helpers in `cmd/bones/` | planned | Phase 6 (ticket `kue`). Base CLI ships; these three helpers are additive. |
 
 ## 10. CLI and plugin surface
 
 | Beads | agent-infra plan | Status | Notes |
 |---|---|---|---|
-| ~29 `bd` subcommands | `agent-init` + `agent-tasks` binaries; narrow CLI | partially implemented | `agent-init` ships `init` + `join`; `agent-tasks` ships `create`/`list`/`show`/`claim`/`update`/`close` (~8 total). Stale/orphans/preflight helpers planned in Phase 6 (`kue`). Won't match beads' breadth at v0.1. |
+| ~29 `bd` subcommands | unified `bones` binary; narrow CLI | partially implemented | `bones` ships `init`/`up`/`join`/`orchestrator` plus a `tasks` subcommand group (`create`/`list`/`show`/`claim`/`update`/`close` etc.). Stale/orphans/preflight helpers planned in Phase 6 (`kue`). Won't match beads' breadth at v0.1. |
 | Claude plugin: `plugin.json` with hooks, commands, skill, agents, MCP | Ship our own plugin in Phase 6 — same shape | planned | Phase 6 (ticket `rbu`). Direct borrow. |
 | MCP server exposing tool-level operations | Sibling binary (Phase 7) | planned | ADR 0011 reserved; ticket `hf1`. |
 | Task-agent autonomous workflow doc | Ship equivalent under `claude-plugin/agents/` | planned | Phase 6 (ticket `rbu`). Direct borrow. |
@@ -260,7 +260,7 @@ For users coming from `bd`, the mental mapping is approximately:
 | `bd close <id> --reason` | `coord.CloseTask(ctx, taskID, reason)` — `coord/close_task.go` |
 | `bd ready --json` | `coord.Ready(ctx)` — `coord/ready.go` |
 | `bd remember` / `bd memories` | No equivalent yet — memory primitive is still TBD (§4). |
-| `bd prime` | Not yet — `coord.Prime()` + `agent-tasks prime` is Phase 6 (`rbu`). |
+| `bd prime` | Not yet — `coord.Prime()` + `bones tasks prime` is Phase 6 (`rbu`). |
 
 The substrate differences that matter most:
 


### PR DESCRIPTION
## Summary

PR #20 consolidated \`agent-init\`, \`agent-tasks\`, and \`orchestrator-validate-plan\` into a single \`bones\` CLI but left the docs unchanged. This sweep updates user-facing docs and active design ADRs to reference the new binary.

## Files updated (9)

- \`README.md\` — Quickstart, layout, repo-organization sections
- \`GETTING_STARTED.md\` — layout line
- \`docs/configuration.md\` — env-var docs, OTel service-name defaults
- \`docs/harness-integration.md\` — \`bones tasks aggregate\` invocation
- \`docs/adr/0018-edgesync-refactor.md\` — \`cmd/orchestrator-validate-plan/\` reference
- \`docs/adr/0019-cli-binaries.md\` — Status block: superseded note added; body untouched (historical record)
- \`docs/adr/0020-defer-until-ready.md\`, \`0021-dispatch-and-autoclaim.md\` — invocation examples
- \`reference/CAPABILITIES.md\` — current-state comparison table

## Out of scope

- \`docs/code-review/2026-04-26-*.md\` — point-in-time audit notes; left as historical record
- ADR bodies other than 0019's status note — historical decisions
- \`cli/templates/\` and \`.claude/\` — already updated in PR #20

## Test plan
- [x] \`grep -rnE "agent-init|agent-tasks|orchestrator-validate-plan" README.md GETTING_STARTED.md docs/ reference/\` (excluding code-review/ and ADR bodies) returns no hits
- [x] \`make check\` clean