### PR TITLE
swarm: Lease as runtime view of a slot; migrate swarm join (ADR 0031)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,102 @@
+# bones — domain glossary
+
+Definitions for the concepts used across the codebase. One paragraph
+each, with a pointer to the ADR that established the term. New terms
+land here when an architecture-review grilling first names them; this
+file is the orientation doc that ADRs assume but don't repeat.
+
+This file is referenced by `.claude/skills/improve-codebase-architecture`
+and adjacent skills. AI agents reading the codebase for the first
+time should start here.
+
+## Topology
+
+**Workspace.** A repo directory bones has bootstrapped (`bones up`).
+Holds `.bones/` (per-process state), `.orchestrator/` (the hub's
+fossil + JetStream store + supervisor scripts), and `.claude/skills/`
+(scaffolded orchestrator and subagent skills). One workspace per
+repo. See ADR 0023 for the original spec.
+
+**Hub.** The single fossil repo + embedded NATS server that holds
+the trunk and the live coordination state. Lives at
+`<workspace>/.orchestrator/hub.fossil` plus JetStream KV buckets.
+Exactly one hub per workspace. See ADR 0023, ADR 0026 (Go
+implementation).
+
+**Leaf.** A per-agent fossil clone of the hub. Each leaf syncs with
+the hub via NATS-bridged HTTP xfer (ADR 0018). The workspace itself
+runs a long-lived **workspace leaf** (the `leaf` daemon started by
+`bones init`); each running swarm slot opens an additional **per-slot
+leaf** for the duration of a CLI verb. See ADR 0023.
+
+**Trunk.** The hub's `trunk` branch. Every commit autosynced from
+every leaf advances trunk linearly. PR #54's autosync feature is
+what turns parallel leaf commits into a single linear chain. See
+ADR 0023, the 2026-04-28 autosync demo.
+
+## Coordination primitives
+
+**Slot.** A planner-assigned partition of work, named by a `[slot:
+name]` annotation on plan tasks. Slots are *static* — a plan
+declares slot-A, slot-B, etc., and the orchestrator dispatches one
+subagent per slot. Slot disjointness (no two slots touch the same
+file) is validated before dispatch. See ADR 0023, ADR 0028.
+
+**Lease.** The runtime view of a slot — what a single CLI invocation
+holds for the duration of its work. Owns the per-slot leaf, the
+claim hold, and the session record. Acquired fresh by `swarm join`
+(creates the session record), resumed by `swarm commit` and
+`swarm close` (read existing record). One lease per CLI invocation;
+the persistent state across invocations is the session record in
+`bones-swarm-sessions[slot]`, not the lease itself. See ADR 0031.
+
+**Claim.** An exclusive bind between an agent and a task. Backed by
+a fossil-recorded ownership marker plus a hold. Released when the
+task is closed or the lease ends. See ADR 0007, ADR 0013.
+
+**Hold.** A scoped exclusive resource lock with a TTL, used to gate
+claim handoff and reclamation. Lives in `bones-holds` (NATS
+JetStream KV). See ADR 0002, ADR 0013.
+
+**Session record.** The per-slot row in
+`bones-swarm-sessions[slot]` (`swarm.Session` type) that ties a
+slot to its current task, agent ID, hub URL, and last-renewed
+timestamp. Persists across CLI verbs; TTL-evicted if not renewed.
+Written by `swarm join` (a fresh `Lease.AcquireFresh`), bumped by
+`swarm commit` (`Lease.Commit`), deleted by `swarm close`
+(`Lease.Close`). See ADR 0028.
+
+## Layering
+
+**Substrate.** The transport / persistence layer: NATS (live
+coordination — claims, holds, presence, chat) and Fossil (durable
+artifacts — commits, chat history). Lives under `internal/coord/`.
+See ADR 0025.
+
+**Domain.** The higher-level packages built on top of the substrate
+— `internal/{tasks, holds, swarm, dispatch, autoclaim, presence,
+chat}`. Domain may import substrate; substrate may not import
+domain (enforced by `depguard` in `.golangci.yml`). See ADR 0025
+for the layering rule and its known exceptions.
+
+## Process
+
+**Orchestrator.** The role that drives bootstrap (`bones up`),
+plan validation, and parallel-agent dispatch. Embodied in the
+`orchestrator` Claude Code skill scaffolded by `bones up`. The
+orchestrator is the only role permitted to bootstrap a workspace
+or restart the hub. See ADR 0023, PR #54 (role-leak guard).
+
+**Subagent.** A Claude Code subagent dispatched by the orchestrator
+to work a single slot. Embodied in the `subagent` skill. Subagents
+acquire a Lease, do verb-specific work, release the lease. They
+must not run `bones up` or otherwise bootstrap. See PR #54.
+
+## Tests
+
+**Real-substrate tests.** Tests that exercise substrate behavior
+(NATS CAS semantics, fossil commit linearization, race conditions)
+run against a real embedded NATS + real libfossil. Mocks are
+forbidden for substrate behavior — see ADR 0030 for rationale.
+Test helpers live in `internal/testutil/natstest/` and the
+in-process hub helpers in `internal/coord/`.

--- a/cli/swarm_close.go
+++ b/cli/swarm_close.go
@@ -138,7 +138,7 @@ func (c *SwarmCloseCmd) releaseAndMaybeCloseTask(
 ) error {
 	hubURL := c.HubURL
 	if hubURL == "" {
-		hubURL = defaultHubFossilURL
+		hubURL = swarm.DefaultHubFossilURL
 	}
 	swarmRoot := info.WorkspaceDir + "/.bones/swarm"
 	leaf, err := coord.OpenLeaf(ctx, coord.LeafConfig{

--- a/cli/swarm_commit.go
+++ b/cli/swarm_commit.go
@@ -132,7 +132,7 @@ func (c *SwarmCommitCmd) resolveHubURL(sess swarm.Session) string {
 	if sess.HubURL != "" {
 		return sess.HubURL
 	}
-	return defaultHubFossilURL
+	return swarm.DefaultHubFossilURL
 }
 
 // assertSessionLocal returns an error if the session's host does not

--- a/cli/swarm_join.go
+++ b/cli/swarm_join.go
@@ -2,36 +2,29 @@ package cli
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
-	"path/filepath"
-	"strconv"
 
-	"github.com/danmestas/libfossil"
 	libfossilcli "github.com/danmestas/libfossil/cli"
 
-	"github.com/danmestas/bones/internal/coord"
 	"github.com/danmestas/bones/internal/swarm"
 	"github.com/danmestas/bones/internal/workspace"
 )
-
-// defaultHubFossilURL is the hub fossil HTTP URL bones writes when
-// `bones up` brings a hub to default ports. Future work will source
-// this from a workspace-recorded hub config; for now mirroring the
-// hardcoded value in cli/up.go keeps the swarm verbs working with
-// the existing workspace shape.
-const defaultHubFossilURL = "http://127.0.0.1:8765"
 
 // SwarmJoinCmd opens a per-slot leaf, ensures the slot's fossil user
 // exists in the hub, claims the named task, writes the swarm session
 // record to KV, and prints the slot's worktree path on stdout (for
 // `cd $(bones swarm cwd ...)`-style sourcing).
 //
-// On a successful return, the leaf process is alive and owns the
-// claim hold. The process is detached from the calling shell so the
-// agent can run `swarm commit` and `swarm close` from later
-// invocations.
+// On a successful return, the leaf process has been stopped (per
+// the per-CLI-invocation lifetime contract — ADR 0028 §"Process
+// lifecycle"). The session record persists so subsequent `swarm
+// commit` and `swarm close` invocations can Resume.
+//
+// All the assembly (workspace check, fossil-user creation, KV
+// session record CAS, leaf open/claim) lives in
+// internal/swarm.Lease (ADR 0031). This verb is a thin adapter
+// from CLI flags to AcquireFresh + Release.
 type SwarmJoinCmd struct {
 	Slot          string `name:"slot" required:"" help:"slot name (matches plan [slot: X])"`
 	TaskID        string `name:"task-id" required:"" help:"open task id to claim"`
@@ -40,15 +33,11 @@ type SwarmJoinCmd struct {
 	HubURL        string `name:"hub-url" help:"override hub fossil HTTP URL"`
 }
 
-// Run implements the join flow per ADR 0028 §"swarm join":
-//
-//  1. Open workspace.
-//  2. Ensure slot user in hub repo (idempotent).
-//  3. Verify no live session record on this slot (or --force).
-//  4. coord.OpenLeaf rooted at .bones/swarm/<slot>/.
-//  5. Claim the task via Leaf.Claim.
-//  6. Write session record to bones-swarm-sessions[<slot>].
-//  7. Print BONES_SLOT_WT=<wt path> for shell sourcing.
+// Run drives the join flow per ADR 0028 §"swarm join", now via
+// swarm.Lease (ADR 0031): open workspace, AcquireFresh (which does
+// the role-guard check, ensures the slot user, CAS-writes the
+// session record, opens the leaf, claims the task, writes the pid
+// file), emit the report, Release.
 func (c *SwarmJoinCmd) Run(g *libfossilcli.Globals) error {
 	ctx, stop, info, err := joinWorkspace()
 	if err != nil {
@@ -59,237 +48,35 @@ func (c *SwarmJoinCmd) Run(g *libfossilcli.Globals) error {
 }
 
 func (c *SwarmJoinCmd) run(ctx context.Context, info workspace.Info) error {
-	if err := c.ensureSlotUser(); err != nil {
-		return fmt.Errorf("ensure slot user: %w", err)
+	hubURL := c.HubURL
+	if hubURL == "" {
+		hubURL = swarm.DefaultHubFossilURL
 	}
-	mgr, closeMgr, err := openSwarmManager(ctx, info)
-	if err != nil {
-		return err
-	}
-	defer closeMgr()
-
-	if err := c.checkExistingSession(ctx, mgr); err != nil {
-		return err
-	}
-	leaf, err := c.openSwarmLeaf(ctx, info)
-	if err != nil {
-		return err
-	}
-	claim, err := leaf.Claim(ctx, coord.TaskID(c.TaskID))
-	if err != nil {
-		_ = leaf.Stop()
-		return fmt.Errorf("claim task: %w", err)
-	}
-	// Release the claim once the session record is persisted. The
-	// underlying hold survives only as long as its TTL — but the
-	// session record is the durable handle for `swarm commit` and
-	// `swarm close` to re-claim atomically by slot identity. Phase
-	// 1 trades hold persistence across verbs for implementation
-	// simplicity; subsequent commit/close re-take the claim each
-	// time. ADR 0028 §"Process lifecycle" outlines the future
-	// detached-leaf design that would change this.
-	if err := c.writeSession(ctx, mgr, info, c.resolvedHubURL()); err != nil {
-		_ = claim.Release()
-		_ = leaf.Stop()
-		return err
-	}
-	if err := c.writePidFile(info); err != nil {
-		_ = claim.Release()
-		_ = leaf.Stop()
-		return err
-	}
-	c.emitJoinReport(info, leaf)
-	_ = claim.Release()
-	_ = leaf.Stop()
-	return nil
-}
-
-func (c *SwarmJoinCmd) slotAgentID() string {
-	return "slot-" + c.Slot
-}
-
-// ensureSlotUser creates the slot user on the hub repo if missing.
-// Mirrors `bones hub user add` (cli/hub_user.go) so the join verb is
-// self-contained — agents do not need to know about the hub user
-// table directly. ADR 0028 §"swarm join" step 2.
-//
-// If the workspace isn't bootstrapped, refuses with a leaf-appropriate
-// message: bootstrap is the orchestrator's job. The orchestrator-side
-// commands (peek, fanin, hub_user) keep the default "run `bones up`"
-// guidance via the same hubRepoPath helper; only the leaf-side join
-// path swaps the message so a swarm subagent doesn't read the error
-// as an instruction to bootstrap from its own context.
-func (c *SwarmJoinCmd) ensureSlotUser() error {
-	repoPath, err := hubRepoPath()
-	if err != nil {
-		if errors.Is(err, ErrHubRepoNotBootstrapped) {
-			return fmt.Errorf(
-				"swarm join: workspace not bootstrapped — the orchestrator " +
-					"must bring up the hub before leaves can join; refusing " +
-					"to bootstrap from a leaf context",
-			)
-		}
-		return err
-	}
-	repo, err := libfossil.Open(repoPath)
-	if err != nil {
-		return fmt.Errorf("open hub repo: %w", err)
-	}
-	defer func() { _ = repo.Close() }()
-
-	login := c.slotAgentID()
-	if _, err := repo.GetUser(login); err == nil {
-		return nil // already present
-	}
-	if err := repo.CreateUser(libfossil.UserOpts{
-		Login: login,
-		Caps:  c.Caps,
-	}); err != nil {
-		return fmt.Errorf("create user %q: %w", login, err)
-	}
-	return nil
-}
-
-// checkExistingSession enforces invariant "one live session per slot"
-// before opening a fresh leaf. Honors --force for recovery scenarios
-// where a previous join crashed leaving stale state.
-//
-// Liveness signal is LastRenewed, not LeafPID. Every swarm verb is a
-// fresh CLI invocation whose pid is already-dead by the time the next
-// verb reads the record, so a pid-alive probe always fails on local
-// records. LastRenewed is stamped at join and bumped on every commit;
-// a record younger than the active threshold means an agent is
-// actively working the slot.
-func (c *SwarmJoinCmd) checkExistingSession(
-	ctx context.Context, mgr *swarm.Manager,
-) error {
-	existing, rev, err := mgr.Get(ctx, c.Slot)
-	if err != nil {
-		if errors.Is(err, swarm.ErrNotFound) {
-			return nil
-		}
-		return fmt.Errorf("read existing session: %w", err)
-	}
-	host, _ := os.Hostname()
-	staleSec := int64(timeNow().Sub(existing.LastRenewed).Seconds())
-	if !c.ForceTakeover {
-		switch {
-		case existing.Host == host && staleSec <= activeThresholdSec:
-			return fmt.Errorf(
-				"slot %q already has a live session on this host"+
-					" (renewed %ds ago) — pass --force to take over",
-				c.Slot, staleSec,
-			)
-		case existing.Host != host:
-			return fmt.Errorf(
-				"slot %q is owned by host %q — refusing to take over;"+
-					" pass --force on the owning host",
-				c.Slot, existing.Host,
-			)
-		}
-	}
-	if err := mgr.Delete(ctx, c.Slot, rev); err != nil && !errors.Is(err, swarm.ErrNotFound) {
-		return fmt.Errorf("clear stale session: %w", err)
-	}
-	return nil
-}
-
-// resolvedHubURL returns the configured hub URL or the package
-// default if the flag was unset. Pulled into a helper so writeSession
-// stamps the same value openSwarmLeaf used.
-func (c *SwarmJoinCmd) resolvedHubURL() string {
-	if c.HubURL != "" {
-		return c.HubURL
-	}
-	return defaultHubFossilURL
-}
-
-// openSwarmLeaf opens the per-slot leaf rooted at the workspace's
-// .bones/swarm directory. Uses HubAddrs (URL-string variant of
-// LeafConfig) because the hub runs in a separate process and the
-// agent-side bones binary cannot share an in-process *Hub.
-//
-// Phase 1 invariant: the bones CLI itself is the leaf-host process —
-// each swarm verb opens a fresh *Leaf, does its work, then stops it
-// at end of the verb. Process-detach (per ADR 0028 §"Process
-// lifecycle") is future work; the current contract is "every verb
-// is a self-contained invocation against the persisted leaf.fossil."
-// This keeps the implementation small while preserving the same
-// observable surface for the test integration.
-func (c *SwarmJoinCmd) openSwarmLeaf(
-	ctx context.Context, info workspace.Info,
-) (*coord.Leaf, error) {
-	hubURL := c.resolvedHubURL()
-	swarmRoot := filepath.Join(info.WorkspaceDir, ".bones", "swarm")
-	if err := os.MkdirAll(swarmRoot, 0o755); err != nil {
-		return nil, fmt.Errorf("mkdir swarm root: %w", err)
-	}
-	leaf, err := coord.OpenLeaf(ctx, coord.LeafConfig{
-		HubAddrs: coord.HubAddrs{
-			LeafUpstream: "", // peer via the workspace leaf-daemon NATS upstream
-			NATSClient:   info.NATSURL,
-			HTTPAddr:     hubURL,
-		},
-		Workdir:    swarmRoot,
-		SlotID:     c.Slot,
-		FossilUser: c.slotAgentID(),
-		Autosync:   true,
+	lease, err := swarm.AcquireFresh(ctx, info, c.Slot, c.TaskID, swarm.AcquireOpts{
+		HubURL:        hubURL,
+		Caps:          c.Caps,
+		ForceTakeover: c.ForceTakeover,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("open leaf: %w", err)
+		// Stamp the verb name into the error so operators see which
+		// CLI command surfaced it (the swarm.* errors are package-
+		// scoped and would otherwise read as bare "swarm: ..."
+		// strings).
+		return fmt.Errorf("swarm join: %w", err)
 	}
-	// coord.OpenLeaf computes wtPath but does not mkdir it; the
-	// agent-side `swarm cwd` consumer expects a real directory it
-	// can `cd` into, so create it eagerly here. Idempotent.
-	if err := os.MkdirAll(leaf.WT(), 0o755); err != nil {
-		_ = leaf.Stop()
-		return nil, fmt.Errorf("mkdir worktree: %w", err)
-	}
-	return leaf, nil
+	c.emitJoinReport(lease)
+	return lease.Release(ctx)
 }
 
-func (c *SwarmJoinCmd) writeSession(
-	ctx context.Context, mgr *swarm.Manager, info workspace.Info, hubURL string,
-) error {
-	host, _ := os.Hostname()
-	now := timeNow()
-	sess := swarm.Session{
-		Slot:        c.Slot,
-		TaskID:      c.TaskID,
-		AgentID:     c.slotAgentID(),
-		Host:        host,
-		LeafPID:     os.Getpid(),
-		HubURL:      hubURL,
-		StartedAt:   now,
-		LastRenewed: now,
-	}
-	if err := mgr.Put(ctx, sess); err != nil {
-		return fmt.Errorf("write session record: %w", err)
-	}
-	_ = info // future: stamp workspace dir on session if observability needs it
-	return nil
-}
-
-// writePidFile mirrors the KV record's leaf_pid into the host-local
-// PID-tracker file. The file lets `kill` work without a NATS round
-// trip and matches the pattern used by `bones hub start --detach`.
-func (c *SwarmJoinCmd) writePidFile(info workspace.Info) error {
-	pidPath := swarm.SlotPidFile(info.WorkspaceDir, c.Slot)
-	if err := os.WriteFile(pidPath, []byte(strconv.Itoa(os.Getpid())+"\n"), 0o644); err != nil {
-		return fmt.Errorf("write pid file: %w", err)
-	}
-	return nil
-}
-
-func (c *SwarmJoinCmd) emitJoinReport(info workspace.Info, leaf *coord.Leaf) {
-	wt := leaf.WT()
-	// Stdout is consumed by `eval $(bones swarm join ... )` patterns;
-	// keep it env-var-shaped so shells can source it directly.
+// emitJoinReport prints the BONES_SLOT_WT line on stdout (consumed
+// by `eval $(bones swarm join ...)` patterns in shells) and a
+// human-readable summary on stderr.
+func (c *SwarmJoinCmd) emitJoinReport(lease *swarm.Lease) {
+	wt := lease.WT()
 	fmt.Printf("BONES_SLOT_WT=%s\n", wt)
 	fmt.Fprintf(
 		os.Stderr,
 		"swarm join: slot=%s task=%s wt=%s pid=%d\n",
-		c.Slot, c.TaskID, wt, os.Getpid(),
+		lease.Slot(), lease.TaskID(), wt, os.Getpid(),
 	)
-	_ = info
 }

--- a/docs/adr/0031-lease-runtime-slot-view.md
+++ b/docs/adr/0031-lease-runtime-slot-view.md
@@ -1,0 +1,165 @@
+# ADR 0031: Lease as the runtime view of a slot
+
+**Status:** accepted
+
+**Date:** 2026-04-29
+
+## Context
+
+The swarm CLI verbs (`bones swarm join / commit / close / status / cwd /
+fan-in`) all share the same opening scaffold:
+
+1. `joinWorkspace` — locate the workspace from cwd, attach to the
+   long-running leaf-daemon's NATS.
+2. `ensureSlotUser` — verify the workspace is bootstrapped and create
+   the slot's fossil user on the hub repo if missing.
+3. `openSwarmManager` — open the swarm sessions KV bucket.
+4. Read or write the per-slot session record (`swarm.Session` in
+   `bones-swarm-sessions[slot]`) under a CAS gate.
+5. `coord.OpenLeaf` — open a fresh per-slot fossil leaf bound to the
+   recorded hub URL and slot user.
+6. Run the verb's actual work (claim, commit, close, status, …).
+7. Stop the leaf, write/update KV, write/remove the per-slot pid file.
+
+Today this scaffold is duplicated across `cli/swarm_*.go`. The 2026-
+04-28 architecture review (ADR 0030 records the rejection of mocks
+that grew out of the same review) named the missing module: a typed
+runtime concept that owns the assembled scaffold so each verb's CLI
+file becomes verb-specific work plus an Acquire/Close pair.
+
+The 2026-04-28 role-leak fix (PR #54, `swarm join: workspace not
+bootstrapped — refusing to bootstrap from a leaf context`) is the
+canonical example of why this matters: a precondition that should
+have lived in *one* place ended up in `cli/swarm_join.go`'s
+`ensureSlotUser`. When the next lifecycle bug touches `swarm commit`
+or `swarm close`, there's no single place to land the fix — the
+scaffold is replicated.
+
+## Decision
+
+Introduce **`internal/swarm.Lease`** — a typed runtime module owning
+the assembled scaffold for the duration of a single CLI invocation.
+
+### Lifetime
+
+A Lease and its underlying `coord.Leaf` share a lifetime: the lease
+opens the leaf at acquire time and stops it at close time. There is
+no long-running per-slot leaf to coordinate. Per-CLI-invocation
+ownership is the existing contract (per `cli/swarm_join.go`'s own
+comment) and this ADR codifies it.
+
+The persistent state across verbs is the **session record** in
+`bones-swarm-sessions[slot]` (`swarm.Session`), not the leaf
+process. `swarm join` writes the record; `swarm commit` and `swarm
+close` re-Acquire the lease against the existing record.
+
+### Two acquisition modes
+
+- **`AcquireFresh(ctx, info, slot, taskID, opts) (*Lease, error)`**
+  for `swarm join`. Creates the session record via CAS-PutIfAbsent
+  (or `--force`-overwrites a stale one), opens the leaf, claims the
+  task. The role-guard from PR #54 ("refusing to bootstrap from a
+  leaf context") is a precondition inside `AcquireFresh`, not a
+  free-standing check in the CLI verb.
+
+- **`Resume(ctx, info, slot, opts) (*Lease, error)`** for every
+  other verb. Reads the existing session record, reconstructs the
+  leaf using the recorded hub URL and slot user, fails with
+  `ErrSessionNotFound` if no record exists.
+
+The constructor split is deliberate: the verbs split cleanly along
+fresh-vs-resume, and the role-guard precondition only applies to
+`AcquireFresh`. A single `Acquire` that infers mode from optional
+fields was rejected because the caller's intent (start vs.
+continue) is load-bearing for error handling and shouldn't be
+hidden in nil-vs-set field semantics.
+
+### Methods (closed verb set)
+
+`Lease` exposes methods that mirror the swarm verbs that operate on
+an open lease:
+
+- `Commit(ctx, files ...File) (uuid string, err error)` — claim →
+  `coord.Leaf.Commit` → bump `LastRenewed` via CAS, atomic from the
+  caller's view.
+- `Close(ctx, result, summary string) error` — delete the session
+  record via CAS, stop the leaf. Replaces `cli/swarm_close.go`'s
+  scaffold.
+- `Release(ctx) error` — release the claim hold and stop the leaf
+  *without* deleting the session record. The path `swarm join`
+  takes after writing the record; the lease stays "live" in KV
+  until a later verb closes it.
+- `Slot() string`, `TaskID() string`, `WT() string`, `Leaf()
+  *coord.Leaf` — accessors. `Leaf()` is a deprecated-on-arrival
+  escape hatch present only during migration so we don't have to
+  port every verb in one PR.
+
+`Renew` is intentionally *not* a method — `Commit` already bumps
+`LastRenewed` and is the only path that needs heartbeating today. A
+standalone Renew can land if a future verb wants to heartbeat
+without committing.
+
+### Methods, not free functions
+
+`swarm.Commit(lease, files)` was rejected in favor of
+`lease.Commit(files)`. The verb set is closed (~6 verbs) and small;
+the operations *are* behavior of the lease, not behavior of
+something the lease is passed into. Methods make discoverability
+better (`lease.<TAB>` in an IDE) and pin the lifetime invariant in
+the type.
+
+## Migration phasing
+
+- **PR A (this work):** ADR 0031 + a top-level `CONTEXT.md` (lazily
+  created — first new domain term named in the architecture-review
+  grilling) + `internal/swarm/lease.go` + `internal/swarm/lease_test.go`
+  using real NATS + real Fossil per ADR 0030 + migrate
+  `cli/swarm_join.go` to call `Lease.AcquireFresh` followed by
+  `Release`. Other verbs unchanged.
+- **PR B:** migrate `cli/swarm_commit.go` to `Resume + Commit`.
+- **PR C:** migrate `cli/swarm_close.go`, `swarm_status.go`,
+  `swarm_cwd.go`, `swarm_fan-in.go` to `Resume + Close / accessors`.
+- **PR D:** delete the `Leaf()` escape hatch once no caller uses it.
+
+Each PR is independent; the existing CLI verbs continue to work
+between phases because the underlying `coord.Leaf` and `swarm.Manager`
+APIs are unchanged.
+
+## Consequences
+
+- The scaffold (workspace join, fossil-user creation, session
+  record CAS, leaf open) lives in one module.
+- Lifecycle bugs land on one set of preconditions instead of being
+  replicated across 6 CLI verbs.
+- The role-guard from PR #54 moves from `cli/swarm_join.go::ensureSlotUser`
+  to `swarm.AcquireFresh`'s precondition path. The integration test
+  that pins the message (`TestCLI_SwarmJoin_RefusesBootstrapFromLeafContext`)
+  stays as-is — it exercises the CLI surface end-to-end and the
+  message contract is preserved. A unit-level lease test pins the
+  same precondition without spawning the bones binary.
+- `cli/swarm_join.go` shrinks from ~300 LoC to ~40 (parse flags,
+  call `AcquireFresh`, emit report, `Release`).
+
+## Out of scope
+
+- The other CLI verbs (commit, close, status, cwd, fan-in) keep
+  their existing scaffold for one more PR cycle. Migrating them is
+  mechanical once the Lease pattern is shipped and proven.
+- Process-detached leaves (per-slot daemons surviving across CLI
+  verbs) — not introduced here. ADR 0028 §"Process lifecycle" is
+  the relevant prior art; this ADR explicitly stays inside the
+  per-CLI-invocation lifetime.
+- Sharing `hubRepoPath` between `cli/hub_user.go` and the new
+  Lease — for now Lease replicates the path-existence check. A
+  follow-up can lift this into `internal/workspace`.
+
+## References
+
+- ADR 0023 (hub-leaf orchestrator topology, originator of the slot
+  concept)
+- ADR 0028 (bones swarm verbs, defines join/commit/close lifecycle)
+- ADR 0030 (real-substrate tests over mocks — Lease tests follow
+  this discipline)
+- PR #54 (autosync + the role-leak guard whose home moves into
+  `AcquireFresh`)
+- 2026-04-29 architecture review (this skill's grilling output)

--- a/internal/swarm/lease.go
+++ b/internal/swarm/lease.go
@@ -1,0 +1,633 @@
+package swarm
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"time"
+
+	"github.com/danmestas/libfossil"
+	"github.com/nats-io/nats.go"
+
+	"github.com/danmestas/bones/internal/assert"
+	"github.com/danmestas/bones/internal/coord"
+	"github.com/danmestas/bones/internal/workspace"
+)
+
+// DefaultHubFossilURL is the hub fossil HTTP URL bones writes when
+// `bones up` brings a hub to default ports. Mirrors the constant in
+// cli/swarm_join.go so AcquireFresh callers don't have to plumb the
+// URL through the CLI flag layer.
+const DefaultHubFossilURL = "http://127.0.0.1:8765"
+
+// DefaultCaps is the fossil capability string granted to a slot
+// user when the caller doesn't override. Matches cli/swarm_join.go.
+const DefaultCaps = "oih"
+
+// activeThresholdSec is the seconds-since-LastRenewed cutoff between
+// "active" and "stale" sessions, mirroring cli/swarm_status.go. Lives
+// here too so AcquireFresh can apply the same active-on-this-host
+// rule when refusing to take over a non-stale record.
+const activeThresholdSec = 90
+
+// ErrWorkspaceNotBootstrapped is returned by AcquireFresh when
+// `<workspace>/.orchestrator/hub.fossil` is missing. The role-leak
+// guard from PR #54 lives here: a leaf must NEVER read the error as
+// "run `bones up`" — bootstrap is the orchestrator's job. The
+// error string deliberately omits the `bones up` phrase so a
+// subagent reading stderr can't be misled into bootstrapping its
+// own context.
+var ErrWorkspaceNotBootstrapped = errors.New(
+	"swarm: workspace not bootstrapped — the orchestrator must " +
+		"bring up the hub before leaves can join; refusing to " +
+		"bootstrap from a leaf context",
+)
+
+// ErrSessionNotFound is returned by Resume when no session record
+// exists for the slot. Distinct from swarm.ErrNotFound so callers
+// can disambiguate "no record yet" from "Manager closed".
+var ErrSessionNotFound = errors.New(
+	"swarm: session record not found — run `bones swarm join` first",
+)
+
+// ErrSessionAlreadyLive is returned by AcquireFresh when a live
+// session record exists for the slot on this host and ForceTakeover
+// is false. Callers that want to overwrite it must set
+// AcquireOpts.ForceTakeover.
+var ErrSessionAlreadyLive = errors.New(
+	"swarm: live session already on this slot — pass --force to take over",
+)
+
+// ErrSessionForeignHost is returned by AcquireFresh when the
+// existing session record was written by a different host. Cross-
+// host takeover is refused unconditionally; the operator must run
+// the takeover from the owning host.
+var ErrSessionForeignHost = errors.New(
+	"swarm: session owned by another host — refusing cross-host takeover",
+)
+
+// AcquireOpts tunes AcquireFresh and Resume. Zero-value defaults are
+// production-correct: HubURL → DefaultHubFossilURL, Caps →
+// DefaultCaps, NATSConn dialed from info.NATSURL, Now →
+// time.Now().UTC.
+type AcquireOpts struct {
+	// HubURL overrides the hub fossil HTTP URL stamped into a fresh
+	// session record. Resume reads HubURL from the existing record
+	// and ignores this field. Empty → DefaultHubFossilURL.
+	HubURL string
+
+	// Hub is an in-process *coord.Hub. When set, the lease's
+	// underlying coord.Leaf opens against this Hub directly
+	// (LeafConfig.Hub) rather than via HubAddrs. Tests use this to
+	// avoid spinning up a separate hub process; the CLI never sets
+	// it.
+	Hub *coord.Hub
+
+	// Caps overrides fossil capabilities for the slot user on
+	// AcquireFresh. Resume ignores this. Empty → DefaultCaps.
+	Caps string
+
+	// ForceTakeover lets AcquireFresh CAS-delete an existing same-
+	// host session record on the slot. Recovery only — the typical
+	// path is an explicit operator decision after `bones doctor`.
+	ForceTakeover bool
+
+	// NATSConn is a pre-connected NATS connection. If nil, the
+	// lease dials info.NATSURL itself and the resulting connection
+	// is closed when the lease is released. When set, the caller
+	// owns the connection's lifetime.
+	NATSConn *nats.Conn
+
+	// Now is the time source for StartedAt and LastRenewed. nil →
+	// time.Now().UTC. Tests inject a fixed clock.
+	Now func() time.Time
+}
+
+// Lease is a single CLI invocation's grip on a slot. A Lease owns
+// the per-slot coord.Leaf, an optional claim hold, and the
+// JetStream KV session record for the duration of one CLI verb.
+//
+// Acquired fresh by `bones swarm join` (which CAS-creates the
+// session record), resumed by every other swarm verb (which read
+// the existing record and reconstruct the leaf). Per-CLI-invocation
+// lifetime — the leaf and claim die with the lease; the persistent
+// state across verbs is the session record in
+// bones-swarm-sessions[slot], not the lease itself.
+//
+// See ADR 0031 for the design and the rationale for the
+// AcquireFresh / Resume split. See ADR 0030 for why tests against
+// Lease use real NATS + real Fossil rather than mocks.
+type Lease struct {
+	info       workspace.Info
+	slot       string
+	taskID     string
+	fossilUser string
+	hubURL     string
+	now        func() time.Time
+
+	leaf  *coord.Leaf
+	claim *coord.Claim
+
+	mgr          *Manager
+	natsConn     *nats.Conn
+	ownsNATSConn bool
+	rev          uint64
+
+	released bool
+}
+
+// AcquireFresh opens a Lease for a slot that has no live session
+// record yet. Used by `bones swarm join`. Steps, in order, with any
+// partial work cleaned up on error:
+//
+//  1. Verify `<workspace>/.orchestrator/hub.fossil` exists. If not,
+//     return ErrWorkspaceNotBootstrapped — the role-leak guard from
+//     PR #54.
+//  2. Create the slot's fossil user on the hub repo if missing.
+//  3. Open the swarm.Manager (dial NATS or reuse opts.NATSConn).
+//  4. Read any existing session record. Active on this host without
+//     --force → ErrSessionAlreadyLive. Different host →
+//     ErrSessionForeignHost. Stale or --force → CAS-delete and
+//     continue.
+//  5. Open coord.Leaf with Autosync=true and claim the task.
+//  6. Put the session record (CAS create) and write the pid file.
+//
+// Returns a live Lease the caller MUST Release (when the session
+// record should persist for later verbs) or Close (when the slot's
+// work is done and the record should be deleted).
+func AcquireFresh(
+	ctx context.Context, info workspace.Info,
+	slot, taskID string, opts AcquireOpts,
+) (*Lease, error) {
+	assert.NotNil(ctx, "swarm.AcquireFresh: ctx is nil")
+	assert.NotEmpty(slot, "swarm.AcquireFresh: slot is empty")
+	assert.NotEmpty(taskID, "swarm.AcquireFresh: taskID is empty")
+	assert.NotEmpty(info.WorkspaceDir, "swarm.AcquireFresh: info.WorkspaceDir is empty")
+
+	now, hubURL, caps := defaultAcquireOpts(opts)
+	fossilUser := "slot-" + slot
+
+	if err := ensureSlotUser(info.WorkspaceDir, fossilUser, caps); err != nil {
+		return nil, err
+	}
+
+	mgr, nc, ownsConn, err := openLeaseManager(ctx, info, opts.NATSConn)
+	if err != nil {
+		return nil, err
+	}
+	cleanupConn := func() {
+		_ = mgr.Close()
+		if ownsConn && nc != nil {
+			nc.Close()
+		}
+	}
+
+	if err := clearExistingRecord(ctx, mgr, slot, opts.ForceTakeover, now); err != nil {
+		cleanupConn()
+		return nil, err
+	}
+
+	leaf, claim, err := openLeafAndClaim(ctx, info, slot, fossilUser, hubURL, taskID, opts.Hub)
+	if err != nil {
+		cleanupConn()
+		return nil, err
+	}
+	rev, err := writeSessionAndPid(
+		ctx, mgr, info.WorkspaceDir, slot, taskID, fossilUser, hubURL, now,
+	)
+	if err != nil {
+		_ = claim.Release()
+		_ = leaf.Stop()
+		cleanupConn()
+		return nil, err
+	}
+
+	return &Lease{
+		info:         info,
+		slot:         slot,
+		taskID:       taskID,
+		fossilUser:   fossilUser,
+		hubURL:       hubURL,
+		now:          now,
+		leaf:         leaf,
+		claim:        claim,
+		mgr:          mgr,
+		natsConn:     nc,
+		ownsNATSConn: ownsConn,
+		rev:          rev,
+	}, nil
+}
+
+// defaultAcquireOpts returns the (now, hubURL, caps) triple after
+// substituting package defaults for any zero-valued fields. Pulled
+// out so AcquireFresh and Resume share the defaulting logic and so
+// AcquireFresh fits under the funlen lint cap.
+func defaultAcquireOpts(opts AcquireOpts) (func() time.Time, string, string) {
+	now := opts.Now
+	if now == nil {
+		now = func() time.Time { return time.Now().UTC() }
+	}
+	hubURL := opts.HubURL
+	if hubURL == "" {
+		hubURL = DefaultHubFossilURL
+	}
+	caps := opts.Caps
+	if caps == "" {
+		caps = DefaultCaps
+	}
+	return now, hubURL, caps
+}
+
+// openLeafAndClaim opens the per-slot coord.Leaf and acquires a
+// claim on the named task. On error, any partially-opened leaf is
+// stopped before return.
+func openLeafAndClaim(
+	ctx context.Context, info workspace.Info,
+	slot, fossilUser, hubURL, taskID string, hub *coord.Hub,
+) (*coord.Leaf, *coord.Claim, error) {
+	leaf, err := openLeaf(ctx, info, slot, fossilUser, hubURL, hub)
+	if err != nil {
+		return nil, nil, fmt.Errorf("swarm.AcquireFresh: open leaf: %w", err)
+	}
+	if err := os.MkdirAll(leaf.WT(), 0o755); err != nil {
+		_ = leaf.Stop()
+		return nil, nil, fmt.Errorf("swarm.AcquireFresh: mkdir worktree: %w", err)
+	}
+	claim, err := leaf.Claim(ctx, coord.TaskID(taskID))
+	if err != nil {
+		_ = leaf.Stop()
+		return nil, nil, fmt.Errorf("swarm.AcquireFresh: claim task: %w", err)
+	}
+	return leaf, claim, nil
+}
+
+// writeSessionAndPid CAS-creates the session record and writes the
+// host-local pid file. Returns the post-Put KV revision so the
+// Lease can CAS against it during Close. On pid-file failure the
+// session record is best-effort deleted before return so the slot
+// stays clean for the next AcquireFresh.
+func writeSessionAndPid(
+	ctx context.Context, mgr *Manager,
+	workspaceDir, slot, taskID, fossilUser, hubURL string,
+	now func() time.Time,
+) (uint64, error) {
+	host, _ := os.Hostname()
+	t := now()
+	sess := Session{
+		Slot:        slot,
+		TaskID:      taskID,
+		AgentID:     fossilUser,
+		Host:        host,
+		LeafPID:     os.Getpid(),
+		HubURL:      hubURL,
+		StartedAt:   t,
+		LastRenewed: t,
+	}
+	if err := mgr.Put(ctx, sess); err != nil {
+		return 0, fmt.Errorf("swarm.AcquireFresh: write session record: %w", err)
+	}
+	if err := writePidFile(workspaceDir, slot); err != nil {
+		_ = mgr.Delete(ctx, slot, 0)
+		return 0, fmt.Errorf("swarm.AcquireFresh: %w", err)
+	}
+	_, rev, err := mgr.Get(ctx, slot)
+	if err != nil {
+		return 0, fmt.Errorf("swarm.AcquireFresh: re-read session: %w", err)
+	}
+	return rev, nil
+}
+
+// Resume opens a Lease for a slot whose session record already
+// exists in KV. Used by every swarm verb other than join.
+//
+// Resume does NOT re-take the claim — verbs that need a claim
+// (commit, close) re-acquire via Lease.Commit / Lease.Close. This
+// mirrors today's CLI behavior: claim holds have a TTL that
+// outlives a single verb only when bumped by a commit, and the
+// record's LastRenewed is the durable liveness signal.
+//
+// Returns ErrSessionNotFound if the slot has no record. Returns the
+// underlying NATS / Fossil errors otherwise.
+func Resume(
+	ctx context.Context, info workspace.Info,
+	slot string, opts AcquireOpts,
+) (*Lease, error) {
+	assert.NotNil(ctx, "swarm.Resume: ctx is nil")
+	assert.NotEmpty(slot, "swarm.Resume: slot is empty")
+	assert.NotEmpty(info.WorkspaceDir, "swarm.Resume: info.WorkspaceDir is empty")
+
+	now := opts.Now
+	if now == nil {
+		now = func() time.Time { return time.Now().UTC() }
+	}
+
+	mgr, nc, ownsConn, err := openLeaseManager(ctx, info, opts.NATSConn)
+	if err != nil {
+		return nil, err
+	}
+	cleanup := func() {
+		_ = mgr.Close()
+		if ownsConn && nc != nil {
+			nc.Close()
+		}
+	}
+
+	sess, rev, err := mgr.Get(ctx, slot)
+	if err != nil {
+		cleanup()
+		if errors.Is(err, ErrNotFound) {
+			return nil, ErrSessionNotFound
+		}
+		return nil, fmt.Errorf("swarm.Resume: read session: %w", err)
+	}
+
+	hubURL := sess.HubURL
+	if hubURL == "" {
+		hubURL = DefaultHubFossilURL
+	}
+
+	leaf, err := openLeaf(ctx, info, slot, sess.AgentID, hubURL, opts.Hub)
+	if err != nil {
+		cleanup()
+		return nil, fmt.Errorf("swarm.Resume: open leaf: %w", err)
+	}
+
+	return &Lease{
+		info:         info,
+		slot:         slot,
+		taskID:       sess.TaskID,
+		fossilUser:   sess.AgentID,
+		hubURL:       hubURL,
+		now:          now,
+		leaf:         leaf,
+		claim:        nil, // Resume does not take a claim
+		mgr:          mgr,
+		natsConn:     nc,
+		ownsNATSConn: ownsConn,
+		rev:          rev,
+	}, nil
+}
+
+// Release closes the lease without deleting the session record.
+// Stops the leaf, releases any held claim, closes the swarm
+// Manager, and (if the lease owns the NATS connection) closes that
+// too. Idempotent.
+//
+// `bones swarm join` calls Release after writing the session
+// record so subsequent verbs can Resume against it. `bones swarm
+// close` calls Close instead, which also deletes the record.
+func (l *Lease) Release(ctx context.Context) error {
+	assert.NotNil(l, "swarm.Lease.Release: receiver is nil")
+	if l.released {
+		return nil
+	}
+	l.released = true
+	if l.claim != nil {
+		_ = l.claim.Release()
+	}
+	if l.leaf != nil {
+		_ = l.leaf.Stop()
+	}
+	if l.mgr != nil {
+		_ = l.mgr.Close()
+	}
+	if l.ownsNATSConn && l.natsConn != nil {
+		l.natsConn.Close()
+	}
+	_ = ctx // ctx kept for symmetry with Close; cleanup is local
+	return nil
+}
+
+// Close terminates the lease and deletes the session record via a
+// CAS gate against the revision the lease holds. Idempotent — a
+// second Close after a successful first is a no-op. After Close,
+// the slot is available for a fresh AcquireFresh.
+//
+// `bones swarm close` calls this. The CAS gate ensures we don't
+// delete a record some other process renewed; if it raced us, the
+// caller sees ErrCASConflict and can decide whether to re-Resume
+// and retry.
+func (l *Lease) Close(ctx context.Context) error {
+	assert.NotNil(l, "swarm.Lease.Close: receiver is nil")
+	assert.NotNil(ctx, "swarm.Lease.Close: ctx is nil")
+	if l.released {
+		return nil
+	}
+	if l.mgr != nil && l.rev != 0 {
+		if err := l.mgr.Delete(ctx, l.slot, l.rev); err != nil &&
+			!errors.Is(err, ErrNotFound) {
+			// Best-effort cleanup of the underlying resources even on
+			// CAS failure; the caller decides whether to retry the
+			// delete after re-Resume.
+			_ = l.releaseUnderlying()
+			return fmt.Errorf("swarm.Lease.Close: delete record: %w", err)
+		}
+	}
+	return l.releaseUnderlying()
+}
+
+// releaseUnderlying tears down the leaf + claim + manager + NATS
+// connection. Shared by Release and Close so the cleanup ordering
+// stays in one place.
+func (l *Lease) releaseUnderlying() error {
+	l.released = true
+	if l.claim != nil {
+		_ = l.claim.Release()
+	}
+	if l.leaf != nil {
+		_ = l.leaf.Stop()
+	}
+	if l.mgr != nil {
+		_ = l.mgr.Close()
+	}
+	if l.ownsNATSConn && l.natsConn != nil {
+		l.natsConn.Close()
+	}
+	return nil
+}
+
+// Slot returns the slot this lease holds.
+func (l *Lease) Slot() string { return l.slot }
+
+// TaskID returns the task ID bound to the lease's session record.
+func (l *Lease) TaskID() string { return l.taskID }
+
+// HubURL returns the hub fossil HTTP URL the lease's leaf is
+// peered against.
+func (l *Lease) HubURL() string { return l.hubURL }
+
+// FossilUser returns the slot's fossil user (e.g. "slot-rendering").
+func (l *Lease) FossilUser() string { return l.fossilUser }
+
+// WT returns the slot's worktree path. Equivalent to
+// l.Leaf().WT() during the deprecated-on-arrival escape-hatch
+// window; will outlive Leaf() once swarm_commit and swarm_close
+// migrate.
+func (l *Lease) WT() string {
+	if l.leaf == nil {
+		return ""
+	}
+	return l.leaf.WT()
+}
+
+// Leaf returns the underlying coord.Leaf. ESCAPE HATCH —
+// deprecated on arrival. Present so cli/swarm_commit.go and
+// cli/swarm_close.go can be migrated to use Lease in PR B and C
+// without porting their full code in PR A. Will be removed once
+// all swarm verbs use Lease's typed methods.
+func (l *Lease) Leaf() *coord.Leaf { return l.leaf }
+
+// SessionRevision returns the JetStream KV revision the lease
+// captured at acquisition. Callers that want to do their own CAS
+// updates against the session record (e.g. a future commit-without-
+// claim path) can pass this to swarm.Manager.Update.
+func (l *Lease) SessionRevision() uint64 { return l.rev }
+
+// Manager returns the lease's swarm.Manager. Same escape-hatch
+// caveat as Leaf — used during migration; will be encapsulated
+// once Lease.Commit / Lease.Close cover all swarm verbs.
+func (l *Lease) Manager() *Manager { return l.mgr }
+
+// ensureSlotUser creates the slot's fossil user on the hub repo
+// if missing. The role-guard for "workspace not bootstrapped" lives
+// here: if `<workspace>/.orchestrator/hub.fossil` is absent,
+// returns ErrWorkspaceNotBootstrapped without trying to create
+// anything. Bootstrap is the orchestrator's job; a leaf must never
+// fix it (PR #54).
+func ensureSlotUser(workspaceDir, login, caps string) error {
+	hubRepoPath := filepath.Join(workspaceDir, ".orchestrator", "hub.fossil")
+	if _, err := os.Stat(hubRepoPath); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return ErrWorkspaceNotBootstrapped
+		}
+		return fmt.Errorf("swarm: stat hub repo: %w", err)
+	}
+	repo, err := libfossil.Open(hubRepoPath)
+	if err != nil {
+		return fmt.Errorf("swarm: open hub repo: %w", err)
+	}
+	defer func() { _ = repo.Close() }()
+
+	if _, err := repo.GetUser(login); err == nil {
+		return nil
+	}
+	if err := repo.CreateUser(libfossil.UserOpts{
+		Login: login,
+		Caps:  caps,
+	}); err != nil {
+		return fmt.Errorf("swarm: create user %q: %w", login, err)
+	}
+	return nil
+}
+
+// openLeaseManager dials NATS (or reuses preNC) and opens a swarm.Manager.
+// Returns the manager, the NATS connection, and a flag indicating
+// whether the manager owns the connection's close.
+func openLeaseManager(
+	ctx context.Context, info workspace.Info, preNC *nats.Conn,
+) (*Manager, *nats.Conn, bool, error) {
+	var (
+		nc       *nats.Conn
+		ownsConn bool
+	)
+	if preNC != nil {
+		nc = preNC
+	} else {
+		assert.NotEmpty(info.NATSURL, "swarm: info.NATSURL is empty and no opts.NATSConn provided")
+		var err error
+		nc, err = nats.Connect(info.NATSURL)
+		if err != nil {
+			return nil, nil, false, fmt.Errorf("swarm: nats connect: %w", err)
+		}
+		ownsConn = true
+	}
+	m, err := Open(ctx, Config{NATSConn: nc})
+	if err != nil {
+		if ownsConn {
+			nc.Close()
+		}
+		return nil, nil, false, fmt.Errorf("swarm: open manager: %w", err)
+	}
+	return m, nc, ownsConn, nil
+}
+
+// clearExistingRecord enforces the "one live session per slot" rule
+// before AcquireFresh writes a new record. Returns nil if no record
+// exists or the existing record was successfully cleared. Returns
+// ErrSessionAlreadyLive if the existing record is active on this
+// host and force is false; ErrSessionForeignHost if it lives on a
+// different host (cross-host takeover refused unconditionally).
+func clearExistingRecord(
+	ctx context.Context, mgr *Manager, slot string, force bool, now func() time.Time,
+) error {
+	existing, rev, err := mgr.Get(ctx, slot)
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			return nil
+		}
+		return fmt.Errorf("swarm: read existing record: %w", err)
+	}
+	host, _ := os.Hostname()
+	staleSec := int64(now().Sub(existing.LastRenewed).Seconds())
+	if !force {
+		switch {
+		case existing.Host == host && staleSec <= activeThresholdSec:
+			return fmt.Errorf("%w (slot=%q renewed %ds ago)",
+				ErrSessionAlreadyLive, slot, staleSec)
+		case existing.Host != host:
+			return fmt.Errorf("%w (slot=%q owner=%q)",
+				ErrSessionForeignHost, slot, existing.Host)
+		}
+	}
+	if err := mgr.Delete(ctx, slot, rev); err != nil && !errors.Is(err, ErrNotFound) {
+		return fmt.Errorf("swarm: clear stale record: %w", err)
+	}
+	return nil
+}
+
+// openLeaf opens the per-slot coord.Leaf rooted at
+// `<workspace>/.bones/swarm`. When opts.Hub is set, opens against
+// the in-process hub directly (test path). Otherwise uses HubAddrs
+// with the workspace's NATS URL and the supplied hub HTTP URL.
+func openLeaf(
+	ctx context.Context, info workspace.Info,
+	slot, fossilUser, hubURL string, hub *coord.Hub,
+) (*coord.Leaf, error) {
+	swarmRoot := filepath.Join(info.WorkspaceDir, ".bones", "swarm")
+	if err := os.MkdirAll(swarmRoot, 0o755); err != nil {
+		return nil, fmt.Errorf("mkdir swarm root: %w", err)
+	}
+	cfg := coord.LeafConfig{
+		Workdir:    swarmRoot,
+		SlotID:     slot,
+		FossilUser: fossilUser,
+		Autosync:   true,
+	}
+	if hub != nil {
+		cfg.Hub = hub
+	} else {
+		cfg.HubAddrs = coord.HubAddrs{
+			LeafUpstream: "",
+			NATSClient:   info.NATSURL,
+			HTTPAddr:     hubURL,
+		}
+	}
+	return coord.OpenLeaf(ctx, cfg)
+}
+
+// writePidFile writes the slot's host-local pid tracker. Mirrors
+// cli/swarm_join.go::writePidFile so `kill $(cat ...)` works
+// without a NATS round-trip.
+func writePidFile(workspaceDir, slot string) error {
+	pidPath := SlotPidFile(workspaceDir, slot)
+	if err := os.MkdirAll(filepath.Dir(pidPath), 0o755); err != nil {
+		return fmt.Errorf("mkdir slot dir: %w", err)
+	}
+	if err := os.WriteFile(pidPath, []byte(strconv.Itoa(os.Getpid())+"\n"), 0o644); err != nil {
+		return fmt.Errorf("write pid file: %w", err)
+	}
+	return nil
+}

--- a/internal/swarm/lease_test.go
+++ b/internal/swarm/lease_test.go
@@ -1,0 +1,295 @@
+package swarm
+
+import (
+	"context"
+	"errors"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/danmestas/bones/internal/coord"
+	"github.com/danmestas/bones/internal/workspace"
+)
+
+// freePort returns a random unused TCP port for an in-process hub.
+// Mirrors internal/coord/hub_test.go's helper.
+func freePort(t *testing.T) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	addr := ln.Addr().String()
+	_ = ln.Close()
+	return addr
+}
+
+// leaseFixture brings up a workspace dir + an in-process hub
+// (writing hub.fossil under .orchestrator) and returns the
+// workspace.Info shape AcquireFresh / Resume consume. Per ADR
+// 0030 this uses real NATS + real Fossil — no mocks.
+type leaseFixture struct {
+	dir  string
+	hub  *coord.Hub
+	info workspace.Info
+}
+
+func newLeaseFixture(t *testing.T) *leaseFixture {
+	t.Helper()
+	dir := t.TempDir()
+	orch := filepath.Join(dir, ".orchestrator")
+	if err := os.MkdirAll(orch, 0o755); err != nil {
+		t.Fatalf("mkdir orchestrator: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+	hub, err := coord.OpenHub(ctx, orch, freePort(t))
+	if err != nil {
+		t.Fatalf("OpenHub: %v", err)
+	}
+	t.Cleanup(func() { _ = hub.Stop() })
+	return &leaseFixture{
+		dir: dir,
+		hub: hub,
+		info: workspace.Info{
+			WorkspaceDir: dir,
+			NATSURL:      hub.NATSURL(),
+		},
+	}
+}
+
+// createTask inserts an open task on the hub so AcquireFresh has
+// something to claim. Uses a temporary fixture leaf to call
+// coord.Leaf.OpenTask — same path the bones tasks-create CLI verb
+// takes — so the substrate sees a fully-formed task record. The
+// fixture leaf is closed before returning; the lease under test
+// opens its own leaf inside AcquireFresh.
+func (f *leaseFixture) createTask(t *testing.T, title, holdPath string) coord.TaskID {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	fixtureLeaf, err := coord.OpenLeaf(ctx, coord.LeafConfig{
+		Hub:     f.hub,
+		Workdir: filepath.Join(f.dir, ".bones", "fixture"),
+		SlotID:  "fixture-" + title,
+	})
+	if err != nil {
+		t.Fatalf("fixture OpenLeaf: %v", err)
+	}
+	defer func() { _ = fixtureLeaf.Stop() }()
+	taskID, err := fixtureLeaf.OpenTask(ctx, title, []string{holdPath})
+	if err != nil {
+		t.Fatalf("OpenTask: %v", err)
+	}
+	return taskID
+}
+
+// TestAcquireFresh_RefusesWithoutHubFossil pins the role-leak
+// guard from PR #54. A workspace dir with no
+// `.orchestrator/hub.fossil` MUST cause AcquireFresh to return
+// ErrWorkspaceNotBootstrapped without attempting any other work.
+// The error string MUST NOT contain "run `bones up`" — that
+// guidance is for orchestrators, not leaves.
+func TestAcquireFresh_RefusesWithoutHubFossil(t *testing.T) {
+	dir := t.TempDir() // no .orchestrator/hub.fossil
+	info := workspace.Info{WorkspaceDir: dir, NATSURL: "nats://127.0.0.1:1"}
+
+	_, err := AcquireFresh(context.Background(), info, "demo", "task-x", AcquireOpts{})
+	if !errors.Is(err, ErrWorkspaceNotBootstrapped) {
+		t.Fatalf("AcquireFresh: want ErrWorkspaceNotBootstrapped, got %v", err)
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "refusing to bootstrap from a leaf context") {
+		t.Errorf("error missing leaf-context refusal: %s", msg)
+	}
+	if strings.Contains(msg, "run `bones up`") {
+		t.Errorf("error contains orchestrator-targeted guidance: %s", msg)
+	}
+}
+
+// TestAcquireFresh_SuccessAndRelease covers the happy path: fresh
+// acquire writes the session record + opens the leaf + claims the
+// task; Release tears down the leaf without deleting the record.
+func TestAcquireFresh_SuccessAndRelease(t *testing.T) {
+	f := newLeaseFixture(t)
+	holdPath := filepath.Join(f.dir, "rendering", "hello.txt")
+	taskID := string(f.createTask(t, "rendering-task-1", holdPath))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	lease, err := AcquireFresh(ctx, f.info, "rendering", taskID, AcquireOpts{
+		Hub: f.hub,
+	})
+	if err != nil {
+		t.Fatalf("AcquireFresh: %v", err)
+	}
+	if lease.Slot() != "rendering" {
+		t.Errorf("Slot: got %q want %q", lease.Slot(), "rendering")
+	}
+	if lease.TaskID() != taskID {
+		t.Errorf("TaskID: got %q want %q", lease.TaskID(), taskID)
+	}
+	if lease.WT() == "" {
+		t.Errorf("WT: empty")
+	}
+	if lease.SessionRevision() == 0 {
+		t.Errorf("SessionRevision: zero")
+	}
+
+	// Session record must be visible on the manager.
+	mgr := lease.Manager()
+	got, _, err := mgr.Get(ctx, "rendering")
+	if err != nil {
+		t.Fatalf("post-acquire Get: %v", err)
+	}
+	if got.TaskID != taskID {
+		t.Errorf("session task: got %q want %q", got.TaskID, taskID)
+	}
+	if got.HubURL == "" {
+		t.Errorf("session hub URL: empty")
+	}
+
+	// Pid file must exist.
+	if _, err := os.Stat(SlotPidFile(f.dir, "rendering")); err != nil {
+		t.Errorf("pid file missing: %v", err)
+	}
+
+	// Release should NOT delete the session record. Verify by opening
+	// a fresh Manager (different from the lease's, which Release just
+	// closed) and reading the slot's record back.
+	if err := lease.Release(ctx); err != nil {
+		t.Fatalf("Release: %v", err)
+	}
+	verifyMgr := openVerifyManager(t, f)
+	if _, _, err := verifyMgr.Get(ctx, "rendering"); err != nil {
+		t.Errorf("session record gone after Release (expected to persist): %v", err)
+	}
+
+	// Release must be idempotent.
+	if err := lease.Release(ctx); err != nil {
+		t.Errorf("second Release: %v", err)
+	}
+}
+
+// openVerifyManager dials NATS at the fixture hub's URL and opens a
+// swarm.Manager that the test owns the lifetime of. Used to read
+// session records the lease wrote, after the lease's own Manager
+// has been closed by Release/Close.
+func openVerifyManager(t *testing.T, f *leaseFixture) *Manager {
+	t.Helper()
+	mgr, _, _, err := openLeaseManager(context.Background(), f.info, nil)
+	if err != nil {
+		t.Fatalf("openVerifyManager: %v", err)
+	}
+	t.Cleanup(func() { _ = mgr.Close() })
+	return mgr
+}
+
+// TestAcquireFresh_RefusesActiveLiveSession pins the
+// ErrSessionAlreadyLive path: a live session on the same host
+// without --force must be rejected.
+func TestAcquireFresh_RefusesActiveLiveSession(t *testing.T) {
+	f := newLeaseFixture(t)
+	holdPath := filepath.Join(f.dir, "physics", "hello.txt")
+	taskID := string(f.createTask(t, "physics-task-1", holdPath))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	first, err := AcquireFresh(ctx, f.info, "physics", taskID, AcquireOpts{Hub: f.hub})
+	if err != nil {
+		t.Fatalf("first AcquireFresh: %v", err)
+	}
+	t.Cleanup(func() { _ = first.Release(ctx) })
+
+	// Without --force, second acquire must refuse.
+	_, err = AcquireFresh(ctx, f.info, "physics", taskID, AcquireOpts{Hub: f.hub})
+	if !errors.Is(err, ErrSessionAlreadyLive) {
+		t.Fatalf("second AcquireFresh: want ErrSessionAlreadyLive, got %v", err)
+	}
+}
+
+// TestResume_FailsWithoutSession ensures Resume on a slot that
+// has no session record returns ErrSessionNotFound, not a generic
+// substrate error.
+func TestResume_FailsWithoutSession(t *testing.T) {
+	f := newLeaseFixture(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := Resume(ctx, f.info, "ghost", AcquireOpts{Hub: f.hub})
+	if !errors.Is(err, ErrSessionNotFound) {
+		t.Fatalf("Resume: want ErrSessionNotFound, got %v", err)
+	}
+}
+
+// TestResume_AfterAcquireFresh confirms Resume reconstructs a
+// usable lease from the session record AcquireFresh wrote.
+func TestResume_AfterAcquireFresh(t *testing.T) {
+	f := newLeaseFixture(t)
+	holdPath := filepath.Join(f.dir, "ui", "hello.txt")
+	taskID := string(f.createTask(t, "ui-task-1", holdPath))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	first, err := AcquireFresh(ctx, f.info, "ui", taskID, AcquireOpts{Hub: f.hub})
+	if err != nil {
+		t.Fatalf("AcquireFresh: %v", err)
+	}
+	if err := first.Release(ctx); err != nil {
+		t.Fatalf("Release: %v", err)
+	}
+
+	resumed, err := Resume(ctx, f.info, "ui", AcquireOpts{Hub: f.hub})
+	if err != nil {
+		t.Fatalf("Resume: %v", err)
+	}
+	t.Cleanup(func() { _ = resumed.Release(ctx) })
+
+	if resumed.Slot() != "ui" || resumed.TaskID() != taskID {
+		t.Errorf("resumed lease: slot=%q task=%q want slot=%q task=%q",
+			resumed.Slot(), resumed.TaskID(), "ui", taskID)
+	}
+	if resumed.HubURL() == "" {
+		t.Errorf("resumed lease: hubURL empty")
+	}
+	if resumed.FossilUser() != "slot-ui" {
+		t.Errorf("resumed lease: fossilUser=%q", resumed.FossilUser())
+	}
+}
+
+// TestClose_DeletesRecord pins the Close contract: removes the
+// session record (CAS-gated against the lease's revision) and
+// stops the underlying leaf. After Close, AcquireFresh on the
+// same slot must succeed without --force.
+func TestClose_DeletesRecord(t *testing.T) {
+	f := newLeaseFixture(t)
+	holdPath := filepath.Join(f.dir, "audio", "hello.txt")
+	taskID := string(f.createTask(t, "audio-task-1", holdPath))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	first, err := AcquireFresh(ctx, f.info, "audio", taskID, AcquireOpts{Hub: f.hub})
+	if err != nil {
+		t.Fatalf("first AcquireFresh: %v", err)
+	}
+	if err := first.Close(ctx); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	// Second acquire on same slot without --force should now succeed.
+	holdPath2 := filepath.Join(f.dir, "audio", "v2.txt")
+	taskID2 := string(f.createTask(t, "audio-task-2", holdPath2))
+	second, err := AcquireFresh(ctx, f.info, "audio", taskID2, AcquireOpts{Hub: f.hub})
+	if err != nil {
+		t.Fatalf("post-Close AcquireFresh: %v", err)
+	}
+	t.Cleanup(func() { _ = second.Release(ctx) })
+}


### PR DESCRIPTION
## Summary
PR A of the architecture-review follow-up (ADR 0031). Introduces \`internal/swarm.Lease\` — a typed module owning the assembled scaffold (workspace check, fossil-user creation, swarm.Manager, session-record CAS, coord.Leaf open, claim) for the duration of one CLI invocation — and migrates the first verb (\`bones swarm join\`) to use it.

The smoking-gun motivator was PR #54's role-leak fix: a precondition (\"refusing to bootstrap from a leaf context\") that should have lived in one place ended up in \`cli/swarm_join.go::ensureSlotUser\`. The same scaffold is duplicated across \`cli/swarm_*.go\` today; this PR consolidates it into \`Lease\`.

## API

- \`swarm.AcquireFresh(ctx, info, slot, taskID, opts) (*Lease, error)\` — used by \`swarm join\`. Owns the role-guard, fossil-user creation, takeover semantics, leaf open, claim, CAS write of session record, pid file.
- \`swarm.Resume(ctx, info, slot, opts) (*Lease, error)\` — used by every other verb (migrating in PRs B & C). Reads the existing record and reconstructs the leaf.
- \`Lease.Release(ctx)\` — stops leaf, keeps record. Used by \`swarm join\`.
- \`Lease.Close(ctx)\` — CAS-deletes the record + stops leaf. Used by \`swarm close\` (PR C).
- Accessors: \`Slot\`, \`TaskID\`, \`WT\`, \`HubURL\`, \`FossilUser\`, \`SessionRevision\`. Plus \`Manager\` and \`Leaf\` as deprecated-on-arrival escape hatches for the migration.

## Tests
Real NATS + real Fossil per ADR 0030 (no mocks). \`internal/swarm/lease_test.go\` covers:

- Role-guard refusal when \`<workspace>/.orchestrator/hub.fossil\` is missing
- \`AcquireFresh\` success path: session record + pid file written, leaf alive, accessors correct
- \`Release\` does NOT delete the session record (idempotent)
- \`AcquireFresh\` refuses when an active record exists on the same host (no \`--force\`)
- \`Resume\` returns \`ErrSessionNotFound\` for a slot with no record
- \`Resume\` after \`AcquireFresh + Release\` reconstructs a usable lease
- \`Close\` deletes the record so a subsequent \`AcquireFresh\` succeeds without \`--force\`

The \`TestCLI_SwarmJoin_RefusesBootstrapFromLeafContext\` integration test still pins the role-guard contract end-to-end. The verb name \"swarm join\" is now stamped via \`fmt.Errorf\` wrap in the CLI run path so the test's command-tag assertion still matches.

## Migration
- \`cli/swarm_join.go\`: ~300 LoC → ~80. Just flag parsing, \`AcquireFresh\`, report, \`Release\`.
- \`cli/swarm_commit.go\` + \`cli/swarm_close.go\`: replace the deleted \`defaultHubFossilURL\` constant with \`swarm.DefaultHubFossilURL\`. No behavior change.

## CONTEXT.md
First time a domain concept (\"Lease\") was named in an architecture-review grilling. Adds a top-level \`CONTEXT.md\` as the orientation doc ADRs assume but don't repeat.

## Out of scope
- **PR B**: migrate \`swarm commit\` (\`Resume\` + a new \`Lease.Commit\` method).
- **PR C**: migrate \`swarm close\`, \`swarm status\`, \`swarm cwd\`, \`swarm fan-in\` (\`Resume\` + \`Close\` + accessors).
- **PR D**: remove the \`Leaf()\` and \`Manager()\` escape hatches once unused.

## Test plan
- [x] \`make check\` clean (fmt, vet, lint, race, todo)
- [x] \`go test ./...\` clean
- [x] \`TestCLI_SwarmJoin_RefusesBootstrapFromLeafContext\` still passes against the new code
- [x] \`internal/swarm/lease_test.go\` — 6 tests, all real-substrate