### PR TITLE
swarm commit: acquire holds + auto-discover dirty files (#50)

### DIFF
--- a/cli/swarm_commit.go
+++ b/cli/swarm_commit.go
@@ -182,8 +182,8 @@ func (c *SwarmCommitCmd) openLeafForCommit(
 
 // gatherFiles materializes the file set passed to Leaf.Commit. When
 // the caller listed files explicitly, read them from the slot's
-// worktree. Otherwise, surface a clear error: explicit-file commit is
-// required for now (auto-discovery of modified files is a follow-up).
+// worktree. Otherwise, walk the slot's wt/ for regular files and
+// commit them all (auto-discovery — ADR 0028 §"swarm commit").
 //
 // Each File.Path is set to the absolute workspace path so the
 // holds-gate (Invariant 4 / coord.checkHolds) sees a key matching
@@ -192,13 +192,10 @@ func (c *SwarmCommitCmd) openLeafForCommit(
 // relative-to-repo Name, so the same Path field works as both the
 // hold key and the commit target.
 func (c *SwarmCommitCmd) gatherFiles(info workspace.Info, slot string) ([]coord.File, error) {
-	if len(c.Files) == 0 {
-		return nil, fmt.Errorf(
-			"swarm commit: at least one file argument required" +
-				" (auto-discovery of dirty files is not yet implemented)",
-		)
-	}
 	wt := swarm.SlotWorktree(info.WorkspaceDir, slot)
+	if len(c.Files) == 0 {
+		return c.discoverDirtyFiles(info, wt)
+	}
 	out := make([]coord.File, 0, len(c.Files))
 	for _, rel := range c.Files {
 		// Strip prefixes so callers can pass any of:
@@ -218,6 +215,76 @@ func (c *SwarmCommitCmd) gatherFiles(info workspace.Info, slot string) ([]coord.
 		// bucket. Search via filepath.Join(workspaceDir, ...).
 		taskPath := filepath.Join(info.WorkspaceDir, clean)
 		out = append(out, coord.File{Path: taskPath, Content: data})
+	}
+	return out, nil
+}
+
+// discoverDirtyFiles walks the slot's worktree for regular files and
+// returns one coord.File per discovered path. Used when `swarm
+// commit` is invoked with no positional file arguments.
+//
+// libfossil exposes a Checkout.Status() that reports tracked-file
+// changes, but the slot's wt/ has no .fslckout (Phase 1 swarm join
+// creates wt as a plain directory — see internal/coord/leaf.go
+// OpenLeaf), so a checkout-based scan would error before returning
+// any results. Walking the directory directly mirrors the actual
+// swarm workflow: the slot writes new files under wt/ as it works
+// and Leaf.Commit ships the bytes via libfossil's content-addressed
+// FileToCommit path (no checkout required).
+//
+// Skipped: anything under .fslckout / .fossil-settings (fossil
+// metadata that may appear if a future change wires checkouts in),
+// hidden directories starting with "." (common scratch dirs like
+// .git, .vscode), and non-regular files (symlinks, sockets,
+// devices). Returns ErrNothingToCommit when wt/ has no commitable
+// files so callers see a clear "nothing to commit" error rather
+// than a downstream Leaf.Commit precondition panic.
+func (c *SwarmCommitCmd) discoverDirtyFiles(
+	info workspace.Info, wt string,
+) ([]coord.File, error) {
+	var out []coord.File
+	err := filepath.WalkDir(wt, func(path string, d os.DirEntry, werr error) error {
+		if werr != nil {
+			return werr
+		}
+		if d.IsDir() {
+			// Skip fossil metadata + hidden dirs at any depth.
+			name := d.Name()
+			if path != wt && (name == ".fslckout" ||
+				name == ".fossil-settings" ||
+				strings.HasPrefix(name, ".")) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !d.Type().IsRegular() {
+			return nil
+		}
+		// Belt-and-suspenders: also skip the .fslckout database file
+		// itself if it ever appears as a file rather than a dir.
+		if d.Name() == ".fslckout" {
+			return nil
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("read %s: %w", path, err)
+		}
+		rel, err := filepath.Rel(wt, path)
+		if err != nil {
+			return fmt.Errorf("rel %s: %w", path, err)
+		}
+		// Same path convention as the explicit-files branch: the
+		// holds-gate key is workspaceDir/<rel>, which is what the
+		// task record carries when --files= is passed.
+		taskPath := filepath.Join(info.WorkspaceDir, rel)
+		out = append(out, coord.File{Path: taskPath, Content: data})
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("scan wt %s: %w", wt, err)
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("swarm commit: nothing to commit (wt %s is empty)", wt)
 	}
 	return out, nil
 }

--- a/cli/swarm_commit.go
+++ b/cli/swarm_commit.go
@@ -227,6 +227,14 @@ func (c *SwarmCommitCmd) gatherFiles(info workspace.Info, slot string) ([]coord.
 // releases (the session record keeps the swarm hold across processes
 // on the bones-holds bucket — claim-release here only undoes the
 // re-claim we just took, not the underlying session ownership).
+//
+// Before Commit we also AnnounceHolds for every file's path, so
+// commits succeed even when the task was created with --slot=X but
+// no --files=. The slot owns its wt/ — files inside that dir are
+// commitable territory whether or not the task record listed them
+// up front. AnnounceHolds is idempotent for files this slot already
+// holds (e.g. via the task's pre-populated Files list at Claim
+// time), so this is safe to call unconditionally.
 func (c *SwarmCommitCmd) commitViaLeaf(
 	ctx context.Context, leaf *coord.Leaf, taskID string, files []coord.File,
 ) (string, error) {
@@ -235,6 +243,15 @@ func (c *SwarmCommitCmd) commitViaLeaf(
 		return "", fmt.Errorf("re-claim task %q: %w", taskID, err)
 	}
 	defer func() { _ = claim.Release() }()
+	paths := make([]string, 0, len(files))
+	for _, f := range files {
+		paths = append(paths, f.Path)
+	}
+	releaseHolds, err := leaf.AnnounceHolds(ctx, paths)
+	if err != nil {
+		return "", fmt.Errorf("announce holds: %w", err)
+	}
+	defer releaseHolds()
 	uuid, err := leaf.Commit(ctx, claim, files, coord.WithMessage(c.Message))
 	if err != nil {
 		return "", fmt.Errorf("leaf commit: %w", err)

--- a/cmd/bones/integration/swarm_test.go
+++ b/cmd/bones/integration/swarm_test.go
@@ -293,3 +293,135 @@ func createSwarmTask(t *testing.T, dir, absFile, title string) string {
 	}
 	return id
 }
+
+// createSwarmTaskNoFiles creates a task with NO --files= and only a
+// --slot= context. Mirrors the orchestrator-skill flow where agents
+// create per-slot tasks without enumerating files up front; the slot
+// owns its wt/ and `swarm commit` should announce holds + auto-
+// discover files at commit time.
+func createSwarmTaskNoFiles(t *testing.T, dir, slot, title string) string {
+	t.Helper()
+	stdout, stderr, code := runCmd(t, bonesBin, dir, "tasks", "create",
+		"--context", "slot="+slot,
+		title)
+	if code != 0 {
+		t.Fatalf("tasks create (no files) exit=%d stderr=%s", code, stderr)
+	}
+	id := firstLine(stdout)
+	if len(id) < 16 {
+		t.Fatalf("expected uuid on stdout, got %q", stdout)
+	}
+	return id
+}
+
+// TestCLI_SwarmAutoDiscover exercises the no-pre-populated-files
+// path: a task created with --slot= but NO --files=, joined,
+// populated with two new files in wt/, then committed via `swarm
+// commit -m "..."` with NO positional file args. Auto-discovery
+// must pick up both files and the commit must land in the hub
+// timeline. Regression guard for the two gaps surfaced by the
+// 2026-04-28 swarm-demo retro.
+func TestCLI_SwarmAutoDiscover(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip in -short: integration test")
+	}
+	requireBinaries(t)
+	dir := setupSwarmWorkspace(t)
+	if resolved, err := filepath.EvalSymlinks(dir); err == nil {
+		dir = resolved
+	}
+	httpPort, natsPort := pickPortPair(t)
+	startSwarmHub(t, dir, httpPort, natsPort)
+	hubURL := fmt.Sprintf("http://127.0.0.1:%d", httpPort)
+
+	slot := "rendering"
+	taskID := createSwarmTaskNoFiles(t, dir, slot, "[slot: rendering] no-files task")
+
+	// Join.
+	if _, stderr, code := runCmd(t, bonesBin, dir,
+		"swarm", "join",
+		"--slot="+slot, "--task-id="+taskID,
+		"--hub-url="+hubURL,
+	); code != 0 {
+		t.Fatalf("swarm join exit=%d stderr=%s", code, stderr)
+	}
+
+	// Populate wt/ with two files. Both untracked.
+	wt := filepath.Join(dir, ".bones", "swarm", slot, "wt")
+	files := map[string][]byte{
+		filepath.Join(wt, "out", "a.txt"):     []byte("first auto file\n"),
+		filepath.Join(wt, "out", "b", "c.txt"): []byte("second auto file\n"),
+	}
+	for path, content := range files {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("mkdir wt subdir: %v", err)
+		}
+		if err := os.WriteFile(path, content, 0o644); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+
+	// Commit with NO file args — auto-discovery should pick up both.
+	stdout, stderr, code := runCmd(t, bonesBin, dir,
+		"swarm", "commit",
+		"--slot="+slot, "-m=auto-discover both files",
+		"--hub-url="+hubURL,
+	)
+	if code != 0 {
+		t.Fatalf("swarm commit (auto) exit=%d stderr=%s stdout=%s", code, stderr, stdout)
+	}
+	uuid := firstLine(stdout)
+	if len(uuid) < 16 {
+		t.Fatalf("expected commit uuid on stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "files=2") {
+		t.Errorf("stderr should report files=2 from auto-discover; got: %s", stderr)
+	}
+
+	// Hub timeline must carry the commit.
+	hubRepoPath := filepath.Join(dir, ".orchestrator", "hub.fossil")
+	tlOut, err := exec.Command("fossil",
+		"timeline", "-R", hubRepoPath, "-n", "5", "-t", "ci",
+	).CombinedOutput()
+	if err != nil {
+		t.Fatalf("fossil timeline -R %s: %v\n%s", hubRepoPath, err, tlOut)
+	}
+	uuidPrefix := uuid
+	if len(uuidPrefix) > 10 {
+		uuidPrefix = uuidPrefix[:10]
+	}
+	if !strings.Contains(string(tlOut), uuidPrefix) {
+		t.Fatalf("commit %s not in hub timeline; commit-stderr=%s\ntimeline:\n%s",
+			uuid, stderr, tlOut)
+	}
+
+	// Verify both files landed in the manifest. `fossil artifact
+	// <uuid>` dumps the raw checkin manifest; the F-cards list
+	// every file with its name and content hash. We grep for the
+	// workspace-relative tail because the in-fossil filename is
+	// the disk-absolute path with the leading slash trimmed (per
+	// gatherFiles' Path mapping — the hold-bucket key is the
+	// abs path, and Leaf.Commit reuses File.Path as the commit
+	// filename via normalizeLeadingSlash).
+	manifestOut, mErr := exec.Command("fossil",
+		"artifact", "-R", hubRepoPath, uuid,
+	).CombinedOutput()
+	if mErr != nil {
+		t.Fatalf("fossil artifact -R %s %s: %v\n%s",
+			hubRepoPath, uuid, mErr, manifestOut)
+	}
+	for _, want := range []string{"out/a.txt", "out/b/c.txt"} {
+		if !strings.Contains(string(manifestOut), want) {
+			t.Errorf("hub commit missing %q; artifact:\n%s", want, manifestOut)
+		}
+	}
+
+	// Clean shutdown.
+	if _, stderr, code := runCmd(t, bonesBin, dir,
+		"swarm", "close",
+		"--slot="+slot, "--result=success", "--summary=auto",
+		"--hub-url="+hubURL,
+	); code != 0 {
+		t.Fatalf("swarm close exit=%d stderr=%s", code, stderr)
+	}
+}

--- a/cmd/bones/integration/swarm_test.go
+++ b/cmd/bones/integration/swarm_test.go
@@ -349,7 +349,7 @@ func TestCLI_SwarmAutoDiscover(t *testing.T) {
 	// Populate wt/ with two files. Both untracked.
 	wt := filepath.Join(dir, ".bones", "swarm", slot, "wt")
 	files := map[string][]byte{
-		filepath.Join(wt, "out", "a.txt"):     []byte("first auto file\n"),
+		filepath.Join(wt, "out", "a.txt"):      []byte("first auto file\n"),
 		filepath.Join(wt, "out", "b", "c.txt"): []byte("second auto file\n"),
 	}
 	for path, content := range files {

--- a/internal/coord/leaf.go
+++ b/internal/coord/leaf.go
@@ -315,6 +315,55 @@ func (l *Leaf) Claim(ctx context.Context, taskID TaskID) (*Claim, error) {
 	return &Claim{taskID: taskID, release: rel}, nil
 }
 
+// AnnounceHolds acquires file-scoped holds under the leaf's slot
+// identity for every path in paths. Idempotent for files already held
+// by this slot (holds.Announce treats same-agent re-announce as a
+// lease renewal); returns an error if any path is currently held by a
+// DIFFERENT identity (ErrHeldByAnother, wrapped). On success returns
+// a release closure that releases every successfully-held file.
+//
+// Designed for swarm-style flows where the slot's worktree is its
+// territory but the task record's Files list may not have been
+// pre-populated at task-create time. Callers (e.g. `bones swarm
+// commit`) call AnnounceHolds before Commit so the hold-gate (see
+// checkHolds / Invariant 20) sees the per-path holds the slot needs
+// to commit.
+//
+// Paths must be absolute (holds.Announce asserts on this). The
+// release closure swallows individual release errors — best-effort
+// cleanup, mirroring the semantics of the Claim release closure.
+func (l *Leaf) AnnounceHolds(
+	ctx context.Context, paths []string,
+) (release func(), err error) {
+	assert.NotNil(l, "coord.Leaf.AnnounceHolds: receiver is nil")
+	assert.NotNil(ctx, "coord.Leaf.AnnounceHolds: ctx is nil")
+	if len(paths) == 0 {
+		return func() {}, nil
+	}
+	ttl := l.coord.cfg.Tuning.HoldTTLDefault
+	if l.claimTTL != 0 {
+		ttl = l.claimTTL
+	}
+	// Reuse the Coord's claimAll helper: same semantics as Claim's
+	// per-file Announce loop, parameterized on a synthetic taskID
+	// (the slot identity) so the holds-bucket value carries a
+	// meaningful CheckoutPath. No task CAS happens here — these
+	// holds are purely the file-level locks the commit-time gate
+	// reads via WhoHas.
+	held, herr := l.coord.claimAll(ctx, TaskID(l.slotID), paths, ttl)
+	if herr != nil {
+		// Roll back any partially-acquired holds before surfacing the
+		// error so we don't leak holds on a path the caller never got
+		// to see succeed.
+		l.coord.rollback(ctx, held)
+		return nil, fmt.Errorf("coord.Leaf.AnnounceHolds: %w", herr)
+	}
+	rel := func() {
+		l.coord.rollback(ctx, held)
+	}
+	return rel, nil
+}
+
 // Commit writes files into the leaf's libfossil repo as a new checkin
 // authored by the slot, then triggers a sync round (SyncNow).
 //


### PR DESCRIPTION
## Summary

Two quality-of-life gaps in \`bones swarm commit\` surfaced by the #49 smoke. Closes both. After this PR, the orchestrator skill's documented flow (\`bones tasks create --slot=X\` → \`bones swarm join\` → \`bones swarm commit\`) works end-to-end without the orchestrator pre-populating task \`--files=\`.

## Gap 1: hold-gate rejects files not in task's Files list

**The bug**: when a task is created with no \`--files=\`, \`coord.Coord.Claim\` doesn't acquire any holds (it walks \`task.Files\` which is empty). The commit-time \`checkHolds\` then fails any file the slot tries to commit. The smoke surfaced this as:

\`\`\`
leaf commit: coord.Commit: coord: file(s) not held by caller: [/abs/path/to/file]
\`\`\`

**The fix**: new public method \`*coord.Leaf.AnnounceHolds(ctx, paths) (release, error)\` exposes the existing internal \`claimAll\` for swarm-style flows. \`cli/swarm_commit.go\` calls it before \`Leaf.Commit\` so the slot's \"my worktree is my territory\" model works without orchestrator gymnastics. Idempotent for files already held by THIS slot; errors if a different identity holds them.

## Gap 2: swarm commit doesn't auto-discover dirty files

\`bones swarm commit -m \"x\"\` previously errored: \"at least one file argument required (auto-discovery of dirty files is not yet implemented).\" Per ADR 0028 the verb should scan \`wt/\` for modifications when no positional file args are given.

**The fix**: when \`c.Files\` is empty, walk the slot's \`wt/\` directory and commit every regular file found. Subagent's note: walks the dir directly rather than calling \`libfossil.Checkout.Status()\` because Phase 1 \`OpenLeaf\` creates \`wt/\` as a plain directory (no \`.fslckout\`); \`Status()\` would error before returning anything. The walk matches actual swarm usage where the slot writes new files via \`Leaf.Commit\`'s content-addressed \`FileToCommit\` path.

## Test coverage

New \`TestCLI_SwarmAutoDiscover\` exercises the full flow:

1. Task created with NO \`--files=\` and \`--slot=X\`
2. \`swarm join\`
3. Two files written into \`wt/\`
4. \`swarm commit -m \"...\"\` (no positional args)
5. Hub timeline confirms both files are in the new commit

Existing \`TestCLI_Swarm\` (explicit-files path) still passes.

## Commits

| SHA | What |
|---|---|
| \`8ad654a\` | coord/leaf: AnnounceHolds for swarm-style hold acquisition |
| \`cea8a60\` | cli/swarm_commit: acquire holds before commit (slot owns its worktree) |
| \`6477d9e\` | cli/swarm_commit: auto-discover dirty files when none specified |
| \`91e5e5c\` | cmd/bones/integration: swarm commit works without pre-populated --files |
| \`43f6251\` | cmd/bones/integration: gofmt swarm_test.go (trivial) |

## Subagent's design notes worth your read

1. **Auto-discovery via direct walk, not \`Checkout.Status()\`** — see "the fix" above. If a future PR wires libfossil checkouts into slot worktrees, swap the walker for \`Status()\`.
2. **Files in fossil are committed under disk-absolute paths with leading slash trimmed** (e.g., \`private/var/folders/.../out/a.txt\`). This is the existing \`gatherFiles\` behavior — keeps the holds-bucket key consistent. The integration test asserts via \`fossil artifact <uuid>\` and matches on the workspace-relative tail to avoid the tmpdir prefix.
3. **\`AnnounceHolds\` reuses \`claimAll\`** with the slot ID as the synthetic \`CheckoutPath\` value. No task-CAS; pure file-level locks. Idempotent for same-agent re-announce (lease renewal).

## Test plan

- [x] \`go build ./...\`
- [x] \`go test ./...\` — green; new \`TestCLI_SwarmAutoDiscover\` passes
- [x] \`go test -tags=otel ./...\` — green
- [x] \`make check\` — \`check: OK\`

## Out of scope

- C (detached daemon) still skipped — purely polish
- Future: when slot worktrees gain a \`.fslckout\` (i.e., become real fossil checkouts), the auto-discovery should switch from dir-walk to \`Checkout.Status()\` so deletions and renames are tracked correctly. Today the slot's \`wt/\` is a plain dir; the walker is the right tool.