### PR TITLE
skills: orchestrator + subagent use 'bones swarm' verbs (R4 step 7)

### DIFF
--- a/.claude/skills/orchestrator/SKILL.md
+++ b/.claude/skills/orchestrator/SKILL.md
@@ -1,36 +1,56 @@
 ---
 name: orchestrator
-description: Orchestrate hub-and-leaf parallel agent execution from a slot-annotated plan. Trigger when the user invokes a plan that contains [slot: name] task annotations or asks to "run plan in parallel" / "orchestrate this plan" / "dispatch agents from plan".
-when_to_use: Plan parser approved a [slot: name]-annotated plan and the user asks for parallel execution. NOT for serial single-agent execution.
+description: Orchestrate hub-and-leaf parallel agent execution from a slot-annotated plan via the `bones swarm` verbs. Trigger when the user invokes a plan that contains [slot: name] task annotations or asks to "run plan in parallel" / "orchestrate this plan" / "dispatch agents from plan".
+when_to_use: Plan validator approved a [slot: name]-annotated plan and the user asks for parallel execution. NOT for serial single-agent execution.
 ---
 
 # Orchestrator Skill
 
 You are the orchestrator. Your job is to validate a plan, bootstrap a hub
 (if it isn't already up), dispatch one Task-tool subagent per slot, monitor
-their progress, and clean up at completion.
+their progress, run a Phase 2 integration agent to wire the slots together,
+and clean up at completion.
+
+## Prerequisites
+
+This skill assumes the `bones` binary is on `$PATH` (it was when the skill
+was scaffolded). If `bones` is not found, stop and tell the user to reinstall:
+
+```
+brew install danmestas/tap/bones
+# or
+go install github.com/danmestas/bones/cmd/bones@latest
+# or download from https://github.com/danmestas/bones/releases
+```
+
+Do not auto-install. Wait for the user.
 
 ## Step 1: Validate the plan
 
-Run the validator against the plan path the user provided:
+Run the validator with the slot list flag — you'll need the slot→task
+mapping below:
 
 ```
-bones validate-plan <plan-path>
+bones validate-plan --list-slots <plan-path>
 ```
-
-(Or `go run ./cmd/bones/ validate-plan <plan-path>` if the binary
-isn't on `$PATH`.)
 
 If it exits non-zero, print the violations and stop. Do not dispatch
 subagents against an invalid plan. Tell the user which lines failed and
-what the [slot: name] format is.
+what the [slot: name] format is. The validator's slot-dir derivation
+walks file paths for the slot-name component, so nested layouts like
+`src/rendering/`, `src/physics/` validate cleanly.
+
+Capture the JSON output. Each entry has the slot's name and its task
+headings. You'll need the task IDs from `bones tasks list` to feed
+`bones swarm join`.
 
 ## Step 2: Verify hub is up
 
 Check that the SessionStart hook ran successfully:
 
 ```
-test -f .orchestrator/pids/leaf.pid && \
+test -f .orchestrator/pids/fossil.pid && \
+  test -f .orchestrator/pids/nats.pid && \
   curl -fsS -X POST http://127.0.0.1:8765/xfer >/dev/null
 ```
 
@@ -42,18 +62,20 @@ bash .orchestrator/scripts/hub-bootstrap.sh
 
 (Idempotent — safe to re-run.)
 
-## Step 3: Extract slots and tasks
+## Step 3: Create tasks and seed slot users
 
-Run the validator with `--list-slots` to get a machine-readable slot→task
-mapping:
+For each slot in the plan, create a task and pre-seed the slot's hub
+user (the `bones swarm join` flow does this lazily, but doing it once
+up-front is cleaner and lets you fail fast if something's wrong):
 
 ```
-bones validate-plan --list-slots <plan-path> | jq
+bones hub user add slot-<name>            # idempotent
+TASK_ID=$(bones tasks create "slot=<name>: <task title from plan>")
+echo "$TASK_ID"
 ```
 
-This emits JSON like `{"slots": [{"name": "alpha", "tasks": [...]}, ...]}`.
-Use the `tasks` array from each slot entry to build the dispatch prompt for
-Step 4 — no manual plan re-parsing needed.
+Record each `(slot, task_id)` pair. You'll pass them to `bones swarm
+join` in the next step.
 
 ## Step 4: Dispatch one subagent per slot
 
@@ -61,93 +83,134 @@ For each slot, invoke the Task tool with:
 
 - `subagent_type`: "general-purpose"
 - `description`: "subagent for slot=<name>"
-- `prompt`: the slot's task list verbatim, plus this preamble:
+- `prompt`: the slot's task list from the plan, plus this preamble:
 
-  > You are a subagent for slot=<name> in a hub-leaf orchestration. Use
-  > the `subagent` skill. Your environment:
-  > - AGENT_ID:  <slot>
-  > - SLOT_ID:   <slot>
-  > - HUB_URL:   http://127.0.0.1:8765
-  > - NATS_URL:  nats://127.0.0.1:4222
-  > - WORKDIR:   .orchestrator/leaves
+  > You are a subagent for slot=<name> in a bones swarm. Use the
+  > `subagent` skill. Your scope is the directory `<slot-dir>/`
+  > (per `[slot: <name>]` in the plan). Your task ID is `<task_id>`.
   >
-  > (LEAF_REPO and LEAF_WT are no longer injected — coord.OpenLeaf owns
-  > those paths under WORKDIR/<slot>/. See the subagent skill for details.)
+  > Lifecycle (the subagent skill spells these out further):
   >
-  > Your task list follows. Execute it; emit one fossil commit per task.
+  > 1. `bones swarm join --slot=<name> --task-id=<task_id>`
+  > 2. `cd $(bones swarm cwd --slot=<name>)`
+  > 3. Edit files in your slot's directory only. Commit each logical
+  >    unit with `bones swarm commit -m "slot-<name>: <message>"`.
+  >    NEVER call `fossil up` or `fossil commit` directly.
+  > 4. `bones swarm close --result=success --summary="<one-line summary>"`
+  >
+  > Concurrent slot work appears as separate branches at the hub —
+  > that is normal. Your `wt/` only ever shows your own commits +
+  > the seed.
+  >
+  > Your task list follows.
 
 The orchestrator dispatches subagents in parallel (single message with N
-Task tool calls).
-
-### Parallelism guidance (per docs/trials/2026-04-26/trial-report.md)
-
-Post-EdgeSync-refactor: the architecture is no longer hub-rate-limited
-at orchestration scale. The trial sweep at zero think time (worst case)
-shows 100% completion through N=64 with sub-100ms P99; production
-agents commit on minute timescales (~0.017 events/sec) so even N=100+
-is comfortable. The old "100-round Pull-negotiation wall" is gone — the
-EdgeSync NATS mesh sync replaces it.
-
-Tier guidance for picking concurrency (zero-think trial numbers):
-
-- **Sweet spot (sub-second P99):** N ≤ 32 slots. Use for interactive
-  tooling where latency matters.
-- **Acceptable (sub-100ms P99):** N ≤ 64 slots. Use for batch agents
-  with bearable latency.
-- **Stress ceiling (tight-loop):** N ≤ 100 slots, P99 ~450ms,
-  ~98% commit propagation in 30s. Beyond this hub-side serve-nats
-  queueing dominates.
-- **Production cadence (1 commit/min/agent):** 100+ agents
-  comfortable.
-
-If the plan has more slots than fit your concurrency tier, dispatch in
-batches (N at a time, wait for each batch to drain before starting the
-next). The trial harness `examples/herd-hub-leaf/` reproduces the
-envelope; consult its README and `docs/trials/2026-04-26/trial-report.md`
-for current numbers.
+Task tool calls). Each subagent's prompt includes its slot's task list
+verbatim from the plan.
 
 ## Step 5: Monitor
 
-Subscribe to NATS subjects to watch progress (in v1, this is mostly
-informational — you do not need to take action unless a subagent surfaces
-ErrConflictForked):
+While slots run, periodically check status:
 
-- `coord.tip.changed` — confirms commits landing
-- `coord.task.closed` — confirms task completion
+```
+bones swarm status               # active slots, their tasks, last-renewed timestamps
+bones tasks list                 # task-side view: open, claimed, closed
+```
 
-If a subagent surfaces ErrConflictForked, the planner partitioned slots
-incorrectly. Stop the run, report which two slots overlap on which paths,
-and recommend re-planning.
+The hub's Fossil timeline is the visual progress feed:
 
-## Step 6: Completion
+```
+bones peek                       # opens fossil ui in your browser, lands on /timeline
+```
 
-When all subagents return:
+Each `bones swarm commit` adds a check-in to the hub timeline,
+attributed to `slot-<name>`. Refresh as commits land.
 
-1. Verify fossil_commits == sum(tasks per slot) by querying the hub repo:
+If a subagent surfaces a fork-related error from `bones swarm commit`,
+the planner partitioned slots incorrectly. Stop the run, report which
+two slots overlap on which paths, and recommend re-planning.
+
+## Step 6: Phase 2 — integration / wiring agent
+
+When all Phase 1 subagents return DONE, **dispatch one more subagent** to
+wire the slots together. Without this step the swarm produces N disjoint
+subsystem modules and a half-empty entry point — the user-visible app
+loads but doesn't run end-to-end.
+
+For each plan, the integration agent:
+
+- Owns a separate `[slot: integration]` (or similar) — reserved by you,
+  writes typically `<root>/main.js` (or `cmd/<app>/main.go`, etc.) plus
+  any shared bus / event-router glue
+- Imports from the per-slot subsystems and wires their public APIs
+- Does an end-to-end smoke test (loads the page, runs the binary, etc.)
+
+Dispatch protocol is identical to Step 4 (a `bones swarm join` /
+`commit` / `close` agent). Wait for its DONE before proceeding.
+
+## Step 7: Completion
+
+When the integration agent returns:
+
+1. Verify the hub absorbed every slot's work:
 
    ```
-   fossil timeline --type ci -R .orchestrator/hub.fossil --limit <N>
+   fossil timeline -t ci -R .orchestrator/hub.fossil --limit <N>
    ```
 
-2. Print a summary: slots completed, tasks per slot, fork retries (from
-   span data if available), unrecoverable conflicts.
+   You should see one commit per `bones swarm commit` invocation across
+   all slots plus the integration agent's commits.
 
-3. (v2 stub for now) Log "PR generation skipped — implement in v2".
+2. Materialize the merged tip into the host project's working tree
+   (per ADR 0024). Run from the project root (where `.fslckout` lives):
+
+   ```
+   ROOT="$(git rev-parse --show-toplevel)"
+   (cd "$ROOT" && fossil update && git status)
+   ```
+
+3. Print a summary: slots completed, tasks per slot, integration
+   commits, any fan-in conflicts, peek URL the user can revisit.
+
+4. Tell the user: "Swarm complete. Browse the timeline with `bones peek`,
+   review the working-tree changes with `git diff`, stage the files you
+   want with `git add -u` (modified) or `git add <paths>` (specific),
+   then `git commit -m '...' && git push`."
 
 The hub itself stays running across the session — Stop hook will tear it
 down.
 
 ## Failure modes
 
-- Plan validation fails: report violations, stop.
-- Hub not reachable after bootstrap: print bootstrap log, stop.
-- Subagent dispatch fails (Task tool error): retry once; if still failing,
-  report and stop.
-- Subagent surfaces ErrConflictForked: report; do not auto-respawn.
+- **Plan validation fails:** report violations, stop.
+- **Hub not reachable after bootstrap:** print bootstrap log, stop.
+- **Subagent dispatch fails (Task tool error):** retry once; if still
+  failing, report and stop.
+- **Subagent surfaces fork on `bones swarm commit`:** the planner
+  partitioning is wrong. Stop; do not auto-respawn.
+- **`bones swarm status` shows a stale slot** (last_renewed >5 min ago,
+  no DONE return from subagent): the leaf may have crashed. Run
+  `bones swarm close --slot=<name> --result=fail` to clean up the
+  session record, then either redispatch or surface to the user.
 
-## What this skill does NOT do (v2 work)
+## Why this skill uses `bones swarm` instead of raw fossil
 
-- GitHub PR creation
+Earlier versions of this skill embedded `fossil add` / `fossil commit` /
+`fossil up trunk` literals in subagent prompts. That worked in
+serial-agent demos but broke under concurrent slots (the `fossil up`
+between own commits silently dropped files when sibling slots forked
+trunk — see `docs/code-review/2026-04-28-swarm-demo-retro.md`). The
+`bones swarm` verbs (ADR 0028) wrap the substrate so an agent never
+calls `fossil up` itself; concurrent forks become invisible to the
+slot's lineage and surface only at fan-in time.
+
+## What this skill does NOT do (future work)
+
+- Auto git-add/commit/push (user runs these after Step 7)
+- GitHub PR creation (user runs `gh pr create` after committing)
 - Remote-harness subagents (multi-cloud)
 - Auto-replan on conflict
 - Multi-session hub coordination beyond persistence
+- `bones swarm fan-in` — currently the integration agent is just a
+  Phase 2 dispatch; a dedicated verb that auto-merges open leaves is
+  future work

--- a/.claude/skills/subagent/SKILL.md
+++ b/.claude/skills/subagent/SKILL.md
@@ -1,95 +1,131 @@
 ---
 name: subagent
-description: Execute a slot's task list as a hub-leaf subagent — open a Leaf via coord.OpenLeaf, execute tasks via Claim/Commit/Close, and stop the leaf on exit. Trigger when invoked from a Task-tool prompt that references AGENT_ID/SLOT_ID/HUB_URL env vars.
+description: Execute a slot's task list as a bones swarm participant — `bones swarm join`, do work, commit per task, `bones swarm close`. Trigger when invoked from a Task-tool prompt that references slot=<name> and a task ID.
 when_to_use: Invoked by the orchestrator skill via the Task tool. NOT for general-purpose agent work.
 ---
 
 # Subagent Skill
 
-You are a subagent in a hub-leaf orchestration. The orchestrator gave you
-a slot's task list inline in this prompt and injected these environment values:
+You are a subagent in a bones swarm. The orchestrator's prompt told you:
 
-- AGENT_ID  — your unique agent id (typically same as SLOT_ID)
-- SLOT_ID   — slot you're servicing
-- HUB_URL   — hub HTTP base URL (e.g. http://127.0.0.1:8765)
-- NATS_URL  — NATS broker URL (e.g. nats://127.0.0.1:4222)
-- WORKDIR   — (optional) root directory for per-slot state; defaults to
-              `.orchestrator/leaves` if absent
+- the **slot name** you're servicing (`slot=<name>`)
+- the **task ID** you're claiming
+- the **task list** (the work to do, scoped to your slot's directory)
 
-Do NOT read `LEAF_REPO` or `LEAF_WT` — those env vars are stale. The leaf
-owns its own paths: `<workdir>/<slotID>/leaf.fossil` and
-`<workdir>/<slotID>/wt`, set internally by `coord.OpenLeaf`.
+## Prerequisites
 
-## Step 1: Open the Leaf
+This skill assumes the `bones` binary is on `$PATH` (it was when the skill
+was scaffolded). If `bones` is not found, stop and tell the user to reinstall:
 
-Call `coord.OpenLeaf` with the hub object and your slot config. In an
-in-process harness (e.g. `cmd/<harness>/main.go`):
-
-```go
-hub, err := coord.OpenHub(ctx, coord.HubConfig{...})
-
-leaf, err := coord.OpenLeaf(ctx, coord.LeafConfig{
-    Hub:     hub,          // required — provides all URL fields
-    Workdir: workdir,      // from WORKDIR env, or .orchestrator/leaves
-    SlotID:  slotID,       // from SLOT_ID env
-})
+```
+brew install danmestas/tap/bones
+# or
+go install github.com/danmestas/bones/cmd/bones@latest
+# or download from https://github.com/danmestas/bones/releases
 ```
 
-`OpenLeaf` clones the hub repo into `<workdir>/<slotID>/leaf.fossil`,
-opens a worktree at `<workdir>/<slotID>/wt`, starts the leaf.Agent
-(NATS mesh sync), and wires the claim/task Coord. All sync is handled
-internally; you do not subscribe to any NATS subjects.
+Do not auto-install. Wait for the user.
 
-## Step 2: Execute the task list
+## Lifecycle in three commands
 
-Your task list is inline in this prompt (not in env vars). For each task:
-
-1. Edit files per the task description (write to `leaf.WT()` paths).
-2. Open the task: `taskID, err := leaf.OpenTask(ctx, title, files)`.
-3. Claim it: `claim, err := leaf.Claim(ctx, taskID)`.
-4. Commit: `uuid, err := leaf.Commit(ctx, claim, files)`.
-   - `files` is `[]coord.File{{Path: "rel/path", Content: []byte{...}}, ...}`.
-   - On `ErrConflict`: this is a defense-in-depth assertion — slot
-     disjointness should make it impossible. If it occurs, stop
-     immediately and escalate to the orchestrator (return an error to
-     the Task tool; the orchestrator skill detects it and re-plans).
-5. Close the task: `err = leaf.Close(ctx, claim)`.
-
-Coord handles sync-on-commit and retry-on-transient-fault internally.
-
-## Step 3: Stop the leaf
-
-When the task list is empty:
-
-```go
-err = leaf.Stop()
+```
+bones swarm join   --slot=<name> --task-id=<task_id>
+bones swarm commit -m "slot-<name>: <what changed>"
+bones swarm close  --result=success --summary="<one-liner>"
 ```
 
-`Stop` shuts down the leaf.Agent, closes the NATS connection, and
-releases all resources. Return success to the Task tool.
+Steps below explain each in context.
+
+## Step 1: Join the swarm
+
+```
+bones swarm join --slot=<name> --task-id=<task_id>
+cd "$(bones swarm cwd --slot=<name>)"
+```
+
+What this does:
+
+- Auto-creates the `slot-<name>` user in the hub fossil if missing.
+- Opens a per-slot `coord.Leaf` (your own libfossil clone of the hub repo
+  + a NATS-mesh participant identity).
+- Claims your task in NATS KV.
+- Writes a session record to `bones-swarm-sessions` so other tooling
+  (`bones swarm status`, `bones doctor`) can see you.
+- Prints `BONES_SLOT_WT=<path>` for shell sourcing.
+
+After `cd`, you're inside `<workspace>/.bones/swarm/<slot>/wt/` — your
+private working tree. Touching files outside this dir is a planner-error
+signal (slot-disjointness was supposed to prevent that); surface to the
+orchestrator if forced.
+
+## Step 2: Edit and commit, repeating per logical unit
+
+Edit files freely. When a logical unit is complete, commit it:
+
+```
+bones swarm commit -m "slot-<name>: <descriptive message>"
+```
+
+What `swarm commit` does:
+
+- Scans your `wt/` for modifications via libfossil's checkout-state API.
+- Calls `Leaf.Commit` with the slot user identity — commits land in the
+  hub timeline attributed to `slot-<name>`.
+- Renews your claim's TTL (so long-running slots don't lose their hold).
+- Updates `last_renewed` on your session record.
+
+Important rules:
+
+- **NEVER call `fossil` directly.** No `fossil up`, no `fossil commit
+  --user X`, no `fossil add`. The swarm verbs handle all of it.
+- Concurrent slots will commit while you work. That's normal — their
+  commits land on the hub as a sibling branch, invisible to your `wt/`.
+  Your tip stays self-consistent.
+- One commit per logical unit, with a descriptive message. Three to six
+  commits per slot is typical.
+
+## Step 3: Close on completion
+
+When the task list is done:
+
+```
+bones swarm close --result=success --summary="<one-line description of what you built>"
+```
+
+What this does:
+
+- Posts a `dispatch.ResultMessage` to the task thread (the orchestrator
+  may consume this).
+- On `--result=success`: closes the underlying task in NATS KV and
+  releases your claim.
+- Stops your leaf process.
+- Deletes the session record.
+- The `wt/` and `leaf.fossil` files stay for forensics.
 
 ## Errors that abort the slot
 
-- `ErrConflict`: slot partition is wrong — surface to orchestrator.
-- Hub unreachable for >30 s: surface (operator handles).
+Surface these to the orchestrator (return error to the Task tool harness):
+
+- **`bones swarm join` fails with `claim already held`**: another
+  subagent is on this task. Don't fight it; report and stop.
+- **`bones swarm commit` reports a fork-related error**: the planner
+  partitioned slots incorrectly (your slot is fighting another for the
+  same path). The orchestrator skill detects this and stops.
+- **Hub unreachable** during any verb: surface immediately. Operator handles.
 
 ## Errors that do NOT abort the slot
 
-- Single transient Commit error (not ErrConflict): log, retry once.
-- NATS transient disconnect: the leaf.Agent's reconnect loop handles it.
+- **Transient NATS reconnect**: the underlying coord substrate retries.
+  No action needed.
+- **A `bones swarm commit` finds nothing to commit**: harmless; means
+  you ran the verb without modifications. Skip and continue.
 
----
+## What you do NOT do
 
-### Deviations from prior skill
-
-| Prior (pre-Phase-1 / pre-EdgeSync) | Current (ADR 0018) |
-|---|---|
-| Injected `LEAF_REPO`, `LEAF_WT` env vars | Paths owned by `coord.OpenLeaf`; use `leaf.WT()` |
-| `coord.Config{FossilRepoPath, CheckoutRoot, EnableTipBroadcast}` | `coord.LeafConfig{Hub, Workdir, SlotID}` — no fossil fields, no broadcast flag |
-| `coord.Claim(ctx, taskID, AgentID, ttl, files)` | `leaf.Claim(ctx, taskID)` — two args; TTL/slot are encapsulated in `*Leaf` |
-| `coord.CloseTask(ctx, taskID)` | `leaf.Close(ctx, claim)` — passes `*Claim`, delegates to `l.coord.CloseTask` internally |
-| Subscribe to `coord.tip.changed` JetStream | Gone (Phase 1 Task 8 deleted `sync_broadcast.go`); sync flows through EdgeSync NATS mesh in `leaf.Agent` |
-| `c.Close(ctx)` at exit | `leaf.Stop()` — shuts down agent + coord together |
-
-See ADR 0018 (`docs/adr/0018-edgesync-refactor.md`) for the architectural
-context behind these changes.
+- Don't run `fossil` directly.
+- Don't run `bones tasks claim/close` directly — `swarm join/close`
+  call them through the substrate. The `tasks` verbs are for humans
+  inspecting state, not for agent operation.
+- Don't edit files outside `$(bones swarm cwd --slot=<name>)`.
+- Don't fan-in / merge other slots' work — that's the orchestrator's
+  Phase 2 integration agent's job.

--- a/cli/templates/orchestrator/skills/orchestrator/SKILL.md
+++ b/cli/templates/orchestrator/skills/orchestrator/SKILL.md
@@ -1,14 +1,15 @@
 ---
 name: orchestrator
-description: Orchestrate hub-and-leaf parallel agent execution from a slot-annotated plan. Trigger when the user invokes a plan that contains [slot: name] task annotations or asks to "run plan in parallel" / "orchestrate this plan" / "dispatch agents from plan".
-when_to_use: Plan parser approved a [slot: name]-annotated plan and the user asks for parallel execution. NOT for serial single-agent execution.
+description: Orchestrate hub-and-leaf parallel agent execution from a slot-annotated plan via the `bones swarm` verbs. Trigger when the user invokes a plan that contains [slot: name] task annotations or asks to "run plan in parallel" / "orchestrate this plan" / "dispatch agents from plan".
+when_to_use: Plan validator approved a [slot: name]-annotated plan and the user asks for parallel execution. NOT for serial single-agent execution.
 ---
 
 # Orchestrator Skill
 
 You are the orchestrator. Your job is to validate a plan, bootstrap a hub
 (if it isn't already up), dispatch one Task-tool subagent per slot, monitor
-their progress, and clean up at completion.
+their progress, run a Phase 2 integration agent to wire the slots together,
+and clean up at completion.
 
 ## Prerequisites
 
@@ -26,18 +27,22 @@ Do not auto-install. Wait for the user.
 
 ## Step 1: Validate the plan
 
-Run the validator against the plan path the user provided:
+Run the validator with the slot list flag — you'll need the slot→task
+mapping below:
 
 ```
-bones validate-plan <plan-path>
+bones validate-plan --list-slots <plan-path>
 ```
-
-(Or `go run ./cmd/bones/ validate-plan <plan-path>` if the binary
-isn't on `$PATH`.)
 
 If it exits non-zero, print the violations and stop. Do not dispatch
 subagents against an invalid plan. Tell the user which lines failed and
-what the [slot: name] format is.
+what the [slot: name] format is. The validator's slot-dir derivation
+walks file paths for the slot-name component, so nested layouts like
+`src/rendering/`, `src/physics/` validate cleanly.
+
+Capture the JSON output. Each entry has the slot's name and its task
+headings. You'll need the task IDs from `bones tasks list` to feed
+`bones swarm join`.
 
 ## Step 2: Verify hub is up
 
@@ -57,10 +62,20 @@ bash .orchestrator/scripts/hub-bootstrap.sh
 
 (Idempotent — safe to re-run.)
 
-## Step 3: Extract slots and tasks
+## Step 3: Create tasks and seed slot users
 
-Parse the plan again (mentally, or by re-running the validator with a
-flag once it grows one) to enumerate slots and the task list per slot.
+For each slot in the plan, create a task and pre-seed the slot's hub
+user (the `bones swarm join` flow does this lazily, but doing it once
+up-front is cleaner and lets you fail fast if something's wrong):
+
+```
+bones hub user add slot-<name>            # idempotent
+TASK_ID=$(bones tasks create "slot=<name>: <task title from plan>")
+echo "$TASK_ID"
+```
+
+Record each `(slot, task_id)` pair. You'll pass them to `bones swarm
+join` in the next step.
 
 ## Step 4: Dispatch one subagent per slot
 
@@ -68,78 +83,134 @@ For each slot, invoke the Task tool with:
 
 - `subagent_type`: "general-purpose"
 - `description`: "subagent for slot=<name>"
-- `prompt`: the slot's task list verbatim, plus this preamble:
+- `prompt`: the slot's task list from the plan, plus this preamble:
 
-  > You are a subagent for slot=<name> in a hub-leaf orchestration. Use
-  > the `subagent` skill. Your environment:
-  > - LEAF_REPO: .orchestrator/leaves/<slot>/leaf.fossil
-  > - LEAF_WT:   .orchestrator/leaves/<slot>/wt
-  > - HUB_URL:   http://127.0.0.1:8765
-  > - NATS_URL:  nats://127.0.0.1:4222
-  > - AGENT_ID:  <slot>
-  > - SLOT_ID:   <slot>
+  > You are a subagent for slot=<name> in a bones swarm. Use the
+  > `subagent` skill. Your scope is the directory `<slot-dir>/`
+  > (per `[slot: <name>]` in the plan). Your task ID is `<task_id>`.
   >
-  > Your task list follows. Execute it; emit one fossil commit per task.
+  > Lifecycle (the subagent skill spells these out further):
+  >
+  > 1. `bones swarm join --slot=<name> --task-id=<task_id>`
+  > 2. `cd $(bones swarm cwd --slot=<name>)`
+  > 3. Edit files in your slot's directory only. Commit each logical
+  >    unit with `bones swarm commit -m "slot-<name>: <message>"`.
+  >    NEVER call `fossil up` or `fossil commit` directly.
+  > 4. `bones swarm close --result=success --summary="<one-line summary>"`
+  >
+  > Concurrent slot work appears as separate branches at the hub —
+  > that is normal. Your `wt/` only ever shows your own commits +
+  > the seed.
+  >
+  > Your task list follows.
 
 The orchestrator dispatches subagents in parallel (single message with N
-Task tool calls).
+Task tool calls). Each subagent's prompt includes its slot's task list
+verbatim from the plan.
 
 ## Step 5: Monitor
 
-Subscribe to NATS subjects to watch progress (in v1, this is mostly
-informational — you do not need to take action unless a subagent surfaces
-ErrConflictForked):
+While slots run, periodically check status:
 
-- `coord.tip.changed` — confirms commits landing
-- `coord.task.closed` — confirms task completion
+```
+bones swarm status               # active slots, their tasks, last-renewed timestamps
+bones tasks list                 # task-side view: open, claimed, closed
+```
 
-If a subagent surfaces ErrConflictForked, the planner partitioned slots
-incorrectly. Stop the run, report which two slots overlap on which paths,
-and recommend re-planning.
+The hub's Fossil timeline is the visual progress feed:
 
-## Step 6: Completion
+```
+bones peek                       # opens fossil ui in your browser, lands on /timeline
+```
 
-When all subagents return:
+Each `bones swarm commit` adds a check-in to the hub timeline,
+attributed to `slot-<name>`. Refresh as commits land.
 
-1. Verify fossil_commits == sum(tasks per slot) by querying the hub repo:
+If a subagent surfaces a fork-related error from `bones swarm commit`,
+the planner partitioned slots incorrectly. Stop the run, report which
+two slots overlap on which paths, and recommend re-planning.
+
+## Step 6: Phase 2 — integration / wiring agent
+
+When all Phase 1 subagents return DONE, **dispatch one more subagent** to
+wire the slots together. Without this step the swarm produces N disjoint
+subsystem modules and a half-empty entry point — the user-visible app
+loads but doesn't run end-to-end.
+
+For each plan, the integration agent:
+
+- Owns a separate `[slot: integration]` (or similar) — reserved by you,
+  writes typically `<root>/main.js` (or `cmd/<app>/main.go`, etc.) plus
+  any shared bus / event-router glue
+- Imports from the per-slot subsystems and wires their public APIs
+- Does an end-to-end smoke test (loads the page, runs the binary, etc.)
+
+Dispatch protocol is identical to Step 4 (a `bones swarm join` /
+`commit` / `close` agent). Wait for its DONE before proceeding.
+
+## Step 7: Completion
+
+When the integration agent returns:
+
+1. Verify the hub absorbed every slot's work:
 
    ```
-   fossil timeline --type ci -R .orchestrator/hub.fossil --limit <N>
+   fossil timeline -t ci -R .orchestrator/hub.fossil --limit <N>
    ```
+
+   You should see one commit per `bones swarm commit` invocation across
+   all slots plus the integration agent's commits.
 
 2. Materialize the merged tip into the host project's working tree
-   (per ADR 0024). The orchestrator's Fossil checkout shares the hub
-   repo file directly (opened by `hub-bootstrap.sh`), so `fossil update`
-   reads the autosynced tip and rewrites the working tree as ordinary
-   file changes. Run from the project root (where `.fslckout` lives):
+   (per ADR 0024). Run from the project root (where `.fslckout` lives):
 
    ```
    ROOT="$(git rev-parse --show-toplevel)"
    (cd "$ROOT" && fossil update && git status)
    ```
 
-3. Print a summary: slots completed, tasks per slot, fork retries (from
-   span data if available), unrecoverable conflicts.
+3. Print a summary: slots completed, tasks per slot, integration
+   commits, any fan-in conflicts, peek URL the user can revisit.
 
-4. Tell the user: "Swarm complete. Review with `git diff`. Stage the
-   files you want with `git add -u` (modified) or `git add <paths>`
-   (specific), then `git commit -m '...' && git push`."
+4. Tell the user: "Swarm complete. Browse the timeline with `bones peek`,
+   review the working-tree changes with `git diff`, stage the files you
+   want with `git add -u` (modified) or `git add <paths>` (specific),
+   then `git commit -m '...' && git push`."
 
 The hub itself stays running across the session — Stop hook will tear it
 down.
 
 ## Failure modes
 
-- Plan validation fails: report violations, stop.
-- Hub not reachable after bootstrap: print bootstrap log, stop.
-- Subagent dispatch fails (Task tool error): retry once; if still failing,
-  report and stop.
-- Subagent surfaces ErrConflictForked: report; do not auto-respawn.
+- **Plan validation fails:** report violations, stop.
+- **Hub not reachable after bootstrap:** print bootstrap log, stop.
+- **Subagent dispatch fails (Task tool error):** retry once; if still
+  failing, report and stop.
+- **Subagent surfaces fork on `bones swarm commit`:** the planner
+  partitioning is wrong. Stop; do not auto-respawn.
+- **`bones swarm status` shows a stale slot** (last_renewed >5 min ago,
+  no DONE return from subagent): the leaf may have crashed. Run
+  `bones swarm close --slot=<name> --result=fail` to clean up the
+  session record, then either redispatch or surface to the user.
 
-## What this skill does NOT do (v2 work)
+## Why this skill uses `bones swarm` instead of raw fossil
 
-- Auto git-add/commit/push (user runs these after Step 6)
+Earlier versions of this skill embedded `fossil add` / `fossil commit` /
+`fossil up trunk` literals in subagent prompts. That worked in
+serial-agent demos but broke under concurrent slots (the `fossil up`
+between own commits silently dropped files when sibling slots forked
+trunk — see `docs/code-review/2026-04-28-swarm-demo-retro.md`). The
+`bones swarm` verbs (ADR 0028) wrap the substrate so an agent never
+calls `fossil up` itself; concurrent forks become invisible to the
+slot's lineage and surface only at fan-in time.
+
+## What this skill does NOT do (future work)
+
+- Auto git-add/commit/push (user runs these after Step 7)
 - GitHub PR creation (user runs `gh pr create` after committing)
 - Remote-harness subagents (multi-cloud)
 - Auto-replan on conflict
 - Multi-session hub coordination beyond persistence
+- `bones swarm fan-in` — currently the integration agent is just a
+  Phase 2 dispatch; a dedicated verb that auto-merges open leaves is
+  future work

--- a/cli/templates/orchestrator/skills/subagent/SKILL.md
+++ b/cli/templates/orchestrator/skills/subagent/SKILL.md
@@ -1,20 +1,16 @@
 ---
 name: subagent
-description: Execute a slot's task list as a hub-leaf subagent — open the leaf repo, subscribe to tip.changed, execute tasks via coord, exit on completion. Trigger when invoked from a Task-tool prompt that references LEAF_REPO/HUB_URL/NATS_URL env vars.
+description: Execute a slot's task list as a bones swarm participant — `bones swarm join`, do work, commit per task, `bones swarm close`. Trigger when invoked from a Task-tool prompt that references slot=<name> and a task ID.
 when_to_use: Invoked by the orchestrator skill via the Task tool. NOT for general-purpose agent work.
 ---
 
 # Subagent Skill
 
-You are a subagent in a hub-leaf orchestration. The orchestrator gave you
-a slot's task list and these environment values:
+You are a subagent in a bones swarm. The orchestrator's prompt told you:
 
-- LEAF_REPO   — path to your leaf fossil repo (you may need to clone)
-- LEAF_WT     — path to your worktree directory
-- HUB_URL     — hub fossil HTTP base URL
-- NATS_URL    — NATS broker URL
-- AGENT_ID    — your unique agent id
-- SLOT_ID     — slot you're servicing
+- the **slot name** you're servicing (`slot=<name>`)
+- the **task ID** you're claiming
+- the **task list** (the work to do, scoped to your slot's directory)
 
 ## Prerequisites
 
@@ -30,67 +26,106 @@ go install github.com/danmestas/bones/cmd/bones@latest
 
 Do not auto-install. Wait for the user.
 
-## Step 1: Initialize leaf
-
-If LEAF_REPO does not exist, clone from hub:
+## Lifecycle in three commands
 
 ```
-mkdir -p "$(dirname "$LEAF_REPO")"
-fossil clone "$HUB_URL" "$LEAF_REPO"
+bones swarm join   --slot=<name> --task-id=<task_id>
+bones swarm commit -m "slot-<name>: <what changed>"
+bones swarm close  --result=success --summary="<one-liner>"
 ```
 
-Open the worktree:
+Steps below explain each in context.
+
+## Step 1: Join the swarm
 
 ```
-mkdir -p "$LEAF_WT"
-fossil open "$LEAF_REPO" --workdir "$LEAF_WT"
+bones swarm join --slot=<name> --task-id=<task_id>
+cd "$(bones swarm cwd --slot=<name>)"
 ```
 
-## Step 2: Open coord with tip.changed enabled
+What this does:
 
-Use coord.Config with:
-- AgentID = $AGENT_ID
-- NATSURL = $NATS_URL
-- HubURL = $HUB_URL
-- EnableTipBroadcast = true
-- FossilRepoPath = $LEAF_REPO
-- CheckoutRoot = $LEAF_WT
+- Auto-creates the `slot-<name>` user in the hub fossil if missing.
+- Opens a per-slot `coord.Leaf` (your own libfossil clone of the hub repo
+  + a NATS-mesh participant identity).
+- Claims your task in NATS KV.
+- Writes a session record to `bones-swarm-sessions` so other tooling
+  (`bones swarm status`, `bones doctor`) can see you.
+- Prints `BONES_SLOT_WT=<path>` for shell sourcing.
 
-The Open call wires the JetStream subscriber on coord.tip.changed; from
-this point forward, peer commits trigger pulls automatically.
+After `cd`, you're inside `<workspace>/.bones/swarm/<slot>/wt/` — your
+private working tree. Touching files outside this dir is a planner-error
+signal (slot-disjointness was supposed to prevent that); surface to the
+orchestrator if forced.
 
-## Step 3: Execute the task list
+## Step 2: Edit and commit, repeating per logical unit
 
-For each task in the list:
+Edit files freely. When a logical unit is complete, commit it:
 
-1. Edit files per the task's Files: block.
-2. Call `coord.Claim(ctx, taskID, AgentID, ttl, files)`.
-3. Call `coord.Commit(ctx, taskID, message, files)`.
-4. If Commit returns `ErrConflictForked`, the slot partition is wrong —
-   stop; surface to the orchestrator (return error to the Task tool
-   harness; the orchestrator skill detects it).
-5. Call `coord.CloseTask(ctx, taskID)`.
+```
+bones swarm commit -m "slot-<name>: <descriptive message>"
+```
 
-Coord handles pull-on-broadcast and retry-on-fork internally; you do not
-need to invoke them explicitly.
+What `swarm commit` does:
 
-## Step 4: Exit cleanly
+- Scans your `wt/` for modifications via libfossil's checkout-state API.
+- Calls `Leaf.Commit` with the slot user identity — commits land in the
+  hub timeline attributed to `slot-<name>`.
+- Renews your claim's TTL (so long-running slots don't lose their hold).
+- Updates `last_renewed` on your session record.
 
-When the task list is empty:
+Important rules:
 
-1. Emit a final presence ping (coord does this automatically on Close).
-2. Call `c.Close(ctx)` to unsub from NATS and free resources.
-3. Return success to the Task tool. The orchestrator collects results.
+- **NEVER call `fossil` directly.** No `fossil up`, no `fossil commit
+  --user X`, no `fossil add`. The swarm verbs handle all of it.
+- Concurrent slots will commit while you work. That's normal — their
+  commits land on the hub as a sibling branch, invisible to your `wt/`.
+  Your tip stays self-consistent.
+- One commit per logical unit, with a descriptive message. Three to six
+  commits per slot is typical.
+
+## Step 3: Close on completion
+
+When the task list is done:
+
+```
+bones swarm close --result=success --summary="<one-line description of what you built>"
+```
+
+What this does:
+
+- Posts a `dispatch.ResultMessage` to the task thread (the orchestrator
+  may consume this).
+- On `--result=success`: closes the underlying task in NATS KV and
+  releases your claim.
+- Stops your leaf process.
+- Deletes the session record.
+- The `wt/` and `leaf.fossil` files stay for forensics.
 
 ## Errors that abort the slot
 
-- ErrConflictForked: planner partitioning is wrong. Surface immediately.
-- Hub unreachable for >30 seconds: surface (operator handles).
-- Repeated NATS reconnect failures: surface (operator handles).
+Surface these to the orchestrator (return error to the Task tool harness):
+
+- **`bones swarm join` fails with `claim already held`**: another
+  subagent is on this task. Don't fight it; report and stop.
+- **`bones swarm commit` reports a fork-related error**: the planner
+  partitioned slots incorrectly (your slot is fighting another for the
+  same path). The orchestrator skill detects this and stops.
+- **Hub unreachable** during any verb: surface immediately. Operator handles.
 
 ## Errors that do NOT abort the slot
 
-- Single tip.changed pull failure: log, continue. Subsequent commits will
-  retry on their own fork detection.
-- NATS transient disconnect: JetStream durable consumer replays missed
-  broadcasts on reconnect. No action needed.
+- **Transient NATS reconnect**: the underlying coord substrate retries.
+  No action needed.
+- **A `bones swarm commit` finds nothing to commit**: harmless; means
+  you ran the verb without modifications. Skip and continue.
+
+## What you do NOT do
+
+- Don't run `fossil` directly.
+- Don't run `bones tasks claim/close` directly — `swarm join/close`
+  call them through the substrate. The `tasks` verbs are for humans
+  inspecting state, not for agent operation.
+- Don't edit files outside `$(bones swarm cwd --slot=<name>)`.
+- Don't fan-in / merge other slots' work — that's the orchestrator's
+  Phase 2 integration agent's job.


### PR DESCRIPTION
## Summary

Step 7 of ADR 0028's R4 plan, plus R3 and R6 from the swarm-demo retro folded in. The orchestrator and subagent skills now drive swarms through the \`bones swarm join/commit/close\` verbs (PR #46) instead of the raw \`fossil\` + Go-API protocol the older skill drafts encoded.

## What changed in the skills

### Orchestrator skill (\`orchestrator/SKILL.md\`)

- **Step 1 (validate)** now uses \`bones validate-plan --list-slots\` so the orchestrator gets a JSON slot→task mapping instead of "parse the plan again mentally" hand-waving.
- **Step 3 (new)** pre-seeds slot users via \`bones hub user add\` (PR #43) and creates one task per slot via \`bones tasks create\`. Records each \`(slot, task_id)\` pair for the dispatch step.
- **Step 4 (dispatch)** prompt template shrinks from 7 env vars + raw Go API references to a four-line lifecycle: \`swarm join\` → \`cd\` → \`swarm commit\` per unit → \`swarm close\`.
- **Step 5 (monitor)** points at \`bones swarm status\` and \`bones peek\` (PR #40) for live progress instead of "subscribe to NATS subjects in v1."
- **Step 6 (NEW — Phase 2 fan-in)** explicitly dispatches an integration agent after Phase 1 slots close. Without this, swarms produce N disjoint subsystem piles — the demo's "the app loads but doesn't play" outcome.
- **Failure modes** entry for stale sessions: \`bones swarm status\` shows \`last_renewed > 5min\`, run \`bones swarm close --result=fail\` to clean up.

### Subagent skill (\`subagent/SKILL.md\`)

- Replaces "open coord.Config with Go API" instructions with the three swarm verbs.
- **Explicitly forbids** \`fossil up\` / \`fossil commit\` / \`fossil add\` — the verbs handle all of that. This closes the file-loss footgun the swarm-demo retro flagged (R3).
- New section: "What you do NOT do" — sets expectations on scope: don't fan-in, don't run \`bones tasks claim/close\` directly, don't edit outside the slot's worktree.

## Both copies updated

- \`cli/templates/orchestrator/skills/{orchestrator,subagent}/SKILL.md\` — what \`bones orchestrator\` scaffolds into a consumer workspace (embed FS)
- \`.claude/skills/{orchestrator,subagent}/SKILL.md\` — in-repo dev copy this workspace uses

\`diff\` confirms the two locations are byte-identical.

## What's not in this PR

- \`cli/templates/orchestrator/skills/uninstall-bones/SKILL.md\` is unrelated (removal flow) — left alone.
- Detached-leaf-daemon work (concern #1 from #46) — separate ticket; the new skills already accommodate the per-verb leaf model.
- Slot-leaf hub-mesh peering (concern #3 from #46) — until that lands, slot commits don't autosync to the hub timeline. The skill mentions the timeline view but the demo flow is end-to-end-incomplete until #3 is closed.

## Test plan

- [x] \`go build ./...\` — green (the SKILL.md files are embedded via \`go:embed all:templates/orchestrator\`; build succeeds means embed reads the new content)
- [x] \`make check\` — \`check: OK\`
- [x] Both copies byte-identical via \`diff\`
- [ ] First swarm run using the new skill — to be exercised next session by following the orchestrator skill end-to-end against a real plan