### PR TITLE
cli: tasks close attributes ClosedBy to the original claimer

### DIFF
--- a/cli/tasks_close.go
+++ b/cli/tasks_close.go
@@ -38,7 +38,20 @@ func (c *TasksCloseCmd) Run(g *libfossilcli.Globals) error {
 			now := time.Now().UTC()
 			t.Status = tasks.StatusClosed
 			t.ClosedAt = &now
-			t.ClosedBy = info.AgentID
+			// ClosedBy attributes the work, not the click. If the task
+			// was claimed, the claimer did the work — even if the
+			// workspace agent (or an admin) is what physically ran
+			// `bones tasks close`. Without this, invariant 11 (claimed_by
+			// empty when not claimed) erases the original claimer and
+			// every closed-task aggregate buckets under the workspace
+			// UUID. Coord-level close already attributes to the caller
+			// (which equals the claimer there, since it enforces a
+			// claim-match precondition), so this aligns the two paths.
+			if t.ClaimedBy != "" {
+				t.ClosedBy = t.ClaimedBy
+			} else {
+				t.ClosedBy = info.AgentID
+			}
 			t.ClosedReason = c.Reason
 			t.UpdatedAt = now
 			// Invariant 11: claimed_by must be empty when status != claimed.


### PR DESCRIPTION
## Summary

Closes the last pre-existing test failure surfaced by the Hipp-audit `-tags=otel` CI lane: `TestCLI_Aggregate_Smoke`. After this PR, **`go test ./...` is fully green for the first time in weeks**.

## Root cause

`cli/tasks_close.go` did:
```go
t.ClosedBy = info.AgentID  // workspace agent's UUID
// Invariant 11: claimed_by must be empty when status != claimed.
t.ClaimedBy = ""
```

So when the workspace agent ran `bones tasks close X` on a task `slot-A` had claimed:
- `ClosedBy` = workspace UUID (loses slot-A)
- `ClaimedBy` = "" (per invariant 11)

The original claimer's identity was erased entirely. `cli/tasks_aggregate.go` `resolvedAgent()` then bucketed every closed task under the workspace UUID instead of the worker that did it.

## Fix

If the task is claimed at close time, attribute `ClosedBy` to the claimer; otherwise keep the existing workspace-agent attribution for genuinely unclaimed closes.

```go
if t.ClaimedBy != "" {
    t.ClosedBy = t.ClaimedBy
} else {
    t.ClosedBy = info.AgentID
}
```

This aligns the CLI close path with the coord-level `close_task.go`, which already attributes to the caller (and enforces a claim-match precondition there, so caller = claimer). The CLI is a privileged shortcut that bypasses the precondition; this preserves the same attribution semantics.

## Why not a new field?

Considered: a separate `OriginalClaimer` field on `tasks.Task`, or seeding the original claimer into the `Context` map before clearing. Both add a schema change for one consumer (aggregate). Option C — overload `ClosedBy` to mean "the agent the work attributes to" — is the smallest change and matches the natural reading of the field name in the test:

> `closed_by` = the agent that closed the task

…where "closed" naturally means "did the work that finished the task," not "physically pressed close."

## Test plan

- [x] `go test ./...` — fully green
- [x] `make check` — `check: OK`
- [x] `TestCLI_Aggregate_Smoke` — **PASS** (was FAIL on main)
- [x] No tests assert `ClosedBy == workspaceAgentID` (verified by grep — only `closed_by=` non-empty assertion in `integration_test.go:498`)

## Audit trail concern

Q: Don't we lose the "the workspace ran the close" info?

A: Yes — and that's fine. The close-runner identity is in the JetStream KV revision history (every Update has a NATS-level publisher) and in slog events. The semantically-loaded `ClosedBy` field is now correctly "who did the work."