### PR TITLE
polish: CHANGELOG + CONTRIBUTING + README badges (libfossil-level hygiene)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,34 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- `bones-on-PATH` prerequisite check skill.
+- `uninstall-bones` skill for safe project removal.
+
+## [0.1.0] - 2026-04-27
+
+Initial release of `bones`, a multi-agent orchestration framework that combines
+Fossil for durable state with NATS for real-time coordination. Supports parallel
+agent collaboration on a shared codebase via hold-based mutual exclusion,
+fork-and-merge conflict resolution, and Fossil-backed task storage.
+
+### Added
+
+- Hub-and-leaf agent orchestration with NATS-backed pub/sub coordination.
+- Fossil-backed durable task state shared across agents.
+- Hold protocol (announce/release/subscribe/watch) for resource collision avoidance.
+- Tasks stored as markdown files with YAML frontmatter in a Fossil repository.
+- Conflict resolution via Fossil fork model with chat-assisted merge.
+- Scoped holds and lease semantics for exclusive resource access.
+- CLI (`bones`) with subcommands for task add/claim/close/status/watch.
+- Closed task compaction to limit long-horizon agent context.
+- GoReleaser-based binary distribution with `bones --version`.
+- Apache-2.0 LICENSE.
+- 21 architecture decision records documenting design rationale.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,66 @@
+# Contributing to bones
+
+Thanks for your interest in `bones`, a multi-agent orchestration framework
+combining Fossil (durable state) with NATS (real-time coordination). This
+document covers everything you need to get a working checkout, run the tests,
+and submit changes.
+
+## Development setup
+
+Requires Go 1.26 or newer.
+
+```
+git clone https://github.com/danmestas/bones
+cd bones
+make
+git config core.hooksPath .githooks
+```
+
+`make` builds `bin/bones`. EdgeSync is pulled in as a normal Go module
+dependency for the main binary — no sibling checkout needed.
+
+To run integration tests that exercise the leaf binary (`make leaf`), clone
+EdgeSync as a sibling:
+
+```
+git clone https://github.com/danmestas/EdgeSync ../EdgeSync
+make leaf
+```
+
+The pre-commit hook at `.githooks/pre-commit` runs the same gate as CI;
+pointing `core.hooksPath` at it catches problems before they hit a PR.
+
+For end-user installation (running bones, not building it), see
+[GETTING_STARTED.md](./GETTING_STARTED.md).
+
+## Running tests
+
+```
+make check       # fmt-check, vet, lint, race, todo-check
+make test        # unit tests
+make race        # race-detector tests
+```
+
+`make check` is the canonical pre-PR gate — the same checks run in CI.
+
+## Code layout
+
+- `cmd/`, `bin/` — CLI entry points (`bones`, `leaf`).
+- `internal/` — implementation packages, not exported.
+- `pkg/` — exported packages.
+- `docs/adr/` — 21 architecture decision records documenting design rationale
+  and trade-offs; read the relevant ADRs before proposing structural changes.
+- `scripts/`, `.orchestrator/` — orchestrator and bootstrap scaffolding.
+
+## Submitting changes
+
+1. Open a feature branch off `main`. Direct commits to `main` are not accepted.
+2. Run `make check` locally before pushing.
+3. Open a PR; CI will re-run `make check`.
+4. Significant design changes should land an ADR in `docs/adr/` either before
+   or alongside the implementation PR.
+
+## Reporting issues
+
+Open an issue at https://github.com/danmestas/bones/issues with reproduction
+steps, expected vs. actual behavior, and the output of `bones --version`.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # bones
 
+[![Go Reference](https://pkg.go.dev/badge/github.com/danmestas/bones.svg)](https://pkg.go.dev/github.com/danmestas/bones)
+[![Go Report Card](https://goreportcard.com/badge/github.com/danmestas/bones)](https://goreportcard.com/report/github.com/danmestas/bones)
+[![CI](https://github.com/danmestas/bones/actions/workflows/ci.yml/badge.svg)](https://github.com/danmestas/bones/actions/workflows/ci.yml)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](./LICENSE)
+[![Go](https://img.shields.io/badge/Go-1.26+-00ADD8.svg)](https://go.dev)
+
 State memory and real-time comms for embedded agent processes, built on Fossil
 (durable state) and NATS (live coordination). Beads-inspired — but without the
 git cleanup tax that multi-agent divergence imposes on branch-based VCS.


### PR DESCRIPTION
## Summary

Brings `bones` repo hygiene up to libfossil-level polish. This is the template PR for a multi-repo polish program; the same shape will land in `dagnats`, `edgesync`, `opfs`, `darken`, and `agent-config` once this one looks right.

## What's in here

- **`CHANGELOG.md`** — Keep-a-Changelog format. Retroactive `[0.1.0]` entry summarizing the release scope (hub-and-leaf orchestration, hold protocol, Fossil-backed task state, GoReleaser distribution, 21 ADRs). `[Unreleased]` carries the post-v0.1.0 skill additions.
- **`CONTRIBUTING.md`** — Modeled on libfossil's structure: Development setup, Running tests, Code layout, Submitting changes, Reporting issues. Documents the `make` build, `make check` quality gate, the `.githooks/pre-commit` setup, and the EdgeSync sibling requirement for `make leaf` integration tests.
- **README badges** — 5 badges added below the title: Go Reference, Go Report Card, CI, License (Apache-2.0), Go version (1.26+). Skipped libfossil's "Docs" badge since `bones` doesn't have a separate docs site.

## Things explicitly NOT in this PR

- No README rewrite — only the badge block was added; the existing Quickstart and other sections are unchanged.
- No CODE_OF_CONDUCT.md or SECURITY.md — libfossil doesn't have them either.
- No issue/PR templates — same reason.
- A small inaccuracy in the README Quickstart (it tells users to clone EdgeSync as a sibling, which is no longer required for the main build) was noted but is out of scope here. Will fix in a follow-up.

## Test plan

- [x] `CHANGELOG.md` validates as Keep-a-Changelog format
- [x] All 5 badge URLs are well-formed
- [ ] Verify `pkg.go.dev` badge resolves once merged (depends on Go module proxy having indexed the v0.1.0 tag)
- [ ] Verify Go Report Card scores green
- [ ] Verify CI badge reflects the latest `ci` workflow run on main