### PR TITLE
cli: 'bones peek --page' lands on a specific Fossil page (default: timeline)

### DIFF
--- a/cli/peek.go
+++ b/cli/peek.go
@@ -23,7 +23,7 @@ import (
 // shells out to the canonical `fossil ui` for that.
 type PeekCmd struct {
 	Port int    `name:"port" help:"bind the UI on this port (default: fossil chooses)"`
-	Page string `name:"page" default:"timeline?y=ci&n=50" help:"fossil page to land on; e.g. 'timeline', 'brlist', 'dir'"`
+	Page string `name:"page" default:"timeline?y=ci&n=50" help:"fossil page (e.g. timeline)"`
 }
 
 func (c *PeekCmd) Run(g *libfossilcli.Globals) error {

--- a/cli/peek.go
+++ b/cli/peek.go
@@ -22,7 +22,8 @@ import (
 // /xfer for sync) does not implement the rich Fossil web UI; peek
 // shells out to the canonical `fossil ui` for that.
 type PeekCmd struct {
-	Port int `name:"port" help:"bind the UI on this port (default: fossil chooses)"`
+	Port int    `name:"port" help:"bind the UI on this port (default: fossil chooses)"`
+	Page string `name:"page" default:"timeline?y=ci&n=50" help:"fossil page to land on; e.g. 'timeline', 'brlist', 'dir'"`
 }
 
 func (c *PeekCmd) Run(g *libfossilcli.Globals) error {
@@ -57,6 +58,9 @@ func (c *PeekCmd) Run(g *libfossilcli.Globals) error {
 	args := []string{"ui", hubRepo}
 	if c.Port > 0 {
 		args = append(args, "--port", strconv.Itoa(c.Port))
+	}
+	if c.Page != "" {
+		args = append(args, "--page", c.Page)
 	}
 
 	fmt.Printf("peek: %s ui %s\n", fossilBin, hubRepo)

--- a/cli/peek.go
+++ b/cli/peek.go
@@ -1,0 +1,68 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+
+	libfossilcli "github.com/danmestas/libfossil/cli"
+
+	"github.com/danmestas/bones/internal/workspace"
+)
+
+// PeekCmd opens the workspace's hub Fossil repo in the system fossil
+// binary's web UI (timeline, branches, files). It is an *enhancement*,
+// not a hard dependency: when `fossil` isn't on PATH, peek prints the
+// hub repo path with a one-line install hint and exits cleanly.
+//
+// libfossil's embedded HTTP server (used by `bones hub start` to serve
+// /xfer for sync) does not implement the rich Fossil web UI; peek
+// shells out to the canonical `fossil ui` for that.
+type PeekCmd struct {
+	Port int `name:"port" help:"bind the UI on this port (default: fossil chooses)"`
+}
+
+func (c *PeekCmd) Run(g *libfossilcli.Globals) error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("cwd: %w", err)
+	}
+	info, err := workspace.Join(context.Background(), cwd)
+	if err != nil {
+		return fmt.Errorf("workspace: %w (run `bones init` first)", err)
+	}
+
+	hubRepo := filepath.Join(info.WorkspaceDir, ".orchestrator", "hub.fossil")
+	if _, err := os.Stat(hubRepo); err != nil {
+		return fmt.Errorf(
+			"hub repo not found at %s — run `bones up` or `bones hub start` first",
+			hubRepo,
+		)
+	}
+
+	fossilBin, lookErr := exec.LookPath("fossil")
+	if lookErr != nil {
+		fmt.Printf("peek: install fossil to open the rich timeline UI:\n")
+		fmt.Printf("  brew install fossil   # macOS / Linux (homebrew)\n")
+		fmt.Printf("  apt install fossil    # Debian / Ubuntu\n")
+		fmt.Printf("\n")
+		fmt.Printf("hub repo: %s\n", hubRepo)
+		fmt.Printf("(any Fossil-compatible tool can open this file directly)\n")
+		return nil
+	}
+
+	args := []string{"ui", hubRepo}
+	if c.Port > 0 {
+		args = append(args, "--port", strconv.Itoa(c.Port))
+	}
+
+	fmt.Printf("peek: %s ui %s\n", fossilBin, hubRepo)
+	cmd := exec.Command(fossilBin, args...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}

--- a/cmd/bones/cli.go
+++ b/cmd/bones/cli.go
@@ -28,6 +28,7 @@ type CLI struct {
 	// Tooling — used by humans authoring plans/skills.
 	ValidatePlan bonescli.ValidatePlanCmd `cmd:"" group:"tooling" help:"Validate plan"`
 	Orchestrator bonescli.OrchestratorCmd `cmd:"" group:"tooling" help:"Install orchestrator"`
+	Peek         bonescli.PeekCmd         `cmd:"" group:"tooling" help:"Open the hub repo in fossil's web UI (if installed)"`
 
 	// Plumbing — rarely invoked directly.
 	Init bonescli.InitCmd `cmd:"" group:"plumbing" help:"Create a workspace"`

--- a/cmd/bones/cli.go
+++ b/cmd/bones/cli.go
@@ -28,7 +28,7 @@ type CLI struct {
 	// Tooling — used by humans authoring plans/skills.
 	ValidatePlan bonescli.ValidatePlanCmd `cmd:"" group:"tooling" help:"Validate plan"`
 	Orchestrator bonescli.OrchestratorCmd `cmd:"" group:"tooling" help:"Install orchestrator"`
-	Peek         bonescli.PeekCmd         `cmd:"" group:"tooling" help:"Open the hub repo in fossil's web UI (if installed)"`
+	Peek         bonescli.PeekCmd         `cmd:"" group:"tooling" help:"Browse hub via fossil ui"`
 
 	// Plumbing — rarely invoked directly.
 	Init bonescli.InitCmd `cmd:"" group:"plumbing" help:"Create a workspace"`

--- a/docs/site/content/docs/reference/cli.md
+++ b/docs/site/content/docs/reference/cli.md
@@ -32,6 +32,7 @@ The `bones` binary is a single Kong-driven entry point covering workspace setup,
 |---|---|
 | `bones orchestrator` | Install orchestrator scaffolding (`.orchestrator/`) |
 | `bones validate-plan <path>` | Validate a slot-annotated plan; `--list-slots` emits JSON |
+| `bones peek` | Open the hub Fossil repo in the system `fossil ui` web view (timeline, branches, files). Optional enhancement — prints a one-line install hint and exits cleanly when `fossil` isn't on PATH. `--port=N` to pin the UI port. |
 
 ### Tasks
 


### PR DESCRIPTION
Follow-up to #39 ('bones peek').

Default \`--page=timeline?y=ci&n=50\` makes \`bones peek\` land directly on the rich check-in timeline (last 50 commits, filtered to checkins) — which is what users want when peeking at swarm work-in-progress. Previously it landed on Fossil's home page and required a second click.

Override with any Fossil page:
- \`bones peek\` — timeline (default)
- \`bones peek --page brlist\` — branches
- \`bones peek --page dir\` — file tree
- \`bones peek --page reportlist\` — tickets

Built on \`fossil ui --page\` (Fossil 2.x). Empty \`--page\` falls through to fossil's default.

## Test plan

- [x] \`go build ./...\`
- [x] \`make check\` — green
- [x] Manual: \`bones peek\` opens browser directly to the timeline view
- [x] Manual: \`bones peek --page brlist\` opens to branches view