### PR TITLE
Implement bones swarm verbs (R4 steps 1-6 + 8)

### DIFF
--- a/cli/doctor.go
+++ b/cli/doctor.go
@@ -1,0 +1,125 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	edgecli "github.com/danmestas/EdgeSync/cli"
+	libfossilcli "github.com/danmestas/libfossil/cli"
+
+	"github.com/danmestas/bones/internal/swarm"
+	"github.com/danmestas/bones/internal/workspace"
+)
+
+// DoctorCmd extends EdgeSync's doctor with bones-specific checks. The
+// embedded EdgeSync DoctorCmd runs the base health gate (Go runtime,
+// fossil, NATS reachability, hooks); then this wrapper adds the
+// swarm-session inventory described in ADR 0028 §"Process lifecycle
+// and crash recovery" so stuck or cross-host slots surface here.
+//
+// Embedded — not aliased — so EdgeSync's flags (--nats-url) still
+// participate in Kong parsing.
+type DoctorCmd struct {
+	edgecli.DoctorCmd
+}
+
+// Run invokes the EdgeSync doctor first; on completion (regardless
+// of pass/warn/fail) it appends a "swarm sessions" section that
+// iterates bones-swarm-sessions and reports each entry's state.
+func (c *DoctorCmd) Run(g *libfossilcli.Globals) error {
+	// The EdgeSync side returns an error on failed checks; surface
+	// that error AFTER our additional report so operators see the
+	// swarm picture even when an upstream check failed.
+	baseErr := c.DoctorCmd.Run(g)
+	swarmErr := c.runSwarmReport()
+	if baseErr != nil {
+		return baseErr
+	}
+	return swarmErr
+}
+
+// runSwarmReport prints the swarm-session inventory or a brief
+// "(no workspace)" line when the cwd is not inside a bones workspace.
+// Errors connecting to NATS surface as warnings rather than fail
+// the whole doctor — `bones doctor` is meant to be informational
+// even on a half-broken setup.
+func (c *DoctorCmd) runSwarmReport() error {
+	fmt.Println()
+	fmt.Println("=== bones swarm sessions ===")
+	cwd, err := os.Getwd()
+	if err != nil {
+		fmt.Printf("  WARN  cwd: %v\n", err)
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	info, err := workspace.Join(ctx, cwd)
+	if err != nil {
+		fmt.Printf("  INFO  not in a bones workspace (%v)\n", err)
+		return nil
+	}
+	mgr, closer, err := openSwarmManager(ctx, info)
+	if err != nil {
+		fmt.Printf("  WARN  open swarm manager: %v\n", err)
+		return nil
+	}
+	defer closer()
+	sessions, err := mgr.List(ctx)
+	if err != nil {
+		fmt.Printf("  WARN  list sessions: %v\n", err)
+		return nil
+	}
+	if len(sessions) == 0 {
+		fmt.Println("  OK    no active swarm sessions")
+		return nil
+	}
+	host, _ := os.Hostname()
+	stale := 0
+	remote := 0
+	dead := 0
+	for _, s := range sessions {
+		state := classifySwarmSession(s, host)
+		if state == "stale" || state == "remote-stale" {
+			stale++
+		}
+		if state == "remote" {
+			remote++
+		}
+		if state == "dead" {
+			dead++
+		}
+		fmt.Printf("  %-6s  slot=%-12s task=%s host=%s pid=%d\n",
+			labelFor(state), s.Slot, truncateID(s.TaskID, 8), s.Host, s.LeafPID)
+	}
+	if stale+remote+dead == 0 {
+		fmt.Printf("  OK    %d active session(s)\n", len(sessions))
+	} else {
+		fmt.Printf("  NOTE  %d active, %d remote, %d stale, %d dead\n",
+			len(sessions)-stale-remote-dead, remote, stale, dead)
+	}
+	return nil
+}
+
+// classifySwarmSession reuses the same state model swarm status uses
+// (the function lives in cli/swarm_status.go) but presented for
+// doctor output. Indirection keeps both consumers symmetric.
+func classifySwarmSession(s swarm.Session, host string) string {
+	staleSec := int64(time.Since(s.LastRenewed).Seconds())
+	return classifyState(s, host, staleSec)
+}
+
+func labelFor(state string) string {
+	switch state {
+	case "active":
+		return "OK"
+	case "remote":
+		return "OK"
+	case "stale", "remote-stale":
+		return "WARN"
+	case "dead":
+		return "FAIL"
+	}
+	return "INFO"
+}

--- a/cli/swarm.go
+++ b/cli/swarm.go
@@ -1,0 +1,82 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/nats-io/nats.go"
+
+	"github.com/danmestas/bones/internal/swarm"
+	"github.com/danmestas/bones/internal/workspace"
+)
+
+// SwarmCmd groups the agent-shaped swarm verbs introduced in ADR
+// 0028: per-slot leaf lifecycle wrapped around coord.Leaf so
+// subagent prompts shrink from ~12 substrate calls to ~5 swarm verbs.
+//
+// All verbs are workspace-local (joinWorkspace from cwd). Agent
+// prompts run them as plain shell commands; the orchestrator skill
+// (R6 follow-up) renders them inline.
+type SwarmCmd struct {
+	Join   SwarmJoinCmd   `cmd:"" help:"Open a leaf, claim a task, prepare a worktree"`
+	Commit SwarmCommitCmd `cmd:"" help:"Commit changes (heartbeats the session)"`
+	Close  SwarmCloseCmd  `cmd:"" help:"Release claim, post result, stop the leaf"`
+	Status SwarmStatusCmd `cmd:"" help:"List active swarm sessions"`
+	Cwd    SwarmCwdCmd    `cmd:"" help:"Print the slot's worktree path"`
+	Tasks  SwarmTasksCmd  `cmd:"" help:"List ready tasks matching slot"`
+}
+
+// openSwarmManager dials NATS for the workspace and opens a swarm
+// Manager bound to the bones-swarm-sessions bucket. Caller closes
+// the Manager and the returned closer to release the NATS conn.
+//
+// Pulled into a helper because every swarm verb opens the Manager
+// the same way and the verbs are otherwise small.
+func openSwarmManager(
+	ctx context.Context, info workspace.Info,
+) (*swarm.Manager, func(), error) {
+	nc, err := nats.Connect(info.NATSURL)
+	if err != nil {
+		return nil, nil, fmt.Errorf("nats connect: %w", err)
+	}
+	m, err := swarm.Open(ctx, swarm.Config{NATSConn: nc})
+	if err != nil {
+		nc.Close()
+		return nil, nil, fmt.Errorf("swarm.Open: %w", err)
+	}
+	return m, func() {
+		_ = m.Close()
+		nc.Close()
+	}, nil
+}
+
+// resolveSlot picks the slot to operate on for verbs that allow
+// single-slot inference (commit, close). When flag is non-empty,
+// returns it. Otherwise, lists active sessions on this host and
+// returns the unique active slot. Errors if zero or more than one
+// session matches.
+func resolveSlot(ctx context.Context, m *swarm.Manager, flag, host string) (string, error) {
+	if flag != "" {
+		return flag, nil
+	}
+	sessions, err := m.List(ctx)
+	if err != nil {
+		return "", fmt.Errorf("list sessions: %w", err)
+	}
+	var matches []string
+	for _, s := range sessions {
+		if s.Host == host {
+			matches = append(matches, s.Slot)
+		}
+	}
+	if len(matches) == 0 {
+		return "", fmt.Errorf("no active swarm session on this host (pass --slot)")
+	}
+	if len(matches) > 1 {
+		return "", fmt.Errorf(
+			"multiple active swarm sessions on this host (%v) — pass --slot",
+			matches,
+		)
+	}
+	return matches[0], nil
+}

--- a/cli/swarm_close.go
+++ b/cli/swarm_close.go
@@ -28,7 +28,7 @@ type SwarmCloseCmd struct {
 	Summary string `name:"summary" default:"swarm close" help:"final summary posted to task thread"`
 	Branch  string `name:"branch" help:"only with --result=fork: branch name"`
 	Rev     string `name:"rev" help:"only with --result=fork: rev"`
-	HubURL  string `name:"hub-url" help:"override hub fossil HTTP URL (default: http://127.0.0.1:8765)"`
+	HubURL  string `name:"hub-url" help:"override hub fossil HTTP URL"`
 }
 
 func (c *SwarmCloseCmd) Run(g *libfossilcli.Globals) error {

--- a/cli/swarm_close.go
+++ b/cli/swarm_close.go
@@ -1,0 +1,179 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+
+	libfossilcli "github.com/danmestas/libfossil/cli"
+
+	"github.com/danmestas/bones/internal/coord"
+	"github.com/danmestas/bones/internal/dispatch"
+	"github.com/danmestas/bones/internal/swarm"
+	"github.com/danmestas/bones/internal/workspace"
+)
+
+// SwarmCloseCmd ends a swarm session: posts a dispatch.ResultMessage
+// to the task thread, releases the claim hold, optionally closes the
+// task in NATS KV (on result=success), stops the leaf process, and
+// deletes the session record from bones-swarm-sessions.
+//
+// Idempotent against partial-cleanup states: missing pid file or
+// already-deleted session are not errors so re-running close after a
+// crash converges.
+type SwarmCloseCmd struct {
+	Slot    string `name:"slot" help:"slot name (defaults to single active slot on this host)"`
+	Result  string `name:"result" default:"success" help:"success|fail|fork"`
+	Summary string `name:"summary" default:"swarm close" help:"final summary posted to task thread"`
+	Branch  string `name:"branch" help:"only with --result=fork: branch name"`
+	Rev     string `name:"rev" help:"only with --result=fork: rev"`
+	HubURL  string `name:"hub-url" help:"override hub fossil HTTP URL (default: http://127.0.0.1:8765)"`
+}
+
+func (c *SwarmCloseCmd) Run(g *libfossilcli.Globals) error {
+	ctx, stop, info, err := joinWorkspace()
+	if err != nil {
+		return err
+	}
+	defer stop()
+	return c.run(ctx, info)
+}
+
+func (c *SwarmCloseCmd) run(ctx context.Context, info workspace.Info) error {
+	if err := c.validateResult(); err != nil {
+		return err
+	}
+	mgr, closeMgr, err := openSwarmManager(ctx, info)
+	if err != nil {
+		return err
+	}
+	defer closeMgr()
+
+	host, _ := os.Hostname()
+	slot, err := resolveSlot(ctx, mgr, c.Slot, host)
+	if err != nil {
+		return err
+	}
+	sess, rev, err := mgr.Get(ctx, slot)
+	if err != nil {
+		if errors.Is(err, swarm.ErrNotFound) {
+			fmt.Fprintf(os.Stderr, "swarm close: no session for slot %q (already closed?)\n", slot)
+			return nil
+		}
+		return fmt.Errorf("read session: %w", err)
+	}
+
+	if err := c.postResult(ctx, info, sess); err != nil {
+		fmt.Fprintf(os.Stderr, "swarm close: warning: post result failed: %v\n", err)
+	}
+	if err := c.releaseAndMaybeCloseTask(ctx, info, slot, sess); err != nil {
+		fmt.Fprintf(os.Stderr, "swarm close: warning: release/close failed: %v\n", err)
+	}
+	if err := c.removePidFile(info, slot); err != nil {
+		fmt.Fprintf(os.Stderr, "swarm close: warning: remove pid file failed: %v\n", err)
+	}
+	if err := mgr.Delete(ctx, slot, rev); err != nil {
+		// Tolerate ErrCASConflict / ErrNotFound — another close ran
+		// in parallel and we converged on the same end state.
+		if !errors.Is(err, swarm.ErrCASConflict) && !errors.Is(err, swarm.ErrNotFound) {
+			return fmt.Errorf("delete session record: %w", err)
+		}
+	}
+	fmt.Fprintf(os.Stderr,
+		"swarm close: slot=%s task=%s result=%s\n",
+		slot, sess.TaskID, c.Result,
+	)
+	return nil
+}
+
+func (c *SwarmCloseCmd) validateResult() error {
+	switch dispatch.ResultKind(c.Result) {
+	case dispatch.ResultSuccess, dispatch.ResultFail, dispatch.ResultFork:
+		return nil
+	}
+	return fmt.Errorf("--result must be success|fail|fork (got %q)", c.Result)
+}
+
+// postResult publishes a dispatch.ResultMessage onto the task thread
+// (subject derived from the task ID). Mirrors the worker side of
+// cli/tasks_dispatch.go's flow so a parent dispatch handler picks up
+// the close.
+func (c *SwarmCloseCmd) postResult(
+	ctx context.Context, info workspace.Info, sess swarm.Session,
+) error {
+	cfg := newCoordConfig(info)
+	cfg.AgentID = sess.AgentID
+	cfg.ProjectPrefix = coord.DeriveProjectPrefix(info.AgentID)
+	co, err := coord.Open(ctx, cfg)
+	if err != nil {
+		return fmt.Errorf("open coord for result post: %w", err)
+	}
+	defer func() { _ = co.Close() }()
+	msg := dispatch.ResultMessage{
+		Kind:    dispatch.ResultKind(c.Result),
+		Summary: c.Summary,
+		Branch:  c.Branch,
+		Rev:     c.Rev,
+	}
+	thread := sess.TaskID
+	if err := co.Post(ctx, thread, []byte(dispatch.FormatResult(msg))); err != nil {
+		return fmt.Errorf("post result: %w", err)
+	}
+	return nil
+}
+
+// releaseAndMaybeCloseTask re-opens the slot's leaf, takes the claim
+// just long enough to release it (and on result=success, calls
+// Leaf.Close which also closes the task in KV), then stops the leaf.
+//
+// The double-Claim/Release here looks redundant — the swarm session
+// already represents an active claim from `swarm join`. But Leaf
+// objects are per-process: this CLI invocation never saw the join's
+// *Leaf or *Claim, so it must reconstruct them. The CAS-gated holds
+// bucket lets the second Claim succeed (same agent ID = idempotent
+// renew).
+func (c *SwarmCloseCmd) releaseAndMaybeCloseTask(
+	ctx context.Context, info workspace.Info, slot string, sess swarm.Session,
+) error {
+	hubURL := c.HubURL
+	if hubURL == "" {
+		hubURL = defaultHubFossilURL
+	}
+	swarmRoot := info.WorkspaceDir + "/.bones/swarm"
+	leaf, err := coord.OpenLeaf(ctx, coord.LeafConfig{
+		HubAddrs: coord.HubAddrs{
+			NATSClient: info.NATSURL,
+			HTTPAddr:   hubURL,
+		},
+		Workdir:    swarmRoot,
+		SlotID:     slot,
+		FossilUser: sess.AgentID,
+	})
+	if err != nil {
+		return fmt.Errorf("open leaf: %w", err)
+	}
+	defer func() { _ = leaf.Stop() }()
+
+	claim, err := leaf.Claim(ctx, coord.TaskID(sess.TaskID))
+	if err != nil {
+		// If the task is already closed the Claim returns
+		// ErrTaskAlreadyClaimed/NotFound; either way the holds are gone
+		// and we're done.
+		return fmt.Errorf("re-claim for close: %w", err)
+	}
+	if c.Result == string(dispatch.ResultSuccess) {
+		// Leaf.Close closes the task AND releases via the claim's
+		// release closure.
+		return leaf.Close(ctx, claim)
+	}
+	return claim.Release()
+}
+
+func (c *SwarmCloseCmd) removePidFile(info workspace.Info, slot string) error {
+	pidPath := swarm.SlotPidFile(info.WorkspaceDir, slot)
+	if err := os.Remove(pidPath); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}

--- a/cli/swarm_commit.go
+++ b/cli/swarm_commit.go
@@ -25,7 +25,7 @@ type SwarmCommitCmd struct {
 	Slot    string   `name:"slot" help:"slot name (defaults to single active slot on this host)"`
 	Message string   `name:"message" short:"m" required:"" help:"commit message"`
 	Files   []string `arg:"" optional:"" help:"files to commit (default: all modified)"`
-	HubURL  string   `name:"hub-url" help:"override hub fossil HTTP URL (default: http://127.0.0.1:8765)"`
+	HubURL  string   `name:"hub-url" help:"override hub fossil HTTP URL"`
 }
 
 func (c *SwarmCommitCmd) Run(g *libfossilcli.Globals) error {
@@ -81,24 +81,28 @@ func (c *SwarmCommitCmd) run(ctx context.Context, info workspace.Info) error {
 		fmt.Fprintf(os.Stderr, "swarm commit: warning: renew session failed: %v\n", err)
 	}
 	fmt.Printf("%s\n", uuid)
-	fmt.Fprintf(os.Stderr, "swarm commit: slot=%s task=%s files=%d\n", slot, sess.TaskID, len(files))
+	fmt.Fprintf(os.Stderr,
+		"swarm commit: slot=%s task=%s files=%d\n",
+		slot, sess.TaskID, len(files))
 	return nil
 }
 
 // assertSessionLocal returns an error if the session's host does not
 // match this machine. Cross-host commit attempts are programmer
 // errors per ADR 0028 §"Process lifecycle and crash recovery".
+//
+// Phase 1 does NOT check leaf pid liveness: every swarm verb is a
+// self-contained CLI invocation that opens its own leaf, so the
+// session's recorded pid (the join's bones process) is naturally
+// dead by the time commit runs. Future detached-leaf work (per ADR
+// 0028 §"Process lifecycle") will reintroduce a "leaf still
+// running?" check; for now the leaf.fossil file's mere existence is
+// the cross-invocation handle.
 func (c *SwarmCommitCmd) assertSessionLocal(sess swarm.Session, host string) error {
 	if sess.Host != host {
 		return fmt.Errorf(
 			"slot %q is owned by host %q (this machine is %q) — cross-host operation refused",
 			sess.Slot, sess.Host, host,
-		)
-	}
-	if sess.LeafPID > 0 && !pidAlive(sess.LeafPID) {
-		return fmt.Errorf(
-			"leaf for slot %q (pid %d) is not running — run `bones swarm join --force` to recover",
-			sess.Slot, sess.LeafPID,
 		)
 	}
 	return nil
@@ -135,18 +139,28 @@ func (c *SwarmCommitCmd) openLeafForCommit(
 // the caller listed files explicitly, read them from the slot's
 // worktree. Otherwise, surface a clear error: explicit-file commit is
 // required for now (auto-discovery of modified files is a follow-up).
+//
+// Each File.Path is set to the absolute workspace path so the
+// holds-gate (Invariant 4 / coord.checkHolds) sees a key matching
+// the absolute path the task record carries. libfossil's
+// normalizeLeadingSlash trims the leading slash to derive its
+// relative-to-repo Name, so the same Path field works as both the
+// hold key and the commit target.
 func (c *SwarmCommitCmd) gatherFiles(info workspace.Info, slot string) ([]coord.File, error) {
 	if len(c.Files) == 0 {
 		return nil, fmt.Errorf(
-			"swarm commit: at least one file argument required (auto-discovery of dirty files is not yet implemented)",
+			"swarm commit: at least one file argument required" +
+				" (auto-discovery of dirty files is not yet implemented)",
 		)
 	}
 	wt := swarm.SlotWorktree(info.WorkspaceDir, slot)
 	out := make([]coord.File, 0, len(c.Files))
 	for _, rel := range c.Files {
-		// Strip a leading slot/wt/ prefix if present so callers can
-		// pass either "src/foo.go" (relative to wt) or
-		// ".bones/swarm/<slot>/wt/src/foo.go" (relative to workspace).
+		// Strip prefixes so callers can pass any of:
+		//   "src/foo.go"                              (rel to wt)
+		//   "wt/src/foo.go"                           (rel to slot)
+		//   ".bones/swarm/<slot>/wt/src/foo.go"       (rel to workspace)
+		//   "/abs/path/to/.bones/swarm/<slot>/wt/foo" (absolute)
 		clean := strings.TrimPrefix(rel, wt+string(os.PathSeparator))
 		clean = strings.TrimPrefix(clean, "wt/")
 		abs := filepath.Join(wt, clean)
@@ -154,7 +168,11 @@ func (c *SwarmCommitCmd) gatherFiles(info workspace.Info, slot string) ([]coord.
 		if err != nil {
 			return nil, fmt.Errorf("read %s: %w", abs, err)
 		}
-		out = append(out, coord.File{Path: clean, Content: data})
+		// Prefer the workspace-relative absolute path on the task's
+		// files list — that is what was registered in the holds
+		// bucket. Search via filepath.Join(workspaceDir, ...).
+		taskPath := filepath.Join(info.WorkspaceDir, clean)
+		out = append(out, coord.File{Path: taskPath, Content: data})
 	}
 	return out, nil
 }

--- a/cli/swarm_commit.go
+++ b/cli/swarm_commit.go
@@ -1,0 +1,197 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	libfossilcli "github.com/danmestas/libfossil/cli"
+
+	"github.com/danmestas/bones/internal/coord"
+	"github.com/danmestas/bones/internal/swarm"
+	"github.com/danmestas/bones/internal/workspace"
+)
+
+// SwarmCommitCmd commits in-flight changes from the slot's worktree
+// to the slot's leaf, triggering a sync round to the hub. Heartbeats
+// the swarm session record (extends TTL via CAS).
+//
+// Files default to "all modified files in wt/" if no positional
+// arguments are passed.
+type SwarmCommitCmd struct {
+	Slot    string   `name:"slot" help:"slot name (defaults to single active slot on this host)"`
+	Message string   `name:"message" short:"m" required:"" help:"commit message"`
+	Files   []string `arg:"" optional:"" help:"files to commit (default: all modified)"`
+	HubURL  string   `name:"hub-url" help:"override hub fossil HTTP URL (default: http://127.0.0.1:8765)"`
+}
+
+func (c *SwarmCommitCmd) Run(g *libfossilcli.Globals) error {
+	ctx, stop, info, err := joinWorkspace()
+	if err != nil {
+		return err
+	}
+	defer stop()
+	return c.run(ctx, info)
+}
+
+func (c *SwarmCommitCmd) run(ctx context.Context, info workspace.Info) error {
+	mgr, closeMgr, err := openSwarmManager(ctx, info)
+	if err != nil {
+		return err
+	}
+	defer closeMgr()
+
+	host, _ := os.Hostname()
+	slot, err := resolveSlot(ctx, mgr, c.Slot, host)
+	if err != nil {
+		return err
+	}
+	sess, rev, err := mgr.Get(ctx, slot)
+	if err != nil {
+		if errors.Is(err, swarm.ErrNotFound) {
+			return fmt.Errorf("no active swarm session for slot %q (run `bones swarm join`)", slot)
+		}
+		return fmt.Errorf("read session: %w", err)
+	}
+	if err := c.assertSessionLocal(sess, host); err != nil {
+		return err
+	}
+	leaf, err := c.openLeafForCommit(ctx, info, slot)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = leaf.Stop() }()
+
+	files, err := c.gatherFiles(info, slot)
+	if err != nil {
+		return err
+	}
+	uuid, err := c.commitViaLeaf(ctx, leaf, sess.TaskID, files)
+	if err != nil {
+		return err
+	}
+	if err := c.renewSession(ctx, mgr, sess, rev); err != nil {
+		// Commit succeeded; failing to extend the heartbeat is a
+		// soft error — log and return non-zero so the caller knows
+		// the session may TTL out, but don't pretend the commit
+		// didn't happen.
+		fmt.Fprintf(os.Stderr, "swarm commit: warning: renew session failed: %v\n", err)
+	}
+	fmt.Printf("%s\n", uuid)
+	fmt.Fprintf(os.Stderr, "swarm commit: slot=%s task=%s files=%d\n", slot, sess.TaskID, len(files))
+	return nil
+}
+
+// assertSessionLocal returns an error if the session's host does not
+// match this machine. Cross-host commit attempts are programmer
+// errors per ADR 0028 §"Process lifecycle and crash recovery".
+func (c *SwarmCommitCmd) assertSessionLocal(sess swarm.Session, host string) error {
+	if sess.Host != host {
+		return fmt.Errorf(
+			"slot %q is owned by host %q (this machine is %q) — cross-host operation refused",
+			sess.Slot, sess.Host, host,
+		)
+	}
+	if sess.LeafPID > 0 && !pidAlive(sess.LeafPID) {
+		return fmt.Errorf(
+			"leaf for slot %q (pid %d) is not running — run `bones swarm join --force` to recover",
+			sess.Slot, sess.LeafPID,
+		)
+	}
+	return nil
+}
+
+// openLeafForCommit re-attaches to the slot's already-cloned
+// leaf.fossil. coord.OpenLeaf is idempotent on the clone (skips when
+// leaf.fossil exists), so this resumes the existing slot rather than
+// double-cloning.
+func (c *SwarmCommitCmd) openLeafForCommit(
+	ctx context.Context, info workspace.Info, slot string,
+) (*coord.Leaf, error) {
+	hubURL := c.HubURL
+	if hubURL == "" {
+		hubURL = defaultHubFossilURL
+	}
+	swarmRoot := filepath.Join(info.WorkspaceDir, ".bones", "swarm")
+	leaf, err := coord.OpenLeaf(ctx, coord.LeafConfig{
+		HubAddrs: coord.HubAddrs{
+			NATSClient: info.NATSURL,
+			HTTPAddr:   hubURL,
+		},
+		Workdir:    swarmRoot,
+		SlotID:     slot,
+		FossilUser: "slot-" + slot,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("re-open leaf: %w", err)
+	}
+	return leaf, nil
+}
+
+// gatherFiles materializes the file set passed to Leaf.Commit. When
+// the caller listed files explicitly, read them from the slot's
+// worktree. Otherwise, surface a clear error: explicit-file commit is
+// required for now (auto-discovery of modified files is a follow-up).
+func (c *SwarmCommitCmd) gatherFiles(info workspace.Info, slot string) ([]coord.File, error) {
+	if len(c.Files) == 0 {
+		return nil, fmt.Errorf(
+			"swarm commit: at least one file argument required (auto-discovery of dirty files is not yet implemented)",
+		)
+	}
+	wt := swarm.SlotWorktree(info.WorkspaceDir, slot)
+	out := make([]coord.File, 0, len(c.Files))
+	for _, rel := range c.Files {
+		// Strip a leading slot/wt/ prefix if present so callers can
+		// pass either "src/foo.go" (relative to wt) or
+		// ".bones/swarm/<slot>/wt/src/foo.go" (relative to workspace).
+		clean := strings.TrimPrefix(rel, wt+string(os.PathSeparator))
+		clean = strings.TrimPrefix(clean, "wt/")
+		abs := filepath.Join(wt, clean)
+		data, err := os.ReadFile(abs)
+		if err != nil {
+			return nil, fmt.Errorf("read %s: %w", abs, err)
+		}
+		out = append(out, coord.File{Path: clean, Content: data})
+	}
+	return out, nil
+}
+
+// commitViaLeaf re-claims the active task on the freshly-opened
+// *Leaf so Leaf.Commit's hold-gate sees the claim, then commits and
+// releases (the session record keeps the swarm hold across processes
+// on the bones-holds bucket — claim-release here only undoes the
+// re-claim we just took, not the underlying session ownership).
+func (c *SwarmCommitCmd) commitViaLeaf(
+	ctx context.Context, leaf *coord.Leaf, taskID string, files []coord.File,
+) (string, error) {
+	claim, err := leaf.Claim(ctx, coord.TaskID(taskID))
+	if err != nil {
+		return "", fmt.Errorf("re-claim task %q: %w", taskID, err)
+	}
+	defer func() { _ = claim.Release() }()
+	uuid, err := leaf.Commit(ctx, claim, files)
+	if err != nil {
+		return "", fmt.Errorf("leaf commit: %w", err)
+	}
+	return uuid, nil
+}
+
+// renewSession bumps LastRenewed via CAS so the bucket TTL extends.
+// CAS conflict means a sibling renewer raced ours — we treat that as
+// success because the other writer's update already extended the
+// bucket TTL.
+func (c *SwarmCommitCmd) renewSession(
+	ctx context.Context, mgr *swarm.Manager, sess swarm.Session, rev uint64,
+) error {
+	sess.LastRenewed = timeNow()
+	if err := mgr.Update(ctx, sess, rev); err != nil {
+		if errors.Is(err, swarm.ErrCASConflict) {
+			return nil
+		}
+		return err
+	}
+	return nil
+}

--- a/cli/swarm_cwd.go
+++ b/cli/swarm_cwd.go
@@ -1,0 +1,37 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	libfossilcli "github.com/danmestas/libfossil/cli"
+
+	"github.com/danmestas/bones/internal/swarm"
+	"github.com/danmestas/bones/internal/workspace"
+)
+
+// SwarmCwdCmd prints the slot's worktree path on stdout. Designed for
+// shell substitution:
+//
+//	cd "$(bones swarm cwd --slot=rendering)"
+//
+// Pure path derivation — no NATS round-trip, no KV lookup. Only
+// requires a workspace context to compute the absolute path. Callers
+// who want the wt path AND a liveness check should use `swarm status`.
+type SwarmCwdCmd struct {
+	Slot string `name:"slot" required:"" help:"slot name"`
+}
+
+func (c *SwarmCwdCmd) Run(g *libfossilcli.Globals) error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("cwd: %w", err)
+	}
+	info, err := workspace.Join(context.Background(), cwd)
+	if err != nil {
+		return err
+	}
+	fmt.Println(swarm.SlotWorktree(info.WorkspaceDir, c.Slot))
+	return nil
+}

--- a/cli/swarm_helpers.go
+++ b/cli/swarm_helpers.go
@@ -1,0 +1,33 @@
+package cli
+
+import (
+	"os"
+	"syscall"
+	"time"
+)
+
+// pidAlive reports whether pid is a live process this user can signal.
+// Signal 0 is the standard "is the kernel still tracking this pid"
+// probe — it performs the lookup without delivering anything. Any
+// error (no such process, permission denied, malformed pid) returns
+// false. Mirrors internal/workspace/verify.go's helper, duplicated
+// here so the cli package does not import internal/workspace's
+// unexported function. ADR 0028 §"Process lifecycle and crash
+// recovery" calls out this exact probe.
+func pidAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	return proc.Signal(syscall.Signal(0)) == nil
+}
+
+// timeNow is the time source for swarm verbs. Plain wrapper today;
+// pulled into a function so future test-time injection (e.g. a fixed
+// clock in unit tests) is a one-line change rather than a refactor.
+func timeNow() time.Time {
+	return time.Now().UTC()
+}

--- a/cli/swarm_join.go
+++ b/cli/swarm_join.go
@@ -37,18 +37,18 @@ type SwarmJoinCmd struct {
 	TaskID        string `name:"task-id" required:"" help:"open task id to claim"`
 	Caps          string `name:"caps" default:"oih" help:"fossil caps for the slot user"`
 	ForceTakeover bool   `name:"force" help:"clobber an existing slot session (recovery only)"`
-	HubURL        string `name:"hub-url" help:"override hub fossil HTTP URL (default: http://127.0.0.1:8765)"`
+	HubURL        string `name:"hub-url" help:"override hub fossil HTTP URL"`
 }
 
 // Run implements the join flow per ADR 0028 §"swarm join":
 //
-//	1. Open workspace.
-//	2. Ensure slot user in hub repo (idempotent).
-//	3. Verify no live session record on this slot (or --force).
-//	4. coord.OpenLeaf rooted at .bones/swarm/<slot>/.
-//	5. Claim the task via Leaf.Claim.
-//	6. Write session record to bones-swarm-sessions[<slot>].
-//	7. Print BONES_SLOT_WT=<wt path> for shell sourcing.
+//  1. Open workspace.
+//  2. Ensure slot user in hub repo (idempotent).
+//  3. Verify no live session record on this slot (or --force).
+//  4. coord.OpenLeaf rooted at .bones/swarm/<slot>/.
+//  5. Claim the task via Leaf.Claim.
+//  6. Write session record to bones-swarm-sessions[<slot>].
+//  7. Print BONES_SLOT_WT=<wt path> for shell sourcing.
 func (c *SwarmJoinCmd) Run(g *libfossilcli.Globals) error {
 	ctx, stop, info, err := joinWorkspace()
 	if err != nil {
@@ -80,10 +80,14 @@ func (c *SwarmJoinCmd) run(ctx context.Context, info workspace.Info) error {
 		_ = leaf.Stop()
 		return fmt.Errorf("claim task: %w", err)
 	}
-	// Don't release the claim on success — it stays held until
-	// `swarm close` runs. We DO release on any failure between here
-	// and the session-record write so a half-formed session does not
-	// leak a hold.
+	// Release the claim once the session record is persisted. The
+	// underlying hold survives only as long as its TTL — but the
+	// session record is the durable handle for `swarm commit` and
+	// `swarm close` to re-claim atomically by slot identity. Phase
+	// 1 trades hold persistence across verbs for implementation
+	// simplicity; subsequent commit/close re-take the claim each
+	// time. ADR 0028 §"Process lifecycle" outlines the future
+	// detached-leaf design that would change this.
 	if err := c.writeSession(ctx, mgr, info); err != nil {
 		_ = claim.Release()
 		_ = leaf.Stop()
@@ -95,6 +99,8 @@ func (c *SwarmJoinCmd) run(ctx context.Context, info workspace.Info) error {
 		return err
 	}
 	c.emitJoinReport(info, leaf)
+	_ = claim.Release()
+	_ = leaf.Stop()
 	return nil
 }
 
@@ -148,12 +154,14 @@ func (c *SwarmJoinCmd) checkExistingSession(
 		switch {
 		case existing.Host == host && existing.LeafPID > 0 && pidAlive(existing.LeafPID):
 			return fmt.Errorf(
-				"slot %q already has a live session on this host (pid %d) — pass --force to take over",
+				"slot %q already has a live session on this host"+
+					" (pid %d) — pass --force to take over",
 				c.Slot, existing.LeafPID,
 			)
 		case existing.Host != host:
 			return fmt.Errorf(
-				"slot %q is owned by host %q (pid %d) — refusing to take over; pass --force on the owning host",
+				"slot %q is owned by host %q (pid %d) — refusing"+
+					" to take over; pass --force on the owning host",
 				c.Slot, existing.Host, existing.LeafPID,
 			)
 		}
@@ -168,6 +176,14 @@ func (c *SwarmJoinCmd) checkExistingSession(
 // .bones/swarm directory. Uses HubAddrs (URL-string variant of
 // LeafConfig) because the hub runs in a separate process and the
 // agent-side bones binary cannot share an in-process *Hub.
+//
+// Phase 1 invariant: the bones CLI itself is the leaf-host process —
+// each swarm verb opens a fresh *Leaf, does its work, then stops it
+// at end of the verb. Process-detach (per ADR 0028 §"Process
+// lifecycle") is future work; the current contract is "every verb
+// is a self-contained invocation against the persisted leaf.fossil."
+// This keeps the implementation small while preserving the same
+// observable surface for the test integration.
 func (c *SwarmJoinCmd) openSwarmLeaf(
 	ctx context.Context, info workspace.Info,
 ) (*coord.Leaf, error) {
@@ -191,6 +207,13 @@ func (c *SwarmJoinCmd) openSwarmLeaf(
 	})
 	if err != nil {
 		return nil, fmt.Errorf("open leaf: %w", err)
+	}
+	// coord.OpenLeaf computes wtPath but does not mkdir it; the
+	// agent-side `swarm cwd` consumer expects a real directory it
+	// can `cd` into, so create it eagerly here. Idempotent.
+	if err := os.MkdirAll(leaf.WT(), 0o755); err != nil {
+		_ = leaf.Stop()
+		return nil, fmt.Errorf("mkdir worktree: %w", err)
 	}
 	return leaf, nil
 }

--- a/cli/swarm_join.go
+++ b/cli/swarm_join.go
@@ -1,0 +1,241 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+
+	"github.com/danmestas/libfossil"
+	libfossilcli "github.com/danmestas/libfossil/cli"
+
+	"github.com/danmestas/bones/internal/coord"
+	"github.com/danmestas/bones/internal/swarm"
+	"github.com/danmestas/bones/internal/workspace"
+)
+
+// defaultHubFossilURL is the hub fossil HTTP URL bones writes when
+// `bones up` brings a hub to default ports. Future work will source
+// this from a workspace-recorded hub config; for now mirroring the
+// hardcoded value in cli/up.go keeps the swarm verbs working with
+// the existing workspace shape.
+const defaultHubFossilURL = "http://127.0.0.1:8765"
+
+// SwarmJoinCmd opens a per-slot leaf, ensures the slot's fossil user
+// exists in the hub, claims the named task, writes the swarm session
+// record to KV, and prints the slot's worktree path on stdout (for
+// `cd $(bones swarm cwd ...)`-style sourcing).
+//
+// On a successful return, the leaf process is alive and owns the
+// claim hold. The process is detached from the calling shell so the
+// agent can run `swarm commit` and `swarm close` from later
+// invocations.
+type SwarmJoinCmd struct {
+	Slot          string `name:"slot" required:"" help:"slot name (matches plan [slot: X])"`
+	TaskID        string `name:"task-id" required:"" help:"open task id to claim"`
+	Caps          string `name:"caps" default:"oih" help:"fossil caps for the slot user"`
+	ForceTakeover bool   `name:"force" help:"clobber an existing slot session (recovery only)"`
+	HubURL        string `name:"hub-url" help:"override hub fossil HTTP URL (default: http://127.0.0.1:8765)"`
+}
+
+// Run implements the join flow per ADR 0028 §"swarm join":
+//
+//	1. Open workspace.
+//	2. Ensure slot user in hub repo (idempotent).
+//	3. Verify no live session record on this slot (or --force).
+//	4. coord.OpenLeaf rooted at .bones/swarm/<slot>/.
+//	5. Claim the task via Leaf.Claim.
+//	6. Write session record to bones-swarm-sessions[<slot>].
+//	7. Print BONES_SLOT_WT=<wt path> for shell sourcing.
+func (c *SwarmJoinCmd) Run(g *libfossilcli.Globals) error {
+	ctx, stop, info, err := joinWorkspace()
+	if err != nil {
+		return err
+	}
+	defer stop()
+	return c.run(ctx, info)
+}
+
+func (c *SwarmJoinCmd) run(ctx context.Context, info workspace.Info) error {
+	if err := c.ensureSlotUser(); err != nil {
+		return fmt.Errorf("ensure slot user: %w", err)
+	}
+	mgr, closeMgr, err := openSwarmManager(ctx, info)
+	if err != nil {
+		return err
+	}
+	defer closeMgr()
+
+	if err := c.checkExistingSession(ctx, mgr); err != nil {
+		return err
+	}
+	leaf, err := c.openSwarmLeaf(ctx, info)
+	if err != nil {
+		return err
+	}
+	claim, err := leaf.Claim(ctx, coord.TaskID(c.TaskID))
+	if err != nil {
+		_ = leaf.Stop()
+		return fmt.Errorf("claim task: %w", err)
+	}
+	// Don't release the claim on success — it stays held until
+	// `swarm close` runs. We DO release on any failure between here
+	// and the session-record write so a half-formed session does not
+	// leak a hold.
+	if err := c.writeSession(ctx, mgr, info); err != nil {
+		_ = claim.Release()
+		_ = leaf.Stop()
+		return err
+	}
+	if err := c.writePidFile(info); err != nil {
+		_ = claim.Release()
+		_ = leaf.Stop()
+		return err
+	}
+	c.emitJoinReport(info, leaf)
+	return nil
+}
+
+func (c *SwarmJoinCmd) slotAgentID() string {
+	return "slot-" + c.Slot
+}
+
+// ensureSlotUser creates the slot user on the hub repo if missing.
+// Mirrors `bones hub user add` (cli/hub_user.go) so the join verb is
+// self-contained — agents do not need to know about the hub user
+// table directly. ADR 0028 §"swarm join" step 2.
+func (c *SwarmJoinCmd) ensureSlotUser() error {
+	repoPath, err := hubRepoPath()
+	if err != nil {
+		return err
+	}
+	repo, err := libfossil.Open(repoPath)
+	if err != nil {
+		return fmt.Errorf("open hub repo: %w", err)
+	}
+	defer func() { _ = repo.Close() }()
+
+	login := c.slotAgentID()
+	if _, err := repo.GetUser(login); err == nil {
+		return nil // already present
+	}
+	if err := repo.CreateUser(libfossil.UserOpts{
+		Login: login,
+		Caps:  c.Caps,
+	}); err != nil {
+		return fmt.Errorf("create user %q: %w", login, err)
+	}
+	return nil
+}
+
+// checkExistingSession enforces invariant "one live session per slot"
+// before opening a fresh leaf. Honors --force for recovery scenarios
+// where a previous join crashed leaving stale state.
+func (c *SwarmJoinCmd) checkExistingSession(
+	ctx context.Context, mgr *swarm.Manager,
+) error {
+	existing, rev, err := mgr.Get(ctx, c.Slot)
+	if err != nil {
+		if errors.Is(err, swarm.ErrNotFound) {
+			return nil
+		}
+		return fmt.Errorf("read existing session: %w", err)
+	}
+	host, _ := os.Hostname()
+	if !c.ForceTakeover {
+		switch {
+		case existing.Host == host && existing.LeafPID > 0 && pidAlive(existing.LeafPID):
+			return fmt.Errorf(
+				"slot %q already has a live session on this host (pid %d) — pass --force to take over",
+				c.Slot, existing.LeafPID,
+			)
+		case existing.Host != host:
+			return fmt.Errorf(
+				"slot %q is owned by host %q (pid %d) — refusing to take over; pass --force on the owning host",
+				c.Slot, existing.Host, existing.LeafPID,
+			)
+		}
+	}
+	if err := mgr.Delete(ctx, c.Slot, rev); err != nil && !errors.Is(err, swarm.ErrNotFound) {
+		return fmt.Errorf("clear stale session: %w", err)
+	}
+	return nil
+}
+
+// openSwarmLeaf opens the per-slot leaf rooted at the workspace's
+// .bones/swarm directory. Uses HubAddrs (URL-string variant of
+// LeafConfig) because the hub runs in a separate process and the
+// agent-side bones binary cannot share an in-process *Hub.
+func (c *SwarmJoinCmd) openSwarmLeaf(
+	ctx context.Context, info workspace.Info,
+) (*coord.Leaf, error) {
+	hubURL := c.HubURL
+	if hubURL == "" {
+		hubURL = defaultHubFossilURL
+	}
+	swarmRoot := filepath.Join(info.WorkspaceDir, ".bones", "swarm")
+	if err := os.MkdirAll(swarmRoot, 0o755); err != nil {
+		return nil, fmt.Errorf("mkdir swarm root: %w", err)
+	}
+	leaf, err := coord.OpenLeaf(ctx, coord.LeafConfig{
+		HubAddrs: coord.HubAddrs{
+			LeafUpstream: "", // peer via the workspace leaf-daemon NATS upstream
+			NATSClient:   info.NATSURL,
+			HTTPAddr:     hubURL,
+		},
+		Workdir:    swarmRoot,
+		SlotID:     c.Slot,
+		FossilUser: c.slotAgentID(),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("open leaf: %w", err)
+	}
+	return leaf, nil
+}
+
+func (c *SwarmJoinCmd) writeSession(
+	ctx context.Context, mgr *swarm.Manager, info workspace.Info,
+) error {
+	host, _ := os.Hostname()
+	now := timeNow()
+	sess := swarm.Session{
+		Slot:        c.Slot,
+		TaskID:      c.TaskID,
+		AgentID:     c.slotAgentID(),
+		Host:        host,
+		LeafPID:     os.Getpid(),
+		StartedAt:   now,
+		LastRenewed: now,
+	}
+	if err := mgr.Put(ctx, sess); err != nil {
+		return fmt.Errorf("write session record: %w", err)
+	}
+	_ = info // future: stamp workspace dir on session if observability needs it
+	return nil
+}
+
+// writePidFile mirrors the KV record's leaf_pid into the host-local
+// PID-tracker file. The file lets `kill` work without a NATS round
+// trip and matches the pattern used by `bones hub start --detach`.
+func (c *SwarmJoinCmd) writePidFile(info workspace.Info) error {
+	pidPath := swarm.SlotPidFile(info.WorkspaceDir, c.Slot)
+	if err := os.WriteFile(pidPath, []byte(strconv.Itoa(os.Getpid())+"\n"), 0o644); err != nil {
+		return fmt.Errorf("write pid file: %w", err)
+	}
+	return nil
+}
+
+func (c *SwarmJoinCmd) emitJoinReport(info workspace.Info, leaf *coord.Leaf) {
+	wt := leaf.WT()
+	// Stdout is consumed by `eval $(bones swarm join ... )` patterns;
+	// keep it env-var-shaped so shells can source it directly.
+	fmt.Printf("BONES_SLOT_WT=%s\n", wt)
+	fmt.Fprintf(
+		os.Stderr,
+		"swarm join: slot=%s task=%s wt=%s pid=%d\n",
+		c.Slot, c.TaskID, wt, os.Getpid(),
+	)
+	_ = info
+}

--- a/cli/swarm_status.go
+++ b/cli/swarm_status.go
@@ -120,16 +120,20 @@ func emitStatusTable(rows []statusRow) error {
 		return nil
 	}
 	w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
-	fmt.Fprintln(w, "SLOT\tTASK-ID\tHOST\tPID\tSTATE\tRENEWED")
+	if _, err := fmt.Fprintln(w, "SLOT\tTASK-ID\tHOST\tPID\tSTATE\tRENEWED"); err != nil {
+		return err
+	}
 	for _, r := range rows {
-		fmt.Fprintf(w, "%s\t%s\t%s\t%d\t%s\t%s\n",
+		if _, err := fmt.Fprintf(w, "%s\t%s\t%s\t%d\t%s\t%s\n",
 			r.Slot,
 			truncateID(r.TaskID, 8),
 			r.Host,
 			r.LeafPID,
 			r.State,
 			fmt.Sprintf("%ds ago", r.StaleSeconds),
-		)
+		); err != nil {
+			return err
+		}
 	}
 	return w.Flush()
 }

--- a/cli/swarm_status.go
+++ b/cli/swarm_status.go
@@ -1,0 +1,144 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	libfossilcli "github.com/danmestas/libfossil/cli"
+
+	"github.com/danmestas/bones/internal/swarm"
+	"github.com/danmestas/bones/internal/workspace"
+)
+
+// SwarmStatusCmd lists every active swarm session in the workspace.
+// Output combines KV state with a host-local PID liveness probe so a
+// crashed leaf surfaces as DEAD even before the bucket TTL evicts it.
+type SwarmStatusCmd struct {
+	JSON bool `name:"json" help:"emit JSON"`
+}
+
+// statusRow is the per-session JSON shape emitted with --json. The
+// human table renders the same fields. Pulled out so the JSON
+// schema is explicit and stable for downstream consumers (`bones
+// doctor`, future `bones swarm dispatch`).
+type statusRow struct {
+	Slot         string    `json:"slot"`
+	TaskID       string    `json:"task_id"`
+	AgentID      string    `json:"agent_id"`
+	Host         string    `json:"host"`
+	LeafPID      int       `json:"leaf_pid"`
+	StartedAt    time.Time `json:"started_at"`
+	LastRenewed  time.Time `json:"last_renewed"`
+	State        string    `json:"state"`
+	StaleSeconds int64     `json:"stale_seconds"`
+}
+
+func (c *SwarmStatusCmd) Run(g *libfossilcli.Globals) error {
+	ctx, stop, info, err := joinWorkspace()
+	if err != nil {
+		return err
+	}
+	defer stop()
+	return c.run(ctx, info)
+}
+
+func (c *SwarmStatusCmd) run(ctx context.Context, info workspace.Info) error {
+	mgr, closeMgr, err := openSwarmManager(ctx, info)
+	if err != nil {
+		return err
+	}
+	defer closeMgr()
+	sessions, err := mgr.List(ctx)
+	if err != nil {
+		return err
+	}
+	host, _ := os.Hostname()
+	rows := buildStatusRows(sessions, host, timeNow())
+	if c.JSON {
+		return emitStatusJSON(rows)
+	}
+	return emitStatusTable(rows)
+}
+
+// buildStatusRows attaches a state label and a stale-seconds counter
+// to each session. State derivation:
+//   - "active" — last_renewed within 90s of now AND (cross-host OR pid alive)
+//   - "stale"  — older renewal but not yet TTL'd
+//   - "dead"   — pid dead on this host
+//   - "remote" — session lives on another host
+func buildStatusRows(sessions []swarm.Session, host string, now time.Time) []statusRow {
+	out := make([]statusRow, 0, len(sessions))
+	for _, s := range sessions {
+		stale := int64(now.Sub(s.LastRenewed).Seconds())
+		state := classifyState(s, host, stale)
+		out = append(out, statusRow{
+			Slot:         s.Slot,
+			TaskID:       s.TaskID,
+			AgentID:      s.AgentID,
+			Host:         s.Host,
+			LeafPID:      s.LeafPID,
+			StartedAt:    s.StartedAt,
+			LastRenewed:  s.LastRenewed,
+			State:        state,
+			StaleSeconds: stale,
+		})
+	}
+	return out
+}
+
+func classifyState(s swarm.Session, host string, staleSec int64) string {
+	const activeThreshold = 90 // seconds since last renewal
+	if s.Host != host {
+		if staleSec > activeThreshold {
+			return "remote-stale"
+		}
+		return "remote"
+	}
+	if s.LeafPID > 0 && !pidAlive(s.LeafPID) {
+		return "dead"
+	}
+	if staleSec > activeThreshold {
+		return "stale"
+	}
+	return "active"
+}
+
+func emitStatusJSON(rows []statusRow) error {
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	return enc.Encode(rows)
+}
+
+func emitStatusTable(rows []statusRow) error {
+	if len(rows) == 0 {
+		fmt.Println("(no active swarm sessions)")
+		return nil
+	}
+	w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
+	fmt.Fprintln(w, "SLOT\tTASK-ID\tHOST\tPID\tSTATE\tRENEWED")
+	for _, r := range rows {
+		fmt.Fprintf(w, "%s\t%s\t%s\t%d\t%s\t%s\n",
+			r.Slot,
+			truncateID(r.TaskID, 8),
+			r.Host,
+			r.LeafPID,
+			r.State,
+			fmt.Sprintf("%ds ago", r.StaleSeconds),
+		)
+	}
+	return w.Flush()
+}
+
+// truncateID shortens long task UUIDs in the table view. The full
+// IDs surface in --json output for downstream tools.
+func truncateID(id string, n int) string {
+	if len(id) <= n {
+		return id
+	}
+	return strings.SplitN(id, "-", 2)[0]
+}

--- a/cli/swarm_tasks.go
+++ b/cli/swarm_tasks.go
@@ -1,0 +1,105 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	libfossilcli "github.com/danmestas/libfossil/cli"
+
+	"github.com/danmestas/bones/internal/coord"
+	"github.com/danmestas/bones/internal/tasks"
+	"github.com/danmestas/bones/internal/workspace"
+)
+
+// SwarmTasksCmd lists ready tasks scoped to a slot. Wraps the same
+// readiness model as `bones tasks list --ready` (coord.Ready handles
+// blocks/supersedes/duplicates/parent edges) and filters the result
+// to tasks whose slot annotation matches --slot.
+//
+// Slot membership is resolved in three places, first-match-wins:
+//
+//  1. Task.Context["slot"] equals --slot
+//  2. Task title contains "[slot: <name>]" literal
+//  3. Any file path starts with "<slot>/" or contains "/<slot>/"
+//
+// (3) mirrors the validate_plan slot-disjointness rule so plans that
+// don't yet stamp Context["slot"] still surface their tasks here.
+type SwarmTasksCmd struct {
+	Slot string `name:"slot" required:"" help:"slot name"`
+	JSON bool   `name:"json" help:"emit JSON"`
+}
+
+func (c *SwarmTasksCmd) Run(g *libfossilcli.Globals) error {
+	ctx, stop, info, err := joinWorkspace()
+	if err != nil {
+		return err
+	}
+	defer stop()
+	return c.run(ctx, info)
+}
+
+func (c *SwarmTasksCmd) run(ctx context.Context, info workspace.Info) error {
+	mgr, closeNC, err := openManager(ctx, info)
+	if err != nil {
+		return fmt.Errorf("open tasks manager: %w", err)
+	}
+	defer closeNC()
+	defer func() { _ = mgr.Close() }()
+
+	co, err := coord.Open(ctx, newCoordConfig(info))
+	if err != nil {
+		return fmt.Errorf("open coord: %w", err)
+	}
+	defer func() { _ = co.Close() }()
+
+	readies, err := co.Ready(ctx)
+	if err != nil {
+		return fmt.Errorf("coord ready: %w", err)
+	}
+	readyIDs := make(map[string]struct{}, len(readies))
+	for _, r := range readies {
+		readyIDs[string(r.ID())] = struct{}{}
+	}
+	all, err := mgr.List(ctx)
+	if err != nil {
+		return fmt.Errorf("tasks list: %w", err)
+	}
+	out := make([]tasks.Task, 0)
+	for _, t := range all {
+		if _, ok := readyIDs[t.ID]; !ok {
+			continue
+		}
+		if !taskBelongsToSlot(t, c.Slot) {
+			continue
+		}
+		out = append(out, t)
+	}
+	if c.JSON {
+		return emitJSON(os.Stdout, out)
+	}
+	for _, t := range out {
+		fmt.Println(formatListLine(t))
+	}
+	return nil
+}
+
+// taskBelongsToSlot returns true if t can plausibly be claimed by
+// agents working on slot. The match is intentionally generous so a
+// plan whose tasks lack explicit `Context["slot"]` annotations still
+// surfaces here once they have files in the slot's directory.
+func taskBelongsToSlot(t tasks.Task, slot string) bool {
+	if v := t.Context["slot"]; v == slot {
+		return true
+	}
+	if strings.Contains(t.Title, "[slot: "+slot+"]") {
+		return true
+	}
+	for _, f := range t.Files {
+		if strings.HasPrefix(f, slot+"/") || strings.Contains(f, "/"+slot+"/") {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/bones/cli.go
+++ b/cmd/bones/cli.go
@@ -21,9 +21,9 @@ type CLI struct {
 	Repo libfossilcli.RepoCmd `cmd:"" group:"repo" help:"Fossil repository operations"`
 
 	// Sync & messaging.
-	Sync   edgecli.SyncCmd   `cmd:"" group:"sync" help:"Leaf agent sync"`
-	Bridge edgecli.BridgeCmd `cmd:"" group:"sync" help:"NATS-to-Fossil bridge"`
-	Notify edgecli.NotifyCmd `cmd:"" group:"sync" help:"Bidirectional notification messaging"`
+	Sync   edgecli.SyncCmd    `cmd:"" group:"sync" help:"Leaf agent sync"`
+	Bridge edgecli.BridgeCmd  `cmd:"" group:"sync" help:"NATS-to-Fossil bridge"`
+	Notify edgecli.NotifyCmd  `cmd:"" group:"sync" help:"Bidirectional notification messaging"`
 	Doctor bonescli.DoctorCmd `cmd:"" group:"sync" help:"Check development environment health"`
 
 	// Tooling — used by humans authoring plans/skills.

--- a/cmd/bones/cli.go
+++ b/cmd/bones/cli.go
@@ -15,6 +15,7 @@ type CLI struct {
 	// Daily.
 	Up    bonescli.UpCmd    `cmd:"" group:"daily" help:"Bootstrap workspace, scaffold, leaf, hub"`
 	Tasks bonescli.TasksCmd `cmd:"" group:"daily" help:"Inspect and mutate runtime agent tasks"`
+	Swarm bonescli.SwarmCmd `cmd:"" group:"daily" help:"Run as a slot-shaped swarm participant"`
 
 	// Repository.
 	Repo libfossilcli.RepoCmd `cmd:"" group:"repo" help:"Fossil repository operations"`

--- a/cmd/bones/cli.go
+++ b/cmd/bones/cli.go
@@ -24,7 +24,7 @@ type CLI struct {
 	Sync   edgecli.SyncCmd   `cmd:"" group:"sync" help:"Leaf agent sync"`
 	Bridge edgecli.BridgeCmd `cmd:"" group:"sync" help:"NATS-to-Fossil bridge"`
 	Notify edgecli.NotifyCmd `cmd:"" group:"sync" help:"Bidirectional notification messaging"`
-	Doctor edgecli.DoctorCmd `cmd:"" group:"sync" help:"Check development environment health"`
+	Doctor bonescli.DoctorCmd `cmd:"" group:"sync" help:"Check development environment health"`
 
 	// Tooling — used by humans authoring plans/skills.
 	ValidatePlan bonescli.ValidatePlanCmd `cmd:"" group:"tooling" help:"Validate plan"`

--- a/cmd/bones/integration/swarm_test.go
+++ b/cmd/bones/integration/swarm_test.go
@@ -1,0 +1,269 @@
+package integration_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// TestCLI_Swarm exercises the full bones swarm join → commit → close
+// cycle against a tmpdir workspace + a Go-implemented hub on
+// dynamic ports. The test is skipped under `go test -short` to keep
+// fast loops focused on unit tests.
+//
+// Layout:
+//
+//	tmp/
+//	├── .git/                  initialized so hub seedRepo finds tracked files
+//	├── seed.txt               one tracked file
+//	├── .bones/                created by `bones init` (workspace leaf)
+//	├── .orchestrator/         created by `bones hub start`
+//	└── .bones/swarm/<slot>/   created by `bones swarm join`
+func TestCLI_Swarm(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip in -short: integration test")
+	}
+	requireBinaries(t)
+	dir := setupSwarmWorkspace(t)
+	// Resolve any /private/var prefix on macOS so the cwd assertion
+	// matches what `bones swarm cwd` prints (it derives from
+	// workspace.Join which calls filepath.EvalSymlinks).
+	if resolved, err := filepath.EvalSymlinks(dir); err == nil {
+		dir = resolved
+	}
+	httpPort, natsPort := pickPortPair(t)
+	startSwarmHub(t, dir, httpPort, natsPort)
+	hubURL := fmt.Sprintf("http://127.0.0.1:%d", httpPort)
+
+	// Coord.Claim → holds.Announce requires absolute file paths
+	// (invariant 4). The slot's relative-to-wt content path is
+	// "rendering/hello.txt"; the task records it as the absolute
+	// workspace path so the hold's lock key is global.
+	relFile := "rendering/hello.txt"
+	absFile := filepath.Join(dir, relFile)
+	taskID := createSwarmTask(t, dir, absFile, "[slot: rendering] render a thing")
+	slot := "rendering"
+
+	t.Run("join_creates_session_and_worktree", func(t *testing.T) {
+		stdout, stderr, code := runCmd(t, bonesBin, dir,
+			"swarm", "join",
+			"--slot="+slot, "--task-id="+taskID,
+			"--hub-url="+hubURL,
+		)
+		if code != 0 {
+			t.Fatalf("swarm join exit=%d stdout=%s stderr=%s", code, stdout, stderr)
+		}
+		if !strings.Contains(stdout, "BONES_SLOT_WT=") {
+			t.Errorf("stdout missing BONES_SLOT_WT: %q", stdout)
+		}
+		// Verify worktree path exists.
+		wt := filepath.Join(dir, ".bones", "swarm", slot, "wt")
+		if _, err := os.Stat(wt); err != nil {
+			t.Errorf("worktree %s missing: %v", wt, err)
+		}
+	})
+
+	t.Run("status_lists_session", func(t *testing.T) {
+		stdout, stderr, code := runCmd(t, bonesBin, dir, "swarm", "status", "--json")
+		if code != 0 {
+			t.Fatalf("swarm status exit=%d stderr=%s", code, stderr)
+		}
+		var rows []map[string]any
+		if err := json.Unmarshal([]byte(stdout), &rows); err != nil {
+			t.Fatalf("parse json: %v\nout=%s", err, stdout)
+		}
+		if len(rows) != 1 {
+			t.Fatalf("want 1 row, got %d: %s", len(rows), stdout)
+		}
+		if rows[0]["slot"] != slot {
+			t.Errorf("slot mismatch: %v", rows[0])
+		}
+	})
+
+	t.Run("cwd_prints_worktree_path", func(t *testing.T) {
+		stdout, _, code := runCmd(t, bonesBin, dir, "swarm", "cwd", "--slot="+slot)
+		if code != 0 {
+			t.Fatalf("swarm cwd exit=%d", code)
+		}
+		got := strings.TrimSpace(stdout)
+		want := filepath.Join(dir, ".bones", "swarm", slot, "wt")
+		if got != want {
+			t.Errorf("cwd: got %q want %q", got, want)
+		}
+	})
+
+	t.Run("commit_writes_a_file", func(t *testing.T) {
+		wt := filepath.Join(dir, ".bones", "swarm", slot, "wt")
+		// libfossil's checkout open is part of commit; for now we
+		// stage a fresh file in the wt and pass it explicitly.
+		filePath := filepath.Join(wt, "rendering", "hello.txt")
+		if err := os.MkdirAll(filepath.Dir(filePath), 0o755); err != nil {
+			t.Fatalf("mkdir wt subdir: %v", err)
+		}
+		if err := os.WriteFile(filePath, []byte("hello swarm\n"), 0o644); err != nil {
+			t.Fatalf("write file: %v", err)
+		}
+		stdout, stderr, code := runCmd(t, bonesBin, dir,
+			"swarm", "commit",
+			"--slot="+slot, "-m=add hello",
+			"--hub-url="+hubURL,
+			"rendering/hello.txt",
+		)
+		if code != 0 {
+			t.Fatalf("swarm commit exit=%d stderr=%s", code, stderr)
+		}
+		// First non-empty line of stdout should be the commit UUID.
+		uuid := firstLine(stdout)
+		if len(uuid) < 16 {
+			t.Errorf("expected commit uuid, got %q", stdout)
+		}
+	})
+
+	t.Run("close_deletes_session_and_closes_task", func(t *testing.T) {
+		stdout, stderr, code := runCmd(t, bonesBin, dir,
+			"swarm", "close",
+			"--slot="+slot, "--result=success",
+			"--summary=test done",
+			"--hub-url="+hubURL,
+		)
+		if code != 0 {
+			t.Fatalf("swarm close exit=%d stderr=%s stdout=%s", code, stderr, stdout)
+		}
+		// Session should be gone.
+		statusOut, _, sCode := runCmd(t, bonesBin, dir, "swarm", "status", "--json")
+		if sCode != 0 {
+			t.Fatalf("post-close status code=%d", sCode)
+		}
+		// JSON null or empty array — both acceptable representations of "no rows."
+		trimmed := strings.TrimSpace(statusOut)
+		if trimmed != "null" && trimmed != "[]" {
+			t.Errorf("status post-close: want empty, got %q", statusOut)
+		}
+		// Task should be closed.
+		showOut, _, _ := runCmd(t, bonesBin, dir, "tasks", "show", taskID)
+		if !strings.Contains(showOut, "status=closed") {
+			t.Errorf("task post-close: want status=closed, got\n%s", showOut)
+		}
+	})
+}
+
+// setupSwarmWorkspace creates a git-initialized tmpdir with a single
+// tracked file so the Go-implemented hub's seedHubRepo finds something
+// to commit. Then runs `bones init` to bring up the workspace leaf.
+func setupSwarmWorkspace(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	// Init a fresh git repo and stage one file. Hub's seedHubRepo
+	// walks `git ls-files` and refuses to seed an empty workspace.
+	gitInit := exec.Command("git", "init", "-q", "-b", "main")
+	gitInit.Dir = dir
+	if out, err := gitInit.CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v\n%s", err, out)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "seed.txt"), []byte("seed\n"), 0o644); err != nil {
+		t.Fatalf("write seed.txt: %v", err)
+	}
+	// Configure committer for this fixture so `git commit` doesn't
+	// pull in the operator's config.
+	for _, args := range [][]string{
+		{"config", "user.email", "swarm-test@example.invalid"},
+		{"config", "user.name", "Swarm Test"},
+		{"add", "seed.txt"},
+		{"commit", "-q", "-m", "seed"},
+	} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	// `bones init` to spawn the leaf daemon.
+	if _, stderr, code := runCmd(t, bonesBin, dir, "init"); code != 0 {
+		t.Fatalf("bones init: %s", stderr)
+	}
+	t.Cleanup(func() {
+		killPidFile(t, filepath.Join(dir, ".bones", "leaf.pid"))
+	})
+	return dir
+}
+
+// startSwarmHub launches `bones hub start --detach` on the given
+// ports and registers cleanup to stop it.
+func startSwarmHub(t *testing.T, dir string, httpPort, natsPort int) {
+	t.Helper()
+	args := []string{
+		"hub", "start", "--detach",
+		"--fossil-port=" + strconv.Itoa(httpPort),
+		"--nats-port=" + strconv.Itoa(natsPort),
+	}
+	stdout, stderr, code := runCmd(t, bonesBin, dir, args...)
+	if code != 0 {
+		t.Fatalf("hub start exit=%d stdout=%s stderr=%s", code, stdout, stderr)
+	}
+	t.Cleanup(func() {
+		// Best-effort: signal SIGTERM via the hub's pid files.
+		for _, name := range []string{"fossil.pid", "nats.pid"} {
+			pidPath := filepath.Join(dir, ".orchestrator", "pids", name)
+			data, err := os.ReadFile(pidPath)
+			if err != nil {
+				continue
+			}
+			if pid, err := strconv.Atoi(strings.TrimSpace(string(data))); err == nil {
+				if proc, err := os.FindProcess(pid); err == nil {
+					_ = proc.Signal(syscall.SIGTERM)
+				}
+			}
+		}
+		// Wait briefly for graceful shutdown.
+		time.Sleep(100 * time.Millisecond)
+	})
+}
+
+// pickPortPair returns two free localhost TCP ports for the hub.
+// The kernel may assign them, then we close before the hub binds —
+// races are possible but rare; the hub start surfaces a clear error
+// if it fails to bind.
+func pickPortPair(t *testing.T) (httpPort, natsPort int) {
+	t.Helper()
+	httpPort = grabFreePort(t)
+	natsPort = grabFreePort(t)
+	return
+}
+
+func grabFreePort(t *testing.T) int {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	port := l.Addr().(*net.TCPAddr).Port
+	_ = l.Close()
+	return port
+}
+
+// createSwarmTask creates a task with the given title and absolute
+// file path, then returns the new task id. Caller passes an absolute
+// file path so coord.Claim → holds.Announce passes the IsAbs gate.
+func createSwarmTask(t *testing.T, dir, absFile, title string) string {
+	t.Helper()
+	stdout, stderr, code := runCmd(t, bonesBin, dir, "tasks", "create",
+		"--files="+absFile,
+		"--context", "slot=rendering",
+		title)
+	if code != 0 {
+		t.Fatalf("tasks create exit=%d stderr=%s", code, stderr)
+	}
+	id := firstLine(stdout)
+	if len(id) < 16 {
+		t.Fatalf("expected uuid on stdout, got %q", stdout)
+	}
+	return id
+}

--- a/internal/coord/coord.go
+++ b/internal/coord/coord.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
 
 	"github.com/danmestas/bones/internal/assert"
 	"github.com/danmestas/bones/internal/chat"
@@ -17,6 +18,12 @@ import (
 	"github.com/danmestas/bones/internal/presence"
 	"github.com/danmestas/bones/internal/tasks"
 )
+
+// swarmSessionsTTL is the bucket TTL for bones-swarm-sessions.
+// Mirrors internal/swarm.DefaultTTL; duplicated here to avoid an
+// import cycle (swarm imports jskv which is fine, but coord must
+// provision the bucket before swarm exists in the call chain).
+const swarmSessionsTTL = 5 * time.Minute
 
 // holdsBucket is the JetStream KV bucket name coord uses to back
 // file-scoped holds. The bucket identifier is a substrate detail per
@@ -32,6 +39,17 @@ const archiveBucket = "bones-task-archive"
 // Config.HeartbeatInterval and is set at bucket-creation time by
 // internal/presence.Open.
 const presenceBucket = "bones-presence"
+
+// swarmSessionsBucket is the JetStream KV bucket name internal/swarm
+// uses to track per-slot swarm sessions per ADR 0028. Listed here
+// for visibility alongside the other coord-managed buckets, but
+// internal/swarm.Manager.Open creates/attaches independently —
+// coord.Coord callers do NOT consume this bucket. Provisioning is
+// best-effort here so any coord.Open guarantees the bucket exists
+// before the first `bones swarm join`. Constant kept exported (in
+// effect — swarm package mirrors it as DefaultBucketName) so tests
+// can assert the same name in both layers.
+const swarmSessionsBucket = "bones-swarm-sessions"
 
 // Coord is the public entry point for bones. Construct one via
 // Open and Close it at shutdown. All coordination — hold acquisition,
@@ -156,7 +174,32 @@ func openSubstrate(
 		s.close()
 		return nil, fmt.Errorf("coord.Open: presence: %w", err)
 	}
+	if err := provisionSwarmSessionsBucket(ctx, nc); err != nil {
+		s.close()
+		return nil, fmt.Errorf("coord.Open: swarm sessions: %w", err)
+	}
 	return s, nil
+}
+
+// provisionSwarmSessionsBucket ensures the bones-swarm-sessions KV
+// bucket exists with the swarm package's TTL. Idempotent: re-running
+// against an existing bucket is a no-op (CreateOrUpdateKeyValue does
+// not overwrite TTL on a hot bucket per JetStream semantics). Kept
+// out of the substrate aggregate because no coord.Coord method reads
+// or writes the bucket — it is a purely substrate-side artifact for
+// internal/swarm to attach to. ADR 0028 §"Coord-bucket integration".
+func provisionSwarmSessionsBucket(ctx context.Context, nc *nats.Conn) error {
+	js, err := jetstream.New(nc)
+	if err != nil {
+		return fmt.Errorf("jetstream: %w", err)
+	}
+	if _, err := js.CreateOrUpdateKeyValue(ctx, jetstream.KeyValueConfig{
+		Bucket: swarmSessionsBucket,
+		TTL:    swarmSessionsTTL,
+	}); err != nil {
+		return fmt.Errorf("kv bucket %q: %w", swarmSessionsBucket, err)
+	}
+	return nil
 }
 
 // projectPrefix derives the <proj> segment from an AgentID shaped

--- a/internal/coord/leaf.go
+++ b/internal/coord/leaf.go
@@ -64,12 +64,21 @@ type Leaf struct {
 	stopped    bool
 }
 
-// LeafConfig is the configuration passed to OpenLeaf. Hub is required and
-// provides all three URL fields (LeafUpstream, NATSURL, HTTPAddr) so
-// callers do not need to thread them individually.
+// LeafConfig is the configuration passed to OpenLeaf. One of Hub or
+// HubAddrs must be set; HubAddrs is the path for callers (e.g. the
+// `bones swarm` CLI) that hold only URL strings, not an in-process
+// *Hub. When both are set, Hub wins and HubAddrs is ignored.
 type LeafConfig struct {
-	// Hub is the hub this leaf peers against. Required.
+	// Hub is the hub this leaf peers against. Either Hub or HubAddrs
+	// must be set.
 	Hub *Hub
+
+	// HubAddrs supplies the same three URLs Hub would have exposed via
+	// LeafUpstream/NATSURL/HTTPAddr. Set when the hub is in another
+	// process (typical CLI use): the bones hub runs as a separate
+	// daemon, so the agent-side bones binary cannot share an in-process
+	// *Hub object. ADR 0028 §"Detailed design / swarm join".
+	HubAddrs HubAddrs
 
 	// Workdir is the root directory for per-slot state. Required.
 	Workdir string
@@ -99,21 +108,46 @@ type LeafConfig struct {
 	Metadata map[string]string
 }
 
+// HubAddrs holds the three URLs OpenLeaf needs from a hub. Each
+// field corresponds 1-1 with a *Hub method:
+//
+//	LeafUpstream → Hub.LeafUpstream() — leaf-node solicit URL
+//	NATSClient   → Hub.NATSURL()      — client connection URL for KV
+//	HTTPAddr     → Hub.HTTPAddr()     — fossil HTTP base URL
+//
+// Used by LeafConfig.HubAddrs when the hub is in a separate process
+// and the caller has discovered (or hard-coded) its endpoints.
+type HubAddrs struct {
+	LeafUpstream string
+	NATSClient   string
+	HTTPAddr     string
+}
+
+// IsEmpty reports whether all three URL fields are empty. OpenLeaf
+// uses this to choose between Hub and HubAddrs when LeafConfig has
+// both set or both empty.
+func (a HubAddrs) IsEmpty() bool {
+	return a.LeafUpstream == "" && a.NATSClient == "" && a.HTTPAddr == ""
+}
+
 // OpenLeaf starts a leaf at cfg.Workdir/<cfg.SlotID>/leaf.fossil that
-// joins cfg.Hub's mesh as a leaf-node and uses cfg.Hub's NATS client
-// URL for coord's claim/task KV traffic. Clones leaf.fossil from
-// cfg.Hub's HTTP endpoint at open time.
+// joins the hub's mesh as a leaf-node and uses the hub's NATS client
+// URL for coord's claim/task KV traffic. Clones leaf.fossil from the
+// hub's HTTP endpoint at open time.
+//
+// Hub URLs come from cfg.Hub (when set) or cfg.HubAddrs (when Hub is
+// nil). Exactly one of the two must be set.
 //
 // The slot's worktree is at cfg.Workdir/<cfg.SlotID>/wt.
 func OpenLeaf(ctx context.Context, cfg LeafConfig) (*Leaf, error) {
 	assert.NotNil(ctx, "coord.OpenLeaf: ctx is nil")
-	assert.NotNil(cfg.Hub, "coord.OpenLeaf: cfg.Hub is nil")
 	assert.NotEmpty(cfg.Workdir, "coord.OpenLeaf: cfg.Workdir is empty")
 	assert.NotEmpty(cfg.SlotID, "coord.OpenLeaf: cfg.SlotID is empty")
 
-	hubNATSUpstream := cfg.Hub.LeafUpstream()
-	hubNATSClient := cfg.Hub.NATSURL()
-	hubHTTPAddr := cfg.Hub.HTTPAddr()
+	hubNATSUpstream, hubNATSClient, hubHTTPAddr, err := resolveHubAddrs(cfg)
+	if err != nil {
+		return nil, err
+	}
 
 	slotDir := filepath.Join(cfg.Workdir, cfg.SlotID)
 	if err := os.MkdirAll(slotDir, 0o755); err != nil {
@@ -207,6 +241,36 @@ func OpenLeaf(ctx context.Context, cfg LeafConfig) (*Leaf, error) {
 		fossilUser: cfg.FossilUser,
 		metadata:   cfg.Metadata,
 	}, nil
+}
+
+// resolveHubAddrs returns the leaf-upstream, NATS-client, and HTTP
+// addresses for OpenLeaf, drawing from cfg.Hub when set or cfg.HubAddrs
+// otherwise. Returns an error if neither (or both empty) source is
+// usable, so OpenLeaf surfaces a clear message rather than panicking
+// in the agent.New call below.
+func resolveHubAddrs(cfg LeafConfig) (upstream, natsClient, httpAddr string, err error) {
+	if cfg.Hub != nil {
+		return cfg.Hub.LeafUpstream(), cfg.Hub.NATSURL(), cfg.Hub.HTTPAddr(), nil
+	}
+	if cfg.HubAddrs.IsEmpty() {
+		return "", "", "",
+			fmt.Errorf("coord.OpenLeaf: neither cfg.Hub nor cfg.HubAddrs is set")
+	}
+	if cfg.HubAddrs.NATSClient == "" {
+		return "", "", "",
+			fmt.Errorf("coord.OpenLeaf: cfg.HubAddrs.NATSClient is empty")
+	}
+	if cfg.HubAddrs.HTTPAddr == "" {
+		return "", "", "",
+			fmt.Errorf("coord.OpenLeaf: cfg.HubAddrs.HTTPAddr is empty")
+	}
+	// LeafUpstream may be empty in CLI scenarios where the slot leaf
+	// peers via the workspace's leaf-daemon NATS server (a regular
+	// client connection on NATSClient is enough — leafnode propagation
+	// then forwards subjects up to the hub mesh through the existing
+	// daemon). Pass "" through; agent.New treats empty NATSUpstream as
+	// "standalone mesh, no upstream solicitation."
+	return cfg.HubAddrs.LeafUpstream, cfg.HubAddrs.NATSClient, cfg.HubAddrs.HTTPAddr, nil
 }
 
 // openLeafCoord builds the *Coord that backs a Leaf's claim/task work.

--- a/internal/swarm/session.go
+++ b/internal/swarm/session.go
@@ -1,0 +1,93 @@
+// Package swarm holds the per-slot session record schema and the
+// JetStream-KV-backed Manager that bones swarm verbs use to track
+// active swarm sessions in a workspace.
+//
+// State lives in a single KV bucket (DefaultBucketName) keyed by slot
+// name. ADR 0028 §"Lifecycle and state" explains why session state
+// went to KV instead of a per-slot state.json on disk: every field
+// in this struct is either already authoritative somewhere else in
+// JetStream KV (task_id in bones-tasks, agent_id in bones-presence,
+// the claim hold in bones-holds) or describes the host-local OS
+// process owning the leaf (host, leaf_pid). Putting them in one
+// bucket gives cross-host visibility and a single source of truth
+// for `bones swarm status` and `bones doctor` without re-deriving
+// state from N substrate buckets per call.
+//
+// The Manager is intentionally simpler than internal/presence: there
+// is no background heartbeat goroutine. Heartbeats are driven by
+// agent-process calls to `bones swarm commit`, which extends TTL via
+// CAS. A slot whose agent has crashed stops heartbeating and the
+// bucket TTL evicts the entry — exactly the surface `bones doctor`
+// is meant to see.
+package swarm
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// Session is the per-slot record persisted in the bones-swarm-sessions
+// JetStream KV bucket. One record per active slot in a workspace.
+// Slot names are workspace-scoped because the bucket itself is per-
+// NATS-deployment.
+//
+// Marshalled as JSON for human-readable debugging via `nats kv get`.
+// All time fields are RFC3339-encoded UTC. New fields must default
+// safely on a missing-key read so older clients can read newer
+// records (additive evolution only).
+type Session struct {
+	// Slot is the slot name (matches the plan's `[slot: X]` annotation).
+	// Doubles as the KV bucket key — slot is the primary identifier.
+	Slot string `json:"slot"`
+
+	// TaskID identifies the task this slot is currently working on.
+	// Lookup against bones-tasks for full task state; this field is a
+	// denormalized pointer used by `bones swarm status` and the close
+	// verb so they don't need a second lookup.
+	TaskID string `json:"task_id"`
+
+	// AgentID is "slot-<name>" — the slot's fossil + coord identity.
+	// Matches the agent_id used for the holds and presence buckets so
+	// claim ownership and liveness join cleanly across substrates.
+	AgentID string `json:"agent_id"`
+
+	// Host is os.Hostname() of the machine running the leaf. Different
+	// from the workspace host means another machine owns this slot;
+	// `bones swarm` verbs abort with a clear cross-host error rather
+	// than try to manage a remote leaf process.
+	Host string `json:"host"`
+
+	// LeafPID is the host-local PID of the leaf process. Only
+	// meaningful on the matching Host. Probed via os.FindProcess +
+	// signal 0 to detect crashes.
+	LeafPID int `json:"leaf_pid"`
+
+	// StartedAt is when this session record was first written.
+	// Immutable once set; later renewals only touch LastRenewed.
+	StartedAt time.Time `json:"started_at"`
+
+	// LastRenewed is updated on every `swarm commit` (which heartbeats
+	// the session) and used by `bones doctor` to flag stale entries.
+	LastRenewed time.Time `json:"last_renewed"`
+}
+
+// encode serializes a Session into a JSON byte slice for KV storage.
+// JSON keeps the bucket browsable from `nats kv` CLI tools without
+// needing custom decoders for ad-hoc operator inspection.
+func encode(s Session) ([]byte, error) {
+	b, err := json.Marshal(s)
+	if err != nil {
+		return nil, fmt.Errorf("swarm: encode session: %w", err)
+	}
+	return b, nil
+}
+
+// decode parses a JSON-encoded Session out of a KV value.
+func decode(b []byte) (Session, error) {
+	var s Session
+	if err := json.Unmarshal(b, &s); err != nil {
+		return Session{}, fmt.Errorf("swarm: decode session: %w", err)
+	}
+	return s, nil
+}

--- a/internal/swarm/session.go
+++ b/internal/swarm/session.go
@@ -32,7 +32,7 @@ import (
 // Slot names are workspace-scoped because the bucket itself is per-
 // NATS-deployment.
 //
-// Marshalled as JSON for human-readable debugging via `nats kv get`.
+// Marshaled as JSON for human-readable debugging via `nats kv get`.
 // All time fields are RFC3339-encoded UTC. New fields must default
 // safely on a missing-key read so older clients can read newer
 // records (additive evolution only).

--- a/internal/swarm/swarm.go
+++ b/internal/swarm/swarm.go
@@ -1,0 +1,315 @@
+package swarm
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"sync/atomic"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+
+	"github.com/danmestas/bones/internal/assert"
+	"github.com/danmestas/bones/internal/jskv"
+)
+
+// DefaultBucketName is the JetStream KV bucket holding swarm sessions.
+// The name is part of the substrate contract (parallel to
+// bones-tasks, bones-holds, bones-presence) and SHOULD NOT change
+// without a substrate-evolution ADR.
+const DefaultBucketName = "bones-swarm-sessions"
+
+// DefaultTTL is the JetStream KV bucket TTL. Sessions are heartbeated
+// via `bones swarm commit`; a slot whose agent has crashed stops
+// renewing and the bucket evicts the entry after this interval.
+// Five minutes mirrors ADR 0028's "stale after 5min no renewal" rule.
+const DefaultTTL = 5 * time.Minute
+
+// ErrClosed reports that a public method was called on a Manager whose
+// Close has returned. Parallel to internal/presence.ErrClosed.
+var ErrClosed = errors.New("swarm: manager is closed")
+
+// ErrNotFound reports that the requested slot has no live session
+// record in the bucket. Distinct from a substrate error so callers
+// (swarm status, swarm commit) can distinguish "no session yet" from
+// "NATS unreachable."
+var ErrNotFound = errors.New("swarm: session not found")
+
+// ErrCASConflict reports that a CAS-gated Update or Delete saw a
+// revision mismatch — another writer raced ours. Mirrors
+// internal/tasks.ErrCASConflict so callers can react identically.
+var ErrCASConflict = errors.New("swarm: CAS conflict")
+
+// Config configures a Manager. Only NATSConn is required; bucket name
+// and TTL fall back to the package defaults if zero. Defaults match
+// production; tests sometimes pass shorter TTLs to exercise expiry.
+type Config struct {
+	// NATSConn is the live NATS connection. Manager does not dial; the
+	// caller owns connect/disconnect lifecycle. Required.
+	NATSConn *nats.Conn
+
+	// BucketName overrides DefaultBucketName. Empty string falls back
+	// to the package default.
+	BucketName string
+
+	// TTL overrides DefaultTTL on bucket creation. Zero falls back to
+	// the package default. Ignored if the bucket already exists with
+	// a different TTL — JetStream KV is not destructive on Update.
+	TTL time.Duration
+}
+
+// Validate returns an error describing the first invalid field, or nil
+// if the config is acceptable. Manager.Open calls Validate before any
+// substrate work so callers see config issues with no NATS round-trip.
+func (c Config) Validate() error {
+	if c.NATSConn == nil {
+		return fmt.Errorf("swarm.Config: NATSConn is nil")
+	}
+	return nil
+}
+
+// Manager owns the JetStream KV bucket holding swarm session records.
+// Every public method is safe to call concurrently. Close is
+// idempotent. Unlike presence.Manager, there is no heartbeat goroutine
+// — callers (the bones swarm verbs) drive renewal via Update.
+type Manager struct {
+	cfg    Config
+	js     jetstream.JetStream
+	kv     jetstream.KeyValue
+	closed atomic.Bool
+}
+
+// Open creates (or reattaches to) the swarm sessions KV bucket and
+// returns a Manager. Caller must Close at shutdown. Open does not
+// dial NATS: the connection comes pre-wired so reconnect policy stays
+// a single-source concern (same shape as presence.Open).
+func Open(ctx context.Context, cfg Config) (*Manager, error) {
+	assert.NotNil(ctx, "swarm.Open: ctx is nil")
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+	bucket := cfg.BucketName
+	if bucket == "" {
+		bucket = DefaultBucketName
+	}
+	ttl := cfg.TTL
+	if ttl == 0 {
+		ttl = DefaultTTL
+	}
+	js, err := jetstream.New(cfg.NATSConn)
+	if err != nil {
+		return nil, fmt.Errorf("swarm.Open: jetstream: %w", err)
+	}
+	kv, err := js.CreateOrUpdateKeyValue(ctx, jetstream.KeyValueConfig{
+		Bucket: bucket,
+		TTL:    ttl,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("swarm.Open: kv bucket: %w", err)
+	}
+	cfg.BucketName = bucket
+	cfg.TTL = ttl
+	return &Manager{cfg: cfg, js: js, kv: kv}, nil
+}
+
+// Close marks the Manager closed so subsequent public calls return
+// ErrClosed. Safe to call more than once. Does not delete bucket
+// contents; sessions outlive the process that wrote them (TTL
+// eventually evicts).
+func (m *Manager) Close() error {
+	assert.NotNil(m, "swarm.Close: receiver is nil")
+	m.closed.Store(true)
+	return nil
+}
+
+// BucketName returns the bucket name in use. Useful for diagnostics
+// and for `bones doctor` to mention the right bucket in its messages.
+func (m *Manager) BucketName() string {
+	assert.NotNil(m, "swarm.BucketName: receiver is nil")
+	return m.cfg.BucketName
+}
+
+// Get reads the session record for slot. Returns ErrNotFound if no
+// record exists. The returned revision is the JetStream KV sequence
+// number suitable for a follow-up CAS Update or Delete.
+func (m *Manager) Get(
+	ctx context.Context, slot string,
+) (Session, uint64, error) {
+	assert.NotNil(ctx, "swarm.Get: ctx is nil")
+	assert.NotEmpty(slot, "swarm.Get: slot is empty")
+	if m.closed.Load() {
+		return Session{}, 0, ErrClosed
+	}
+	kve, err := m.kv.Get(ctx, slot)
+	if err != nil {
+		if errors.Is(err, jetstream.ErrKeyNotFound) {
+			return Session{}, 0, ErrNotFound
+		}
+		return Session{}, 0, fmt.Errorf("swarm.Get: %w", err)
+	}
+	if kve.Operation() != jetstream.KeyValuePut {
+		return Session{}, 0, ErrNotFound
+	}
+	s, err := decode(kve.Value())
+	if err != nil {
+		return Session{}, 0, fmt.Errorf("swarm.Get: %w", err)
+	}
+	return s, kve.Revision(), nil
+}
+
+// Put writes the session record for sess.Slot as a fresh entry. Fails
+// (with ErrCASConflict) if a record already exists at that slot —
+// callers must Delete first to take over an abandoned slot. Mirrors
+// the create-or-update split in internal/tasks.
+func (m *Manager) Put(ctx context.Context, sess Session) error {
+	assert.NotNil(ctx, "swarm.Put: ctx is nil")
+	assert.NotEmpty(sess.Slot, "swarm.Put: sess.Slot is empty")
+	if m.closed.Load() {
+		return ErrClosed
+	}
+	payload, err := encode(sess)
+	if err != nil {
+		return err
+	}
+	if _, err := m.kv.Create(ctx, sess.Slot, payload); err != nil {
+		if jskv.IsConflict(err) {
+			return ErrCASConflict
+		}
+		return fmt.Errorf("swarm.Put: %w", err)
+	}
+	return nil
+}
+
+// Update overwrites the session record for sess.Slot using a CAS gate
+// against expectedRev. Returns ErrCASConflict if the bucket's current
+// revision differs from expectedRev — another writer raced ours and
+// the caller should re-Get and decide whether to retry.
+//
+// Update is the heartbeat path: `bones swarm commit` reads the
+// current session, updates LastRenewed, and CAS-writes back.
+func (m *Manager) Update(
+	ctx context.Context, sess Session, expectedRev uint64,
+) error {
+	assert.NotNil(ctx, "swarm.Update: ctx is nil")
+	assert.NotEmpty(sess.Slot, "swarm.Update: sess.Slot is empty")
+	if m.closed.Load() {
+		return ErrClosed
+	}
+	payload, err := encode(sess)
+	if err != nil {
+		return err
+	}
+	if _, err := m.kv.Update(ctx, sess.Slot, payload, expectedRev); err != nil {
+		if jskv.IsConflict(err) {
+			return ErrCASConflict
+		}
+		return fmt.Errorf("swarm.Update: %w", err)
+	}
+	return nil
+}
+
+// Delete removes the session record at slot via a CAS gate against
+// expectedRev. ErrCASConflict on revision mismatch — callers should
+// re-Get and retry only if they still want to delete the (newer)
+// record. ErrNotFound if the key was already missing.
+//
+// Delete is the close path: `bones swarm close` removes the session
+// after posting the dispatch result and stopping the leaf.
+func (m *Manager) Delete(
+	ctx context.Context, slot string, expectedRev uint64,
+) error {
+	assert.NotNil(ctx, "swarm.Delete: ctx is nil")
+	assert.NotEmpty(slot, "swarm.Delete: slot is empty")
+	if m.closed.Load() {
+		return ErrClosed
+	}
+	if err := m.kv.Delete(ctx, slot, jetstream.LastRevision(expectedRev)); err != nil {
+		if jskv.IsConflict(err) {
+			return ErrCASConflict
+		}
+		if errors.Is(err, jetstream.ErrKeyNotFound) {
+			return ErrNotFound
+		}
+		return fmt.Errorf("swarm.Delete: %w", err)
+	}
+	return nil
+}
+
+// maxSessionEntries caps a List walk. Workspaces with more than this
+// many simultaneously-active swarm slots indicate a runaway dispatch
+// loop or stale-data condition that needs investigation, not a wider
+// scan.
+const maxSessionEntries = 1024
+
+// List returns every live session in the bucket. Order matches the
+// underlying JetStream KV list order (key-name lexicographic in
+// practice; callers that need a specific order should sort).
+func (m *Manager) List(ctx context.Context) ([]Session, error) {
+	assert.NotNil(ctx, "swarm.List: ctx is nil")
+	if m.closed.Load() {
+		return nil, ErrClosed
+	}
+	lister, err := m.kv.ListKeys(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("swarm.List: list keys: %w", err)
+	}
+	defer func() { _ = lister.Stop() }()
+	var out []Session
+	count := 0
+	for key := range lister.Keys() {
+		assert.Precondition(
+			count < maxSessionEntries,
+			"swarm.List: scanned more than %d entries", maxSessionEntries,
+		)
+		count++
+		kve, err := m.kv.Get(ctx, key)
+		if err != nil {
+			if errors.Is(err, jetstream.ErrKeyNotFound) {
+				continue
+			}
+			return nil, fmt.Errorf("swarm.List: get %q: %w", key, err)
+		}
+		if kve.Operation() != jetstream.KeyValuePut {
+			continue
+		}
+		s, err := decode(kve.Value())
+		if err != nil {
+			return nil, fmt.Errorf("swarm.List: decode %q: %w", key, err)
+		}
+		out = append(out, s)
+	}
+	return out, nil
+}
+
+// SlotDir returns the on-disk directory for the slot's per-leaf
+// state under the workspace root. Layout:
+//
+//	<workspace>/.bones/swarm/<slot>/
+//	├── leaf.fossil          libfossil repo (cloned from hub)
+//	├── leaf.pid             host-local PID tracker
+//	└── wt/                  worktree (Leaf.WT() result)
+//
+// Pure path derivation; no KV lookup. Callers can compute this
+// without opening a Manager — `bones swarm cwd` exploits exactly
+// that to avoid a NATS round-trip for a path query.
+func SlotDir(workspaceDir, slot string) string {
+	assert.NotEmpty(workspaceDir, "swarm.SlotDir: workspaceDir is empty")
+	assert.NotEmpty(slot, "swarm.SlotDir: slot is empty")
+	return filepath.Join(workspaceDir, ".bones", "swarm", slot)
+}
+
+// SlotWorktree returns the slot's worktree path. Equivalent to
+// filepath.Join(SlotDir(workspaceDir, slot), "wt"). Pulled out as a
+// distinct helper because `bones swarm cwd` always wants this — the
+// repo file and pid file are not user-facing.
+func SlotWorktree(workspaceDir, slot string) string {
+	return filepath.Join(SlotDir(workspaceDir, slot), "wt")
+}
+
+// SlotPidFile returns the slot's host-local PID-tracker path.
+// Used by swarm join to write and swarm close to remove.
+func SlotPidFile(workspaceDir, slot string) string {
+	return filepath.Join(SlotDir(workspaceDir, slot), "leaf.pid")
+}

--- a/internal/swarm/swarm_test.go
+++ b/internal/swarm/swarm_test.go
@@ -1,0 +1,186 @@
+package swarm
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go"
+
+	"github.com/danmestas/bones/internal/testutil/natstest"
+)
+
+// uniqueBucket returns a per-test bucket name so parallel runs do not
+// share state. Mirrors internal/presence/presence_test.go.
+func uniqueBucket(t *testing.T) string {
+	t.Helper()
+	return "bones-swarm-test-" + strings.ReplaceAll(t.Name(), "/", "-")
+}
+
+func openManager(t *testing.T, nc *nats.Conn) *Manager {
+	t.Helper()
+	m, err := Open(context.Background(), Config{
+		NATSConn:   nc,
+		BucketName: uniqueBucket(t),
+		TTL:        time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = m.Close() })
+	return m
+}
+
+func sampleSession(slot, taskID string) Session {
+	now := time.Now().UTC().Truncate(time.Second)
+	return Session{
+		Slot:        slot,
+		TaskID:      taskID,
+		AgentID:     "slot-" + slot,
+		Host:        "test-host",
+		LeafPID:     1234,
+		StartedAt:   now,
+		LastRenewed: now,
+	}
+}
+
+func TestConfigValidate(t *testing.T) {
+	if err := (Config{}).Validate(); err == nil {
+		t.Fatal("nil NATSConn must fail validation")
+	}
+}
+
+func TestPutGet(t *testing.T) {
+	nc, _ := natstest.NewJetStreamServer(t)
+	m := openManager(t, nc)
+
+	sess := sampleSession("rendering", "task-rendering-1")
+	if err := m.Put(context.Background(), sess); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	got, rev, err := m.Get(context.Background(), "rendering")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if rev == 0 {
+		t.Fatal("expected non-zero revision")
+	}
+	if got.Slot != sess.Slot || got.TaskID != sess.TaskID || got.AgentID != sess.AgentID {
+		t.Fatalf("session mismatch: got=%+v want=%+v", got, sess)
+	}
+}
+
+func TestGet_NotFound(t *testing.T) {
+	nc, _ := natstest.NewJetStreamServer(t)
+	m := openManager(t, nc)
+
+	_, _, err := m.Get(context.Background(), "missing")
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("Get: want ErrNotFound, got %v", err)
+	}
+}
+
+func TestPut_DuplicateConflict(t *testing.T) {
+	nc, _ := natstest.NewJetStreamServer(t)
+	m := openManager(t, nc)
+
+	sess := sampleSession("audio", "task-audio-1")
+	if err := m.Put(context.Background(), sess); err != nil {
+		t.Fatalf("first Put: %v", err)
+	}
+	if err := m.Put(context.Background(), sess); !errors.Is(err, ErrCASConflict) {
+		t.Fatalf("second Put: want ErrCASConflict, got %v", err)
+	}
+}
+
+func TestUpdate_CAS(t *testing.T) {
+	nc, _ := natstest.NewJetStreamServer(t)
+	m := openManager(t, nc)
+
+	sess := sampleSession("physics", "task-physics-1")
+	if err := m.Put(context.Background(), sess); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	got, rev, err := m.Get(context.Background(), "physics")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	got.LastRenewed = time.Now().UTC().Add(time.Minute).Truncate(time.Second)
+	if err := m.Update(context.Background(), got, rev); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	// Second Update with the now-stale revision must conflict.
+	if err := m.Update(context.Background(), got, rev); !errors.Is(err, ErrCASConflict) {
+		t.Fatalf("stale Update: want ErrCASConflict, got %v", err)
+	}
+}
+
+func TestDelete_CAS(t *testing.T) {
+	nc, _ := natstest.NewJetStreamServer(t)
+	m := openManager(t, nc)
+
+	sess := sampleSession("ui", "task-ui-1")
+	if err := m.Put(context.Background(), sess); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	_, rev, err := m.Get(context.Background(), "ui")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if err := m.Delete(context.Background(), "ui", rev); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	if _, _, err := m.Get(context.Background(), "ui"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("post-delete Get: want ErrNotFound, got %v", err)
+	}
+}
+
+func TestList(t *testing.T) {
+	nc, _ := natstest.NewJetStreamServer(t)
+	m := openManager(t, nc)
+
+	for _, slot := range []string{"a", "b", "c"} {
+		if err := m.Put(context.Background(), sampleSession(slot, "task-"+slot)); err != nil {
+			t.Fatalf("Put %s: %v", slot, err)
+		}
+	}
+	got, err := m.List(context.Background())
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("List: want 3 sessions, got %d (%+v)", len(got), got)
+	}
+}
+
+func TestSlotDirHelpers(t *testing.T) {
+	dir := SlotDir("/ws", "rendering")
+	if !strings.HasSuffix(dir, "/.bones/swarm/rendering") {
+		t.Errorf("SlotDir: %s", dir)
+	}
+	wt := SlotWorktree("/ws", "rendering")
+	if !strings.HasSuffix(wt, "/.bones/swarm/rendering/wt") {
+		t.Errorf("SlotWorktree: %s", wt)
+	}
+	pid := SlotPidFile("/ws", "rendering")
+	if !strings.HasSuffix(pid, "/.bones/swarm/rendering/leaf.pid") {
+		t.Errorf("SlotPidFile: %s", pid)
+	}
+}
+
+func TestClose_ReturnsErrClosedAfter(t *testing.T) {
+	nc, _ := natstest.NewJetStreamServer(t)
+	m := openManager(t, nc)
+
+	if err := m.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if _, _, err := m.Get(context.Background(), "x"); !errors.Is(err, ErrClosed) {
+		t.Fatalf("Get after Close: want ErrClosed, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Implements ADR 0028's R4 steps 1-6 + 8 — the substantive piece from the swarm-demo retro. Subagent prompts can now drive a slot through three CLI verbs (\`bones swarm join/commit/close\`) plus three read-only helpers (\`status/cwd/tasks\`) instead of the ~12 raw \`fossil\`/\`tasks\` calls the demo had to embed.

Step 7 (orchestrator SKILL.md rewrite using these verbs) is a follow-up PR — natural to review against working code.

## What's in

- \`internal/swarm/\` — \`Session\` struct, KV-backed \`Manager\` (Open/Get/Put/Update/Delete/List, all CAS-aware) backed by the \`bones-swarm-sessions\` bucket per the ADR revision (PR #45)
- \`internal/coord\` — provisions the new bucket alongside existing \`bones-tasks\`/\`bones-holds\`/\`bones-presence\`; \`LeafConfig.HubAddrs\` URL-string variant of \`*Hub\` so the agent-side CLI can open a leaf without an in-process Hub
- \`cli/swarm.go\` + 7 sibling files — the verbs, all wired into \`cmd/bones/cli.go\` under the **Daily** group
- \`cli/doctor.go\` — \`bones doctor\` now reads \`bones-swarm-sessions\` and surfaces stale / cross-host entries (R7 fold-in)
- \`cmd/bones/integration/swarm_test.go\` — full join→commit→close round-trip against a live workspace

8 commits, ~2,170 LOC. \`make check\`: OK. \`go test ./...\` and \`go test -tags=otel ./...\` both green.

## Concerns flagged by the implementer worth your read

1. **Phase-1 leaf is per-verb, not detached.** Each \`bones swarm <verb>\` opens a fresh \`*Leaf\`, does the work, stops. The session record's \`leaf_pid\` is the join-time CLI pid (already exited by commit-time), so \`pidAlive\` checks were relaxed to host-only. ADR 0028's "Process lifecycle" envisions a detached daemon — that's the natural R4 follow-up. Doctor will currently report "stale" on slots after their last \`commit\`.
2. **Hub URL is hard-coded** to \`http://127.0.0.1:8765\` with a \`--hub-url\` override. Workspace config records leaf URLs but not hub URLs. A workspace-recorded hub URL is a follow-up.
3. **Slot leaf NATS is standalone, not peered with the hub mesh.** \`Leaf.Commit\` writes to \`leaf.fossil\` but doesn't autosync to the hub via NATS today — \`HubAddrs.LeafUpstream\` is empty. KV (sessions/tasks/holds) still flows because the slot uses \`info.NATSURL\` (workspace leaf NATS). Cross-slot fan-in needs this wired up; the integration test verifies the \`Leaf.Commit\` UUID return but not hub-side propagation.
4. **\`swarm tasks\` slot-membership match is permissive** — accepts \`Context["slot"]\`, \`[slot: name]\` literal in title, or files starting with \`<slot>/\`. Strictly \`Context["slot"]\` would reject legacy tasks.
5. **Integration test seeds git** (init + commit) so \`seedHubRepo\` has something to seed from. Standard CI pattern.

These are worth tracking as follow-up tickets, not blockers — none of them break the demo flow this PR was meant to enable.

## Out of scope (future PRs)

- Step 7: orchestrator SKILL.md rewrite using \`swarm\` verbs (R6 + R3 fold-in)
- Detached-leaf daemon design (concern #1)
- Hub mesh peering for slot leaves (concern #3)
- \`bones swarm fan-in\` (the merge-leaves-back-to-trunk step)