### PR TITLE
cli/up: 'bones up' actually initializes the workspace (R1)

### DIFF
--- a/cli/up.go
+++ b/cli/up.go
@@ -1,24 +1,29 @@
 package cli
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"time"
+
+	"github.com/danmestas/bones/internal/workspace"
 )
 
 // runUp performs a full single-command bootstrap from a fresh clone:
-//  1. workspace init (idempotent — skips if already initialized)
+//  1. workspace init (idempotent — joins if already initialized)
 //  2. orchestrator scaffold (scripts, skills, hooks)
 //  3. build bin/leaf if missing
 //  4. run hub-bootstrap.sh and verify the hub is up
 func runUp(cwd string) error {
-	wsDir, err := ensureWorkspaceDir(cwd)
+	info, err := initOrJoinWorkspace(context.Background(), cwd)
 	if err != nil {
 		return fmt.Errorf("workspace: %w", err)
 	}
+	wsDir := info.WorkspaceDir
 	fmt.Printf("up: workspace at %s\n", wsDir)
 
 	if err := scaffoldOrchestrator(wsDir); err != nil {
@@ -41,34 +46,17 @@ func runUp(cwd string) error {
 	return nil
 }
 
-// ensureWorkspaceDir initializes a workspace at cwd if none exists, or
-// walks up to find an existing one. Returns the workspace root.
-func ensureWorkspaceDir(cwd string) (string, error) {
-	if wsDir := findWorkspaceDir(cwd); wsDir != "" {
-		return wsDir, nil
+// initOrJoinWorkspace returns workspace.Info for cwd, creating the
+// workspace if needed. New workspace → Init. Existing workspace → Join.
+// This replaces an earlier ensureWorkspaceDir helper that only mkdir'd
+// the marker dir and left config.json unwritten, which made every fresh
+// `bones up` produce a workspace that workspace.Join couldn't load.
+func initOrJoinWorkspace(ctx context.Context, cwd string) (workspace.Info, error) {
+	info, err := workspace.Init(ctx, cwd)
+	if errors.Is(err, workspace.ErrAlreadyInitialized) {
+		return workspace.Join(ctx, cwd)
 	}
-	if err := os.MkdirAll(cwd, 0o755); err != nil {
-		return "", err
-	}
-	markerDir := filepath.Join(cwd, ".bones")
-	if err := os.MkdirAll(markerDir, 0o755); err != nil {
-		return "", err
-	}
-	return cwd, nil
-}
-
-func findWorkspaceDir(dir string) string {
-	cur := dir
-	for {
-		if _, err := os.Stat(filepath.Join(cur, ".bones")); err == nil {
-			return cur
-		}
-		parent := filepath.Dir(cur)
-		if parent == cur {
-			return ""
-		}
-		cur = parent
-	}
+	return info, err
 }
 
 // ensureLeafBinary checks the standard leaf-binary locations used by

--- a/internal/workspace/migrate_test.go
+++ b/internal/workspace/migrate_test.go
@@ -63,24 +63,35 @@ func TestJoinErrorsWhenBothMarkersExist(t *testing.T) {
 	}
 }
 
-// TestInitMigratesLegacyMarker verifies that Init() also runs the
-// migration. After migration, Init should treat the migrated .bones/
-// as already-initialized rather than starting a second leaf.
+// TestInitMigratesLegacyMarker verifies that Init() runs the migration
+// when only a legacy .agent-infra/ exists. The migrated marker is
+// populated with a config.json (the marker-with-config invariant Init
+// now uses to decide already-initialized), so Init treats the post-
+// migration .bones/ as already-initialized — exactly like a real
+// pre-rename workspace would behave.
 func TestInitMigratesLegacyMarker(t *testing.T) {
 	dir := t.TempDir()
 	legacy := filepath.Join(dir, ".agent-infra")
 	if err := os.MkdirAll(legacy, 0o755); err != nil {
 		t.Fatal(err)
 	}
+	// Drop a populated config.json into the legacy marker so that, post-
+	// migration, .bones/ looks like a real already-initialized workspace.
+	cfg := []byte(
+		`{"version":1,"agent_id":"legacy","nats_url":"nats://x",` +
+			`"leaf_http_url":"http://x","repo_path":"/x",` +
+			`"created_at":"2026-01-01T00:00:00Z"}`,
+	)
+	if err := os.WriteFile(filepath.Join(legacy, "config.json"), cfg, 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	_, err := workspace.Init(context.Background(), dir)
-	// After migration, .bones/ exists and Init must short-circuit with
-	// ErrAlreadyInitialized (not attempt to spawn a leaf).
 	if err == nil {
-		t.Fatal("expected ErrAlreadyInitialized after migration")
+		t.Fatal("expected ErrAlreadyInitialized after migration of populated marker")
 	}
-	if _, statErr := os.Stat(filepath.Join(dir, ".bones")); statErr != nil {
-		t.Fatalf("expected .bones/ after migration: %v", statErr)
+	if _, statErr := os.Stat(filepath.Join(dir, ".bones", "config.json")); statErr != nil {
+		t.Fatalf("expected .bones/config.json after migration: %v", statErr)
 	}
 	if _, statErr := os.Stat(legacy); !os.IsNotExist(statErr) {
 		t.Fatalf("expected .agent-infra/ removed, got err=%v", statErr)

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -110,9 +110,12 @@ func instrumented(
 }
 
 // Init creates a fresh workspace rooted at cwd, starts a leaf daemon, and
-// returns its connection info. Returns ErrAlreadyInitialized if .bones/
-// already exists in cwd. A pre-rename .agent-infra/ marker is silently
-// migrated to .bones/ before the existence check.
+// returns its connection info. Returns ErrAlreadyInitialized only if a
+// fully-formed workspace (marker dir AND config.json) already exists.
+// An empty or partially-created marker dir is treated as a recoverable
+// state and Init proceeds — this fixes the case where 'bones up' had
+// previously mkdir'd .bones/ without writing config.json. A pre-rename
+// .agent-infra/ marker is silently migrated to .bones/ first.
 func Init(ctx context.Context, cwd string) (Info, error) {
 	return instrumented(ctx, "init", cwd, func(ctx context.Context) (Info, error) {
 		return initLogic(ctx, cwd)
@@ -124,10 +127,11 @@ func initLogic(ctx context.Context, cwd string) (Info, error) {
 		return Info{}, err
 	}
 	markerDir := filepath.Join(cwd, markerDirName)
-	if _, err := os.Stat(markerDir); err == nil {
+	configPath := filepath.Join(markerDir, "config.json")
+	if _, err := os.Stat(configPath); err == nil {
 		return Info{}, ErrAlreadyInitialized
 	} else if !errors.Is(err, os.ErrNotExist) {
-		return Info{}, fmt.Errorf("stat marker: %w", err)
+		return Info{}, fmt.Errorf("stat config: %w", err)
 	}
 
 	if err := os.MkdirAll(markerDir, 0o755); err != nil {

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -209,6 +209,39 @@ func killLeafPID(t *testing.T, pidPath string) {
 	_ = proc.Signal(syscall.SIGKILL)
 }
 
+// TestInit_RecoversFromEmptyMarker verifies that an empty .bones/
+// directory (e.g. left by a prior, incomplete `bones up` that mkdir'd
+// the marker without writing config.json) is treated as a recoverable
+// state. Init should proceed and produce a valid config.json — not
+// short-circuit with ErrAlreadyInitialized.
+func TestInit_RecoversFromEmptyMarker(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip in -short: spawns leaf")
+	}
+	requireLeafBinary(t)
+
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, markerDirName), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	info, err := Init(ctx, dir)
+	if err != nil {
+		t.Fatalf("Init on empty marker: %v", err)
+	}
+	t.Cleanup(func() { killLeafPID(t, filepath.Join(dir, markerDirName, "leaf.pid")) })
+
+	if _, statErr := os.Stat(filepath.Join(dir, markerDirName, "config.json")); statErr != nil {
+		t.Fatalf("expected config.json after recovery: %v", statErr)
+	}
+	if info.AgentID == "" {
+		t.Errorf("expected agent_id after recovery, got empty")
+	}
+}
+
 func TestInit_AlreadyInitialized(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skip in -short: spawns leaf")


### PR DESCRIPTION
## Summary

First of three small follow-ups from the 2026-04-28 swarm-demo retro (docs/code-review/2026-04-28-swarm-demo-retro.md §1).

\`bones up\`'s \`ensureWorkspaceDir\` helper only \`mkdir\`d \`.bones/\` and never wrote \`config.json\`. Every other verb (\`peek\`, \`tasks\`, \`hub\`, \`join\`) reads \`config.json\` via \`workspace.Join\` — so the next bones command after \`bones up\` failed with \"workspace: load config: read config: open .bones/config.json: no such file or directory.\" The workaround was \`rm -rf .bones && bones init\`.

## Fix

1. **\`cli/up.go\`:** \`runUp\` now calls \`workspace.Init\`, falling back to \`workspace.Join\` on \`ErrAlreadyInitialized\`. The marker dir + config.json + leaf daemon all land in one shot. Idempotent on re-run.
2. **\`internal/workspace/workspace.go\`:** \`Init\`'s already-initialized check now reads \`config.json\` instead of just the marker dir's existence. An empty marker (e.g. left by the prior bug) is recoverable, not a hard error.
3. **Test surface:**
   - \`TestInitMigratesLegacyMarker\` updated to seed a real \`config.json\` in the legacy marker before migration. (The prior test asserted \"empty migrated marker → ErrAlreadyInitialized,\" which was encoding the bug.)
   - **New** \`TestInit_RecoversFromEmptyMarker\` covers the recovery path directly.

## Test plan

- [x] \`make check\` — green
- [x] Manual smoke: \`rm -rf /tmp/x && mkdir /tmp/x && cd /tmp/x && git init -q && git ... commit && bones up\` produces a working workspace in one command (config.json present, leaf running, hub up)
- [x] Manual smoke: second \`bones up\` is idempotent (joins existing workspace, hub already up)

## Out of scope

- R5 (validate-plan nested slot dirs) — separate PR
- R2 (slot-user pre-seeding) — separate PR
- R4 (\`bones swarm join\` agent verb) — needs ADR first