### PR TITLE
adr: refresh status headers (post-Hipp-audit)

### DIFF
--- a/docs/adr/0016-closed-task-compaction.md
+++ b/docs/adr/0016-closed-task-compaction.md
@@ -7,6 +7,12 @@ Builds on ADR 0005's roadmap note that old closed tasks should eventually
 be compacted out of the hot KV scan path, and on ADR 0010's Fossil
 code-artifact substrate for durable append-only summary storage.
 
+**Partially superseded by ADR 0027 (2026-04-28):** the user-facing
+`bones tasks compact` CLI command was removed; `coord.Leaf.Compact` and
+the `Summarizer` interface remain. The substrate decisions in this ADR
+(eligibility, summary artifact path, archive-vs-prune, level scheme)
+still apply to any future re-binding. See ADR 0027 for the rationale.
+
 ## Context
 
 Agent-infra keeps closed tasks in NATS KV so they remain readable for audit and

--- a/docs/adr/0019-cli-binaries.md
+++ b/docs/adr/0019-cli-binaries.md
@@ -2,17 +2,19 @@
 
 ## Status
 
-Accepted 2026-04-20. Phase 4 deliverable. Establishes the human-facing
-CLI surface for bones workspaces; pairs with ADR 0005 (tasks in
-NATS KV) and ADR 0007 (claim semantics) by giving operators a verb
-vocabulary to drive both. Compressed from three plan/spec pairs
+**Superseded** by the bones consolidation (PR #20, 2026-04). The
+`agent-init`, `agent-tasks`, and `orchestrator-validate-plan` binaries
+were merged into a single `bones` CLI; current behavior, verb list, and
+packaging live under `cmd/bones/`. Subsequent verb-trim and tiered-help
+work landed in PR #33 (Hipp audit) and PR #34/#35 (further pruning).
+
+Originally accepted 2026-04-20 as a Phase 4 deliverable establishing
+the human-facing CLI surface for bones workspaces; paired with ADR 0005
+(tasks in NATS KV) and ADR 0007 (claim semantics) by giving operators a
+verb vocabulary to drive both. Compressed from three plan/spec pairs
 (`cmd/agent-init`, `cmd/agent-tasks`, `examples/two-agents`).
 
-Superseded by the bones consolidation — the `agent-init`,
-`agent-tasks`, and `orchestrator-validate-plan` binaries were merged
-into a single `bones` CLI in 2026-04 (PR #20). The split rationale
-below is preserved for historical context; current behavior, verb
-list, and packaging live under `cmd/bones/`.
+The split rationale below is preserved for historical context.
 
 ## Context
 

--- a/docs/adr/0022-observability-trial.md
+++ b/docs/adr/0022-observability-trial.md
@@ -8,6 +8,14 @@ findings) and the `examples/herd-observability/` harness. This ADR
 captures the durable design decisions surfaced by the trial; the
 implementation steps and TDD task list do not need to persist.
 
+**Trial paused (2026-04-28).** The SigNoz endpoint that consumed these
+spans/metrics is broken; the Hipp audit (PR #33) gated all OpenTelemetry
+imports behind a `-tags=otel` build flag via `internal/telemetry`, so
+the default bones binary records nothing. Re-enable by building with
+`-tags=otel` once a stable backend is in place. The instrumentation
+patterns this ADR documents (span shape, attribute set, metric naming)
+are still the contract any future re-enable should match.
+
 ## Context
 
 After Phase 4–5 closed (CLIs, code-artifact substrate), bones had

--- a/docs/adr/0023-hub-leaf-orchestrator.md
+++ b/docs/adr/0023-hub-leaf-orchestrator.md
@@ -2,16 +2,27 @@
 
 ## Status
 
-Accepted 2026-04-25. Predates and is **substantially modified by** ADR
-0018 (EdgeSync refactor, 2026-04-26). The hub/leaf topology, slot
-partitioning, planner contract, and orchestrator/subagent skill
-responsibilities all carry forward. The custom NATS broadcast +
-fork-retry layer specified here was deleted in ADR 0018 in favor of
-`leaf.Agent`'s native mesh sync. Read this ADR for the orchestrator
-contract; read 0018 for the current sync substrate.
+**Superseded in part** by ADR 0018 (EdgeSync refactor, 2026-04-26) and
+ADR 0024 (orchestrator Fossil checkout = git working tree, 2026-04-27).
 
-Compressed from `2026-04-25-hub-leaf-orchestrator-design.md` and the
-matching plan. Empirical results in `docs/trials/2026-04-25/trial-report.md`.
+What carries forward from this ADR (the orchestrator contract):
+hub/leaf topology, slot partitioning, planner contract, and
+orchestrator/subagent skill responsibilities.
+
+What was replaced:
+- The custom NATS broadcast + fork-retry layer specified here was
+  deleted in ADR 0018 in favor of `leaf.Agent`'s native mesh sync.
+- The "v1 stub" of the Fossil-checkout-vs-git-worktree relationship
+  was closed by ADR 0024.
+- The bash hub-bootstrap implementation referenced here was rewritten
+  in Go in ADR 0026 (PR #33).
+
+Read this ADR for the orchestrator contract; read 0018 for the sync
+substrate, 0024 for checkout-as-worktree, and 0026 for the Go hub.
+
+Originally accepted 2026-04-25. Compressed from
+`2026-04-25-hub-leaf-orchestrator-design.md` and the matching plan.
+Empirical results in `docs/trials/2026-04-25/trial-report.md`.
 
 ## Context
 

--- a/docs/adr/0024-orchestrator-fossil-checkout-as-git-worktree.md
+++ b/docs/adr/0024-orchestrator-fossil-checkout-as-git-worktree.md
@@ -6,6 +6,13 @@ Accepted 2026-04-27. Closes the v1 stub in ADR 0023 §"Orchestrator skill
 responsibilities" step 5 (PR generation skipped — implement in v2).
 Implements the swarm→git bridge.
 
+**Implementation moved to Go** in ADR 0026 (PR #33). The bash
+`hub-bootstrap.sh` referenced throughout this ADR became a thin shim
+around `bones hub start --detach`; the seeding logic, fresh-start
+detection, and PID handling now live in `internal/hub/`. The contract
+this ADR pins (checkout = git working tree, Fossil metadata gitignored,
+seed from `git ls-files`) is unchanged.
+
 ## Context
 
 ADR 0023 ships a hub-and-leaf orchestration model: a bare Fossil repo at


### PR DESCRIPTION
## Summary

After the Hipp-audit remediation wave (PRs #33, #34, #35), five ADRs had Status sections that didn't reflect their current state. Each gets a clear superseded / partial-superseded / paused note up top so a new reader doesn't have to chase the supersession chain mid-paragraph.

| ADR | Action |
|---|---|
| 0016 closed-task compaction | "Partially superseded by 0027" — `bones tasks compact` CLI gone; `coord.Leaf.Compact` substrate retained |
| 0019 cli-binaries | Promoted to "Superseded" header (the consolidation note already existed mid-paragraph) |
| 0022 observability-trial | "Trial paused" — OTel gated behind `-tags=otel` build flag per PR #33 |
| 0023 hub-leaf-orchestrator | "Superseded in part" by 0018/0024/0026; orchestrator contract still in force, three replaced layers named explicitly |
| 0024 orchestrator-fossil-checkout | Forward-ref to 0026 (bash → Go hub) |

## What this PR is **not**

- Not normalizing the cosmetic status-format inconsistency across all 24 ADRs (some use `## Status`, some use `**Status:**`, some include a separate `**Date:**` line). That's a touch-everything change for marginal value; left alone.
- Not rewriting historical "agent-infra" references inside ADR bodies. They're history; same rule we used for code comments during the rename in PR #33.
- Not closing the substrate-vs-domain boundary work the audit flagged in 0025 (still out-of-scope future work).

## Test plan

- [x] `go build ./...` — green (no code touched)
- [x] `make check` — green
- [x] No file outside `docs/adr/` modified