### PR TITLE
cli: 'bones peek' opens hub repo in fossil's web UI

### DIFF
--- a/cli/peek.go
+++ b/cli/peek.go
@@ -1,0 +1,68 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+
+	libfossilcli "github.com/danmestas/libfossil/cli"
+
+	"github.com/danmestas/bones/internal/workspace"
+)
+
+// PeekCmd opens the workspace's hub Fossil repo in the system fossil
+// binary's web UI (timeline, branches, files). It is an *enhancement*,
+// not a hard dependency: when `fossil` isn't on PATH, peek prints the
+// hub repo path with a one-line install hint and exits cleanly.
+//
+// libfossil's embedded HTTP server (used by `bones hub start` to serve
+// /xfer for sync) does not implement the rich Fossil web UI; peek
+// shells out to the canonical `fossil ui` for that.
+type PeekCmd struct {
+	Port int `name:"port" help:"bind the UI on this port (default: fossil chooses)"`
+}
+
+func (c *PeekCmd) Run(g *libfossilcli.Globals) error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("cwd: %w", err)
+	}
+	info, err := workspace.Join(context.Background(), cwd)
+	if err != nil {
+		return fmt.Errorf("workspace: %w (run `bones init` first)", err)
+	}
+
+	hubRepo := filepath.Join(info.WorkspaceDir, ".orchestrator", "hub.fossil")
+	if _, err := os.Stat(hubRepo); err != nil {
+		return fmt.Errorf(
+			"hub repo not found at %s — run `bones up` or `bones hub start` first",
+			hubRepo,
+		)
+	}
+
+	fossilBin, lookErr := exec.LookPath("fossil")
+	if lookErr != nil {
+		fmt.Printf("peek: install fossil to open the rich timeline UI:\n")
+		fmt.Printf("  brew install fossil   # macOS / Linux (homebrew)\n")
+		fmt.Printf("  apt install fossil    # Debian / Ubuntu\n")
+		fmt.Printf("\n")
+		fmt.Printf("hub repo: %s\n", hubRepo)
+		fmt.Printf("(any Fossil-compatible tool can open this file directly)\n")
+		return nil
+	}
+
+	args := []string{"ui", hubRepo}
+	if c.Port > 0 {
+		args = append(args, "--port", strconv.Itoa(c.Port))
+	}
+
+	fmt.Printf("peek: %s ui %s\n", fossilBin, hubRepo)
+	cmd := exec.Command(fossilBin, args...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}

--- a/cmd/bones/cli.go
+++ b/cmd/bones/cli.go
@@ -28,6 +28,7 @@ type CLI struct {
 	// Tooling — used by humans authoring plans/skills.
 	ValidatePlan bonescli.ValidatePlanCmd `cmd:"" group:"tooling" help:"Validate plan"`
 	Orchestrator bonescli.OrchestratorCmd `cmd:"" group:"tooling" help:"Install orchestrator"`
+	Peek         bonescli.PeekCmd         `cmd:"" group:"tooling" help:"Open the hub repo in fossil's web UI (if installed)"`
 
 	// Plumbing — rarely invoked directly.
 	Init bonescli.InitCmd `cmd:"" group:"plumbing" help:"Create a workspace"`

--- a/cmd/bones/cli.go
+++ b/cmd/bones/cli.go
@@ -28,7 +28,7 @@ type CLI struct {
 	// Tooling — used by humans authoring plans/skills.
 	ValidatePlan bonescli.ValidatePlanCmd `cmd:"" group:"tooling" help:"Validate plan"`
 	Orchestrator bonescli.OrchestratorCmd `cmd:"" group:"tooling" help:"Install orchestrator"`
-	Peek         bonescli.PeekCmd         `cmd:"" group:"tooling" help:"Open the hub repo in fossil's web UI (if installed)"`
+	Peek         bonescli.PeekCmd         `cmd:"" group:"tooling" help:"Browse hub via fossil ui"`
 
 	// Plumbing — rarely invoked directly.
 	Init bonescli.InitCmd `cmd:"" group:"plumbing" help:"Create a workspace"`

--- a/docs/site/content/docs/reference/cli.md
+++ b/docs/site/content/docs/reference/cli.md
@@ -32,6 +32,7 @@ The `bones` binary is a single Kong-driven entry point covering workspace setup,
 |---|---|
 | `bones orchestrator` | Install orchestrator scaffolding (`.orchestrator/`) |
 | `bones validate-plan <path>` | Validate a slot-annotated plan; `--list-slots` emits JSON |
+| `bones peek` | Open the hub Fossil repo in the system `fossil ui` web view (timeline, branches, files). Optional enhancement — prints a one-line install hint and exits cleanly when `fossil` isn't on PATH. `--port=N` to pin the UI port. |
 
 ### Tasks
 


### PR DESCRIPTION
## Summary

A new opt-in tooling verb so you can see a swarm's in-flight work in Fossil's full web UI (timeline, branches, files, blame) by shelling out to the system \`fossil ui\` binary. Optional enhancement — gracefully degrades when \`fossil\` isn't installed.

## Why a separate verb instead of libfossil's embedded HTTP

\`bones hub start\` runs libfossil v0.4.4's \`--serve-http\` which exposes \`/xfer\` for sync but not the rich Fossil web UI. The canonical \`fossil ui\` is a one-line shell-out away and produces the timeline view the user wants. Keeps libfossil's surface narrow; doesn't pull in a UI dependency for users who don't want it.

## Behavior

\`\`\`text
bones peek                # opens fossil ui on a fossil-chosen port
bones peek --port=18765   # pin the UI port
\`\`\`

Four paths smoke-tested:

| Path | Result |
|---|---|
| \`fossil\` on PATH, hub repo present | Starts \`fossil ui\`; \`/timeline\` reachable; survives until ctrl-c |
| \`fossil\` not on PATH | Prints install hint + hub repo path; exit 0 |
| Hub repo missing | \`hub repo not found at <path> — run \`bones up\` or \`bones hub start\` first\`; exit 1 |
| No workspace | \`workspace: ... (run \`bones init\` first)\`; exit 1 |

## Files

- New: \`cli/peek.go\`
- Modified: \`cmd/bones/cli.go\` (Tooling group registration), \`docs/site/content/docs/reference/cli.md\` (Orchestrator section)

## Test plan

- [x] \`go build ./...\`
- [x] \`make check\` — \`check: OK\`, lll clean
- [x] Manual smoke: rich-UI start, graceful-degrade, missing hub repo, missing workspace — all four paths verified
- [x] \`bones peek --help\` renders correctly under the Tooling group

## Out of scope

- Auto-open the user's browser — \`fossil ui\` already does that.
- A \`--no-browser\` flag (use \`fossil server\` semantics) — wait for someone to actually want it.
- A \`--leaf=<id>\` variant to peek at a specific leaf's repo — hub view shows everything; YAGNI.