### PR TITLE
docs: scaffold bones docs site (Hugo + Hextra, Cloudflare Workers)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,9 @@ go.work.sum
 # Local scratch — code reviews and implementation plans (ephemeral, per-session)
 docs/code-review/
 docs/plans/
+
+# Hugo build artifacts (docs site)
+docs/site/public/
+docs/site/resources/
+docs/site/.hugo_build.lock
+docs/site/_vendor/

--- a/docs/site/content/_index.md
+++ b/docs/site/content/_index.md
@@ -1,0 +1,4 @@
+---
+title: bones
+layout: landing
+---

--- a/docs/site/content/docs/_index.md
+++ b/docs/site/content/docs/_index.md
@@ -1,0 +1,14 @@
+---
+title: Documentation
+cascade:
+  type: docs
+---
+
+bones is the unified CLI and Go library for the bones substrate — durable state (Fossil) and live coordination (NATS) for embedded agent processes. Beads-inspired, fork-tolerant, and designed so 5–10 Claude subagents can collaborate on a single codebase without the git cleanup tax that branch-based VCS imposes at multi-agent scale.
+
+## What you'll find here
+
+- **[Quickstart](./quickstart)** — install bones, bootstrap a workspace, and run your first orchestrated task.
+- **[Concepts](./concepts)** — the substrate model: workspace, orchestrator, hub-leaf, coord, tasks.
+- **[Architecture](./architecture)** — the canonical design lives in the repo's `docs/adr/` directory; this section indexes those records.
+- **[Reference](./reference)** — CLI surface and the Claude Code skills that ship with bones.

--- a/docs/site/content/docs/architecture/_index.md
+++ b/docs/site/content/docs/architecture/_index.md
@@ -1,0 +1,48 @@
+---
+title: Architecture
+weight: 30
+cascade:
+  type: docs
+---
+
+The canonical design lives in [`docs/adr/`](https://github.com/danmestas/bones/tree/main/docs/adr) in the bones repository — Architecture Decision Records, one per material design call. This page is the index, not a mirror; rendering ADRs here would drift from the repo source of truth.
+
+Read them in repo for the latest text.
+
+## Foundational
+
+- [ADR 0001 — Public surface](https://github.com/danmestas/bones/blob/main/docs/adr/0001-public-surface.md): why `coord/` is the sole public package.
+- [ADR 0003 — Substrate hiding](https://github.com/danmestas/bones/blob/main/docs/adr/0003-substrate-hiding.md): how the substrate is hidden behind `coord`.
+- [ADR 0017 — Beads removal](https://github.com/danmestas/bones/blob/main/docs/adr/0017-beads-removal.md): replacing the original tracker.
+- [ADR 0019 — CLI binaries](https://github.com/danmestas/bones/blob/main/docs/adr/0019-cli-binaries.md): the unified `bones` binary.
+
+## Coordination
+
+- [ADR 0002 — Scoped holds](https://github.com/danmestas/bones/blob/main/docs/adr/0002-scoped-holds.md)
+- [ADR 0004 — Conflict resolution](https://github.com/danmestas/bones/blob/main/docs/adr/0004-conflict-resolution.md): fossil fork + chat.
+- [ADR 0005 — Tasks in NATS KV](https://github.com/danmestas/bones/blob/main/docs/adr/0005-tasks-in-nats-kv.md)
+- [ADR 0006 — Scope-narrow conflict resolution](https://github.com/danmestas/bones/blob/main/docs/adr/0006-scope-narrow-conflict-resolution.md)
+- [ADR 0007 — Claim semantics](https://github.com/danmestas/bones/blob/main/docs/adr/0007-claim-semantics.md)
+- [ADR 0008 — Chat substrate](https://github.com/danmestas/bones/blob/main/docs/adr/0008-chat-substrate.md)
+- [ADR 0013 — Claim reclamation](https://github.com/danmestas/bones/blob/main/docs/adr/0013-claim-reclamation.md)
+- [ADR 0014 — Typed edges](https://github.com/danmestas/bones/blob/main/docs/adr/0014-typed-edges.md)
+- [ADR 0016 — Closed-task compaction](https://github.com/danmestas/bones/blob/main/docs/adr/0016-closed-task-compaction.md)
+
+## Code artifacts
+
+- [ADR 0010 — Fossil code artifacts](https://github.com/danmestas/bones/blob/main/docs/adr/0010-fossil-code-artifacts.md): `coord.Commit`, `OpenFile`, `Checkout`, `Diff`, `Merge`.
+
+## Orchestration
+
+- [ADR 0021 — Dispatch and autoclaim](https://github.com/danmestas/bones/blob/main/docs/adr/0021-dispatch-and-autoclaim.md)
+- [ADR 0023 — Hub-leaf orchestrator](https://github.com/danmestas/bones/blob/main/docs/adr/0023-hub-leaf-orchestrator.md)
+- [ADR 0024 — Orchestrator fossil checkout as git worktree](https://github.com/danmestas/bones/blob/main/docs/adr/0024-orchestrator-fossil-checkout-as-git-worktree.md)
+
+## Operational
+
+- [ADR 0009 — Phase 4](https://github.com/danmestas/bones/blob/main/docs/adr/0009-phase-4.md)
+- [ADR 0018 — EdgeSync refactor](https://github.com/danmestas/bones/blob/main/docs/adr/0018-edgesync-refactor.md)
+- [ADR 0020 — Defer until ready](https://github.com/danmestas/bones/blob/main/docs/adr/0020-defer-until-ready.md)
+- [ADR 0022 — Observability trial](https://github.com/danmestas/bones/blob/main/docs/adr/0022-observability-trial.md)
+
+ADR 0017 also tracks the open roadmap; consult it for what's pending.

--- a/docs/site/content/docs/concepts.md
+++ b/docs/site/content/docs/concepts.md
@@ -1,0 +1,57 @@
+---
+title: Concepts
+weight: 20
+---
+
+bones gives multi-agent processes two things that branch-based VCS plus an external broker can't cleanly provide together: a durable, multi-writer code+state surface and a live coordination channel. This page sketches the moving parts.
+
+## Substrate
+
+The substrate is the shared layer agents read and write through:
+
+- **Fossil** (via [`libfossil`](https://github.com/danmestas/libfossil)) — content-addressed DAG, divergence-tolerant, autosync. Stores code, structured task state, and the timeline as the audit trail.
+- **NATS** (via [`EdgeSync`](https://github.com/danmestas/EdgeSync)'s leaf daemon) — KV with TTL for file holds, pub/sub for chat, request/reply for direct asks.
+
+Agents don't pick one or the other; they call into a single `coord.Coord` that fans out to whichever side fits.
+
+## Workspace
+
+A workspace is the directory tree rooted at the `.agent-infra/` marker. `bones init` creates one (or rejoins from a descendant). It carries:
+
+- The leaf PID and log
+- The local Fossil repo (or a pointer to a sibling)
+- Per-agent checkout directories under `checkouts/<agent-id>/`
+
+Agents inside the workspace share the substrate; agents in different workspaces are independent.
+
+## Orchestrator
+
+The orchestrator is the agent that reads a slot-annotated plan and dispatches one subagent per slot. Bones doesn't prescribe an orchestrator implementation — the shipped Claude Code skill is one possible policy. The CLI surface (`bones orchestrator`, `bones validate-plan`) is the substrate primitive; orchestration logic lives in `.orchestrator/scripts/` and the skill prompt.
+
+## Hub and leaf
+
+Bones uses a hub-leaf topology for parallel runs:
+
+- **Hub** — a single Fossil repo (`hub.fossil`) plus an HTTP xfer endpoint, started by `hub-bootstrap.sh`. The canonical state.
+- **Leaf** — a per-agent clone with its own worktree, opened via `coord.OpenLeaf`. The leaf's `leaf.Agent` (from EdgeSync) handles NATS mesh sync; `coord` wraps the claim and task surfaces on top.
+
+Subagents call `coord.OpenLeaf(ctx, LeafConfig{Hub: hub, ...})`; the leaf clones from the hub, starts NATS sync, and the agent commits via the leaf's worktree. All sync is fire-and-forget — agents don't push or pull manually.
+
+## Coord
+
+`coord/` is the only public Go package. It composes:
+
+- **Holds** — NATS KV bucket with TTL; `AnnounceHold`, `Release`, `WhoHas`, `Subscribe`. Optimistic, not pessimistic — collisions resolve via chat.
+- **Tasks** — `Claim`, `Update`, `List`, `Watch` over Fossil-tracked task files in `tasks/`. State lives in YAML frontmatter.
+- **Chat** — pub/sub with thread short-IDs; reuses EdgeSync's notify service.
+- **Ask** — request/reply over NATS for direct subagent ↔ subagent questions.
+
+See the [CLI reference](./reference/cli) for every command and [ADR 0001](https://github.com/danmestas/bones/blob/main/docs/adr/0001-public-surface.md) for why `coord/` is the sole public package.
+
+## Tasks
+
+A task is a markdown file with YAML frontmatter under `tasks/`. The frontmatter carries the structured state (`id`, `status`, `claimed_by`, `parent`, `context`); the body is freeform notes. Two agents claiming the same task creates a Fossil fork — first-wins or chat-resolved per [ADR 0004](https://github.com/danmestas/bones/blob/main/docs/adr/0004-conflict-resolution.md).
+
+## Plans and slots
+
+A plan is a markdown document with `[slot: name]` annotations. `bones validate-plan` checks the format; `--list-slots` emits a JSON slot→tasks mapping. The orchestrator reads that JSON and dispatches one subagent per slot, each receiving its task list inline plus environment values (`AGENT_ID`, `SLOT_ID`, `HUB_URL`, `NATS_URL`, `WORKDIR`).

--- a/docs/site/content/docs/quickstart.md
+++ b/docs/site/content/docs/quickstart.md
@@ -1,0 +1,64 @@
+---
+title: Quickstart
+weight: 10
+---
+
+A few minutes from `git clone` to a running orchestrator with your first task on the board.
+
+## Prerequisites
+
+- Go 1.26+
+- `git`
+- A sibling clone of [`EdgeSync`](https://github.com/danmestas/EdgeSync) at `../EdgeSync` — bones depends on its `leaf` daemon for embedded NATS and notify
+
+## Install
+
+```sh
+git clone https://github.com/danmestas/bones
+cd bones
+
+# Sibling repo for the leaf daemon — required.
+cd .. && git clone https://github.com/danmestas/EdgeSync && cd bones
+
+# Build all binaries (drops them in ./bin):
+make
+```
+
+The bones CLI ends up at `./bin/bones`. The `leaf` binary lives in EdgeSync — `make` ensures both are built and reachable from `PATH` (or via `LEAF_BIN`).
+
+## Bootstrap a workspace
+
+```sh
+# One-shot: workspace + scaffold + leaf + hub.
+bin/bones up
+```
+
+This is shorthand for the three explicit steps:
+
+```sh
+bin/bones init                              # creates .agent-infra/ workspace + starts leaf
+bin/bones orchestrator                      # scaffolds .orchestrator/ for hub-leaf runs
+bash .orchestrator/scripts/hub-bootstrap.sh # starts the hub
+```
+
+`init` walks up to find an existing `.agent-infra/` marker if you're inside a workspace already; otherwise it creates one.
+
+## First task
+
+```sh
+# Add a task with a file scope:
+bin/bones tasks add "wire up coord.Reclaim" --files coord/reclaim.go
+
+# Inspect the board:
+bin/bones tasks status
+bin/bones tasks open
+```
+
+`tasks open` prints the task IDs that are eligible for claim. From here, an orchestrator agent can use the [orchestrator skill](../reference/skills) to dispatch subagents against a slot-annotated plan, or you can claim and close tasks manually with `bones tasks claim <id>` and `bones tasks close <id>`.
+
+## Next steps
+
+- [Concepts](./concepts) — substrate, orchestrator, hub-leaf
+- [CLI reference](./reference/cli) — every subcommand
+- [Skills reference](./reference/skills) — the Claude Code skills that ship with bones
+- [Architecture](./architecture) — ADR index

--- a/docs/site/content/docs/reference/_index.md
+++ b/docs/site/content/docs/reference/_index.md
@@ -1,0 +1,9 @@
+---
+title: Reference
+weight: 40
+cascade:
+  type: docs
+---
+
+- **[CLI](./cli)** — every `bones` subcommand and what it does.
+- **[Skills](./skills)** — the Claude Code skills that ship with bones (orchestrator, subagent).

--- a/docs/site/content/docs/reference/cli.md
+++ b/docs/site/content/docs/reference/cli.md
@@ -1,0 +1,91 @@
+---
+title: CLI
+weight: 10
+---
+
+The `bones` binary is a single Kong-driven entry point covering workspace setup, the orchestrator, and runtime task management. Run `bones <command> --help` for flag-level details on any subcommand.
+
+## Global flags
+
+| Flag | Description |
+|---|---|
+| `-h, --help` | Show context-sensitive help |
+| `-R, --repo=PATH` | Path to a repository file (overrides workspace lookup) |
+| `-v, --verbose` | Verbose output |
+
+## Top-level command groups
+
+### Workspace and bootstrap
+
+| Command | Purpose |
+|---|---|
+| `bones doctor` | Check development environment health |
+| `bones init` | Create a workspace |
+| `bones join` | Locate an existing workspace (walks up from cwd) |
+| `bones up` | Full bootstrap: workspace + scaffold + leaf + hub |
+
+`up` is the one-shot equivalent of `init` + `orchestrator` + `bash .orchestrator/scripts/hub-bootstrap.sh`.
+
+### Orchestrator
+
+| Command | Purpose |
+|---|---|
+| `bones orchestrator` | Install orchestrator scaffolding (`.orchestrator/`) |
+| `bones validate-plan <path>` | Validate a slot-annotated plan; `--list-slots` emits JSON |
+
+### Tasks
+
+| Command | Purpose |
+|---|---|
+| `bones tasks add <title>` | Alias for `create` |
+| `bones tasks create <title>` | Create a new task |
+| `bones tasks list` | List tasks |
+| `bones tasks show <id>` | Show a task |
+| `bones tasks update <id>` | Update a task |
+| `bones tasks claim <id>` | Claim a task |
+| `bones tasks close <id>` | Close a task |
+| `bones tasks ready` | List tasks ready for claim |
+| `bones tasks watch` | Stream task lifecycle events |
+| `bones tasks status` | Snapshot of all tasks by status |
+| `bones tasks link <from> <to>` | Link two tasks with an edge type |
+| `bones tasks prime` | Print agent-tasks context (prime) |
+| `bones tasks stale` | List stale tasks |
+| `bones tasks orphans` | List orphaned (claimed by absent agent) tasks |
+| `bones tasks preflight` | Combined stale + orphans report |
+| `bones tasks compact` | Compact closed tasks |
+| `bones tasks autoclaim` | Run one autoclaim tick |
+| `bones tasks dispatch parent --task-id=ID` | Run dispatch parent |
+| `bones tasks dispatch worker --task-id=ID --task-thread=THREAD --worker-agent-id=ID` | Run dispatch worker |
+| `bones tasks aggregate` | Aggregate per-slot task summary |
+
+### Repository
+
+`bones repo` exposes the underlying Fossil surface for human inspection. Most agents use the `coord` Go API; the CLI is here for diagnostics.
+
+| Command | Purpose |
+|---|---|
+| `bones repo new <path>` | Create a new repository |
+| `bones repo clone [url [path]]` | Clone a remote repository |
+| `bones repo ci -m MSG <files>` | Checkin file changes |
+| `bones repo co [version]` | Checkout a version |
+| `bones repo ls [version]` | List files in a version |
+| `bones repo timeline` | Show repository history |
+| `bones repo cat <artifact>` | Output artifact content |
+| `bones repo info` | Repository statistics |
+| `bones repo hash <files>` | Hash files (SHA1 or SHA3) |
+| `bones repo delta create/apply` | Create or apply a delta |
+| `bones repo config ls/get/set` | Repository config |
+| `bones repo query <sql>` | Execute SQL against the repository |
+| `bones repo verify` | Verify repository integrity |
+| `bones repo resolve <name>` | Resolve symbolic name to UUID |
+| `bones repo extract [files]` | Extract files from a version |
+| `bones repo wiki ls/export` | Wiki operations |
+| `bones repo tag ls/add` | Tag operations |
+| `bones repo open [dir]` | Open a checkout in a directory |
+| `bones repo status` | Working-tree status |
+
+## See also
+
+- [Quickstart](../quickstart) — the hands-on walkthrough
+- [Concepts](../concepts) — what each command operates on
+- [Skills](./skills) — Claude Code skills layered on top of these commands

--- a/docs/site/content/docs/reference/skills.md
+++ b/docs/site/content/docs/reference/skills.md
@@ -1,0 +1,55 @@
+---
+title: Skills
+weight: 20
+---
+
+bones ships three Claude Code skills under [`.claude/skills/`](https://github.com/danmestas/bones/tree/main/.claude/skills). They sit on top of the [CLI](./cli) and [`coord`](https://github.com/danmestas/bones/tree/main/coord) Go API; the skill prompts encode the orchestration policy that the substrate intentionally leaves out.
+
+Skills are auto-discovered by the harness when it scans the workspace's `.claude/skills/` directory. Each is a single `SKILL.md` file with frontmatter that triggers the skill on matching prompts.
+
+## orchestrator
+
+[`.claude/skills/orchestrator/SKILL.md`](https://github.com/danmestas/bones/blob/main/.claude/skills/orchestrator/SKILL.md)
+
+Triggered when the user invokes a slot-annotated plan or asks to "run plan in parallel" / "orchestrate this plan" / "dispatch agents from plan". The skill drives a four-step flow:
+
+1. **Validate** — `bones validate-plan <plan-path>`. Stops on non-zero exit and surfaces the violations.
+2. **Verify hub** — checks `.orchestrator/pids/leaf.pid` and the hub's `/xfer` endpoint; runs `bash .orchestrator/scripts/hub-bootstrap.sh` if anything's missing (the script is idempotent).
+3. **Extract slots** — `bones validate-plan --list-slots <plan-path>` emits a JSON slot→tasks mapping; the orchestrator uses it to build dispatch prompts without re-parsing the plan.
+4. **Dispatch** — invokes the Task tool once per slot, passing the slot's task list and environment values (`AGENT_ID`, `SLOT_ID`, `HUB_URL`, `NATS_URL`, `WORKDIR`) inline.
+
+The orchestrator skill is policy, not protocol — alternative orchestrators are welcome; the substrate doesn't care which one drives it.
+
+## subagent
+
+[`.claude/skills/subagent/SKILL.md`](https://github.com/danmestas/bones/blob/main/.claude/skills/subagent/SKILL.md)
+
+Triggered by a Task-tool prompt that references the orchestrator's injected env vars. The subagent:
+
+1. Opens its leaf via `coord.OpenLeaf(ctx, LeafConfig{Hub: hub, Workdir: workdir, SlotID: slotID})`. The leaf clones the hub repo, opens a worktree, and starts NATS mesh sync.
+2. Iterates the inline task list, claiming each through `coord.Claim`, doing the work, committing via the leaf's worktree, and closing the task.
+3. Stops the leaf on exit.
+
+Notable contract: subagents do **not** read `LEAF_REPO` or `LEAF_WT` from the environment — those are stale. The leaf owns its paths internally (`<workdir>/<slotID>/leaf.fossil` and `<workdir>/<slotID>/wt`).
+
+## uninstall-bones
+
+[`.claude/skills/uninstall-bones/SKILL.md`](https://github.com/danmestas/bones/blob/main/.claude/skills/uninstall-bones/SKILL.md)
+
+Triggered when the user asks to remove bones from a project ("uninstall bones", "remove the orchestrator", etc.). Walks the LLM through a reversible cleanup, asking the user before each `rm -rf`:
+
+1. Stop running services via `hub-shutdown.sh`.
+2. Remove `.orchestrator/` and the scaffolded `.claude/skills/{orchestrator,subagent,uninstall-bones}/`.
+3. Edit `.claude/settings.json` to remove the `hub-bootstrap.sh` and `hub-shutdown.sh` hooks (preserves unrelated hooks).
+4. Remove the Fossil checkout at root (`.fslckout`, `.fossil-settings/`) per ADR 0024.
+5. Remove `.agent-infra/` workspace marker.
+6. Optionally remove the `.gitignore` entries bones added.
+7. Optionally `brew uninstall danmestas/tap/bones` (or `rm $(command -v bones)`).
+
+Working-tree files are untouched throughout — only metadata managed by bones is removed. Task data already published to NATS or Fossil persists wherever those substrates store it.
+
+## Where skills get scaffolded
+
+`bones orchestrator` writes the orchestrator-runtime artifacts to `.orchestrator/` (scripts, PID directory, leaf workdirs). The `.claude/skills/` directory is part of the bones repo itself — you get it by checking out the bones repo and running `bones init` from inside it (or by copying the directory into a workspace that uses bones as a dependency).
+
+If your workspace doesn't have these skills, run `bones orchestrator` from inside it, or copy the skill directories from the [bones repo](https://github.com/danmestas/bones/tree/main/cli/templates/orchestrator/skills) into your workspace's `.claude/skills/`.

--- a/docs/site/go.mod
+++ b/docs/site/go.mod
@@ -1,0 +1,5 @@
+module github.com/danmestas/bones/docs/site
+
+go 1.26.2
+
+require github.com/imfing/hextra v0.12.2 // indirect

--- a/docs/site/go.sum
+++ b/docs/site/go.sum
@@ -1,0 +1,2 @@
+github.com/imfing/hextra v0.12.2 h1:qa+cHQ1LC/7ys9EhRNnHrRBAHu83Tm8rhh1oWO2a7cc=
+github.com/imfing/hextra v0.12.2/go.mod h1:vi+yhpq8YPp/aghvJlNKVnJKcPJ/VyAEcfC1BSV9ARo=

--- a/docs/site/hugo.yaml
+++ b/docs/site/hugo.yaml
@@ -1,0 +1,66 @@
+title: bones
+baseURL: "https://bones-docs.daniel-mestas.workers.dev/"
+
+module:
+  imports:
+    - path: github.com/imfing/hextra
+
+markup:
+  goldmark:
+    renderer:
+      unsafe: true
+  highlight:
+    noClasses: false
+
+menu:
+  main:
+    - name: Docs
+      pageRef: /docs
+      weight: 1
+    - name: Architecture
+      pageRef: /docs/architecture
+      weight: 2
+    - name: Reference
+      pageRef: /docs/reference
+      weight: 3
+    - name: Search
+      weight: 4
+      params:
+        type: search
+    - name: GitHub
+      weight: 5
+      url: "https://github.com/danmestas/bones"
+      params:
+        icon: github
+
+params:
+  # Default version for local dev. Overwritten at build time by scripts/sync-version.sh
+  # (which reads `git describe --tags --abbrev=0`). Falls back to this value when no
+  # git tag is reachable (e.g. before the first release).
+  version: "0.1.0"
+
+  navbar:
+    displayTitle: true
+    displayLogo: false
+
+  theme:
+    default: system
+    displayToggle: true
+
+  search:
+    enable: true
+    type: flexsearch
+    flexsearch:
+      index: content
+      tokenize: forward
+
+  footer:
+    displayCopyright: true
+    displayPoweredBy: false
+
+  editURL:
+    enable: true
+    base: "https://github.com/danmestas/bones/edit/main/docs/site/content"
+
+  page:
+    width: wide

--- a/docs/site/layouts/_partials/navbar-title.html
+++ b/docs/site/layouts/_partials/navbar-title.html
@@ -1,0 +1,13 @@
+{{- /* Project override: keeps Hextra's title + adds a small version tag. */ -}}
+{{- $logoLink := .Site.Params.navbar.logo.link | default .Site.Home.RelPermalink -}}
+{{- $displayTitle := (.Site.Params.navbar.displayTitle | default true) -}}
+{{- $version := .Site.Params.version -}}
+
+<a class="hx:flex hx:items-center hx:hover:opacity-75 hx:ltr:mr-auto hx:rtl:ml-auto" href="{{ $logoLink }}">
+  {{- if $displayTitle }}
+    <span class="hx:mr-2 hx:font-extrabold hx:inline hx:select-none">{{- .Site.Title -}}</span>
+  {{- end }}
+  {{- with $version }}
+    <span class="hx:text-xs hx:font-mono hx:opacity-60 hx:select-none">v{{ . }}</span>
+  {{- end }}
+</a>

--- a/docs/site/layouts/index.html
+++ b/docs/site/layouts/index.html
@@ -1,0 +1,607 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="description" content="bones — unified CLI for multi-agent development. Workspace, orchestrator, tasks, plus the full Fossil and EdgeSync command surfaces in one binary.">
+<meta name="color-scheme" content="light dark">
+<title>bones — unified CLI for multi-agent development</title>
+<link rel="icon" type="image/svg+xml" href="/favicon.svg">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Geist+Mono:wght@400;500;700&display=swap" rel="stylesheet">
+<style>
+:root {
+  --paper:  #f5f1e6;
+  --paper-2:#ece7d8;
+  --ink:    #14110b;
+  --mute:   #5e5b53;
+  --rule:   #14110b;
+  --ember:  #c63a0f;
+  --measure: 76ch;
+  --gap:   clamp(2.25rem, 5vw, 3.5rem);
+  --mono: "Geist Mono", ui-monospace, "SF Mono", "Cascadia Mono", "Roboto Mono", Consolas, "Courier New", monospace;
+}
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+html { font-size: 16px; -webkit-text-size-adjust: 100%; }
+body {
+  background: var(--paper);
+  color: var(--ink);
+  font: 400 clamp(15px, 1.05vw, 17px)/1.7 var(--mono);
+  font-feature-settings: "tnum" 1, "calt" 1, "ss01" 1;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+}
+.skip { position: absolute; left: -9999px; }
+.skip:focus {
+  position: fixed; top: 0.75rem; left: 0.75rem;
+  background: var(--ember); color: var(--paper);
+  padding: 0.5rem 0.75rem; z-index: 10; text-decoration: none;
+}
+header.topbar {
+  border-bottom: 1px solid var(--rule);
+  padding: clamp(0.625rem, 2.5vw, 0.75rem) clamp(1rem, 4vw, 1.5rem);
+  display: flex; justify-content: space-between; align-items: baseline;
+  gap: 1rem; flex-wrap: wrap;
+  font-size: 0.78125rem;
+  letter-spacing: 0.04em;
+}
+.topbar a { color: inherit; text-decoration: none; border-bottom: 1px solid currentColor; }
+.topbar a:hover { color: var(--ember); }
+.topbar .name { font-weight: 700; letter-spacing: 0.18em; text-transform: uppercase; }
+.topbar .meta { color: var(--mute); display: flex; gap: 1.25rem; flex-wrap: wrap; }
+.topbar .meta span { display: inline-flex; gap: 0.4rem; }
+.topbar .meta b { color: var(--ink); font-weight: 500; }
+
+main {
+  max-width: 88ch;
+  margin: 0 auto;
+  padding: clamp(2rem, 4vw, 3rem) clamp(1rem, 4vw, 1.5rem) clamp(3rem, 6vw, 4.5rem);
+  overflow-wrap: anywhere;
+}
+
+.title {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1.25rem;
+  padding-bottom: clamp(2rem, 4vw, 2.75rem);
+  margin-bottom: clamp(2rem, 4vw, 3rem);
+  border-bottom: 1px solid var(--rule);
+}
+.title h1 {
+  font-size: clamp(2.75rem, 13vw, 6.5rem);
+  font-weight: 700;
+  letter-spacing: -0.05em;
+  line-height: 0.92;
+}
+.title .lead {
+  font-size: clamp(1rem, 1.2vw, 1.0625rem);
+  max-width: var(--measure);
+  color: var(--ink);
+  line-height: 1.6;
+}
+.spec {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.78125rem;
+  margin-top: 0.5rem;
+  letter-spacing: 0.02em;
+}
+.spec td { padding: 0.35rem 0; border-top: 1px dashed var(--rule); vertical-align: top; }
+.spec td:first-child {
+  width: 12rem;
+  color: var(--mute);
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  font-size: 0.6875rem;
+  padding-top: 0.5rem;
+}
+.spec tr:first-child td { border-top: 1px solid var(--rule); }
+.spec tr:last-child td { border-bottom: 1px solid var(--rule); }
+
+section { margin-top: var(--gap); }
+section > .num {
+  display: block;
+  font-size: 0.6875rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--mute);
+  margin-bottom: 0.4rem;
+}
+h2 {
+  font-size: clamp(1.125rem, 1.6vw, 1.3125rem);
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  margin-bottom: 1.25rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid var(--rule);
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+h2 .anchor {
+  font-size: 0.6875rem;
+  font-weight: 400;
+  color: var(--mute);
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+p { max-width: var(--measure); margin-bottom: 1rem; }
+p:last-child { margin-bottom: 0; }
+strong { font-weight: 700; }
+
+a {
+  color: var(--ink);
+  text-decoration: none;
+  border-bottom: 1px solid var(--ink);
+}
+a:hover { color: var(--ember); border-bottom-color: var(--ember); }
+
+code {
+  font: inherit;
+  font-size: 0.94em;
+  background: var(--paper-2);
+  padding: 0.05em 0.35em;
+}
+
+ol, ul { padding-left: 0; max-width: var(--measure); list-style: none; }
+ol li, ul li {
+  margin-bottom: 0.875rem;
+  padding-left: 2.75rem;
+  position: relative;
+  line-height: 1.65;
+}
+ol { counter-reset: item; }
+ol li {
+  counter-increment: item;
+}
+ol li::before {
+  content: counter(item, decimal-leading-zero);
+  position: absolute;
+  left: 0;
+  top: 0.05em;
+  font-weight: 700;
+  font-size: 0.78125rem;
+  letter-spacing: 0.04em;
+  color: var(--ember);
+  width: 2rem;
+}
+ul li::before {
+  content: "—";
+  position: absolute;
+  left: 0.5rem;
+  color: var(--mute);
+}
+
+.code-block {
+  margin-bottom: 1rem;
+  border: 1px solid var(--rule);
+  background: var(--paper-2);
+}
+.code-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  padding: 0.35rem 0.5rem 0.35rem 0.85rem;
+  border-bottom: 1px solid var(--rule);
+  background: var(--paper);
+  font-size: 0.625rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--mute);
+}
+pre {
+  padding: 0.875rem 1.25rem;
+  font-size: 0.85rem;
+  line-height: 1.65;
+  overflow-x: auto;
+  white-space: pre;
+  font-family: var(--mono);
+  color: var(--ink);
+}
+pre.ascii {
+  background: transparent;
+  border: 1px solid var(--rule);
+  padding: clamp(0.75rem, 2.5vw, 1.25rem);
+  font-size: clamp(0.7rem, 1.7vw, 0.8125rem);
+  line-height: 1.45;
+  color: var(--ink);
+  margin-bottom: 1rem;
+  overflow-x: auto;
+}
+
+.diagram {
+  display: block;
+  width: 100%;
+  min-width: 30rem;
+  height: auto;
+  margin-bottom: 0.5rem;
+  font-family: var(--mono);
+  color: var(--ink);
+}
+.diagram .rule { stroke: var(--rule); stroke-width: 1; opacity: 0.5; }
+.diagram .box { fill: none; stroke: var(--rule); stroke-width: 1; }
+.diagram .head {
+  font-size: 11px;
+  letter-spacing: 1.4px;
+  text-transform: uppercase;
+  fill: var(--mute);
+}
+.diagram .item { font-size: 13px; fill: var(--ink); }
+.diagram .stack { font-size: 12px; fill: var(--mute); font-style: italic; }
+.diagram .flow line { stroke: var(--ember); stroke-width: 1.5; fill: none; }
+.diagram .arrowhead { fill: var(--ember); }
+.diagram .flow-label {
+  font-size: 10px;
+  fill: var(--ember);
+  letter-spacing: 0.6px;
+  text-transform: uppercase;
+}
+
+.copy-btn {
+  background: transparent;
+  color: var(--ink);
+  border: 1px solid var(--ink);
+  font: inherit;
+  font-size: 0.625rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 0.15rem 0.55rem;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+.copy-btn:hover, .copy-btn:focus-visible { background: var(--ink); color: var(--paper); outline: none; }
+.copy-btn[data-state="copied"] { color: var(--ember); border-color: var(--ember); background: var(--paper); }
+
+.table-scroll {
+  margin: 0 calc(-1 * clamp(0rem, 2vw, 0.5rem));
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+table.cmp {
+  width: 100%;
+  min-width: 30rem;
+  border-collapse: collapse;
+  font-size: 0.875rem;
+  margin-bottom: 0.75rem;
+}
+table.cmp th, table.cmp td {
+  text-align: left;
+  padding: 0.625rem 0.875rem;
+  vertical-align: top;
+  border-bottom: 1px dashed var(--rule);
+}
+table.cmp thead th {
+  border-bottom: 1px solid var(--rule);
+  border-top: 1px solid var(--rule);
+  font-size: 0.6875rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  background: var(--paper-2);
+}
+table.cmp td:first-child, table.cmp th:first-child {
+  padding-left: 0.875rem;
+  width: 30%;
+  font-weight: 500;
+  color: var(--mute);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+}
+table.cmp td:last-child, table.cmp th:last-child { padding-right: 0.875rem; }
+table.cmp .col-self { color: var(--ember); font-weight: 700; }
+table.cmp tbody tr:last-child td { border-bottom: 1px solid var(--rule); }
+
+.fineprint {
+  font-size: 0.75rem;
+  color: var(--mute);
+  margin-top: 0.5rem;
+  letter-spacing: 0.02em;
+}
+
+footer {
+  border-top: 1px solid var(--rule);
+  margin-top: var(--gap);
+  padding: 1.5rem 0;
+  font-size: 0.78125rem;
+  color: var(--mute);
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 1rem;
+  letter-spacing: 0.04em;
+}
+footer a { color: inherit; border-bottom-color: var(--mute); }
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --paper:  #15140f;
+    --paper-2:#1f1d17;
+    --ink:    #ece8dc;
+    --mute:   #908b80;
+    --rule:   #ece8dc;
+    --ember:  #ff5a26;
+  }
+}
+@media print {
+  body { background: white; color: black; font-size: 11pt; line-height: 1.5; }
+  .code-block, pre { background: white; color: black; border: 1px solid black; }
+  a { color: black; border-bottom: 0; text-decoration: underline; }
+  a::after { content: " (" attr(href) ")"; font-size: 0.85em; color: #555; }
+  .copy-btn, .skip { display: none; }
+  section { break-inside: avoid; }
+}
+@media (max-width: 540px) {
+  header.topbar { flex-direction: column; align-items: flex-start; gap: 0.5rem; }
+  .topbar .meta { gap: 0.75rem; row-gap: 0.35rem; }
+  .spec td:first-child { width: 8rem; font-size: 0.625rem; }
+  .spec td { padding: 0.4rem 0; }
+  table.cmp { font-size: 0.6875rem; min-width: 0; table-layout: auto; }
+  table.cmp th, table.cmp td { padding: 0.45rem 0.4rem; }
+  table.cmp tbody td { white-space: normal; word-break: normal; overflow-wrap: break-word; }
+  table.cmp thead th {
+    font-size: 0.5rem;
+    letter-spacing: 0.06em;
+    padding: 0.5rem 0.3rem;
+    white-space: nowrap;
+  }
+  table.cmp td:first-child, table.cmp th:first-child {
+    padding-left: 0.55rem;
+    width: 28%;
+    font-size: 0.5625rem;
+    letter-spacing: 0.04em;
+  }
+  table.cmp td:last-child, table.cmp th:last-child { padding-right: 0.55rem; }
+  ol li, ul li { padding-left: 2.25rem; }
+  ol li::before { width: 1.75rem; }
+  footer { flex-direction: column; gap: 0.5rem; align-items: flex-start; }
+  .copy-btn { font-size: 0.5625rem; padding: 0.1rem 0.4rem; }
+  pre { font-size: 0.78rem; padding: 0.75rem 0.9rem; }
+  .code-bar { padding: 0.3rem 0.4rem 0.3rem 0.7rem; }
+}
+@media (max-width: 380px) {
+  .topbar .name { letter-spacing: 0.12em; }
+  .spec td:first-child { width: 7rem; }
+  table.cmp { font-size: 0.625rem; }
+  table.cmp th, table.cmp td { padding: 0.4rem 0.25rem; }
+  table.cmp thead th { font-size: 0.4375rem; padding: 0.45rem 0.2rem; }
+  table.cmp td:first-child, table.cmp th:first-child { font-size: 0.5rem; padding-left: 0.4rem; width: 26%; }
+}
+</style>
+</head>
+<body>
+
+<a href="#main" class="skip">skip to content</a>
+
+<header class="topbar">
+  <div class="name">bones</div>
+  <div class="meta">
+    <span>v <b>{{ .Site.Params.version | default "0.1.0" }}</b></span>
+    <span>license <b>Apache-2.0</b></span>
+    <span><a href="https://github.com/danmestas/bones">github</a></span>
+    <span><a href="/docs/">docs</a></span>
+  </div>
+</header>
+
+<main id="main">
+
+<section class="title">
+  <h1>bones</h1>
+  <p class="lead">A unified CLI for multi-agent software development. Coordinates parallel AI agents over NATS and Fossil, with the full repository, sync, and notification command surfaces in one binary.</p>
+  <table class="spec">
+    <tbody>
+      <tr><td>Project</td>      <td>bones — unified CLI for the bones agent-infra substrate</td></tr>
+      <tr><td>Language</td>     <td>Go (module <code>github.com/danmestas/bones</code>)</td></tr>
+      <tr><td>Runtime deps</td> <td><code>fossil</code> binary · NATS server · optional <code>leaf</code> daemon</td></tr>
+      <tr><td>Binaries</td>     <td>1 (bones)</td></tr>
+      <tr><td>License</td>      <td>Apache-2.0</td></tr>
+      <tr><td>Status</td>       <td>v{{ .Site.Params.version | default "0.1.0" }} · alpha · breaking changes possible</td></tr>
+    </tbody>
+  </table>
+</section>
+
+<section>
+  <span class="num">§01</span>
+  <h2>Install <span class="anchor">install</span></h2>
+  <div class="code-block">
+    <div class="code-bar">
+      <span>shell</span>
+      <button type="button" class="copy-btn" data-copy="install" aria-label="Copy install command">copy</button>
+    </div>
+    <pre id="install">$ brew install danmestas/tap/bones
+$ bones --help</pre>
+  </div>
+  <p>Or via Go: <code>go install github.com/danmestas/bones/cmd/bones@latest</code>. Tarballs for darwin/linux × amd64/arm64 are also published on every release: see <a href="https://github.com/danmestas/bones/releases">releases</a>.</p>
+</section>
+
+<section>
+  <span class="num">§02</span>
+  <h2>What it is <span class="anchor">overview</span></h2>
+  <p>bones is the CLI for orchestrating multiple AI coding agents against a shared codebase without merge conflicts, race conditions, or lost work. It bundles three command surfaces — Fossil repository operations, NATS sync and bridging, and workspace/orchestrator/task management native to bones — into a single binary.</p>
+  <p>The substrate underneath is purpose-built for parallel agent work: NATS JetStream KV holds tasks with CAS-gated claims, Fossil stores code artifacts and chat history with content-addressed forks, and a slot-partitioned plan format keeps agents on disjoint files by construction. Agents come and go; durable state outlasts them.</p>
+  <ul>
+    <li><strong>Three surfaces, one binary.</strong> <code>bones repo</code> (Fossil ops, from libfossil), <code>bones sync</code>/<code>bridge</code>/<code>notify</code> (from EdgeSync), <code>bones tasks</code>/<code>orchestrator</code>/<code>validate-plan</code> (native).</li>
+    <li><strong>Conflict-free by construction.</strong> Slot annotations on plan tasks are validated for directory disjointness before dispatch; runtime forks become impossible by design, not by lock contention.</li>
+    <li><strong>Pre-built Claude Code skills.</strong> <code>bones orchestrator</code> scaffolds three skills into <code>.claude/skills/</code>: orchestrator, subagent, and uninstall-bones. The substrate stays policy-neutral; the skills encode the orchestration policy.</li>
+  </ul>
+</section>
+
+<section>
+  <span class="num">§03</span>
+  <h2>Why you might want it <span class="anchor">why</span></h2>
+  <p>Three reasons to reach for bones instead of running agents serially or stitching together <code>git</code> + a task tracker + a chat channel.</p>
+  <p><strong>You're running 3+ AI coding agents in parallel.</strong> Two agents editing the same file is a runtime fork, not a usable PR. bones validates plans for slot disjointness before any agent starts, so the only way to land overlapping work is to misdesign the plan — caught upfront, not at merge time.</p>
+  <p><strong>You want durable state across short-lived sessions.</strong> Each Claude Code session is ephemeral; bones writes claims, holds, presence, and code commits to substrates that outlive the session. An agent that crashes leaves no orphans — TTL-backed claims expire, holds release, the next agent picks up.</p>
+  <p><strong>You don't want to invent your own orchestration substrate.</strong> NATS JetStream KV gives you transactional task state; Fossil gives you content-addressed code with built-in fork detection; libfossil gives you that in pure Go. bones is the assembly that makes all of it usable from a single command.</p>
+</section>
+
+<section>
+  <span class="num">§04</span>
+  <h2>How it fits together <span class="anchor">architecture</span></h2>
+  <div class="table-scroll">
+    <svg class="diagram" viewBox="0 0 640 280" role="img" aria-labelledby="arch-title arch-desc" preserveAspectRatio="xMidYMid meet">
+      <title id="arch-title">bones architecture</title>
+      <desc id="arch-desc">Callers (Claude subagents, humans, CI) invoke bones subcommands. The bones binary assembles three command surfaces (libfossil, EdgeSync, agent-infra). The substrates beneath are NATS for task/hold/presence state, Fossil for code and chat artifacts, and per-leaf clones synced by EdgeSync's leaf agent.</desc>
+
+      <defs>
+        <marker id="b-arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+          <path class="arrowhead" d="M0,0 L10,5 L0,10 Z"/>
+        </marker>
+      </defs>
+
+      <g class="rule">
+        <line x1="40" y1="38" x2="160" y2="38"/>
+        <line x1="240" y1="38" x2="400" y2="38"/>
+        <line x1="480" y1="38" x2="600" y2="38"/>
+      </g>
+
+      <g class="head">
+        <text x="100" y="28" text-anchor="middle">callers</text>
+        <text x="320" y="28" text-anchor="middle">bones</text>
+        <text x="540" y="28" text-anchor="middle">substrates</text>
+      </g>
+
+      <g class="item">
+        <text x="100" y="76" text-anchor="middle">orchestrator</text>
+        <text x="100" y="100" text-anchor="middle">subagents</text>
+        <text x="100" y="124" text-anchor="middle">humans</text>
+        <text x="100" y="148" text-anchor="middle">CI</text>
+      </g>
+
+      <rect class="box" x="240" y="60" width="160" height="120"/>
+      <g class="item">
+        <text x="320" y="84" text-anchor="middle">init / up / orchestrator</text>
+        <text x="320" y="108" text-anchor="middle">tasks (claim/close)</text>
+        <text x="320" y="132" text-anchor="middle">repo (commit/timeline)</text>
+        <text x="320" y="156" text-anchor="middle">sync / bridge / notify</text>
+      </g>
+
+      <rect class="box" x="490" y="60" width="100" height="120"/>
+      <g class="item">
+        <text x="540" y="84" text-anchor="middle">NATS KV</text>
+        <text x="540" y="108" text-anchor="middle">Fossil hub</text>
+        <text x="540" y="132" text-anchor="middle">leaf agents</text>
+        <text x="540" y="156" text-anchor="middle">notify mesh</text>
+      </g>
+
+      <rect class="box" x="240" y="220" width="160" height="40"/>
+      <g class="item">
+        <text x="320" y="245" text-anchor="middle">.agent-infra/ · .orchestrator/</text>
+      </g>
+
+      <g class="flow">
+        <line x1="160" y1="100" x2="234" y2="100" marker-end="url(#b-arrow)"/>
+        <line x1="400" y1="108" x2="486" y2="108" marker-end="url(#b-arrow)"/>
+        <line x1="490" y1="156" x2="404" y2="156" marker-end="url(#b-arrow)"/>
+        <line x1="320" y1="180" x2="320" y2="216" marker-end="url(#b-arrow)"/>
+      </g>
+
+      <g class="flow-label">
+        <text x="197" y="92" text-anchor="middle">invoke</text>
+        <text x="443" y="100" text-anchor="middle">drives</text>
+        <text x="447" y="174" text-anchor="middle">events</text>
+        <text x="334" y="203" text-anchor="start">workspace</text>
+      </g>
+    </svg>
+  </div>
+  <p class="fineprint">bones is the binary; the work happens in the substrates. NATS holds the live coordination state (claims, holds, presence, chat). Fossil holds the durable artifacts (commits, chat history, compaction). Per-slot leaf agents replicate the hub repo so concurrent commits remain race-free.</p>
+</section>
+
+<section>
+  <span class="num">§05</span>
+  <h2>Compared to neighbors <span class="anchor">comparison</span></h2>
+  <div class="table-scroll">
+  <table class="cmp">
+    <thead>
+      <tr>
+        <th></th>
+        <th class="col-self">bones</th>
+        <th>git + Linear</th>
+        <th>beads (bd)</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr><td>Multi-agent first-class</td>   <td class="col-self">yes</td>                          <td>no</td>                          <td>yes</td></tr>
+      <tr><td>Parallel safety</td>            <td class="col-self">slot disjointness, validated</td><td>merge conflicts at PR time</td>   <td>per-task locks</td></tr>
+      <tr><td>Task store</td>                 <td class="col-self">NATS JetStream KV</td>           <td>external (Linear)</td>            <td>SQLite</td></tr>
+      <tr><td>Code store</td>                 <td class="col-self">Fossil (content-addressed)</td>  <td>git</td>                          <td>git</td></tr>
+      <tr><td>Real-time agent chat</td>       <td class="col-self">NATS notify substrate</td>       <td>Slack-or-similar (out-of-band)</td><td>none</td></tr>
+      <tr><td>Pre-built AI skills</td>        <td class="col-self">orchestrator + subagent</td>     <td>none</td>                         <td>workflow doc</td></tr>
+      <tr><td>Single CLI</td>                 <td class="col-self">yes</td>                         <td>no (multiple tools)</td>          <td>yes</td></tr>
+      <tr><td>API stability</td>              <td class="col-self">alpha · v0.1.x</td>              <td>stable</td>                       <td>stable</td></tr>
+    </tbody>
+  </table>
+  </div>
+  <p class="fineprint">bones replaces beads' substrate (SQLite-backed task tracker) with a content-addressed Fossil + NATS pair. Beads remains the right answer when the durable-state needs are simpler and you don't need per-slot leaf isolation.</p>
+</section>
+
+<section>
+  <span class="num">§06</span>
+  <h2>What it is not <span class="anchor">limits</span></h2>
+  <p><strong>Not a hosted service.</strong> bones is a CLI; you run it locally or in CI. The orchestrator skill assumes a Claude Code session; the substrate is usable from any client that speaks NATS + Fossil.</p>
+  <p><strong>Not a Linear or Jira replacement.</strong> No roadmap views, no SLA tracking, no dashboards. Tasks here are agent-runtime artifacts, not product-management artifacts.</p>
+  <p><strong>Not a single-agent tool.</strong> bones works for a single-agent workflow but the substrate cost (NATS server, Fossil hub) outweighs the benefit. If you have one agent, run <code>fossil</code> directly.</p>
+  <p><strong>Not a memory system.</strong> Per-agent memory is the harness's job (Claude Code auto-memory). Cross-agent shared facts go through chat threads or task context maps; bones does not provide a separate <code>remember</code> primitive.</p>
+</section>
+
+<section>
+  <span class="num">§07</span>
+  <h2>Get going <span class="anchor">start</span></h2>
+  <div class="code-block">
+    <div class="code-bar">
+      <span>shell</span>
+      <button type="button" class="copy-btn" data-copy="quickstart" aria-label="Copy quickstart commands">copy</button>
+    </div>
+    <pre id="quickstart">$ brew install danmestas/tap/bones
+$ cd my-project
+$ bones init                                  # workspace + leaf
+$ bones orchestrator                          # scaffold skills + scripts
+$ bones tasks add "first task" --files src/foo.go
+$ bones tasks list</pre>
+  </div>
+  <p>Walkthrough: <a href="/docs/quickstart/">/docs/quickstart</a> · Concepts: <a href="/docs/concepts/">/docs/concepts</a> · CLI reference: <a href="/docs/reference/cli/">/docs/reference/cli</a> · Skills reference: <a href="/docs/reference/skills/">/docs/reference/skills</a> · Architecture: <a href="/docs/architecture/">/docs/architecture</a> · Source: <a href="https://github.com/danmestas/bones">github.com/danmestas/bones</a>.</p>
+</section>
+
+</main>
+
+<footer>
+  <div>bones &nbsp;·&nbsp; Apache-2.0 &nbsp;·&nbsp; v{{ .Site.Params.version | default "0.1.0" }} &nbsp;·&nbsp; {{ now.Year }} &nbsp;·&nbsp; <a href="https://github.com/danmestas/bones">github.com/danmestas/bones</a></div>
+</footer>
+
+<script>
+(function () {
+  var btns = document.querySelectorAll(".copy-btn");
+  btns.forEach(function (b) {
+    b.addEventListener("click", function () {
+      var t = document.getElementById(b.dataset.copy);
+      if (!t) return;
+      var s = t.textContent.replace(/^\s*\$\s?/gm, "").replace(/\s+#.*$/gm, "").trim();
+      var done = function () {
+        b.dataset.state = "copied";
+        b.textContent = "copied";
+        setTimeout(function () { b.dataset.state = ""; b.textContent = "copy"; }, 1500);
+      };
+      if (navigator.clipboard && window.isSecureContext) {
+        navigator.clipboard.writeText(s).then(done).catch(function () { b.textContent = "select+copy"; });
+      } else {
+        var ta = document.createElement("textarea");
+        ta.value = s;
+        ta.style.position = "fixed";
+        ta.style.left = "-9999px";
+        document.body.appendChild(ta);
+        ta.select();
+        try { document.execCommand("copy"); done(); } catch (e) { b.textContent = "select+copy"; }
+        document.body.removeChild(ta);
+      }
+    });
+  });
+})();
+</script>
+
+</body>
+</html>

--- a/scripts/sync-version.sh
+++ b/scripts/sync-version.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Read the latest git tag and write it into docs/site/hugo.yaml's
+# params.version so the landing page picks it up at build time. Run by
+# the Cloudflare build before Hugo invokes; safe to run locally too —
+# it only edits the working tree, never commits.
+#
+# Falls back to whatever value is already in hugo.yaml if no tags are
+# reachable (e.g., very early dev with no releases yet).
+set -euo pipefail
+
+HUGO_YAML="docs/site/hugo.yaml"
+
+# Cloudflare Workers Builds may not fetch tag refs by default; pull them
+# so 'git describe' can find the latest. Tag refs are tiny — no depth
+# limit (--depth=1 would break full clones by marking commits shallow).
+git fetch --tags --no-shallow >/dev/null 2>&1 \
+    || git fetch --tags >/dev/null 2>&1 \
+    || true
+
+if TAG=$(git describe --tags --abbrev=0 2>/dev/null); then
+    VERSION="${TAG#v}"
+else
+    echo "sync-version: no git tags reachable, leaving hugo.yaml untouched" >&2
+    exit 0
+fi
+
+# Replace the version line. Use a temp file to stay portable across
+# GNU sed (Linux/CF) and BSD sed (macOS).
+awk -v v="${VERSION}" '
+    /^  version: "/ { print "  version: \"" v "\""; next }
+    { print }
+' "${HUGO_YAML}" > "${HUGO_YAML}.tmp"
+mv "${HUGO_YAML}.tmp" "${HUGO_YAML}"
+
+echo "sync-version: hugo.yaml params.version set to ${VERSION}"

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,11 @@
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "bones-docs",
+  "compatibility_date": "2026-04-25",
+  "observability": { "enabled": true },
+  "assets": { "directory": "./docs/site/public" },
+  "build": {
+    "command": "curl -sSL https://github.com/gohugoio/hugo/releases/download/v0.160.0/hugo_extended_0.160.0_linux-amd64.tar.gz | tar xz hugo && bash scripts/sync-version.sh && cd docs/site && ../../hugo --minify"
+  },
+  "compatibility_flags": ["nodejs_compat"]
+}


### PR DESCRIPTION
## Summary

Scaffolds a Hugo + Hextra docs site for bones, mirroring the libfossil/EdgeSync/dagnats setup. Deploys to Cloudflare Workers Static Assets at \`https://bones-docs.daniel-mestas.workers.dev/\` once the worker is provisioned.

## Files

**Repo root**
- \`wrangler.jsonc\` — Cloudflare config, build cmd downloads Hugo extended v0.160.0 + runs sync-version + builds
- \`scripts/sync-version.sh\` — copied verbatim from libfossil; reads latest tag, writes into \`hugo.yaml\` params.version

**\`docs/site/\`**
- \`hugo.yaml\` — Hextra v0.12.2 module, menu (Docs / Architecture / Reference / Search / GitHub), flexsearch, edit-on-GitHub
- \`go.mod\` + \`go.sum\` — Hextra module pin
- \`layouts/\` — empty (Hextra defaults are fine for v1)
- \`content/_index.md\` — landing
- \`content/docs/_index.md\`, \`quickstart.md\`, \`concepts.md\` — core docs
- \`content/docs/architecture/_index.md\` — links to ADRs in the repo (no mirroring)
- \`content/docs/reference/_index.md\`, \`cli.md\`, \`skills.md\` — CLI tables + 3-skill descriptions (orchestrator, subagent, uninstall-bones)

## Verification

- [x] \`cd docs/site && hugo --minify\` produces 18 pages, 11 static files, no errors
- [x] \`bash scripts/sync-version.sh\` runs cleanly
- [x] \`wrangler.jsonc\` valid JSONC
- [x] All three skills documented (matches the cli/templates/ scaffolder)

## Divergence from libfossil

- Build command drops \`gen-llms-txt.sh\` step (bones has no auto-generated SDK reference to feed it)
- Menu: \`Architecture\` + \`Reference\` instead of \`SDK\` + \`Examples\` (better fit for bones' shape)
- Landing uses Hextra's stock \`landing\` layout (libfossil has a hand-rolled HTML/CSS landing — bones can iterate to that later if desired)

## Required after merge

1. Provision the Cloudflare Worker. Either via Cloudflare dashboard or:
   \`\`\`bash
   wrangler deploy --name bones-docs
   \`\`\`
   from a checkout with \`docs/site/public/\` already built (\`wrangler\` will read \`wrangler.jsonc\` and use the build command on subsequent CI deploys).
2. Optional: hook up \`docs.bones.dev\` (or whatever domain) via Cloudflare Workers custom domain.