### PR TITLE
swarm commit: HTTP-push to hub so timeline reflects slot work (concerns #1+#3)

### DIFF
--- a/cli/doctor.go
+++ b/cli/doctor.go
@@ -78,7 +78,6 @@ func (c *DoctorCmd) runSwarmReport() error {
 	host, _ := os.Hostname()
 	stale := 0
 	remote := 0
-	dead := 0
 	for _, s := range sessions {
 		state := classifySwarmSession(s, host)
 		if state == "stale" || state == "remote-stale" {
@@ -87,17 +86,14 @@ func (c *DoctorCmd) runSwarmReport() error {
 		if state == "remote" {
 			remote++
 		}
-		if state == "dead" {
-			dead++
-		}
-		fmt.Printf("  %-6s  slot=%-12s task=%s host=%s pid=%d\n",
-			labelFor(state), s.Slot, truncateID(s.TaskID, 8), s.Host, s.LeafPID)
+		fmt.Printf("  %-6s  slot=%-12s task=%s host=%s\n",
+			labelFor(state), s.Slot, truncateID(s.TaskID, 8), s.Host)
 	}
-	if stale+remote+dead == 0 {
+	if stale+remote == 0 {
 		fmt.Printf("  OK    %d active session(s)\n", len(sessions))
 	} else {
-		fmt.Printf("  NOTE  %d active, %d remote, %d stale, %d dead\n",
-			len(sessions)-stale-remote-dead, remote, stale, dead)
+		fmt.Printf("  NOTE  %d active, %d remote, %d stale\n",
+			len(sessions)-stale-remote, remote, stale)
 	}
 	return nil
 }
@@ -118,8 +114,6 @@ func labelFor(state string) string {
 		return "OK"
 	case "stale", "remote-stale":
 		return "WARN"
-	case "dead":
-		return "FAIL"
 	}
 	return "INFO"
 }

--- a/cli/swarm_commit.go
+++ b/cli/swarm_commit.go
@@ -65,7 +65,15 @@ func (c *SwarmCommitCmd) run(ctx context.Context, info workspace.Info) error {
 	if err != nil {
 		return err
 	}
-	defer func() { _ = leaf.Stop() }()
+	// leafStopped tracks whether the explicit Stop below ran so the
+	// defer doesn't call it twice (Agent.Stop is not idempotent on
+	// double-close).
+	leafStopped := false
+	defer func() {
+		if !leafStopped {
+			_ = leaf.Stop()
+		}
+	}()
 
 	files, err := c.gatherFiles(info, slot)
 	if err != nil {
@@ -75,17 +83,27 @@ func (c *SwarmCommitCmd) run(ctx context.Context, info workspace.Info) error {
 	if err != nil {
 		return err
 	}
-	// The Leaf.Commit above broadcasts a fossil-sync NATS announce
-	// over the workspace leaf's NATS connection — but the hub's
-	// xfer subscriber lives on a separate NATS deployment, so the
-	// commit lands locally in <swarm>/<slot>/leaf.fossil only. Push
-	// it explicitly to the hub via HTTP /xfer here so `bones peek`
-	// and the hub timeline see the commit. Soft-fail: if the hub is
-	// unreachable, stderr-warn but don't roll back the local commit.
-	if err := pushSlotToHub(ctx, info.WorkspaceDir, slot, hubURL); err != nil {
+	// Stop the leaf BEFORE pushing so the agent's libfossil.Repo
+	// handle is closed; pushSlotToHub then opens its own handle on
+	// leaf.fossil cleanly. The Leaf.Commit above broadcasts a
+	// fossil-sync NATS announce over the workspace leaf's NATS
+	// connection — but the hub's xfer subscriber lives on a
+	// separate NATS deployment, so the commit lands locally in
+	// <swarm>/<slot>/leaf.fossil only. Push it explicitly to the
+	// hub via HTTP /xfer here so `bones peek` and the hub timeline
+	// see the commit. Soft-fail: if the hub is unreachable,
+	// stderr-warn but don't roll back the local commit.
+	_ = leaf.Stop()
+	leafStopped = true
+	if res, perr := pushSlotToHub(ctx, info.WorkspaceDir, slot, sess.AgentID, hubURL); perr != nil {
 		fmt.Fprintf(os.Stderr,
 			"swarm commit: warning: push to hub %s failed: %v\n",
-			hubURL, err,
+			hubURL, perr,
+		)
+	} else if res != nil {
+		fmt.Fprintf(os.Stderr,
+			"swarm commit: pushed to hub %s rounds=%d files_sent=%d bytes_sent=%d\n",
+			hubURL, res.Rounds, res.FilesSent, res.BytesSent,
 		)
 	}
 	if err := c.renewSession(ctx, mgr, sess, rev); err != nil {
@@ -249,23 +267,40 @@ func (c *SwarmCommitCmd) renewSession(
 // the hub's NATS subscriber (the two NATS deployments are separate by
 // design — see ADR 0028 retro for the bug this fixes).
 //
-// The function opens leaf.fossil read/write, runs Sync(Push: true),
-// and closes the repo. Errors propagate; the caller decides whether
-// a hub-unreachable failure is fatal (commit success keeps the data
-// locally either way).
-func pushSlotToHub(ctx context.Context, workspaceDir, slot, hubURL string) error {
+// The fossilUser is the hub login the push authenticates as. Slot
+// users (created at join time by ensureSlotUser) have caps that
+// include "i" (check-in), so the hub accepts the push. Anonymous
+// "nobody" pushes would be rejected because hubs only grant "g" /
+// "h" / "o" by default — checkin requires authenticated identity.
+//
+// Errors propagate; the caller decides whether a hub-unreachable
+// failure is fatal (commit success keeps the data locally either way).
+func pushSlotToHub(
+	ctx context.Context, workspaceDir, slot, fossilUser, hubURL string,
+) (*libfossil.SyncResult, error) {
 	leafRepoPath := filepath.Join(swarm.SlotDir(workspaceDir, slot), "leaf.fossil")
 	leafRepo, err := libfossil.Open(leafRepoPath)
 	if err != nil {
-		return fmt.Errorf("open leaf repo: %w", err)
+		return nil, fmt.Errorf("open leaf repo: %w", err)
 	}
 	defer func() { _ = leafRepo.Close() }()
-	transport := libfossil.NewHTTPTransport(hubURL)
-	if _, err := leafRepo.Sync(ctx, transport, libfossil.SyncOpts{
-		Push: true,
-		Pull: false,
-	}); err != nil {
-		return fmt.Errorf("sync push: %w", err)
+	// project-code is required for the login-card nonce; libfossil
+	// panics in computeLogin if it's blank. Read it from the cloned
+	// leaf repo (same code as the hub since clone copies the
+	// project-code config row).
+	projectCode, err := leafRepo.Config("project-code")
+	if err != nil {
+		return nil, fmt.Errorf("read project-code: %w", err)
 	}
-	return nil
+	transport := libfossil.NewHTTPTransport(hubURL)
+	res, err := leafRepo.Sync(ctx, transport, libfossil.SyncOpts{
+		Push:        true,
+		Pull:        false,
+		User:        fossilUser,
+		ProjectCode: projectCode,
+	})
+	if err != nil {
+		return res, fmt.Errorf("sync push: %w", err)
+	}
+	return res, nil
 }

--- a/cli/swarm_commit.go
+++ b/cli/swarm_commit.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/danmestas/libfossil"
 	libfossilcli "github.com/danmestas/libfossil/cli"
 
 	"github.com/danmestas/bones/internal/coord"
@@ -59,7 +60,8 @@ func (c *SwarmCommitCmd) run(ctx context.Context, info workspace.Info) error {
 	if err := c.assertSessionLocal(sess, host); err != nil {
 		return err
 	}
-	leaf, err := c.openLeafForCommit(ctx, info, slot)
+	hubURL := c.resolveHubURL(sess)
+	leaf, err := c.openLeafForCommit(ctx, info, slot, hubURL)
 	if err != nil {
 		return err
 	}
@@ -73,6 +75,19 @@ func (c *SwarmCommitCmd) run(ctx context.Context, info workspace.Info) error {
 	if err != nil {
 		return err
 	}
+	// The Leaf.Commit above broadcasts a fossil-sync NATS announce
+	// over the workspace leaf's NATS connection — but the hub's
+	// xfer subscriber lives on a separate NATS deployment, so the
+	// commit lands locally in <swarm>/<slot>/leaf.fossil only. Push
+	// it explicitly to the hub via HTTP /xfer here so `bones peek`
+	// and the hub timeline see the commit. Soft-fail: if the hub is
+	// unreachable, stderr-warn but don't roll back the local commit.
+	if err := pushSlotToHub(ctx, info.WorkspaceDir, slot, hubURL); err != nil {
+		fmt.Fprintf(os.Stderr,
+			"swarm commit: warning: push to hub %s failed: %v\n",
+			hubURL, err,
+		)
+	}
 	if err := c.renewSession(ctx, mgr, sess, rev); err != nil {
 		// Commit succeeded; failing to extend the heartbeat is a
 		// soft error — log and return non-zero so the caller knows
@@ -85,6 +100,21 @@ func (c *SwarmCommitCmd) run(ctx context.Context, info workspace.Info) error {
 		"swarm commit: slot=%s task=%s files=%d\n",
 		slot, sess.TaskID, len(files))
 	return nil
+}
+
+// resolveHubURL picks the hub URL to use for this commit. Precedence:
+// explicit --hub-url flag > recorded session.HubURL > package default.
+// The session-recorded URL is the canonical source — it was captured
+// at join time and matches the leaf's clone origin. The flag is a
+// recovery escape hatch for sessions written before HubURL existed.
+func (c *SwarmCommitCmd) resolveHubURL(sess swarm.Session) string {
+	if c.HubURL != "" {
+		return c.HubURL
+	}
+	if sess.HubURL != "" {
+		return sess.HubURL
+	}
+	return defaultHubFossilURL
 }
 
 // assertSessionLocal returns an error if the session's host does not
@@ -111,14 +141,11 @@ func (c *SwarmCommitCmd) assertSessionLocal(sess swarm.Session, host string) err
 // openLeafForCommit re-attaches to the slot's already-cloned
 // leaf.fossil. coord.OpenLeaf is idempotent on the clone (skips when
 // leaf.fossil exists), so this resumes the existing slot rather than
-// double-cloning.
+// double-cloning. hubURL is resolved by the caller from --hub-url /
+// session.HubURL / package default in that order.
 func (c *SwarmCommitCmd) openLeafForCommit(
-	ctx context.Context, info workspace.Info, slot string,
+	ctx context.Context, info workspace.Info, slot, hubURL string,
 ) (*coord.Leaf, error) {
-	hubURL := c.HubURL
-	if hubURL == "" {
-		hubURL = defaultHubFossilURL
-	}
 	swarmRoot := filepath.Join(info.WorkspaceDir, ".bones", "swarm")
 	leaf, err := coord.OpenLeaf(ctx, coord.LeafConfig{
 		HubAddrs: coord.HubAddrs{
@@ -210,6 +237,35 @@ func (c *SwarmCommitCmd) renewSession(
 			return nil
 		}
 		return err
+	}
+	return nil
+}
+
+// pushSlotToHub HTTP-pushes the slot's leaf.fossil to the hub via
+// libfossil's /xfer transport. Mirrors what raw `fossil sync push`
+// does and what the original swarm-demo used; bones swarm wraps it so
+// commits made through `bones swarm commit` propagate to hub.fossil
+// without depending on the workspace leaf's NATS announce reaching
+// the hub's NATS subscriber (the two NATS deployments are separate by
+// design — see ADR 0028 retro for the bug this fixes).
+//
+// The function opens leaf.fossil read/write, runs Sync(Push: true),
+// and closes the repo. Errors propagate; the caller decides whether
+// a hub-unreachable failure is fatal (commit success keeps the data
+// locally either way).
+func pushSlotToHub(ctx context.Context, workspaceDir, slot, hubURL string) error {
+	leafRepoPath := filepath.Join(swarm.SlotDir(workspaceDir, slot), "leaf.fossil")
+	leafRepo, err := libfossil.Open(leafRepoPath)
+	if err != nil {
+		return fmt.Errorf("open leaf repo: %w", err)
+	}
+	defer func() { _ = leafRepo.Close() }()
+	transport := libfossil.NewHTTPTransport(hubURL)
+	if _, err := leafRepo.Sync(ctx, transport, libfossil.SyncOpts{
+		Push: true,
+		Pull: false,
+	}); err != nil {
+		return fmt.Errorf("sync push: %w", err)
 	}
 	return nil
 }

--- a/cli/swarm_helpers.go
+++ b/cli/swarm_helpers.go
@@ -1,29 +1,8 @@
 package cli
 
 import (
-	"os"
-	"syscall"
 	"time"
 )
-
-// pidAlive reports whether pid is a live process this user can signal.
-// Signal 0 is the standard "is the kernel still tracking this pid"
-// probe — it performs the lookup without delivering anything. Any
-// error (no such process, permission denied, malformed pid) returns
-// false. Mirrors internal/workspace/verify.go's helper, duplicated
-// here so the cli package does not import internal/workspace's
-// unexported function. ADR 0028 §"Process lifecycle and crash
-// recovery" calls out this exact probe.
-func pidAlive(pid int) bool {
-	if pid <= 0 {
-		return false
-	}
-	proc, err := os.FindProcess(pid)
-	if err != nil {
-		return false
-	}
-	return proc.Signal(syscall.Signal(0)) == nil
-}
 
 // timeNow is the time source for swarm verbs. Plain wrapper today;
 // pulled into a function so future test-time injection (e.g. a fixed

--- a/cli/swarm_join.go
+++ b/cli/swarm_join.go
@@ -88,7 +88,7 @@ func (c *SwarmJoinCmd) run(ctx context.Context, info workspace.Info) error {
 	// simplicity; subsequent commit/close re-take the claim each
 	// time. ADR 0028 §"Process lifecycle" outlines the future
 	// detached-leaf design that would change this.
-	if err := c.writeSession(ctx, mgr, info); err != nil {
+	if err := c.writeSession(ctx, mgr, info, c.resolvedHubURL()); err != nil {
 		_ = claim.Release()
 		_ = leaf.Stop()
 		return err
@@ -172,6 +172,16 @@ func (c *SwarmJoinCmd) checkExistingSession(
 	return nil
 }
 
+// resolvedHubURL returns the configured hub URL or the package
+// default if the flag was unset. Pulled into a helper so writeSession
+// stamps the same value openSwarmLeaf used.
+func (c *SwarmJoinCmd) resolvedHubURL() string {
+	if c.HubURL != "" {
+		return c.HubURL
+	}
+	return defaultHubFossilURL
+}
+
 // openSwarmLeaf opens the per-slot leaf rooted at the workspace's
 // .bones/swarm directory. Uses HubAddrs (URL-string variant of
 // LeafConfig) because the hub runs in a separate process and the
@@ -187,10 +197,7 @@ func (c *SwarmJoinCmd) checkExistingSession(
 func (c *SwarmJoinCmd) openSwarmLeaf(
 	ctx context.Context, info workspace.Info,
 ) (*coord.Leaf, error) {
-	hubURL := c.HubURL
-	if hubURL == "" {
-		hubURL = defaultHubFossilURL
-	}
+	hubURL := c.resolvedHubURL()
 	swarmRoot := filepath.Join(info.WorkspaceDir, ".bones", "swarm")
 	if err := os.MkdirAll(swarmRoot, 0o755); err != nil {
 		return nil, fmt.Errorf("mkdir swarm root: %w", err)
@@ -219,7 +226,7 @@ func (c *SwarmJoinCmd) openSwarmLeaf(
 }
 
 func (c *SwarmJoinCmd) writeSession(
-	ctx context.Context, mgr *swarm.Manager, info workspace.Info,
+	ctx context.Context, mgr *swarm.Manager, info workspace.Info, hubURL string,
 ) error {
 	host, _ := os.Hostname()
 	now := timeNow()
@@ -229,6 +236,7 @@ func (c *SwarmJoinCmd) writeSession(
 		AgentID:     c.slotAgentID(),
 		Host:        host,
 		LeafPID:     os.Getpid(),
+		HubURL:      hubURL,
 		StartedAt:   now,
 		LastRenewed: now,
 	}

--- a/cli/swarm_join.go
+++ b/cli/swarm_join.go
@@ -139,6 +139,13 @@ func (c *SwarmJoinCmd) ensureSlotUser() error {
 // checkExistingSession enforces invariant "one live session per slot"
 // before opening a fresh leaf. Honors --force for recovery scenarios
 // where a previous join crashed leaving stale state.
+//
+// Liveness signal is LastRenewed, not LeafPID. Every swarm verb is a
+// fresh CLI invocation whose pid is already-dead by the time the next
+// verb reads the record, so a pid-alive probe always fails on local
+// records. LastRenewed is stamped at join and bumped on every commit;
+// a record younger than the active threshold means an agent is
+// actively working the slot.
 func (c *SwarmJoinCmd) checkExistingSession(
 	ctx context.Context, mgr *swarm.Manager,
 ) error {
@@ -150,19 +157,20 @@ func (c *SwarmJoinCmd) checkExistingSession(
 		return fmt.Errorf("read existing session: %w", err)
 	}
 	host, _ := os.Hostname()
+	staleSec := int64(timeNow().Sub(existing.LastRenewed).Seconds())
 	if !c.ForceTakeover {
 		switch {
-		case existing.Host == host && existing.LeafPID > 0 && pidAlive(existing.LeafPID):
+		case existing.Host == host && staleSec <= activeThresholdSec:
 			return fmt.Errorf(
 				"slot %q already has a live session on this host"+
-					" (pid %d) — pass --force to take over",
-				c.Slot, existing.LeafPID,
+					" (renewed %ds ago) — pass --force to take over",
+				c.Slot, staleSec,
 			)
 		case existing.Host != host:
 			return fmt.Errorf(
-				"slot %q is owned by host %q (pid %d) — refusing"+
-					" to take over; pass --force on the owning host",
-				c.Slot, existing.Host, existing.LeafPID,
+				"slot %q is owned by host %q — refusing to take over;"+
+					" pass --force on the owning host",
+				c.Slot, existing.Host,
 			)
 		}
 	}

--- a/cli/swarm_status.go
+++ b/cli/swarm_status.go
@@ -15,9 +15,18 @@ import (
 	"github.com/danmestas/bones/internal/workspace"
 )
 
+// activeThresholdSec is the seconds-since-LastRenewed cutoff between
+// "active" and "stale" sessions. Sessions younger than this are
+// treated as alive; older ones are stale candidates for `bones doctor`
+// to flag. Mirrors the 90s heartbeat-skew window used elsewhere in
+// the codebase.
+const activeThresholdSec = 90
+
 // SwarmStatusCmd lists every active swarm session in the workspace.
-// Output combines KV state with a host-local PID liveness probe so a
-// crashed leaf surfaces as DEAD even before the bucket TTL evicts it.
+// Output is derived purely from KV state — there is no per-process
+// liveness probe because every swarm verb is a fresh CLI invocation
+// whose pid dies at end of verb. LastRenewed is the canonical signal:
+// active = renewed within activeThresholdSec, stale = older.
 type SwarmStatusCmd struct {
 	JSON bool `name:"json" help:"emit JSON"`
 }
@@ -67,10 +76,15 @@ func (c *SwarmStatusCmd) run(ctx context.Context, info workspace.Info) error {
 
 // buildStatusRows attaches a state label and a stale-seconds counter
 // to each session. State derivation:
-//   - "active" — last_renewed within 90s of now AND (cross-host OR pid alive)
-//   - "stale"  — older renewal but not yet TTL'd
-//   - "dead"   — pid dead on this host
-//   - "remote" — session lives on another host
+//   - "active"        — last_renewed within activeThresholdSec on this host
+//   - "stale"         — older than activeThresholdSec on this host
+//   - "remote"        — session lives on another host, recently renewed
+//   - "remote-stale"  — session lives on another host, last renewal old
+//
+// Note: there is no "dead" state. The Phase 1 contract is "every swarm
+// verb is its own CLI invocation," so the recorded pid is always
+// dead by the time a sibling verb reads the record. LastRenewed is
+// the canonical signal.
 func buildStatusRows(sessions []swarm.Session, host string, now time.Time) []statusRow {
 	out := make([]statusRow, 0, len(sessions))
 	for _, s := range sessions {
@@ -92,17 +106,13 @@ func buildStatusRows(sessions []swarm.Session, host string, now time.Time) []sta
 }
 
 func classifyState(s swarm.Session, host string, staleSec int64) string {
-	const activeThreshold = 90 // seconds since last renewal
 	if s.Host != host {
-		if staleSec > activeThreshold {
+		if staleSec > activeThresholdSec {
 			return "remote-stale"
 		}
 		return "remote"
 	}
-	if s.LeafPID > 0 && !pidAlive(s.LeafPID) {
-		return "dead"
-	}
-	if staleSec > activeThreshold {
+	if staleSec > activeThresholdSec {
 		return "stale"
 	}
 	return "active"

--- a/cmd/bones/integration/swarm_test.go
+++ b/cmd/bones/integration/swarm_test.go
@@ -125,6 +125,30 @@ func TestCLI_Swarm(t *testing.T) {
 		if len(uuid) < 16 {
 			t.Errorf("expected commit uuid, got %q", stdout)
 		}
+		// Hub-side propagation: the commit's UUID must land in the
+		// hub repo's timeline. Without the post-commit HTTP push the
+		// commit only lives in the slot's leaf.fossil — `bones peek`
+		// and any hub consumer would see nothing. This is the
+		// regression guard for the swarm-commit-hub-sync fix.
+		//
+		// Phase 1 ignores the -m flag at the libfossil layer (the
+		// leaf hardcodes a "leaf commit for task <id>" message), so
+		// we assert on the commit UUID prefix instead, which is
+		// stable and cross-version.
+		hubRepoPath := filepath.Join(dir, ".orchestrator", "hub.fossil")
+		tlOut, err := exec.Command("fossil", "timeline", "-R", hubRepoPath, "-n", "5", "-t", "ci").CombinedOutput()
+		if err != nil {
+			t.Fatalf("fossil timeline -R %s: %v\n%s", hubRepoPath, err, tlOut)
+		}
+		// fossil timeline shortens UUIDs to 10 chars; compare on the prefix.
+		uuidPrefix := uuid
+		if len(uuidPrefix) > 10 {
+			uuidPrefix = uuidPrefix[:10]
+		}
+		if !strings.Contains(string(tlOut), uuidPrefix) {
+			t.Fatalf("commit %s not in hub timeline; commit-stderr=%s\ntimeline:\n%s",
+				uuid, stderr, tlOut)
+		}
 	})
 
 	t.Run("close_deletes_session_and_closes_task", func(t *testing.T) {

--- a/cmd/bones/integration/swarm_test.go
+++ b/cmd/bones/integration/swarm_test.go
@@ -136,7 +136,9 @@ func TestCLI_Swarm(t *testing.T) {
 		// we assert on the commit UUID prefix instead, which is
 		// stable and cross-version.
 		hubRepoPath := filepath.Join(dir, ".orchestrator", "hub.fossil")
-		tlOut, err := exec.Command("fossil", "timeline", "-R", hubRepoPath, "-n", "5", "-t", "ci").CombinedOutput()
+		tlOut, err := exec.Command("fossil",
+			"timeline", "-R", hubRepoPath, "-n", "5", "-t", "ci",
+		).CombinedOutput()
 		if err != nil {
 			t.Fatalf("fossil timeline -R %s: %v\n%s", hubRepoPath, err, tlOut)
 		}

--- a/internal/swarm/session.go
+++ b/internal/swarm/session.go
@@ -58,10 +58,21 @@ type Session struct {
 	// than try to manage a remote leaf process.
 	Host string `json:"host"`
 
-	// LeafPID is the host-local PID of the leaf process. Only
-	// meaningful on the matching Host. Probed via os.FindProcess +
-	// signal 0 to detect crashes.
+	// LeafPID is the host-local PID of the bones CLI process that
+	// wrote this record at join time. Informational only — every
+	// swarm verb is its own short-lived CLI invocation, so this PID
+	// is already-dead by the time any later verb reads it. Kept as a
+	// debugging crumb (a pid that was alive at join means the join
+	// did happen on this host) but NOT a liveness signal; use
+	// LastRenewed for active/stale classification instead.
 	LeafPID int `json:"leaf_pid"`
+
+	// HubURL is the hub fossil HTTP URL recorded at join time. Later
+	// verbs read this so they can post-commit push the slot's
+	// leaf.fossil to the hub via /xfer without re-deriving the URL
+	// from a flag. Empty on records written by older clients;
+	// callers fall back to the join-flag default.
+	HubURL string `json:"hub_url,omitempty"`
 
 	// StartedAt is when this session record was first written.
 	// Immutable once set; later renewals only touch LastRenewed.
@@ -69,6 +80,8 @@ type Session struct {
 
 	// LastRenewed is updated on every `swarm commit` (which heartbeats
 	// the session) and used by `bones doctor` to flag stale entries.
+	// This is the canonical active/stale signal — see LeafPID for the
+	// "why we don't use the pid" discussion.
 	LastRenewed time.Time `json:"last_renewed"`
 }
 


### PR DESCRIPTION
## Summary

Closes the user-visible gap from PR #46's deferred concerns: \`bones swarm commit\` now actually propagates the slot's commit to the hub's \`hub.fossil\` so \`bones peek\` shows it and end-to-end demos work.

## What was wrong

\`cli/swarm_join.go\` opened each slot's leaf with \`NATSClient: info.NATSURL\` (the **workspace** leaf NATS, not the **hub** NATS). \`Leaf.Commit\` calls \`agent.SyncNow()\` which broadcasts on \`fossil.<projectcode>.sync\` over its NATS connection — so the broadcast reached the workspace leaf, not the hub. Slot commits landed in \`<workspace>/.bones/swarm/<slot>/leaf.fossil\` locally and never made it to the hub timeline.

## Primary fix (concern #3): post-commit HTTP push to hub

After \`Leaf.Commit\` succeeds in \`cli/swarm_commit.go\`, push the slot's leaf.fossil to the hub via libfossil's HTTP transport — the same \`/xfer\` endpoint hub-bootstrap.sh exposes, the same path raw \`fossil\` sync uses. Doesn't touch the NATS architecture.

\`Session.HubURL\` (new field on \`internal/swarm.Session\`) carries the hub URL from join-time to commit-time so the verb stays stateless across invocations.

Two implementation wrinkles worth knowing:

1. **Stop the leaf before the push.** The leaf's libfossil handle holds the SQLite WAL; opening a sibling connection from inside the same process while the agent is active would race. The commit verb now stops the leaf, opens libfossil directly, syncs, and exits. Documented inline.
2. **Authenticated push, not anonymous.** The hub's \"nobody\" caps don't include \`i\` (check-in), so anonymous push fails with \"authentication failed.\" The push uses \`User: sess.AgentID\` (= \`slot-<name>\`) and the leaf's stored \`ProjectCode\` for fossil's login flow. Slot users were pre-seeded by \`bones hub user add\` (PR #43).

Test stderr:
\`\`\`
swarm commit: pushed to hub http://127.0.0.1:NNNN rounds=2 files_sent=2 bytes_sent=369
\`\`\`

## Secondary fix (concern #1 partial): drop the leaf-PID liveness lie

The Phase-1 leaf is the bones CLI itself, which exits at end of verb. So \`Session.LeafPID\` was already-dead by the time anyone read it. \`bones swarm status\` then reported \"stale\" for slots that had just committed seconds ago.

\`cli/swarm_status.go\` now uses \`Session.LastRenewed\` exclusively as the active/stale signal (active = renewed within \`activeThresholdSec=90\`). The \`LeafPID\` field stays in the struct as informational metadata but no code makes claims about it being alive.

## Tertiary cleanups

- **#4 (slot-tasks match)**: Left as-is. Current 3-tier match (\`Context[slot]\` / title literal / file-prefix) works; tightening to \`Context[slot]\`-only would require validator + plan-format changes. Non-trivial scope-creep; flagged for a future PR if anyone hits a real false-match.
- **#5 (test git-init seed)**: Already explained by an existing comment (\"Hub's seedHubRepo walks \`git ls-files\` and refuses to seed an empty workspace\"). No change needed.

## Integration test coverage

\`cmd/bones/integration/swarm_test.go\` now asserts the slot commit appears at the hub's timeline:

\`\`\`go
// After swarm commit returns, verify the commit's UUID prefix is in
// the hub's fossil timeline (not just the slot's leaf.fossil).
\`\`\`

Test passes locally; CI should match.

## Commits

| SHA | What |
|---|---|
| \`4ca02ad\` | internal/swarm: persist HubURL on Session for cross-verb access |
| \`ddcc0e5\` | cli/swarm_commit: HTTP-push leaf.fossil to hub after Leaf.Commit |
| \`030860f\` | cli/swarm_status: drop PID liveness check; rely on LastRenewed only |
| \`9197ea7\` | cli/swarm_commit: stop leaf before hub push, set User and ProjectCode |
| \`232e3cc\` | cmd/bones/integration: verify slot commit appears at hub timeline |
| \`dcd59e6\` | cmd/bones/integration: wrap fossil timeline call to satisfy 100-col rule |

## Out of scope

- **\`-m\` flag is dropped at the leaf today.** \`coord.Leaf.Commit\` hardcodes \`\"leaf commit for task <id>\"\`; the user-supplied \`--message\` is unused beyond CLI parsing. Wiring it through \`libfossil.CommitOpts.Comment\` is a one-line follow-up — separate PR.
- **Detached-leaf daemon.** Each verb still opens a fresh leaf. With explicit hub push at commit-time, the per-verb leaf model works correctly; the daemon refinement is now optional, not required for correctness.
- **\`bones swarm fan-in\`** — auto-merging open leaves remains future work.

## Test plan

- [x] \`go build ./...\`
- [x] \`go test ./...\` — green; new \`TestCLI_Swarm/commit_writes_a_file\` asserts hub propagation
- [x] \`go test -tags=otel ./...\` — green
- [x] \`make check\` — \`check: OK\`