### PR TITLE
coord+swarm: fix orphan-commit bug + fan-in USER detection (#51)

### DIFF
--- a/cli/swarm_fanin.go
+++ b/cli/swarm_fanin.go
@@ -162,8 +162,19 @@ func openLeavesOnTrunk(fossilBin, hubRepo string) ([]string, error) {
 	return leaves, nil
 }
 
+// fossilEnv ensures USER is set for fossil's "who am I" detection.
+// Inherited subprocess envs may lack USER (sandboxed test runners,
+// some daemons), in which case `fossil update` and `fossil merge`
+// abort with "Cannot figure out who you are!" before any user-mode
+// flag like --user can apply. The orchestrator is the only sensible
+// default for fan-in operations.
+func fossilEnv() []string {
+	return append(os.Environ(), "USER=orchestrator")
+}
+
 func runFossil(fossilBin string, args ...string) error {
 	cmd := exec.Command(fossilBin, args...)
+	cmd.Env = fossilEnv()
 	cmd.Stdout = os.Stderr
 	cmd.Stderr = os.Stderr
 	return cmd.Run()
@@ -172,6 +183,7 @@ func runFossil(fossilBin string, args ...string) error {
 func runFossilIn(fossilBin, dir string, args ...string) error {
 	cmd := exec.Command(fossilBin, args...)
 	cmd.Dir = dir
+	cmd.Env = fossilEnv()
 	cmd.Stdout = os.Stderr
 	cmd.Stderr = os.Stderr
 	return cmd.Run()

--- a/internal/coord/leaf.go
+++ b/internal/coord/leaf.go
@@ -425,10 +425,24 @@ func (l *Leaf) Commit(
 	if co.message != "" {
 		commitComment = co.message
 	}
+	// Resolve the current branch tip so the new commit lists it as
+	// its parent. Without this, libfossil writes an orphan checkin
+	// (no P-card on the manifest), every commit becomes its own
+	// root, and the hub timeline shows N disconnected leaves
+	// instead of a chain. BranchTip on a fresh slot leaf returns
+	// the seed commit's rid (cloned from hub at OpenLeaf time).
+	// On a brand-new empty repo with no trunk tip yet, BranchTip
+	// returns "no rows" / "branch not found"; that's the legitimate
+	// first-commit case where ParentID=0 is correct (orphan root).
+	parentID, btErr := repo.BranchTip("trunk")
+	if btErr != nil && !isBranchTipMissing(btErr) {
+		return "", fmt.Errorf("coord.Leaf.Commit: resolve trunk tip: %w", btErr)
+	}
 	_, uuid, err := repo.Commit(libfossil.CommitOpts{
-		Files:   toCommit,
-		Comment: commitComment,
-		User:    commitUser,
+		Files:    toCommit,
+		ParentID: parentID,
+		Comment:  commitComment,
+		User:     commitUser,
 	})
 	if err != nil {
 		return "", fmt.Errorf("coord.Leaf.Commit: %w", err)
@@ -461,6 +475,15 @@ func (l *Leaf) Close(ctx context.Context, claim *Claim) error {
 // the caller doesn't pass WithMessage.
 func commitMessage(c *Claim) string {
 	return "leaf commit for task " + string(c.TaskID())
+}
+
+// isBranchTipMissing reports whether err is libfossil's "this branch
+// has no commits yet" error. BranchTip wraps sql.ErrNoRows in that
+// case (queried table has zero matching rows). The first commit on
+// an empty repo is legitimate; ParentID=0 produces the correct
+// orphan-root manifest.
+func isBranchTipMissing(err error) bool {
+	return errors.Is(err, sql.ErrNoRows)
 }
 
 // CommitOption tunes Leaf.Commit. Construct with WithMessage / WithUser.


### PR DESCRIPTION
## Summary

The #50 swarm demo surfaced two real bugs by inspection — the timeline showed 13 disconnected "leaf check-ins" instead of a tree. This fixes both.

## Bug 1: \`Leaf.Commit\` produces orphan commits (no P-card)

\`internal/coord/leaf.go\`'s \`Leaf.Commit\` built \`libfossil.CommitOpts\` without setting \`ParentID\`. libfossil treats a zero \`ParentID\` as "this is a root commit," so **every commit landed with no P-card and no parent linkage**. Within a single slot, three sequential commits looked like three independent roots; across slots, the hub saw N×M unrelated histories.

This silently affected every \`Leaf.Commit\` call site — \`examples/herd-hub-leaf\`, \`examples/hub-leaf-e2e\`, \`demos/space-invaders-orchestrate\`, and the integration test. None asserted on parent linkage so it stayed hidden until the user spotted it on the timeline.

**Fix**: resolve \`repo.BranchTip("trunk")\` and pass its rid as \`ParentID\`. Slot commits now chain off the seed (or the previous commit). Empty-repo first-commit case (\`sql.ErrNoRows\` from \`BranchTip\`) handled by a small \`isBranchTipMissing\` helper that lets \`ParentID=0\` through — which is the correct orphan-root for the very first commit.

**Verified** via smoke: third rendering commit's manifest now carries \`P <previous-uuid>\` properly. Existing \`TestLeaf_CommitWritesAndSyncs\` (which exercised the empty-repo path) confirms the helper handles that case.

## Bug 2: \`bones swarm fan-in\` errors with "Cannot figure out who you are!"

\`cli/swarm_fanin.go\` ran fossil with the inherited environment. Some launch contexts (sandboxed test runners, detached daemons) lack \`USER\`, and fossil aborts on \`fossil update <canonical>\` before any \`--user\`-style flag can apply. Fan-in's first call hit this in the demo.

**Fix**: \`fossilEnv()\` helper appends \`USER=orchestrator\` to \`os.Environ()\`, applied to both \`runFossil\` and \`runFossilIn\`. The orchestrator is the only sensible default for fan-in.

## Test plan

- [x] \`go build ./...\`
- [x] \`go test ./...\` — green; existing \`TestLeaf_CommitWritesAndSyncs\` covers the empty-repo path
- [x] \`go test -tags=otel ./...\` — green
- [x] \`make check\` — \`check: OK\`
- [x] Manual smoke: \`bones up\` → \`bones swarm join/commit/close\` × 5 → \`fossil artifact <hash>\` shows P-cards present and pointing at the previous commit's UUID

## Files changed

- \`internal/coord/leaf.go\` — \`Leaf.Commit\` resolves and passes \`ParentID\`; new \`isBranchTipMissing(err)\` helper
- \`cli/swarm_fanin.go\` — new \`fossilEnv()\` helper; applied to both \`runFossil\` and \`runFossilIn\`