### PR TITLE
ci: skip on doc-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,24 @@ name: ci
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'LICENSE'
+      - 'CHANGELOG*'
+      - '.gitignore'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/pull_request_template.md'
   pull_request:
     branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'LICENSE'
+      - 'CHANGELOG*'
+      - '.gitignore'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/pull_request_template.md'
 
 # Sibling EdgeSync checkout is still used to `make leaf` so integration
 # tests have a local bin/leaf binary at LEAF_BIN.


### PR DESCRIPTION
## Summary
Add \`paths-ignore\` to the \`ci\` workflow's push + pull_request triggers so doc-only changes (README, ADRs, docs site, LICENSE, gitignore, issue/PR templates) don't kick off the full lint+race+otel suite.

## Patterns ignored
- \`**.md\` — README, ADRs, docs/site/content/**
- \`docs/**\` — anything else under docs (SVGs, layouts, plans)
- \`LICENSE\`, \`CHANGELOG*\`, \`.gitignore\`
- \`.github/ISSUE_TEMPLATE/**\`, \`.github/pull_request_template.md\`

## Caveat
If branch protection ever requires \`ci/check\` to merge, doc-only PRs would block on a missing required check. No required-check setup is in place today, so \`paths-ignore\` is the simplest fix. Revisit with an always-pass companion job if that changes.

## Test plan
- [ ] Doc-only PR doesn't trigger \`ci\` (verify on next README change)
- [ ] Code change PR still triggers \`ci\`