### PR TITLE
release: GoReleaser config + tag-push workflow + bones --version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,33 @@
+name: release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.26.0'
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: '~> v2'
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,106 @@
+# GoReleaser config for bones.
+# https://goreleaser.com
+#
+# Cross-compiles bones for macOS and Linux on amd64/arm64, archives as
+# tarballs, generates checksums, publishes a GitHub release, and
+# updates the Homebrew formula in danmestas/homebrew-tap.
+
+version: 2
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - id: bones
+    main: ./cmd/bones
+    binary: bones
+    env:
+      - CGO_ENABLED=0
+    flags:
+      - -trimpath
+      - -buildvcs=false
+    ldflags:
+      - -s -w
+      - -X main.version={{.Version}}
+      - -X main.commit={{.ShortCommit}}
+      - -X main.date={{.CommitDate}}
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+
+archives:
+  - id: bones
+    formats: [tar.gz]
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- .Version }}_
+      {{- .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else }}{{ .Arch }}{{ end }}
+    files:
+      - LICENSE*
+      - README*
+
+checksum:
+  name_template: 'checksums.txt'
+  algorithm: sha256
+
+snapshot:
+  version_template: "{{ incpatch .Version }}-next"
+
+changelog:
+  sort: asc
+  use: github
+  filters:
+    exclude:
+      - '^docs:'
+      - '^chore:'
+      - '^test:'
+      - 'merge conflict'
+      - Merge pull request
+      - Merge remote-tracking branch
+      - Merge branch
+
+release:
+  github:
+    owner: danmestas
+    name: bones
+  draft: false
+  prerelease: auto
+  name_template: "{{.ProjectName}} v{{.Version}}"
+  footer: |
+    **Full Changelog**: https://github.com/danmestas/bones/compare/{{ .PreviousTag }}...{{ .Tag }}
+
+    ## Install
+
+    ### Homebrew (macOS / Linux)
+    ```bash
+    brew install danmestas/tap/bones
+    ```
+
+    ### Go
+    ```bash
+    go install github.com/danmestas/bones/cmd/bones@{{ .Tag }}
+    ```
+
+    ### Direct download
+    Pick a binary from the assets above for your OS/arch.
+
+brews:
+  - name: bones
+    repository:
+      owner: danmestas
+      name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+    directory: Formula
+    homepage: https://github.com/danmestas/bones
+    description: "Unified CLI for the bones agent-infrastructure substrate (workspace, orchestrator, tasks)."
+    license: Apache-2.0
+    install: |
+      bin.install "bones"
+    test: |
+      system "#{bin}/bones --version"

--- a/cmd/bones/main.go
+++ b/cmd/bones/main.go
@@ -16,7 +16,21 @@ import (
 	_ "github.com/danmestas/libfossil/db/driver/modernc"
 )
 
+// Build-time variables, populated via -ldflags by GoReleaser.
+var (
+	version = "dev"
+	commit  = "none"
+	date    = "unknown"
+)
+
 func main() {
+	// Handle --version / -V at the top level. Done before Kong.Parse so
+	// it doesn't collide with sub-flags like `bones repo extract --version`.
+	if len(os.Args) == 2 && (os.Args[1] == "--version" || os.Args[1] == "-V") {
+		fmt.Printf("bones %s (commit %s, built %s)\n", version, commit, date)
+		return
+	}
+
 	var c CLI
 	ctx := kong.Parse(&c,
 		kong.Name("bones"),


### PR DESCRIPTION
## Summary

Wires up the release pipeline for bones. On every \`v*\` tag push:

1. Cross-compile \`bones\` for darwin/linux × amd64/arm64 (CGO_ENABLED=0, pure Go).
2. Archive as \`.tar.gz\` with binary + LICENSE + README.
3. SHA-256 checksums file.
4. Publish a GitHub release with auto-generated changelog (excludes docs/chore/test commits).
5. Update the Homebrew formula at [\`danmestas/homebrew-tap/Formula/bones.rb\`](https://github.com/danmestas/homebrew-tap).

## Files

- \`.goreleaser.yml\` — build matrix, archive shape, brews stanza, version-injection ldflags
- \`.github/workflows/release.yml\` — runs on \`v*\` tags, calls \`goreleaser-action@v6 --clean\`
- \`cmd/bones/main.go\` — \`version\`/\`commit\`/\`date\` package vars; \`bones --version\` / \`-V\` short-circuit before Kong (avoids collision with \`repo extract --version\` sub-flag from libfossil/cli)

## Required secret (post-merge)

The release workflow needs \`HOMEBREW_TAP_TOKEN\` set on this repo — a PAT with \`contents:write\` on \`danmestas/homebrew-tap\`. \`GITHUB_TOKEN\` is auto-provided.

Create at: https://github.com/danmestas/bones/settings/secrets/actions

## Test plan
- [x] \`make check\` clean
- [x] \`go build -ldflags "-X main.version=v0.1.0 ..." -o bones ./cmd/bones/\` produces a binary that prints \`bones v0.1.0 (commit abc1234, built 2026-04-27)\` for both \`--version\` and \`-V\`
- [x] Non-version invocations still work (\`bones --help\`, \`bones tasks --help\`, etc.)
- [ ] After merge + secret + retag, the release workflow runs end-to-end on \`v0.1.0\`

## Follow-up after merge

1. Create the \`HOMEBREW_TAP_TOKEN\` secret.
2. Delete the existing \`v0.1.0\` tag (it predates this config) and re-push:
   \`\`\`bash
   git tag -d v0.1.0
   git push origin --delete v0.1.0
   git tag -a v0.1.0 -m "v0.1.0"
   git push origin v0.1.0
   \`\`\`
3. Watch the release workflow run.
4. Verify \`brew install danmestas/tap/bones\` works.