### PR TITLE
validate-plan: derive slot dir by slot name (R5)

### DIFF
--- a/cli/testdata/invalid_files_outside_slot.md
+++ b/cli/testdata/invalid_files_outside_slot.md
@@ -1,8 +1,9 @@
-# Bad Plan
+# Bad Plan — file outside slot directory
 
 ## Phase 1: A [slot: alpha]
 
 ### Task 1 [slot: alpha]
 
 **Files:**
-- Modify: beta/x.go
+- Modify: src/alpha/x.go
+- Modify: pkg/alpha/y.go

--- a/cli/testdata/invalid_overlap.md
+++ b/cli/testdata/invalid_overlap.md
@@ -1,15 +1,15 @@
-# Bad Plan
+# Bad Plan — slot directory overlap
 
-## Phase 1: A [slot: alpha]
+## Phase 1: outer [slot: alpha]
 
 ### Task 1 [slot: alpha]
 
 **Files:**
-- Modify: shared/x.go
+- Modify: src/alpha/x.go
 
-## Phase 2: B [slot: beta]
+## Phase 2: inner [slot: beta]
 
 ### Task 2 [slot: beta]
 
 **Files:**
-- Modify: shared/y.go
+- Modify: src/alpha/beta/y.go

--- a/cli/validate_plan.go
+++ b/cli/validate_plan.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -129,7 +130,14 @@ func checkTasks(tasks []taskInfo) []string {
 		if t.slot == "" || len(t.files) == 0 {
 			continue
 		}
-		dir := topDir(t.files[0])
+		dir := slotDir(t.files[0], t.slot)
+		if dir == "" {
+			violations = append(violations, fmt.Sprintf(
+				"line %d: file %q has no path component matching slot %q",
+				t.line, t.files[0], t.slot,
+			))
+			continue
+		}
 		if existing, ok := slotDirs[t.slot]; ok && existing != dir {
 			violations = append(violations, fmt.Sprintf(
 				"line %d: slot %q used for both %q and %q",
@@ -141,24 +149,30 @@ func checkTasks(tasks []taskInfo) []string {
 	}
 	dirOwners := map[string]string{}
 	for slot, dir := range slotDirs {
-		if other, ok := dirOwners[dir]; ok && other != slot {
-			violations = append(violations, fmt.Sprintf(
-				"slot %q overlap with %q: both own directory %q",
-				slot, other, dir,
-			))
-		} else {
-			dirOwners[dir] = slot
+		for otherDir, otherSlot := range dirOwners {
+			if otherSlot == slot {
+				continue
+			}
+			if dirOverlap(dir, otherDir) {
+				violations = append(violations, fmt.Sprintf(
+					"slot %q overlap with %q: %q vs %q",
+					slot, otherSlot, dir, otherDir,
+				))
+			}
 		}
+		dirOwners[dir] = slot
 	}
 	for _, t := range tasks {
 		if t.slot == "" {
 			continue
 		}
+		want := slotDirs[t.slot]
 		for _, f := range t.files {
-			if topDir(f) != t.slot {
+			got := slotDir(f, t.slot)
+			if got != want {
 				violations = append(violations, fmt.Sprintf(
 					"line %d: file %q outside slot directory %q (slot=%s)",
-					t.line, f, t.slot, t.slot,
+					t.line, f, want, t.slot,
 				))
 			}
 		}
@@ -166,11 +180,42 @@ func checkTasks(tasks []taskInfo) []string {
 	return violations
 }
 
-func topDir(p string) string {
-	if i := strings.IndexAny(p, "/\\"); i >= 0 {
-		return p[:i]
+// slotDir returns the path to (and including) the LAST component of p
+// that equals slotName, e.g. slotDir("src/rendering/renderer.js",
+// "rendering") = "src/rendering". Empty when no path component matches
+// slotName. Lets slot directories live anywhere in the tree
+// ("rendering/" at root, "src/rendering/" nested under src, "pkg/foo/
+// rendering/" nested arbitrarily) without forcing the validator to
+// guess; the slot name in the plan IS the disambiguator.
+func slotDir(p, slotName string) string {
+	parts := strings.Split(filepath.ToSlash(p), "/")
+	lastIdx := -1
+	for i, part := range parts {
+		if part == slotName {
+			lastIdx = i
+		}
 	}
-	return p
+	if lastIdx < 0 {
+		return ""
+	}
+	return strings.Join(parts[:lastIdx+1], "/")
+}
+
+// dirOverlap returns true if a and b are equal, or one is a strict
+// path-component prefix of the other ("src/foo" overlaps "src/foo/bar"
+// but NOT "src/foobar"). Used to detect slot directories that would
+// shadow each other at the filesystem level.
+func dirOverlap(a, b string) bool {
+	if a == b {
+		return true
+	}
+	if strings.HasPrefix(a+"/", b+"/") {
+		return true
+	}
+	if strings.HasPrefix(b+"/", a+"/") {
+		return true
+	}
+	return false
 }
 
 type slotEntry struct {


### PR DESCRIPTION
## Summary

Second of three follow-ups from the 2026-04-28 swarm-demo retro (docs/code-review/2026-04-28-swarm-demo-retro.md §5).

\`validate-plan\`'s \`topDir(p)\` returned the first '/'-separated path component. Slots with files under a shared parent (e.g. \`src/rendering/\`, \`src/physics/\`, \`src/input/\`, \`src/audio/\`) all collided on \`src\`. The validator forced flat top-level slot directories, which is unnatural for any real codebase. The swarm-demo's plan was rejected; the demo skipped validation and moved on.

## Fix

Derive each slot's owned directory from the LAST path component matching the slot name. For \`[slot: rendering]\` with file \`src/rendering/renderer.js\` → owned dir is \`src/rendering\`. The slot name in the plan IS the disambiguator.

New helpers in \`cli/validate_plan.go\`:

\`\`\`go
slotDir(p, slotName)  // path up to and including last component == slotName
dirOverlap(a, b)      // path-component prefix overlap (not byte prefix)
\`\`\`

Replaces the old \`topDir(p)\` — gone.

## Test plan

- [x] \`make check\` — green
- [x] Existing fixture \`valid_plan.md\` (flat-top-level dirs \`alpha/\`, \`beta/\`) — still validates cleanly
- [x] Updated fixture \`invalid_overlap.md\` — \`src/alpha\` vs \`src/alpha/beta\` correctly flagged as overlap
- [x] Updated fixture \`invalid_files_outside_slot.md\` — slot \`alpha\` with files in \`src/alpha\` and \`pkg/alpha\` correctly flagged as outside
- [x] Manual smoke: the swarm-demo's nested plan (4 slots all under \`src/\`) now validates and \`--list-slots\` emits clean JSON

\`\`\`text
$ bones validate-plan /tmp/test-plan-nested.md
$ echo \$?
0

$ bones validate-plan /tmp/test-plan-overlap.md   # outer/inner nested
slot "inner" overlap with "outer": "src/outer/inner" vs "src/outer"
$ echo \$?
1
\`\`\`

## Out of scope

- R1 (\`bones up\` init) shipped as #41
- R2 (slot-user pre-seeding) — separate PR coming next
- R4 (\`bones swarm join\` agent verb) — needs ADR first