### PR TITLE
docs(readme): restore badge image syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # bones
 
-[Go Reference](https://pkg.go.dev/github.com/danmestas/bones)  
-[Go Report Card](https://goreportcard.com/report/github.com/danmestas/bones)  
-[CI](https://github.com/danmestas/bones/actions/workflows/ci.yml)  
-[License](./LICENSE)  
-[Go](https://go.dev)
+[![Go Reference](https://pkg.go.dev/badge/github.com/danmestas/bones.svg)](https://pkg.go.dev/github.com/danmestas/bones)
+[![Go Report Card](https://goreportcard.com/badge/github.com/danmestas/bones)](https://goreportcard.com/report/github.com/danmestas/bones)
+[![CI](https://github.com/danmestas/bones/actions/workflows/ci.yml/badge.svg)](https://github.com/danmestas/bones/actions/workflows/ci.yml)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](./LICENSE)
+[![Go](https://img.shields.io/badge/Go-1.26+-00ADD8.svg)](https://go.dev)
 
 Containerized isolation for your source tree, with trunk-based development built in for parallel AI agents. Drop ten Claude subagents on a repo and bones gives each one its own checkout, syncs commits through a single hub before parenting (so the trunk advances linearly under any concurrency), and lands changes in your filesystem only when _you_ sign off. Two embedded dependencies — SQLite and NATS — in a single static binary. No Postgres, no Redis, no Docker required. Doesn't replace git. Doesn't have opinions about your memory tool.
 


### PR DESCRIPTION
Plain-text `[alt](url)` was committed instead of `[![alt](badge.svg)](url)` so badges weren't rendering on the main README. This restores the image-embed form. No CI trigger expected (paths-ignore covers `**.md`).