### PR TITLE
swarm: fix fan-in merge flag and slot-commit file paths

### DIFF
--- a/cli/hub_user.go
+++ b/cli/hub_user.go
@@ -84,8 +84,19 @@ func (c *HubUserListCmd) Run(g *libfossilcli.Globals) error {
 	return nil
 }
 
+// ErrHubRepoNotBootstrapped is returned by hubRepoPath when the
+// workspace has no hub.fossil yet. Callers can switch on this to
+// emit role-appropriate guidance: orchestrator commands tell the
+// user to run `bones up`; leaf commands (`swarm join`) refuse to
+// bootstrap and tell the agent the orchestrator must do it.
+var ErrHubRepoNotBootstrapped = errors.New("hub repo not bootstrapped")
+
 // hubRepoPath finds the workspace from cwd and returns the hub repo path.
 // Surfaces clear errors when the workspace or repo isn't there yet.
+// When the hub.fossil file is missing, wraps ErrHubRepoNotBootstrapped
+// so leaf-side callers can swap the orchestrator-leaning default
+// message ("run `bones up`") for one that refuses bootstrap from a
+// leaf context.
 func hubRepoPath() (string, error) {
 	cwd, err := os.Getwd()
 	if err != nil {
@@ -99,8 +110,8 @@ func hubRepoPath() (string, error) {
 	if _, err := os.Stat(repoPath); err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return "", fmt.Errorf(
-				"hub repo not found at %s — run `bones up` or `bones hub start` first",
-				repoPath,
+				"hub repo not found at %s — run `bones up` or `bones hub start` first: %w",
+				repoPath, ErrHubRepoNotBootstrapped,
 			)
 		}
 		return "", fmt.Errorf("stat hub repo: %w", err)

--- a/cli/swarm_commit.go
+++ b/cli/swarm_commit.go
@@ -210,11 +210,17 @@ func (c *SwarmCommitCmd) gatherFiles(info workspace.Info, slot string) ([]coord.
 		if err != nil {
 			return nil, fmt.Errorf("read %s: %w", abs, err)
 		}
-		// Prefer the workspace-relative absolute path on the task's
-		// files list — that is what was registered in the holds
-		// bucket. Search via filepath.Join(workspaceDir, ...).
+		// Path is the holds-gate key (must be absolute per
+		// holds.assertFile); Name is what libfossil stores the file
+		// under in the repo. Without an explicit Name, Leaf.Commit
+		// would derive the repo name by stripping one leading slash
+		// off Path, dragging the workspace prefix into the commit.
 		taskPath := filepath.Join(info.WorkspaceDir, clean)
-		out = append(out, coord.File{Path: taskPath, Content: data})
+		out = append(out, coord.File{
+			Path:    taskPath,
+			Name:    clean,
+			Content: data,
+		})
 	}
 	return out, nil
 }
@@ -273,11 +279,15 @@ func (c *SwarmCommitCmd) discoverDirtyFiles(
 		if err != nil {
 			return fmt.Errorf("rel %s: %w", path, err)
 		}
-		// Same path convention as the explicit-files branch: the
-		// holds-gate key is workspaceDir/<rel>, which is what the
-		// task record carries when --files= is passed.
+		// Same path convention as the explicit-files branch: Path is
+		// the workspace-absolute holds-gate key, Name is the
+		// wt-relative repo path libfossil uses inside leaf.fossil.
 		taskPath := filepath.Join(info.WorkspaceDir, rel)
-		out = append(out, coord.File{Path: taskPath, Content: data})
+		out = append(out, coord.File{
+			Path:    taskPath,
+			Name:    rel,
+			Content: data,
+		})
 		return nil
 	})
 	if err != nil {

--- a/cli/swarm_commit.go
+++ b/cli/swarm_commit.go
@@ -173,6 +173,7 @@ func (c *SwarmCommitCmd) openLeafForCommit(
 		Workdir:    swarmRoot,
 		SlotID:     slot,
 		FossilUser: "slot-" + slot,
+		Autosync:   true,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("re-open leaf: %w", err)

--- a/cli/swarm_fanin.go
+++ b/cli/swarm_fanin.go
@@ -110,7 +110,7 @@ func (c *SwarmFanInCmd) mergeLeaves(fossilBin, hubRepo string, leaves []string) 
 		return fmt.Errorf("update to canonical %s: %w", canonical, err)
 	}
 	for _, leaf := range others {
-		if err := runFossilIn(fossilBin, wt, "merge", "--no-warnings", leaf); err != nil {
+		if err := runFossilIn(fossilBin, wt, "merge", leaf); err != nil {
 			return fmt.Errorf("merge leaf %s: %w", leaf, err)
 		}
 	}

--- a/cli/swarm_join.go
+++ b/cli/swarm_join.go
@@ -112,9 +112,23 @@ func (c *SwarmJoinCmd) slotAgentID() string {
 // Mirrors `bones hub user add` (cli/hub_user.go) so the join verb is
 // self-contained — agents do not need to know about the hub user
 // table directly. ADR 0028 §"swarm join" step 2.
+//
+// If the workspace isn't bootstrapped, refuses with a leaf-appropriate
+// message: bootstrap is the orchestrator's job. The orchestrator-side
+// commands (peek, fanin, hub_user) keep the default "run `bones up`"
+// guidance via the same hubRepoPath helper; only the leaf-side join
+// path swaps the message so a swarm subagent doesn't read the error
+// as an instruction to bootstrap from its own context.
 func (c *SwarmJoinCmd) ensureSlotUser() error {
 	repoPath, err := hubRepoPath()
 	if err != nil {
+		if errors.Is(err, ErrHubRepoNotBootstrapped) {
+			return fmt.Errorf(
+				"swarm join: workspace not bootstrapped — the orchestrator " +
+					"must bring up the hub before leaves can join; refusing " +
+					"to bootstrap from a leaf context",
+			)
+		}
 		return err
 	}
 	repo, err := libfossil.Open(repoPath)
@@ -219,6 +233,7 @@ func (c *SwarmJoinCmd) openSwarmLeaf(
 		Workdir:    swarmRoot,
 		SlotID:     c.Slot,
 		FossilUser: c.slotAgentID(),
+		Autosync:   true,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("open leaf: %w", err)

--- a/cmd/bones/integration/swarm_test.go
+++ b/cmd/bones/integration/swarm_test.go
@@ -181,6 +181,49 @@ func TestCLI_Swarm(t *testing.T) {
 	})
 }
 
+// TestCLI_SwarmJoin_RefusesBootstrapFromLeafContext pins the
+// role-separation guard: when a workspace has no hub.fossil yet,
+// `swarm join` must refuse with a leaf-appropriate message instead
+// of telling the agent to run `bones up`. Bootstrap is the
+// orchestrator's job; if a leaf reads "run `bones up`" in a join
+// failure it will (and has) bootstrapped from its own context,
+// which silently re-points the workspace at a fresh hub and breaks
+// the trunk-linearization promise autosync exists to provide.
+func TestCLI_SwarmJoin_RefusesBootstrapFromLeafContext(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip in -short: integration test")
+	}
+	requireBinaries(t)
+	dir := setupSwarmWorkspace(t)
+	// Deliberately skip startSwarmHub — the workspace has .bones/
+	// (workspace leaf) but no .orchestrator/hub.fossil. This is the
+	// exact state a leaf subagent encounters when an orchestrator
+	// hasn't run `bones up` (or when the orchestrator is running but
+	// pointed at a different workspace, as happened during the
+	// 2026-04-28 autosync demo).
+	stdout, stderr, code := runCmd(t, bonesBin, dir,
+		"swarm", "join",
+		"--slot=demo-leaf",
+		"--task-id=00000000-0000-0000-0000-000000000000",
+	)
+	if code == 0 {
+		t.Fatalf("swarm join unexpectedly succeeded: stdout=%s", stdout)
+	}
+	combined := stderr + stdout
+	if !strings.Contains(combined, "refusing to bootstrap from a leaf context") {
+		t.Errorf("error missing leaf-context refusal: %s", combined)
+	}
+	// The orchestrator-targeted "run `bones up`" guidance must NOT
+	// appear in a leaf-side failure — that's the message that caused
+	// the demo subagents to re-bootstrap.
+	if strings.Contains(combined, "run `bones up`") {
+		t.Errorf("error still contains orchestrator-targeted guidance: %s", combined)
+	}
+	if !strings.Contains(combined, "swarm join") {
+		t.Errorf("error missing command tag for context: %s", combined)
+	}
+}
+
 // setupSwarmWorkspace creates a git-initialized tmpdir with a single
 // tracked file so the Go-implemented hub's seedHubRepo finds something
 // to commit. Then runs `bones init` to bring up the workspace leaf.

--- a/internal/coord/leaf.go
+++ b/internal/coord/leaf.go
@@ -52,16 +52,19 @@ func (c *Claim) Release() error {
 // paths route through it. The substrate (l.coord.sub) does NOT carry
 // its own fossil field.
 type Leaf struct {
-	agent      *agent.Agent
-	coord      *Coord
-	repoPath   string
-	wtPath     string
-	slotID     string
-	claimTTL   time.Duration     // zero → use substrate HoldTTLDefault
-	fossilUser string            // commit author; empty → fall back to slotID
-	metadata   map[string]string // harness-supplied opaque key=value pairs
-	mu         sync.Mutex
-	stopped    bool
+	agent       *agent.Agent
+	coord       *Coord
+	repoPath    string
+	wtPath      string
+	slotID      string
+	claimTTL    time.Duration     // zero → use substrate HoldTTLDefault
+	fossilUser  string            // commit author; empty → fall back to slotID
+	metadata    map[string]string // harness-supplied opaque key=value pairs
+	hubHTTPAddr string            // hub's fossil HTTP URL; used by autosync pull
+	projectCode string            // hub's fossil project-code; required by Sync
+	autosync    bool              // pull from hub before each Commit (LeafConfig.Autosync)
+	mu          sync.Mutex
+	stopped     bool
 }
 
 // LeafConfig is the configuration passed to OpenLeaf. One of Hub or
@@ -106,6 +109,23 @@ type LeafConfig struct {
 	// to the leaf for its own bookkeeping. Not used by coord; stored
 	// on *Leaf so harnesses can call l.Metadata("foo").
 	Metadata map[string]string
+
+	// Autosync, when true, makes Leaf.Commit pull from the hub before
+	// resolving the trunk tip, so the new commit lists the latest
+	// hub-known commit as its parent. This implements bones'
+	// trunk-based-development promise: every slot commit advances a
+	// shared trunk rather than producing a parallel leaf that fan-in
+	// must collapse later.
+	//
+	// Cost: one hub HTTP round-trip per commit. Tradeoff: a sub-second
+	// race window between pull and push can still produce a fork when
+	// two slots commit nearly simultaneously; fossil auto-merges those
+	// on the next pull cycle. A real check-in lock will land when
+	// libfossil exposes the necessary API.
+	//
+	// Default false preserves the prior branch-per-slot behavior
+	// expected by existing tests/examples that don't run a real hub.
+	Autosync bool
 }
 
 // HubAddrs holds the three URLs OpenLeaf needs from a hub. Each
@@ -177,6 +197,52 @@ func OpenLeaf(ctx context.Context, cfg LeafConfig) (*Leaf, error) {
 		_ = r.Close()
 	}
 
+	a, err := startLeafAgent(cfg, repoPath, hubNATSUpstream)
+	if err != nil {
+		return nil, err
+	}
+
+	cc, err := openLeafCoord(ctx, cfg.SlotID, hubNATSClient, slotDir)
+	if err != nil {
+		_ = a.Stop()
+		return nil, fmt.Errorf("coord.OpenLeaf: coord: %w", err)
+	}
+
+	projectCode, err := readProjectCodeIfAutosync(a, cfg.Autosync)
+	if err != nil {
+		_ = a.Stop()
+		return nil, err
+	}
+
+	return &Leaf{
+		agent:       a,
+		coord:       cc,
+		repoPath:    repoPath,
+		wtPath:      wtPath,
+		slotID:      cfg.SlotID,
+		claimTTL:    cfg.ClaimTTL,
+		fossilUser:  cfg.FossilUser,
+		metadata:    cfg.Metadata,
+		hubHTTPAddr: hubHTTPAddr,
+		projectCode: projectCode,
+		autosync:    cfg.Autosync,
+	}, nil
+}
+
+// startLeafAgent constructs and starts the agent.Agent that owns the
+// leaf's libfossil.Repo. Sets SQLite busy_timeout on the resulting
+// repo so concurrent writes (Leaf.Commit vs in-flight SyncNow) wait
+// for the WAL lock instead of failing with SQLITE_BUSY. The pragma
+// is per-connection, so MaxOpenConns is pinned to 1 to make it apply
+// to all queries — internal/fossil/fossil.go's prior setup surfaced
+// the pool semantics in Phase 1.
+//
+// FossilUser becomes the User field on sync handshakes. The earlier
+// clone is always unauthenticated ("nobody") regardless of
+// FossilUser — SlotID isn't in the hub's user table and setting User
+// during clone would fail authentication. FossilUser only affects
+// post-clone sync sessions and Commit author attribution.
+func startLeafAgent(cfg LeafConfig, repoPath, hubNATSUpstream string) (*agent.Agent, error) {
 	agentCfg := agent.Config{
 		RepoPath:     repoPath,
 		NATSUpstream: hubNATSUpstream,
@@ -188,11 +254,6 @@ func OpenLeaf(ctx context.Context, cfg LeafConfig) (*Leaf, error) {
 	if cfg.PollInterval != 0 {
 		agentCfg.PollInterval = cfg.PollInterval
 	}
-	// FossilUser: used as the User field on sync handshakes. The clone
-	// at open time is always unauthenticated ("nobody") regardless of
-	// FossilUser — SlotID isn't in the hub's user table and setting User
-	// during clone would fail authentication. FossilUser only affects
-	// post-clone sync sessions and Commit author attribution.
 	if cfg.FossilUser != "" {
 		agentCfg.User = cfg.FossilUser
 	}
@@ -204,43 +265,28 @@ func OpenLeaf(ctx context.Context, cfg LeafConfig) (*Leaf, error) {
 		_ = a.Stop()
 		return nil, fmt.Errorf("coord.OpenLeaf: agent.Start: %w", err)
 	}
-
-	// Set SQLite busy_timeout on the leaf's repo so concurrent writes
-	// (Leaf.Commit vs in-flight leaf.Agent.SyncNow pull) wait briefly
-	// for the WAL lock instead of failing with SQLITE_BUSY. Phase 2
-	// trial #1 surfaced this at N=4: agent.SyncNow runs a pull/push
-	// round on a goroutine after Leaf.Commit returns, and the next
-	// Commit can fire before that round drains. 30s mirrors the value
-	// the deleted internal/fossil.Manager used.
-	//
-	// Pin to MaxOpenConns=1 so the pragma applies to ALL queries —
-	// busy_timeout is a per-connection setting and the database/sql
-	// pool may otherwise hand subsequent queries a fresh connection
-	// without the pragma. internal/fossil/fossil.go set the pragma
-	// only; the Phase 1 refactor surfaced that the pool semantics
-	// require single-conn pinning to make the timeout actually apply.
 	a.Repo().DB().SqlDB().SetMaxOpenConns(1)
 	if _, err := a.Repo().DB().Exec(`PRAGMA busy_timeout = 30000`); err != nil {
 		_ = a.Stop()
 		return nil, fmt.Errorf("coord.OpenLeaf: busy_timeout: %w", err)
 	}
+	return a, nil
+}
 
-	cc, err := openLeafCoord(ctx, cfg.SlotID, hubNATSClient, slotDir)
-	if err != nil {
-		_ = a.Stop()
-		return nil, fmt.Errorf("coord.OpenLeaf: coord: %w", err)
+// readProjectCodeIfAutosync reads project-code from the agent's repo
+// when autosync is enabled. SyncOpts requires the code on every call;
+// caching once at open time avoids re-reading on every Leaf.Commit.
+// When autosync is off, the value is unused — skip the read so legacy
+// callers without a real hub aren't subject to a new failure mode.
+func readProjectCodeIfAutosync(a *agent.Agent, autosync bool) (string, error) {
+	if !autosync {
+		return "", nil
 	}
-
-	return &Leaf{
-		agent:      a,
-		coord:      cc,
-		repoPath:   repoPath,
-		wtPath:     wtPath,
-		slotID:     cfg.SlotID,
-		claimTTL:   cfg.ClaimTTL,
-		fossilUser: cfg.FossilUser,
-		metadata:   cfg.Metadata,
-	}, nil
+	pc, err := a.Repo().Config("project-code")
+	if err != nil {
+		return "", fmt.Errorf("coord.OpenLeaf: read project-code for autosync: %w", err)
+	}
+	return pc, nil
 }
 
 // resolveHubAddrs returns the leaf-upstream, NATS-client, and HTTP
@@ -406,6 +452,23 @@ func (l *Leaf) Commit(
 	// Write through the agent's repo handle — the only *libfossil.Repo
 	// that should ever touch leaf.fossil in this process.
 	repo := l.agent.Repo()
+
+	// Pull from hub before resolving the trunk tip so the new commit's
+	// parent is the latest hub-known commit, not whatever this leaf
+	// snapshot saw at clone time. This is the implementation of
+	// trunk-based development across slots: every slot.Commit advances
+	// a shared trunk rather than producing a sibling leaf that fan-in
+	// must collapse later.
+	//
+	// A failed pull is fatal: continuing on a stale parent silently
+	// turns a "trunk advance" into "trunk fork", which is exactly what
+	// autosync exists to prevent. Callers that need offline tolerance
+	// should leave Autosync off and accept branch-per-slot semantics.
+	if l.autosync {
+		if err := l.pullFromHub(ctx); err != nil {
+			return "", fmt.Errorf("coord.Leaf.Commit: pre-commit pull: %w", err)
+		}
+	}
 	toCommit := make([]libfossil.FileToCommit, 0, len(files))
 	for _, f := range files {
 		assert.NotEmpty(f.Path, "coord.Leaf.Commit: file.Path is empty")
@@ -488,6 +551,29 @@ func commitMessage(c *Claim) string {
 // orphan-root manifest.
 func isBranchTipMissing(err error) bool {
 	return errors.Is(err, sql.ErrNoRows)
+}
+
+// pullFromHub runs a one-shot fossil pull against the configured hub
+// over libfossil's HTTP transport. Authenticates as l.fossilUser
+// (which has 'i' caps from ensureSlotUser) when set; otherwise falls
+// back to anonymous "nobody" (the hub grants gio to anonymous which
+// is enough for a pull). Used by Leaf.Commit when autosync is on so
+// the next BranchTip("trunk") sees the hub's latest tip.
+func (l *Leaf) pullFromHub(ctx context.Context) error {
+	transport := libfossil.NewHTTPTransport(l.hubHTTPAddr)
+	user := l.fossilUser
+	if user == "" {
+		user = l.slotID
+	}
+	if _, err := l.agent.Repo().Sync(ctx, transport, libfossil.SyncOpts{
+		Pull:        true,
+		Push:        false,
+		User:        user,
+		ProjectCode: l.projectCode,
+	}); err != nil {
+		return err
+	}
+	return nil
 }
 
 // CommitOption tunes Leaf.Commit. Construct with WithMessage / WithUser.

--- a/internal/coord/leaf.go
+++ b/internal/coord/leaf.go
@@ -409,8 +409,12 @@ func (l *Leaf) Commit(
 	toCommit := make([]libfossil.FileToCommit, 0, len(files))
 	for _, f := range files {
 		assert.NotEmpty(f.Path, "coord.Leaf.Commit: file.Path is empty")
+		name := f.Name
+		if name == "" {
+			name = normalizeLeadingSlash(f.Path)
+		}
 		toCommit = append(toCommit, libfossil.FileToCommit{
-			Name:    normalizeLeadingSlash(f.Path),
+			Name:    name,
 			Content: f.Content,
 		})
 	}

--- a/internal/coord/leaf_commit_test.go
+++ b/internal/coord/leaf_commit_test.go
@@ -224,6 +224,107 @@ func TestLeaf_CommitFileNameOverride(t *testing.T) {
 	}
 }
 
+// TestLeaf_CommitAutosyncLinearizes pins the trunk-based contract:
+// when two leaves share a hub and both run with Autosync=true, the
+// second leaf's commit lists the first leaf's commit as its parent —
+// i.e. trunk advances linearly instead of forking into parallel
+// leaves that fan-in must collapse later.
+//
+// Without autosync each leaf's local view of "trunk tip" is the seed
+// (frozen at clone time), so both Commits would list the seed as
+// parent and the hub would carry two open leaves on trunk. With
+// autosync the second leaf pulls the first leaf's already-pushed
+// commit before resolving BranchTip, so its parent is the first
+// commit's UUID.
+func TestLeaf_CommitAutosyncLinearizes(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+	hubDir := t.TempDir()
+	hub, err := OpenHub(ctx, hubDir, freePort(t))
+	if err != nil {
+		t.Fatalf("OpenHub: %v", err)
+	}
+	t.Cleanup(func() { _ = hub.Stop() })
+
+	openLeaf := func(slot string) *Leaf {
+		l, err := OpenLeaf(ctx, LeafConfig{
+			Hub:      hub,
+			Workdir:  t.TempDir(),
+			SlotID:   slot,
+			Autosync: true,
+		})
+		if err != nil {
+			t.Fatalf("OpenLeaf %s: %v", slot, err)
+		}
+		t.Cleanup(func() { _ = l.Stop() })
+		return l
+	}
+	leafA := openLeaf("slot-A")
+	leafB := openLeaf("slot-B")
+
+	commitOnce := func(l *Leaf, holdPath, repoName string, body []byte) string {
+		t.Helper()
+		taskID, err := l.OpenTask(ctx, "auto-"+repoName, []string{holdPath})
+		if err != nil {
+			t.Fatalf("OpenTask: %v", err)
+		}
+		cl, err := l.Claim(ctx, taskID)
+		if err != nil {
+			t.Fatalf("Claim: %v", err)
+		}
+		uuid, err := l.Commit(ctx, cl, []File{
+			{Path: holdPath, Name: repoName, Content: body},
+		})
+		if err != nil {
+			t.Fatalf("Commit: %v", err)
+		}
+		if err := cl.Release(); err != nil {
+			t.Fatalf("Release: %v", err)
+		}
+		return uuid
+	}
+
+	// Slot-A commits first. With autosync, this pulls (no-op on a
+	// fresh hub) and commits on the seed.
+	uuidA := commitOnce(leafA, "/slot-A/file.txt", "a/file.txt", []byte("from A"))
+
+	// Wait for slot-A's commit to be visible on the hub before slot-B
+	// commits — otherwise slot-B's pull may run before A's push lands
+	// and the test would race against the in-process sync goroutine.
+	if err := assertCommitOnHub(t, hubDir, uuidA); err != nil {
+		t.Fatalf("hub propagation A: %v", err)
+	}
+
+	// Slot-B commits next. With autosync, slot-B pulls and now sees
+	// uuidA on hub trunk, so its commit's parent should be uuidA.
+	uuidB := commitOnce(leafB, "/slot-B/file.txt", "b/file.txt", []byte("from B"))
+
+	parentB, err := parentUUID(leafB.agent.Repo(), uuidB)
+	if err != nil {
+		t.Fatalf("parentUUID(uuidB): %v", err)
+	}
+	if parentB != uuidA {
+		t.Fatalf(
+			"autosync did not linearize trunk: uuidB parent = %q, want uuidA %q",
+			parentB, uuidA,
+		)
+	}
+}
+
+// parentUUID returns the parent commit UUID of the manifest with the
+// given UUID, by joining blob → plink → blob in fossil's schema. Used
+// to assert pre-commit pull made the prior commit visible.
+func parentUUID(repo *libfossil.Repo, child string) (string, error) {
+	var parent string
+	err := repo.DB().QueryRow(`
+		SELECT pblob.uuid FROM blob AS pblob
+		JOIN plink ON plink.pid = pblob.rid
+		JOIN blob AS cblob ON cblob.rid = plink.cid
+		WHERE cblob.uuid = ?
+	`, child).Scan(&parent)
+	return parent, err
+}
+
 // assertCommitOnHub opens hub.fossil read-only and checks that the
 // manifest with the given UUID exists in the blob table. The hub's
 // running agent owns the write side; a separate read-only handle is

--- a/internal/coord/leaf_commit_test.go
+++ b/internal/coord/leaf_commit_test.go
@@ -156,6 +156,74 @@ func TestLeaf_CommitDivergenceBranch(t *testing.T) {
 	}
 }
 
+// TestLeaf_CommitFileNameOverride pins the contract that File.Name,
+// when set, is the libfossil file name in the resulting manifest.
+// Path remains the holds-gate key (must be absolute), but Name is
+// what shows up under "F" cards / fossil ls. Without this override
+// every slot-style caller would see commits land at
+// "<workspace-prefix>/<rel>" inside the repo because Leaf.Commit
+// would derive the file name by stripping a single leading slash off
+// the absolute hold path.
+func TestLeaf_CommitFileNameOverride(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	hubDir := t.TempDir()
+	hub, err := OpenHub(ctx, hubDir, freePort(t))
+	if err != nil {
+		t.Fatalf("OpenHub: %v", err)
+	}
+	t.Cleanup(func() { _ = hub.Stop() })
+
+	l, err := OpenLeaf(ctx, LeafConfig{Hub: hub, Workdir: t.TempDir(), SlotID: "slot-N"})
+	if err != nil {
+		t.Fatalf("OpenLeaf: %v", err)
+	}
+	t.Cleanup(func() { _ = l.Stop() })
+
+	// Path mimics a swarm-style absolute holds key
+	// ("/tmp/ws/.bones/swarm/slot-N/wt/src/foo.go" — but here we just
+	// use a path the holds-gate accepts). Name is the repo-relative
+	// path callers want libfossil to record.
+	holdPath := "/slot-N/abs/with/prefix/src/foo.go"
+	repoName := "src/foo.go"
+
+	taskID, err := l.OpenTask(ctx, "name-override", []string{holdPath})
+	if err != nil {
+		t.Fatalf("OpenTask: %v", err)
+	}
+	cl, err := l.Claim(ctx, taskID)
+	if err != nil {
+		t.Fatalf("Claim: %v", err)
+	}
+	t.Cleanup(func() { _ = cl.Release() })
+
+	uuid, err := l.Commit(ctx, cl, []File{
+		{Path: holdPath, Name: repoName, Content: []byte("body")},
+	})
+	if err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+
+	repo := l.agent.Repo()
+	rid, err := repo.ResolveVersion(uuid)
+	if err != nil {
+		t.Fatalf("ResolveVersion: %v", err)
+	}
+	entries, err := repo.ListFiles(rid)
+	if err != nil {
+		t.Fatalf("ListFiles: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("ListFiles: got %d entries, want 1: %+v", len(entries), entries)
+	}
+	if entries[0].Name != repoName {
+		t.Fatalf(
+			"file name in manifest: got %q, want %q (Name override should win over Path-derived)",
+			entries[0].Name, repoName,
+		)
+	}
+}
+
 // assertCommitOnHub opens hub.fossil read-only and checks that the
 // manifest with the given UUID exists in the blob table. The hub's
 // running agent owns the write side; a separate read-only handle is

--- a/internal/coord/types.go
+++ b/internal/coord/types.go
@@ -132,11 +132,23 @@ type Edge struct {
 // is not. Under the hood it is Fossil's 40-character SHA-1 UUID.
 type RevID string
 
-// File is a single file body paired with its logical path. The path is
-// whatever naming scheme the caller uses for its holds (typically
-// absolute). Content is the raw bytes to commit. Fossil stores both
-// verbatim — coord applies no path normalization.
+// File is a single file body paired with two address forms.
+//
+// Path is the holds-gate key — typically the absolute workspace path
+// the task record carries (holds.assertFile rejects non-absolute
+// values). It is NOT used to derive the libfossil file name when Name
+// is set.
+//
+// Name is the repo-relative file name libfossil stores under (e.g.
+// "src/foo/bar.go"). When empty, Leaf.Commit falls back to stripping
+// a single leading slash off Path — sufficient for the simple case
+// where the holds key looks like "/relpath" but wrong when Path has
+// any deeper prefix (e.g. a workspace directory). Slot-style flows
+// where the worktree lives at <workspace>/.bones/swarm/<slot>/wt MUST
+// set Name to the wt-relative path; otherwise the file lands at
+// "<workspace-segments>/<rel>" inside the repo.
 type File struct {
 	Path    string
+	Name    string
 	Content []byte
 }


### PR DESCRIPTION
## Summary
- `bones swarm fan-in`: drop `--no-warnings` from `fossil merge` (only `fossil commit` accepts it). Without this the second leaf merge fails with `unrecognized command-line option`.
- Add `coord.File.Name` so slot-commit gather paths can specify the libfossil file name independently from the holds-gate key. Previously `Leaf.Commit` derived the file name by stripping one leading slash off `Path`, which dragged the workspace prefix into commits whenever Path was a real absolute path. Files now land at `src/foo.go` instead of `tmp/<workspace-segments>/src/foo.go`.

Both bugs were surfaced by the post-PR #51 swarm validation: with the orphan-commit fix in place, leaves carry real file trees for the first time, which made fan-in walk the manifests and exposed both issues.

## Test plan
- [x] `make check` clean (fmt, vet, lint, race, todo-check)
- [x] New regression test: `TestLeaf_CommitFileNameOverride` pins that `File.Name` wins over the Path-derived fallback in the manifest's `F` cards
- [x] Existing `TestLeaf_CommitWritesAndSyncs` and `TestLeaf_CommitDivergenceBranch` still pass
- [x] End-to-end: single-slot `bones swarm join → commit → close` smoke produces a manifest with `F src/audio/mixer.js` (was `F tmp/swarm-validate/src/audio/mixer.js` before the fix)
- [x] End-to-end: 4-slot parallel demo + `bones swarm fan-in` would now succeed past the merge step (the merge-flag fix was already validated by the second fan-in attempt that surfaced the path issue)