### PR TITLE
tasks: unify CLI and coord on the same NATS-KV bucket

### DIFF
--- a/cli/tasks_common.go
+++ b/cli/tasks_common.go
@@ -139,7 +139,7 @@ func openManager(
 		return nil, nil, fmt.Errorf("openManager: nats connect: %w", err)
 	}
 	m, err := tasks.Open(ctx, nc, tasks.Config{
-		BucketName:   "agent_tasks",
+		BucketName:   tasks.DefaultBucketName,
 		HistoryDepth: 10,
 		MaxValueSize: 64 * 1024,
 		ChanBuffer:   32,

--- a/cli/tasks_list.go
+++ b/cli/tasks_list.go
@@ -71,7 +71,18 @@ func (c *TasksListCmd) Run(g *libfossilcli.Globals) error {
 
 		out := filterTasks(allTasks, c.All, filterStatus, c.ClaimedBy)
 		if c.Ready {
-			out = selectReady(out, time.Now().UTC())
+			// Delegate readiness to coord — it knows the full edge
+			// model (blocks/supersedes/duplicates/parent) that a flat
+			// per-task check would miss.
+			readies, err := co.Ready(ctx)
+			if err != nil {
+				return fmt.Errorf("coord ready: %w", err)
+			}
+			readyIDs := make(map[string]struct{}, len(readies))
+			for _, r := range readies {
+				readyIDs[string(r.ID())] = struct{}{}
+			}
+			out = filterByIDSet(out, readyIDs)
 		}
 		if c.Stale > 0 {
 			out = selectStale(out, c.Stale, time.Now().UTC())
@@ -113,18 +124,15 @@ func filterTasks(in []tasks.Task, all bool, status tasks.Status, claimedBy strin
 	return out
 }
 
-// selectReady returns open, non-deferred tasks (claimable right now).
-// `now` is injected for testability.
-func selectReady(in []tasks.Task, now time.Time) []tasks.Task {
-	out := make([]tasks.Task, 0, len(in))
+// filterByIDSet returns the subset of in whose IDs are in keep.
+// Used by --ready, where coord.Ready computes the eligible-ID set
+// using the full edge model (blocks/supersedes/duplicates/parent).
+func filterByIDSet(in []tasks.Task, keep map[string]struct{}) []tasks.Task {
+	out := make([]tasks.Task, 0, len(keep))
 	for _, t := range in {
-		if t.Status != tasks.StatusOpen {
-			continue
+		if _, ok := keep[t.ID]; ok {
+			out = append(out, t)
 		}
-		if t.DeferUntil != nil && t.DeferUntil.After(now) {
-			continue
-		}
-		out = append(out, t)
 	}
 	return out
 }

--- a/cli/tasks_list_test.go
+++ b/cli/tasks_list_test.go
@@ -7,34 +7,25 @@ import (
 	"github.com/danmestas/bones/internal/tasks"
 )
 
-func TestSelectReady(t *testing.T) {
-	now := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
-	future := now.Add(time.Hour)
-	past := now.Add(-time.Hour)
+func TestFilterByIDSet(t *testing.T) {
 	all := []tasks.Task{
-		{ID: "open-now", Status: tasks.StatusOpen},
-		{ID: "open-deferred-future", Status: tasks.StatusOpen, DeferUntil: &future},
-		{ID: "open-deferred-past", Status: tasks.StatusOpen, DeferUntil: &past},
-		{ID: "claimed", Status: tasks.StatusClaimed, ClaimedBy: "a"},
-		{ID: "closed", Status: tasks.StatusClosed},
+		{ID: "a", Title: "alpha"},
+		{ID: "b", Title: "bravo"},
+		{ID: "c", Title: "charlie"},
 	}
-	got := selectReady(all, now)
+	keep := map[string]struct{}{"a": {}, "c": {}}
 
-	gotIDs := make(map[string]bool, len(got))
-	for _, ts := range got {
-		gotIDs[ts.ID] = true
+	got := filterByIDSet(all, keep)
+	if len(got) != 2 {
+		t.Fatalf("len=%d want 2", len(got))
 	}
-	if !gotIDs["open-now"] {
-		t.Errorf("selectReady missing open-now; got %v", gotIDs)
+	if got[0].ID != "a" || got[1].ID != "c" {
+		t.Errorf("order/contents wrong: %+v", got)
 	}
-	if !gotIDs["open-deferred-past"] {
-		t.Errorf("selectReady missing open-deferred-past; got %v", gotIDs)
-	}
-	if gotIDs["open-deferred-future"] {
-		t.Errorf("selectReady should exclude open-deferred-future; got %v", gotIDs)
-	}
-	if gotIDs["claimed"] || gotIDs["closed"] {
-		t.Errorf("selectReady should exclude non-open tasks; got %v", gotIDs)
+
+	// Empty keep set returns empty slice.
+	if got := filterByIDSet(all, nil); len(got) != 0 {
+		t.Errorf("nil keep should yield empty; got %+v", got)
 	}
 }
 

--- a/cli/tasks_status.go
+++ b/cli/tasks_status.go
@@ -59,7 +59,7 @@ func (c *TasksStatusCmd) Run(g *libfossilcli.Globals) error {
 	defer nc.Close()
 
 	m, err := tasks.Open(ctx, nc, tasks.Config{
-		BucketName:   "agent_tasks",
+		BucketName:   tasks.DefaultBucketName,
 		HistoryDepth: 10,
 		MaxValueSize: 64 * 1024,
 		ChanBuffer:   32,

--- a/cli/tasks_watch.go
+++ b/cli/tasks_watch.go
@@ -30,7 +30,7 @@ func (c *TasksWatchCmd) Run(g *libfossilcli.Globals) error {
 	defer nc.Close()
 
 	m, err := tasks.Open(ctx, nc, tasks.Config{
-		BucketName:   "agent_tasks",
+		BucketName:   tasks.DefaultBucketName,
 		HistoryDepth: 10,
 		MaxValueSize: 64 * 1024,
 		ChanBuffer:   64,

--- a/cmd/bones/integration/integration_test.go
+++ b/cmd/bones/integration/integration_test.go
@@ -554,7 +554,7 @@ func TestCLI_Ready(t *testing.T) {
 	}
 
 	t.Run("empty_bucket", func(t *testing.T) {
-		stdout, stderr, code := runCmd(t, bonesBin, dir, "tasks", "ready")
+		stdout, stderr, code := runCmd(t, bonesBin, dir, "tasks", "list", "--ready")
 		if code != 0 {
 			t.Fatalf("ready exit=%d stderr=%s", code, stderr)
 		}
@@ -565,7 +565,7 @@ func TestCLI_Ready(t *testing.T) {
 
 	t.Run("shows_open_tasks", func(t *testing.T) {
 		id := seed("ready task")
-		stdout, stderr, code := runCmd(t, bonesBin, dir, "tasks", "ready")
+		stdout, stderr, code := runCmd(t, bonesBin, dir, "tasks", "list", "--ready")
 		if code != 0 {
 			t.Fatalf("ready exit=%d stderr=%s", code, stderr)
 		}
@@ -580,7 +580,7 @@ func TestCLI_Ready(t *testing.T) {
 		if code != 0 {
 			t.Fatalf("seed claim failed code=%d", code)
 		}
-		stdout, _, _ := runCmd(t, bonesBin, dir, "tasks", "ready")
+		stdout, _, _ := runCmd(t, bonesBin, dir, "tasks", "list", "--ready")
 		if strings.Contains(stdout, id) {
 			t.Errorf("claimed task should be hidden; got:\n%s", stdout)
 		}
@@ -594,7 +594,7 @@ func TestCLI_Ready(t *testing.T) {
 			t.Fatalf("create exit=%d stderr=%s", code, stderr)
 		}
 		id := firstLine(stdout)
-		ready, _, code := runCmd(t, bonesBin, dir, "tasks", "ready")
+		ready, _, code := runCmd(t, bonesBin, dir, "tasks", "list", "--ready")
 		if code != 0 {
 			t.Fatalf("ready exit=%d", code)
 		}
@@ -605,7 +605,7 @@ func TestCLI_Ready(t *testing.T) {
 
 	t.Run("json", func(t *testing.T) {
 		id := seed("json ready")
-		stdout, stderr, code := runCmd(t, bonesBin, dir, "tasks", "ready", "--json")
+		stdout, stderr, code := runCmd(t, bonesBin, dir, "tasks", "list", "--ready", "--json")
 		if code != 0 {
 			t.Fatalf("ready --json exit=%d stderr=%s", code, stderr)
 		}
@@ -825,7 +825,7 @@ func TestCLI_Link(t *testing.T) {
 		if code != 0 {
 			t.Fatalf("link exit=%d stderr=%s", code, stderr)
 		}
-		stdout, _, _ := runCmd(t, bonesBin, dir, "tasks", "ready")
+		stdout, _, _ := runCmd(t, bonesBin, dir, "tasks", "list", "--ready")
 		if strings.Contains(stdout, to) {
 			t.Errorf("blocked target should be hidden; got:\n%s", stdout)
 		}
@@ -842,7 +842,7 @@ func TestCLI_Link(t *testing.T) {
 		if code != 0 {
 			t.Fatalf("link exit=%d stderr=%s", code, stderr)
 		}
-		stdout, _, _ := runCmd(t, bonesBin, dir, "tasks", "ready")
+		stdout, _, _ := runCmd(t, bonesBin, dir, "tasks", "list", "--ready")
 		if strings.Contains(stdout, to) {
 			t.Errorf("superseded task should be hidden; got:\n%s", stdout)
 		}
@@ -856,7 +856,7 @@ func TestCLI_Link(t *testing.T) {
 		if code != 0 {
 			t.Fatalf("link exit=%d stderr=%s", code, stderr)
 		}
-		stdout, _, _ := runCmd(t, bonesBin, dir, "tasks", "ready")
+		stdout, _, _ := runCmd(t, bonesBin, dir, "tasks", "list", "--ready")
 		if !strings.Contains(stdout, to) {
 			t.Errorf("discovered-from should not hide target; got:\n%s", stdout)
 		}

--- a/internal/coord/coord.go
+++ b/internal/coord/coord.go
@@ -23,10 +23,6 @@ import (
 // ADR 0003 and therefore lives here, not on Config.
 const holdsBucket = "bones-holds"
 
-// tasksBucket is the JetStream KV bucket name coord uses to back task
-// records per ADR 0005. Also substrate-internal per ADR 0003.
-const tasksBucket = "bones-tasks"
-
 // archiveBucket is the cold JetStream KV bucket name coord uses for
 // pruned closed-task snapshots after compaction.
 const archiveBucket = "bones-task-archive"
@@ -121,7 +117,7 @@ func openSubstrate(
 		return nil, fmt.Errorf("coord.Open: holds: %w", err)
 	}
 	if s.tasks, err = tasks.Open(ctx, nc, tasks.Config{
-		BucketName:   tasksBucket,
+		BucketName:   tasks.DefaultBucketName,
 		HistoryDepth: cfg.Tuning.TaskHistoryDepth,
 		MaxValueSize: int32(cfg.Tuning.MaxTaskValueSize),
 	}); err != nil {

--- a/internal/tasks/tasks.go
+++ b/internal/tasks/tasks.go
@@ -14,6 +14,13 @@ import (
 	"github.com/danmestas/bones/internal/jskv"
 )
 
+// DefaultBucketName is the canonical JetStream KV bucket name for task
+// records, pinned by ADR 0005. Both the CLI's openManager helper and
+// internal/coord must point at this same bucket; otherwise create-then-
+// link/prime/autoclaim cross-store and silently miss the just-created
+// task. Tests may override via Config.BucketName for isolation.
+const DefaultBucketName = "bones-tasks"
+
 // Config configures Open. Every field is required; there are no silent
 // defaults. ADR 0005 fixes the recommended values — HistoryDepth 8,
 // MaxValueSize 8 KB — and coord.Config is the enforcement surface for


### PR DESCRIPTION
## Summary

Two-commit fix for the substrate-vs-domain split flagged in the Hipp/Ousterhout audits. Closes 5 of the 7 silently-failing integration tests by unifying the bucket name; the remaining two (TestCLI_Compact, TestCLI_Dispatch/parent_spawns) are different bugs and out of scope here.

### Commit 1 — bucket-name unification

Three CLI sites (`cli/tasks_common.go`, `cli/tasks_watch.go`, `cli/tasks_status.go`) hardcoded `BucketName: "agent_tasks"` (legacy name from before the bones rename). `internal/coord` hardcoded its own `const tasksBucket = "bones-tasks"` (canonical per ADR 0005). Same `tasks.Task` struct, same UUIDs, two different buckets — they never met.

- New: `tasks.DefaultBucketName = "bones-tasks"` exported from `internal/tasks`.
- Both sides now point at it. The `internal/coord` local const is gone.

### Commit 2 — `--ready` delegates to `coord.Ready`

Phase 1's `selectReady` helper only checked `status/deferred`; it lost the `blocks/supersedes/duplicates/parent` edge walk that `coord.Ready` performs. Even with the bucket aligned, `TestCLI_Link/blocks_hides_target_from_ready` still failed because `list --ready` didn't hide blocked tasks.

- Replaced `selectReady` with `filterByIDSet` (set-membership intersection).
- When `--ready` is set, the existing lazy-opened coord session computes the eligible-ID set via `coord.Ready(ctx)` — the deep-module path the Ousterhout audit recommended.
- Eight `tasks ready` references in `integration_test.go` updated to `tasks list --ready`.

## Test plan

Before / after on this branch:

| Test                                   | main | this PR |
|----------------------------------------|------|---------|
| TestCLI_Link (6 subtests)              | FAIL | **PASS** |
| TestCLI_Prime/json                     | FAIL | **PASS** |
| TestCLI_AutoClaim (3 subtests)         | FAIL | **PASS** |
| TestCLI_Status                         | FAIL | **PASS** |
| TestCLI_Watch_Smoke                    | FAIL | **PASS** |
| TestCLI_Ready (4 subtests, after Phase 1 verb removal) | already broken | **PASS** |
| TestTick_* (autoclaim internal, 7)     | flaky | **PASS** |
| TestCLI_Dispatch/parent_spawns         | FAIL (different mode) | FAIL — separate bug, see below |
| TestCLI_Compact                        | FAIL | FAIL — separate PR |

- [x] `go build ./...`
- [x] `go test ./...`
- [x] `go test -tags=otel ./...`
- [x] `make check` — `check: OK`
- [x] `make bones && go test ./cmd/bones/integration -count=1` — only the two known-out-of-scope tests fail

## Out of scope

**`TestCLI_Dispatch/parent_spawns_worker_for_claimed_task`** — pre-existing on `main` with a different failure mode. On `main`, dispatch-parent failed immediately at the lookup step (`claimed task X not found` — same bucket-mismatch root). With the bucket aligned, the lookup now succeeds, but the parent times out at 5s waiting for the worker subprocess to publish a `ResultMessage` to its task thread. That's a real dispatch-flow bug worth its own ticket.

**`TestCLI_Compact`** — `Compact moved to *Leaf in EdgeSync refactor; rework CLI to drive a Leaf`. Separate refactor, separate PR.