### PR TITLE
cli: 'bones hub user add/list' for swarm slot pre-seeding (R2)

### DIFF
--- a/cli/hub.go
+++ b/cli/hub.go
@@ -16,8 +16,10 @@ import (
 //
 // Subcommands:
 //
-//	hub start [--detach]   bring the hub up
-//	hub stop               tear it down
+//	hub start [--detach]    bring the hub up
+//	hub stop                tear it down
+//	hub user add <login>    pre-create a fossil user in the hub repo
+//	hub user list           list fossil users in the hub repo
 //
 // The shipped scripts under .orchestrator/scripts/ are thin shims around
 // these subcommands, kept for backward compatibility with .claude/settings.json
@@ -25,6 +27,7 @@ import (
 type HubCmd struct {
 	Start HubStartCmd `cmd:"" help:"Start the embedded Fossil hub + NATS server"`
 	Stop  HubStopCmd  `cmd:"" help:"Stop the embedded Fossil hub + NATS server"`
+	User  HubUserCmd  `cmd:"" help:"Manage fossil users in the hub repo"`
 }
 
 // HubStartCmd wires `bones hub start` flags to hub.Start.

--- a/cli/hub_user.go
+++ b/cli/hub_user.go
@@ -1,0 +1,109 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/danmestas/libfossil"
+	libfossilcli "github.com/danmestas/libfossil/cli"
+
+	"github.com/danmestas/bones/internal/workspace"
+)
+
+// HubUserCmd groups subcommands that manage the fossil user table on
+// the hub repo (.orchestrator/hub.fossil). The table is consulted by
+// every `fossil commit --user X` against that repo, so swarm slots that
+// commit under their own identity (slot-rendering, slot-physics, etc.)
+// must exist here first or fossil rejects the commit with "no such
+// user."
+//
+// This primitive is the manual escape hatch; future swarm-join tooling
+// will call into the same internal helpers automatically.
+type HubUserCmd struct {
+	Add  HubUserAddCmd  `cmd:"" help:"Add (or noop-if-exists) a user to the hub repo"`
+	List HubUserListCmd `cmd:"" help:"List users in the hub repo"`
+}
+
+// HubUserAddCmd creates a user in the hub repo. Idempotent: if the user
+// already exists, exits 0 without changing anything.
+type HubUserAddCmd struct {
+	Login string `arg:"" help:"login (e.g. slot-rendering)"`
+	Caps  string `name:"caps" default:"oih" help:"fossil caps (default: clone+checkin+history)"`
+}
+
+func (c *HubUserAddCmd) Run(g *libfossilcli.Globals) error {
+	repoPath, err := hubRepoPath()
+	if err != nil {
+		return err
+	}
+	repo, err := libfossil.Open(repoPath)
+	if err != nil {
+		return fmt.Errorf("open hub repo: %w", err)
+	}
+	defer func() { _ = repo.Close() }()
+
+	if _, err := repo.GetUser(c.Login); err == nil {
+		fmt.Printf("hub user %q already exists (no change)\n", c.Login)
+		return nil
+	}
+
+	if err := repo.CreateUser(libfossil.UserOpts{
+		Login: c.Login,
+		Caps:  c.Caps,
+	}); err != nil {
+		return fmt.Errorf("create user %q: %w", c.Login, err)
+	}
+	fmt.Printf("hub user %q created (caps=%s)\n", c.Login, c.Caps)
+	return nil
+}
+
+// HubUserListCmd prints the hub repo's user table.
+type HubUserListCmd struct{}
+
+func (c *HubUserListCmd) Run(g *libfossilcli.Globals) error {
+	repoPath, err := hubRepoPath()
+	if err != nil {
+		return err
+	}
+	repo, err := libfossil.Open(repoPath)
+	if err != nil {
+		return fmt.Errorf("open hub repo: %w", err)
+	}
+	defer func() { _ = repo.Close() }()
+
+	users, err := repo.ListUsers()
+	if err != nil {
+		return fmt.Errorf("list users: %w", err)
+	}
+	for _, u := range users {
+		fmt.Printf("%-30s caps=%s\n", u.Login, u.Caps)
+	}
+	return nil
+}
+
+// hubRepoPath finds the workspace from cwd and returns the hub repo path.
+// Surfaces clear errors when the workspace or repo isn't there yet.
+func hubRepoPath() (string, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("cwd: %w", err)
+	}
+	info, err := workspace.Join(context.Background(), cwd)
+	if err != nil {
+		return "", fmt.Errorf("workspace: %w (run `bones init` or `bones up` first)", err)
+	}
+	repoPath := filepath.Join(info.WorkspaceDir, ".orchestrator", "hub.fossil")
+	if _, err := os.Stat(repoPath); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return "", fmt.Errorf(
+				"hub repo not found at %s — run `bones up` or `bones hub start` first",
+				repoPath,
+			)
+		}
+		return "", fmt.Errorf("stat hub repo: %w", err)
+	}
+	return repoPath, nil
+}


### PR DESCRIPTION
## Summary

Third of three follow-ups from the 2026-04-28 swarm-demo retro (docs/code-review/2026-04-28-swarm-demo-retro.md §2, R2).

Fossil's commit path requires \`--user X\` to exist in the repo's user table. After \`bones up\` / \`bones hub start\` seeded only the \`orchestrator\` admin (plus the default \`nobody\` row), every swarm slot that tried to commit as its own identity (\`slot-rendering\`, \`slot-physics\`, etc.) hit \`fossil: no such user\` and had to self-recover by shelling out \`fossil user new <slot>\`. Each of four slots in the retro redundantly created its own user.

## Fix

Add the primitive directly to bones. New verbs under \`bones hub user\`:

\`\`\`
bones hub user add <login> [--caps=oih]   idempotent create
bones hub user list                        inspect the table
\`\`\`

Goes through libfossil's \`CreateUser\` / \`GetUser\` / \`ListUsers\` — no shell-out to the system \`fossil\` binary. Default caps \`oih\` (clone + check-in + history) is the minimum a slot needs to push commits; override via \`--caps\` for special roles.

Idempotent: re-adding an existing user is a no-op (no error).

## Test plan

- [x] \`make check\` — green
- [x] Smoke against a fresh workspace:
  - \`bones hub user list\` shows seed users (\`orchestrator\` caps=s, \`nobody\` caps=cghijknorswy)
  - \`bones hub user add slot-rendering\` → \`created (caps=oih)\`
  - \`bones hub user add slot-rendering\` (again) → \`already exists (no change)\`
  - \`bones hub user add slot-physics --caps=oihrw\` → created with custom caps
  - A subsequent \`fossil commit --user slot-rendering\` against the hub repo's checkout succeeds (timeline shows \`slot-rendering: smoke test\`)

## Out of scope

- R1 (\`bones up\` init) shipped as #41
- R5 (validate-plan nested slot dirs) shipped as #42
- R4 (\`bones swarm join\` agent verb) — needs ADR first; will call into this primitive automatically
- Auto-pre-seeding from a plan file (\`bones up --slots-from=PLAN.md\`) — possible future ergonomic, but the explicit primitive is the building block