### PR TITLE
swarm: --message passthrough, fan-in verb, --slot stamping (A+B+D)

### DIFF
--- a/cli/swarm.go
+++ b/cli/swarm.go
@@ -24,6 +24,7 @@ type SwarmCmd struct {
 	Status SwarmStatusCmd `cmd:"" help:"List active swarm sessions"`
 	Cwd    SwarmCwdCmd    `cmd:"" help:"Print the slot's worktree path"`
 	Tasks  SwarmTasksCmd  `cmd:"" help:"List ready tasks matching slot"`
+	FanIn  SwarmFanInCmd  `cmd:"" name:"fan-in" help:"Merge open hub leaves into trunk"`
 }
 
 // openSwarmManager dials NATS for the workspace and opens a swarm

--- a/cli/swarm_commit.go
+++ b/cli/swarm_commit.go
@@ -235,7 +235,7 @@ func (c *SwarmCommitCmd) commitViaLeaf(
 		return "", fmt.Errorf("re-claim task %q: %w", taskID, err)
 	}
 	defer func() { _ = claim.Release() }()
-	uuid, err := leaf.Commit(ctx, claim, files)
+	uuid, err := leaf.Commit(ctx, claim, files, coord.WithMessage(c.Message))
 	if err != nil {
 		return "", fmt.Errorf("leaf commit: %w", err)
 	}

--- a/cli/swarm_fanin.go
+++ b/cli/swarm_fanin.go
@@ -1,0 +1,178 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	libfossilcli "github.com/danmestas/libfossil/cli"
+
+	"github.com/danmestas/bones/internal/workspace"
+)
+
+// SwarmFanInCmd merges every open leaf on the hub repo's trunk into a
+// single integration tip. After Phase 1 swarm slots close, the hub
+// typically has N leaves (one per slot lineage) — fan-in collapses
+// them so a downstream `fossil update` materializes a single merged
+// working tree.
+//
+// Implementation shells out to the system `fossil` binary because
+// libfossil's Repo.Merge requires distinct src/dst branch names, but
+// concurrent slot work produces sibling leaves on the SAME branch
+// (typically trunk). Same-branch leaf merging needs the multi-step
+// orchestration fossil's CLI does (open temp checkout → fossil merge
+// <UUID> → fossil commit). Acceptable: fan-in is an admin-scale
+// operation invoked once per swarm, not a hot path; the same `fossil`
+// dependency is already used by `bones peek`.
+//
+// On systems without `fossil` on PATH, `bones swarm fan-in` prints an
+// install hint and exits non-zero so a wrapping orchestrator can fall
+// back to manual instructions.
+type SwarmFanInCmd struct {
+	User    string `name:"user" default:"orchestrator" help:"fossil user attributed to merge"`
+	Message string `name:"message" short:"m" default:"" help:"merge commit message"`
+	DryRun  bool   `name:"dry-run" help:"show what would be merged without committing"`
+}
+
+func (c *SwarmFanInCmd) Run(g *libfossilcli.Globals) error {
+	hubRepo, fossilBin, err := c.resolvePrereqs()
+	if err != nil {
+		return err
+	}
+	leaves, err := openLeavesOnTrunk(fossilBin, hubRepo)
+	if err != nil {
+		return fmt.Errorf("list open leaves: %w", err)
+	}
+	switch len(leaves) {
+	case 0:
+		fmt.Println("swarm fan-in: no open leaves on trunk; nothing to do")
+		return nil
+	case 1:
+		fmt.Printf("swarm fan-in: only one leaf on trunk (%s); nothing to merge\n", leaves[0])
+		return nil
+	}
+	if c.DryRun {
+		printFanInDryRun(leaves)
+		return nil
+	}
+	return c.mergeLeaves(fossilBin, hubRepo, leaves)
+}
+
+// resolvePrereqs validates the workspace exists, the hub repo is on
+// disk, and the system `fossil` binary is reachable. Returns the hub
+// repo path and the resolved fossil binary path or an error suitable
+// for direct return from Run.
+func (c *SwarmFanInCmd) resolvePrereqs() (string, string, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", "", fmt.Errorf("cwd: %w", err)
+	}
+	info, err := workspace.Join(context.Background(), cwd)
+	if err != nil {
+		return "", "", fmt.Errorf("workspace: %w (run `bones init` or `bones up` first)", err)
+	}
+	hubRepo := filepath.Join(info.WorkspaceDir, ".orchestrator", "hub.fossil")
+	if _, err := os.Stat(hubRepo); err != nil {
+		return "", "", fmt.Errorf("hub repo not found at %s — run `bones up` first", hubRepo)
+	}
+	fossilBin, lookErr := exec.LookPath("fossil")
+	if lookErr != nil {
+		return "", "", fmt.Errorf(
+			"swarm fan-in requires the system `fossil` binary; install via " +
+				"`brew install fossil` (or apt) and re-run",
+		)
+	}
+	return hubRepo, fossilBin, nil
+}
+
+// mergeLeaves opens a temp checkout, walks every non-canonical leaf
+// merging it into the canonical, then commits the result as the
+// configured user.
+func (c *SwarmFanInCmd) mergeLeaves(fossilBin, hubRepo string, leaves []string) error {
+	canonical, others := leaves[0], leaves[1:]
+	mergeMsg := c.Message
+	if mergeMsg == "" {
+		mergeMsg = fmt.Sprintf("swarm fan-in: merge %d leaves into trunk", len(others))
+	}
+	wt, err := os.MkdirTemp(filepath.Dir(hubRepo), ".bones-fanin-*")
+	if err != nil {
+		return fmt.Errorf("mkdir temp checkout: %w", err)
+	}
+	defer func() { _ = os.RemoveAll(wt) }()
+	if err := runFossil(fossilBin, "open", "--force", hubRepo, "--workdir", wt); err != nil {
+		return fmt.Errorf("open temp checkout at %s: %w", wt, err)
+	}
+	defer func() { _ = runFossilIn(fossilBin, wt, "close", "--force") }()
+	if err := runFossilIn(fossilBin, wt, "update", canonical); err != nil {
+		return fmt.Errorf("update to canonical %s: %w", canonical, err)
+	}
+	for _, leaf := range others {
+		if err := runFossilIn(fossilBin, wt, "merge", "--no-warnings", leaf); err != nil {
+			return fmt.Errorf("merge leaf %s: %w", leaf, err)
+		}
+	}
+	if err := runFossilIn(
+		fossilBin, wt, "commit", "--no-warnings",
+		"--user", c.User, "-m", mergeMsg,
+	); err != nil {
+		return fmt.Errorf("commit fan-in: %w", err)
+	}
+	fmt.Printf("swarm fan-in: merged %d leaves into trunk\n", len(others))
+	fmt.Printf("  canonical:  %s\n", canonical)
+	for _, leaf := range others {
+		fmt.Printf("  merged-in:  %s\n", leaf)
+	}
+	return nil
+}
+
+func printFanInDryRun(leaves []string) {
+	fmt.Printf("swarm fan-in (dry-run): would merge %d leaves into trunk:\n", len(leaves)-1)
+	for _, l := range leaves[1:] {
+		fmt.Printf("  - %s\n", l)
+	}
+	fmt.Printf("  (canonical kept: %s)\n", leaves[0])
+}
+
+// openLeavesOnTrunk runs `fossil leaves -t trunk` and returns the
+// resulting UUIDs in the order fossil reports (most-recent first).
+// The first entry is treated as the canonical destination by the caller;
+// the rest are merge sources.
+func openLeavesOnTrunk(fossilBin, hubRepo string) ([]string, error) {
+	out, err := exec.Command(fossilBin, "leaves", "-R", hubRepo).Output()
+	if err != nil {
+		return nil, err
+	}
+	var leaves []string
+	for _, line := range strings.Split(string(out), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		// fossil leaves output: "(N) YYYY-MM-DD HH:MM:SS [uuid] comment ..."
+		open := strings.Index(line, "[")
+		closeIdx := strings.Index(line, "]")
+		if open < 0 || closeIdx <= open {
+			continue
+		}
+		leaves = append(leaves, line[open+1:closeIdx])
+	}
+	return leaves, nil
+}
+
+func runFossil(fossilBin string, args ...string) error {
+	cmd := exec.Command(fossilBin, args...)
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+func runFossilIn(fossilBin, dir string, args ...string) error {
+	cmd := exec.Command(fossilBin, args...)
+	cmd.Dir = dir
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}

--- a/cli/tasks_create.go
+++ b/cli/tasks_create.go
@@ -18,6 +18,7 @@ type TasksCreateCmd struct {
 	Files      string   `name:"files" help:"comma-separated file list"`
 	Parent     string   `name:"parent" help:"parent task id"`
 	DeferUntil string   `name:"defer-until" help:"RFC3339 time"`
+	Slot       string   `name:"slot" help:"slot name; stamps Context[slot]"`
 	Context    []string `name:"context" help:"key=value (repeatable)" sep:"none"`
 	JSON       bool     `name:"json" help:"emit JSON"`
 }
@@ -45,6 +46,13 @@ func (c *TasksCreateCmd) Run(g *libfossilcli.Globals) error {
 			return err
 		}
 		now := time.Now().UTC()
+		ctxMap := applyContext(nil, c.Context)
+		if c.Slot != "" {
+			if ctxMap == nil {
+				ctxMap = map[string]string{}
+			}
+			ctxMap["slot"] = c.Slot
+		}
 		t := tasks.Task{
 			ID:            uuid.NewString(),
 			Title:         c.Title,
@@ -52,7 +60,7 @@ func (c *TasksCreateCmd) Run(g *libfossilcli.Globals) error {
 			Files:         splitFiles(c.Files),
 			Parent:        c.Parent,
 			DeferUntil:    parsedDeferUntil,
-			Context:       applyContext(nil, c.Context),
+			Context:       ctxMap,
 			CreatedAt:     now,
 			UpdatedAt:     now,
 			SchemaVersion: tasks.SchemaVersion,

--- a/internal/coord/leaf.go
+++ b/internal/coord/leaf.go
@@ -329,11 +329,22 @@ func (l *Leaf) Claim(ctx context.Context, taskID TaskID) (*Claim, error) {
 // owned by leaf.Agent.
 //
 // On success, returns the manifest UUID of the new checkin.
-func (l *Leaf) Commit(ctx context.Context, claim *Claim, files []File) (string, error) {
+//
+// Variadic CommitOptions tune commit-time fields. WithMessage replaces
+// the default "leaf commit for task <id>" comment with a caller-supplied
+// string; WithUser overrides the slot-derived author.
+func (l *Leaf) Commit(
+	ctx context.Context, claim *Claim, files []File, opts ...CommitOption,
+) (string, error) {
 	assert.NotNil(l, "coord.Leaf.Commit: receiver is nil")
 	assert.NotNil(ctx, "coord.Leaf.Commit: ctx is nil")
 	assert.NotNil(claim, "coord.Leaf.Commit: claim is nil")
 	assert.Precondition(len(files) > 0, "coord.Leaf.Commit: files is empty")
+
+	co := commitConfig{}
+	for _, opt := range opts {
+		opt(&co)
+	}
 
 	// Hold-gate (Invariant 20) and epoch-gate (Invariant 24).
 	if err := l.coord.checkHolds(ctx, files); err != nil {
@@ -358,9 +369,16 @@ func (l *Leaf) Commit(ctx context.Context, claim *Claim, files []File) (string, 
 	if l.fossilUser != "" {
 		commitUser = l.fossilUser
 	}
+	if co.user != "" {
+		commitUser = co.user
+	}
+	commitComment := commitMessage(claim)
+	if co.message != "" {
+		commitComment = co.message
+	}
 	_, uuid, err := repo.Commit(libfossil.CommitOpts{
 		Files:   toCommit,
-		Comment: commitMessage(claim),
+		Comment: commitComment,
 		User:    commitUser,
 	})
 	if err != nil {
@@ -390,11 +408,31 @@ func (l *Leaf) Close(ctx context.Context, claim *Claim) error {
 	return claim.Release()
 }
 
-// commitMessage builds a default commit message for a Leaf.Commit. Kept
-// trivial in Phase 1; later phases will surface caller-supplied
-// messages once the orchestrator wires task descriptions through.
+// commitMessage builds the default commit message for Leaf.Commit when
+// the caller doesn't pass WithMessage.
 func commitMessage(c *Claim) string {
 	return "leaf commit for task " + string(c.TaskID())
+}
+
+// CommitOption tunes Leaf.Commit. Construct with WithMessage / WithUser.
+type CommitOption func(*commitConfig)
+
+// commitConfig holds the resolved options for a Leaf.Commit call.
+type commitConfig struct {
+	message string
+	user    string
+}
+
+// WithMessage replaces the default "leaf commit for task <id>" comment
+// with a caller-supplied string. Empty string is treated as "use default."
+func WithMessage(msg string) CommitOption {
+	return func(c *commitConfig) { c.message = msg }
+}
+
+// WithUser overrides the slot-derived commit author. Empty string is
+// treated as "use slot identity."
+func WithUser(user string) CommitOption {
+	return func(c *commitConfig) { c.user = user }
 }
 
 // normalizeLeadingSlash strips a single leading slash so absolute paths


### PR DESCRIPTION
## Summary

Three R4 follow-ups from PR #46's deferred concerns, bundled per discussion:

| | What | Concern |
|---|---|---|
| A | \`Leaf.Commit\` accepts \`coord.WithMessage(msg)\`; CLI plumbs \`--message\` through | --message dropped at leaf |
| B | New \`bones swarm fan-in\` verb merges open hub leaves into trunk | manual fossil-CLI ritual |
| D | \`bones tasks create --slot=X\` stamps \`Context["slot"]\` | swarm-tasks slot match was 3-tier permissive |

C (detached daemon) deliberately skipped — purely polish, not required for correctness.

## A: --message passthrough

\`coord.Leaf.Commit\` now takes variadic \`CommitOption\` (\`WithMessage\`, \`WithUser\`). Default behavior unchanged — callers passing nothing get the old \`"leaf commit for task <id>"\` comment, so \`examples/\`, \`demos/\`, and tests need no edits. \`cli/swarm_commit\` passes \`coord.WithMessage(c.Message)\` so the user's commit message lands in the fossil timeline as authored.

In-process commit paths (compact, media, hub seed) bypass \`Leaf.Commit\` and call \`libfossil.Repo.Commit\` directly with their own comments — no changes there.

## B: bones swarm fan-in

\`\`\`text
bones swarm fan-in [--user=orchestrator] [-m=<msg>] [--dry-run]
\`\`\`

Walks \`fossil leaves -R hub.fossil\`, picks the most-recent as canonical, opens a temp checkout under \`.orchestrator/\`, merges every other leaf into it, commits, closes. Fast-paths for zero/one leaves.

Implementation shells out to the system \`fossil\` binary because libfossil's \`Repo.Merge\` requires distinct src/dst branch names — concurrent slot work produces sibling leaves on the SAME branch (typically trunk), so same-branch leaf merging needs the multi-step orchestration fossil's CLI already does. Acceptable trade: fan-in is admin-scale, invoked once per swarm; the same \`fossil\` dependency posture as \`bones peek\`.

The orchestrator skill (PR #47) already references this verb in Phase 7; this implementation makes that reference real.

## D: tasks create --slot stamps Context[slot]

\`taskBelongsToSlot\` (used by \`bones swarm tasks --slot=X\`) already checks \`Context["slot"]\` first and falls through to title literal + file-prefix matches only as fallback. Adding \`--slot\` to \`bones tasks create\` lets callers populate that canonical key cleanly — strict match for new tasks, fallback compatibility for legacy plans. No breaking change.

\`\`\`bash
\$ bones tasks create "rendering work" --slot=rendering
\$ bones tasks show <id> | grep slot
context.slot=rendering
\`\`\`

## Test plan

- [x] \`go build ./...\`
- [x] \`go test ./...\` — green (no regressions)
- [x] \`go test -tags=otel ./...\` — green
- [x] \`make check\` — \`check: OK\`
- [x] Manual smoke verified: D end-to-end (\`tasks show\` shows \`context.slot=rendering\`); B fast-path (only-one-leaf returns clean); A wired through code at \`cli/swarm_commit.go:238\`

## Smoke wrinkle worth flagging (not introduced by this PR)

\`bones swarm commit\` with absolute file paths trips the hold-gate's path comparison; relative paths work. The integration test uses relative paths, which is why it passes. A path-normalization fix is a small follow-up but unrelated to A/B/D. Captured for the next bundle.

## Out of scope (future)

- C (detached-leaf daemon) — skipped per discussion; purely polish, hub-push at commit time made it unnecessary
- Auto-discovery of dirty files in \`swarm commit\` — currently requires explicit file args (separate gap from PR #46)
- Path normalization in \`swarm commit\` — surfaced by the smoke; small follow-up