### PR TITLE
dispatch: fix parent_spawns_worker_for_claimed_task end-to-end

### DIFF
--- a/cli/tasks_dispatch.go
+++ b/cli/tasks_dispatch.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -73,6 +74,12 @@ func (c *TasksDispatchParentCmd) run(
 		return dispatch.Spec{}, dispatch.ResultMessage{}, nil, nil, false, err
 	}
 	c.appendWorkerArgs(cmd, spec)
+	// Capture worker output so a timeout can show what the worker did
+	// or said. Without this, a worker crash or panic just looks like a
+	// silent 5s timeout in the parent.
+	var workerOut bytes.Buffer
+	cmd.Stdout = &workerOut
+	cmd.Stderr = &workerOut
 	if err := cmd.Start(); err != nil {
 		_ = closeSub()
 		_ = co.Close()
@@ -83,7 +90,8 @@ func (c *TasksDispatchParentCmd) run(
 	if err != nil {
 		_ = closeSub()
 		_ = co.Close()
-		return dispatch.Spec{}, dispatch.ResultMessage{}, nil, nil, false, err
+		return dispatch.Spec{}, dispatch.ResultMessage{}, nil, nil, false,
+			fmt.Errorf("%w; worker output:\n%s", err, workerOut.String())
 	}
 	return spec, result, co, closeSub, c.WorkerClaimHandoff, nil
 }
@@ -110,7 +118,7 @@ type TasksDispatchWorkerCmd struct {
 	TaskThread       string        `name:"task-thread" required:"" help:"task chat thread"`
 	WorkerAgentID    string        `name:"worker-agent-id" required:"" help:"worker agent id"`
 	ClaimFromAgentID string        `name:"claim-from-agent-id" help:"expected previous claimer"`
-	HandoffTTL       time.Duration `name:"handoff-ttl" help:"handoff hold ttl"`
+	HandoffTTL       time.Duration `name:"handoff-ttl" default:"30s" help:"handoff hold ttl"`
 	Result           string        `name:"result" default:"success" help:"success|fork|fail"`
 	Summary          string        `name:"summary" default:"done" help:"final summary"`
 	Branch           string        `name:"branch" help:"fork branch"`
@@ -126,10 +134,17 @@ func (c *TasksDispatchWorkerCmd) Run(g *libfossilcli.Globals) error {
 
 	return taskCLIError(runOp(ctx, "dispatch-worker", func(ctx context.Context) error {
 		cfg := newCoordConfig(info)
+		// HandoffTTL has a Kong default (30s), so no fallback to
+		// cfg.Tuning is needed — and reading cfg.Tuning before
+		// coord.Open is wrong anyway: Open populates Tuning internally
+		// from defaultTuning, but the caller's cfg stays zero.
 		ttl := c.HandoffTTL
-		if ttl == 0 {
-			ttl = cfg.Tuning.HoldTTLDefault
-		}
+		// Pin ProjectPrefix to the workspace identity BEFORE replacing
+		// AgentID. The worker's compound id (parent + "/" + taskID)
+		// would otherwise produce a different project prefix than the
+		// parent and the chat thread the parent is subscribed to would
+		// land on a different NATS subject.
+		cfg.ProjectPrefix = coord.DeriveProjectPrefix(info.AgentID)
 		cfg.AgentID = c.WorkerAgentID
 		co, err := coord.Open(ctx, cfg)
 		if err != nil {

--- a/cmd/bones/integration/integration_test.go
+++ b/cmd/bones/integration/integration_test.go
@@ -685,7 +685,8 @@ func TestCLI_Dispatch(t *testing.T) {
 		if code != 1 {
 			t.Fatalf("exit=%d, want 1", code)
 		}
-		if !strings.Contains(stderr, "parent|worker") {
+		// Kong emits: expected one of "parent", "worker"
+		if !strings.Contains(stderr, "parent") || !strings.Contains(stderr, "worker") {
 			t.Fatalf("stderr=%q", stderr)
 		}
 	})

--- a/internal/coord/config.go
+++ b/internal/coord/config.go
@@ -117,8 +117,26 @@ type Config struct {
 	// CheckoutRoot/<AgentID>/. In tests, pass t.TempDir().
 	CheckoutRoot string
 
+	// ProjectPrefix scopes chat threads, presence, and KV subjects.
+	// Zero means "derive from AgentID" (everything before the last
+	// '-'); single-agent callers can leave it blank. Multi-process
+	// flows where the agent identities don't share a prefix (e.g.
+	// dispatch worker = parentID + "/" + taskID) must set this
+	// explicitly to the workspace identity so all participants meet
+	// on the same NATS subject namespace.
+	ProjectPrefix string
+
 	// Tuning carries substrate knobs. Zero means "use sane defaults".
 	Tuning TuningConfig
+}
+
+// DeriveProjectPrefix exposes the default ProjectPrefix derivation —
+// everything in agentID before the last '-' — for callers that need to
+// build a Config whose AgentID does not itself contain a sensible
+// project prefix (e.g. the dispatch-worker compound identity). Mirrors
+// the unexported projectPrefix used by Open's default path.
+func DeriveProjectPrefix(agentID string) string {
+	return projectPrefix(agentID)
 }
 
 // Validate checks every Config field against its documented bounds and

--- a/internal/coord/coord.go
+++ b/internal/coord/coord.go
@@ -132,9 +132,13 @@ func openSubstrate(
 		s.close()
 		return nil, fmt.Errorf("coord.Open: archive tasks: %w", err)
 	}
+	chatProject := cfg.ProjectPrefix
+	if chatProject == "" {
+		chatProject = projectPrefix(cfg.AgentID)
+	}
 	if s.chat, err = chat.Open(ctx, chat.Config{
 		AgentID:        cfg.AgentID,
-		ProjectPrefix:  projectPrefix(cfg.AgentID),
+		ProjectPrefix:  chatProject,
 		Nats:           nc,
 		FossilRepoPath: cfg.ChatFossilRepoPath,
 		MaxSubscribers: cfg.Tuning.MaxSubscribers,

--- a/internal/dispatch/spawn.go
+++ b/internal/dispatch/spawn.go
@@ -1,19 +1,23 @@
 package dispatch
 
 import (
-	"os"
 	"os/exec"
 )
 
+// BuildWorkerCommand assembles the `bones tasks dispatch worker` invocation
+// with the required flags wired from spec. The parent appends per-result
+// flags (--result, --summary, --claim-from-agent-id) before Start.
+//
+// Earlier iterations passed these as AGENT_INFRA_* env vars, but the
+// worker's Kong struct never read them — the worker would fail Kong's
+// required-flag validation immediately and the parent would hit its
+// 5s subscribe timeout. Flags-only is the single source of truth.
 func BuildWorkerCommand(bin string, spec Spec) (*exec.Cmd, error) {
-	cmd := exec.Command(bin, "tasks", "dispatch", "worker")
-	cmd.Dir = spec.WorkspaceDir
-	cmd.Env = append(os.Environ(),
-		"AGENT_INFRA_TASK_ID="+string(spec.TaskID),
-		"AGENT_INFRA_TASK_THREAD="+spec.Thread,
-		"AGENT_INFRA_TASK_TITLE="+spec.Title,
-		"AGENT_INFRA_WORKER_AGENT_ID="+spec.WorkerAgentID,
-		"AGENT_INFRA_PARENT_AGENT_ID="+spec.ParentAgentID,
+	cmd := exec.Command(bin, "tasks", "dispatch", "worker",
+		"--task-id="+string(spec.TaskID),
+		"--task-thread="+spec.Thread,
+		"--worker-agent-id="+spec.WorkerAgentID,
 	)
+	cmd.Dir = spec.WorkspaceDir
 	return cmd, nil
 }

--- a/internal/dispatch/spawn_test.go
+++ b/internal/dispatch/spawn_test.go
@@ -6,15 +6,6 @@ import (
 	"testing"
 )
 
-func hasEnv(env []string, want string) bool {
-	for _, e := range env {
-		if e == want {
-			return true
-		}
-	}
-	return false
-}
-
 func TestBuildWorkerCommand_EncodesSpecForChildProcess(t *testing.T) {
 	spec := Spec{
 		TaskID:        "bones-abc12345",
@@ -29,14 +20,19 @@ func TestBuildWorkerCommand_EncodesSpecForChildProcess(t *testing.T) {
 	if err != nil {
 		t.Fatalf("BuildWorkerCommand: %v", err)
 	}
-	if got := strings.Join(cmd.Args, " "); !strings.Contains(got, "dispatch worker") {
-		t.Fatalf("Args=%q, want dispatch worker", got)
+	got := strings.Join(cmd.Args, " ")
+	for _, want := range []string{
+		"dispatch worker",
+		"--task-id=bones-abc12345",
+		"--task-thread=bones-abc12345",
+		"--worker-agent-id=parent-agent/bones-abc12345",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("Args=%q missing %q", got, want)
+		}
 	}
 	if cmd.Dir != "/workspace" {
 		t.Fatalf("Dir=%q", cmd.Dir)
-	}
-	if !hasEnv(cmd.Env, "AGENT_INFRA_WORKER_AGENT_ID=parent-agent/bones-abc12345") {
-		t.Fatalf("Env missing worker agent id: %#v", cmd.Env)
 	}
 }
 


### PR DESCRIPTION
## Summary

Three compounding bugs were silently breaking `bones tasks dispatch parent --worker-claim-handoff=true`. PR #34 noted the symptom (parent times out at 5s waiting for the worker's ResultMessage) and deferred. This PR remediates.

Found via systematic debugging — each fix exposed the next layer.

### Bug 1: Worker spec passed as env vars the worker never reads

`dispatch.BuildWorkerCommand` set `AGENT_INFRA_TASK_ID`, `AGENT_INFRA_TASK_THREAD`, `AGENT_INFRA_WORKER_AGENT_ID` env vars on the spawned subprocess. But `TasksDispatchWorkerCmd` declares those as Kong-required CLI flags and never reads the env. The worker exited immediately with `bones: error: missing flags: --task-id=STRING, --task-thread=STRING, --worker-agent-id=STRING`. Parent had no visibility because subprocess stdout/stderr were swallowed.

**Fix:** assemble the data as flags in `BuildWorkerCommand`. Drop the dead env vars.

### Bug 2: `--handoff-ttl` had no default; reading `cfg.Tuning.HoldTTLDefault` returned zero

The worker code:
```go
ttl := c.HandoffTTL                   // Kong flag, no default → 0
if ttl == 0 {
    ttl = cfg.Tuning.HoldTTLDefault   // also 0: Open populates Tuning
}                                       // *internally*; caller cfg stays zero
co, err := coord.Open(ctx, cfg)
```

`coord.HandoffClaim` asserts `ttl > 0`, so this panicked with `coord.HandoffClaim: ttl must be > 0`.

**Fix:** Kong `default:"30s"` on `HandoffTTL`; drop the broken Tuning fallback.

### Bug 3: Worker's compound AgentID broke ProjectPrefix derivation

`coord.Open` derives `chat.ProjectPrefix` via `projectPrefix(cfg.AgentID)` — substring before the last `-`. The parent's AgentID is a UUID like `f1306d16-93d0-4f2a-acfc-28d46cc7eac0` → prefix `f1306d16-93d0-4f2a-acfc`. The worker overrides `cfg.AgentID = WorkerAgentID = parentID + "/" + taskID` → prefix derived from the *task* UUID's last hyphen, totally different namespace. Parent and worker subscribed/posted on different NATS subjects. The post landed nowhere the parent was listening.

**Fix:** add an optional `coord.Config.ProjectPrefix` field plus an exported `coord.DeriveProjectPrefix(agentID)` helper. When ProjectPrefix is empty, Open derives it from AgentID exactly as before — single-agent callers are unaffected. The worker now sets `cfg.ProjectPrefix = DeriveProjectPrefix(info.AgentID)` *before* overriding `cfg.AgentID`. Both processes meet on the workspace's namespace.

### Diagnostic improvement

`tasks_dispatch.go` now captures the worker subprocess's stdout+stderr into a buffer and includes it in the parent's timeout error. A future regression in this flow won't be a silent 5s with no breadcrumb.

## Test plan

| Test | Before | After |
|---|---|---|
| TestCLI_Dispatch/requires_mode | FAIL (Kong format) | **PASS** |
| TestCLI_Dispatch/worker_posts_progress | PASS | PASS |
| TestCLI_Dispatch/parent_spawns_worker_for_claimed_task | FAIL (5s timeout) | **PASS** |

- [x] `go build ./...`
- [x] `go test ./...` — `cmd/bones/integration` packageapart from one pre-existing unrelated failure (Aggregate, see below) is green
- [x] `make check` — `check: OK`
- [x] Manual reproduction in /tmp scratch — full handoff flow completes cleanly

## Out of scope

**TestCLI_Aggregate_Smoke** still fails (pre-existing on `main`, hidden by `-short`). Root cause: `cli/tasks_aggregate.go` `resolvedAgent()` prefers `ClosedBy` over `ClaimedBy`, but `cli/tasks_close.go` clears `ClaimedBy` on close per invariant 11 — so closed tasks attribute to the workspace agent's UUID instead of the original claimer (slot-A). Real fix needs a way to preserve the original claimer through close (new field, or context-map seed). Worth its own ticket.