### PR TITLE
skills: add bones-on-PATH prereq check + uninstall-bones skill

### DIFF
--- a/cli/orchestrator_test.go
+++ b/cli/orchestrator_test.go
@@ -19,6 +19,7 @@ func TestScaffoldOrchestrator_FreshWorkspace(t *testing.T) {
 		".orchestrator/.gitignore",
 		".claude/skills/orchestrator/SKILL.md",
 		".claude/skills/subagent/SKILL.md",
+		".claude/skills/uninstall-bones/SKILL.md",
 		".claude/settings.json",
 	} {
 		if _, err := os.Stat(filepath.Join(dir, want)); err != nil {

--- a/cli/templates/orchestrator/skills/orchestrator/SKILL.md
+++ b/cli/templates/orchestrator/skills/orchestrator/SKILL.md
@@ -10,6 +10,20 @@ You are the orchestrator. Your job is to validate a plan, bootstrap a hub
 (if it isn't already up), dispatch one Task-tool subagent per slot, monitor
 their progress, and clean up at completion.
 
+## Prerequisites
+
+This skill assumes the `bones` binary is on `$PATH` (it was when the skill
+was scaffolded). If `bones` is not found, stop and tell the user to reinstall:
+
+```
+brew install danmestas/tap/bones
+# or
+go install github.com/danmestas/bones/cmd/bones@latest
+# or download from https://github.com/danmestas/bones/releases
+```
+
+Do not auto-install. Wait for the user.
+
 ## Step 1: Validate the plan
 
 Run the validator against the plan path the user provided:

--- a/cli/templates/orchestrator/skills/subagent/SKILL.md
+++ b/cli/templates/orchestrator/skills/subagent/SKILL.md
@@ -16,6 +16,20 @@ a slot's task list and these environment values:
 - AGENT_ID    — your unique agent id
 - SLOT_ID     — slot you're servicing
 
+## Prerequisites
+
+This skill assumes the `bones` binary is on `$PATH` (it was when the skill
+was scaffolded). If `bones` is not found, stop and tell the user to reinstall:
+
+```
+brew install danmestas/tap/bones
+# or
+go install github.com/danmestas/bones/cmd/bones@latest
+# or download from https://github.com/danmestas/bones/releases
+```
+
+Do not auto-install. Wait for the user.
+
 ## Step 1: Initialize leaf
 
 If LEAF_REPO does not exist, clone from hub:

--- a/cli/templates/orchestrator/skills/uninstall-bones/SKILL.md
+++ b/cli/templates/orchestrator/skills/uninstall-bones/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: uninstall-bones
+description: Remove bones-scaffolded files from a project (orchestrator scaffolding, workspace marker, Fossil checkout). Trigger on "uninstall bones", "remove bones from this project", "clean out the orchestrator", or similar.
+when_to_use: User explicitly asks to remove bones from a project. NOT for routine cleanup between runs.
+---
+
+# Uninstall Bones Skill
+
+Reverses what `bones init` and `bones orchestrator` did to a project. The
+skill is destructive — ask before each `rm -rf`. Walk through the steps in
+order; skip any that don't apply (e.g., scaffolding never installed).
+
+## Step 1: Stop running services
+
+If `.orchestrator/scripts/hub-shutdown.sh` exists, run it first so the hub
+and NATS shut down cleanly:
+
+```
+bash .orchestrator/scripts/hub-shutdown.sh
+```
+
+## Step 2: Remove orchestrator scaffolding
+
+Ask before running. This removes the hub scripts, leaves dir, and skill
+templates that bones scaffolded:
+
+```
+rm -rf .orchestrator/
+rm -rf .claude/skills/orchestrator/
+rm -rf .claude/skills/subagent/
+rm -rf .claude/skills/uninstall-bones/
+```
+
+## Step 3: Remove SessionStart/Stop hooks
+
+Read `.claude/settings.json`, show the user the current hooks, and ask
+which to keep. Edit out only the bones-scaffolded entries — the ones whose
+`command` references `hub-bootstrap.sh` (SessionStart) or
+`hub-shutdown.sh` (Stop). Leave unrelated hooks intact.
+
+## Step 4: Remove the Fossil checkout at root
+
+Per ADR 0024, bones opens a Fossil checkout at the project root. Working-
+tree files are not stored in these paths — only Fossil metadata — so
+removing them is safe:
+
+```
+rm -rf .fslckout .fossil-settings/
+```
+
+## Step 5: Remove the workspace marker
+
+```
+rm -rf .agent-infra/
+```
+
+This only clears bones runtime state. Task data already published to NATS
+or Fossil persists wherever those stored it (NATS server data dir;
+`.orchestrator/hub.fossil` if Step 2 was skipped).
+
+## Step 6: Optionally remove gitignore entries
+
+Ask the user. Bones added these lines to `.gitignore`:
+
+- `.fslckout`
+- `.fossil-settings/`
+- `.orchestrator/`
+
+Remove only those lines. Leave other gitignore entries alone.
+
+## Step 7: Optionally uninstall the binary
+
+Ask the user:
+
+```
+brew uninstall danmestas/tap/bones
+# or
+rm $(command -v bones)
+```
+
+## Persistence note
+
+Did the user want to keep their NATS-stored task history or Fossil commit
+history? Those live outside the project tree but may still exist on disk
+(NATS server data dir; `hub.fossil` if `.orchestrator/` was kept). Mention
+this so the user can archive or purge intentionally.


### PR DESCRIPTION
## Summary

Two skill changes scaffolded into consumer projects by \`bones orchestrator\`:

1. **Prerequisites section** added to \`orchestrator/SKILL.md\` and \`subagent/SKILL.md\` — the LLM checks that \`bones\` is on \`\$PATH\` before running, and if missing, tells the user how to install (brew / go / direct download) and stops. Explicitly forbids auto-install.

2. **New \`uninstall-bones\` skill** — guides the LLM through a reversible cleanup of everything \`bones init\` and \`bones orchestrator\` add to a project: \`.orchestrator/\`, scaffolded skills (including itself), settings.json hooks (carefully — preserves unrelated hooks), Fossil checkout metadata at root, \`.agent-infra/\` workspace marker, gitignore entries, and optionally the binary itself. Asks before each \`rm -rf\`.

## Files

- \`cli/templates/orchestrator/skills/orchestrator/SKILL.md\` (+14 lines)
- \`cli/templates/orchestrator/skills/subagent/SKILL.md\` (+14 lines)
- \`cli/templates/orchestrator/skills/uninstall-bones/SKILL.md\` (new, ~80 lines)
- \`cli/orchestrator_test.go\` — adds the new skill path to the expected scaffold list

## Test plan
- [x] \`go test ./cli/ -run TestScaffoldOrchestrator -count=1\` — passes
- [x] \`make check\` clean

## Notes

The scaffolder needed no changes — \`//go:embed all:templates/orchestrator\` + \`copyTree\` walks new skill dirs automatically.

The uninstall skill removes its own scaffolded dir (\`.claude/skills/uninstall-bones/\`) as part of the cleanup; the LLM's last act before exiting the skill is to delete it. Intentional and explicit.