### PR TITLE
swarm: migrate commit + close to Lease (ADR 0031 PRs B + C + D combined)

### DIFF
--- a/cli/swarm_close.go
+++ b/cli/swarm_close.go
@@ -15,13 +15,13 @@ import (
 )
 
 // SwarmCloseCmd ends a swarm session: posts a dispatch.ResultMessage
-// to the task thread, releases the claim hold, optionally closes the
-// task in NATS KV (on result=success), stops the leaf process, and
-// deletes the session record from bones-swarm-sessions.
+// to the task thread, then has the lease close the task in KV
+// (on result=success), release the claim hold, stop the leaf,
+// remove the host-local pid file, and CAS-delete the session record.
 //
-// Idempotent against partial-cleanup states: missing pid file or
-// already-deleted session are not errors so re-running close after a
-// crash converges.
+// Idempotent against partial-cleanup states: a missing session
+// record (already closed) is not an error so re-running close
+// after a crash converges.
 type SwarmCloseCmd struct {
 	Slot    string `name:"slot" help:"slot name (defaults to single active slot on this host)"`
 	Result  string `name:"result" default:"success" help:"success|fail|fork"`
@@ -44,45 +44,42 @@ func (c *SwarmCloseCmd) run(ctx context.Context, info workspace.Info) error {
 	if err := c.validateResult(); err != nil {
 		return err
 	}
-	mgr, closeMgr, err := openSwarmManager(ctx, info)
+	slot, err := c.resolveTargetSlot(ctx, info)
 	if err != nil {
 		return err
 	}
-	defer closeMgr()
-
-	host, _ := os.Hostname()
-	slot, err := resolveSlot(ctx, mgr, c.Slot, host)
-	if err != nil {
-		return err
+	hubURL := c.HubURL
+	if hubURL == "" {
+		hubURL = swarm.DefaultHubFossilURL
 	}
-	sess, rev, err := mgr.Get(ctx, slot)
+	lease, err := swarm.Resume(ctx, info, slot, swarm.AcquireOpts{HubURL: hubURL})
 	if err != nil {
-		if errors.Is(err, swarm.ErrNotFound) {
-			fmt.Fprintf(os.Stderr, "swarm close: no session for slot %q (already closed?)\n", slot)
+		if errors.Is(err, swarm.ErrSessionNotFound) {
+			fmt.Fprintf(os.Stderr,
+				"swarm close: no session for slot %q (already closed?)\n", slot)
 			return nil
 		}
-		return fmt.Errorf("read session: %w", err)
+		return fmt.Errorf("swarm close: %w", err)
 	}
 
-	if err := c.postResult(ctx, info, sess); err != nil {
+	// Post the dispatch ResultMessage on the task thread BEFORE we
+	// transition the lease to closed — once Lease.Close runs, the
+	// claim hold is gone and the underlying task may be closed too,
+	// so the result post must happen first. Soft-fail per ADR 0028
+	// retro: a failed post is logged but not a hard error.
+	if err := c.postResult(ctx, info, lease.FossilUser(), lease.TaskID()); err != nil {
 		fmt.Fprintf(os.Stderr, "swarm close: warning: post result failed: %v\n", err)
 	}
-	if err := c.releaseAndMaybeCloseTask(ctx, info, slot, sess); err != nil {
-		fmt.Fprintf(os.Stderr, "swarm close: warning: release/close failed: %v\n", err)
+
+	closeOpts := swarm.CloseOpts{
+		CloseTaskOnSuccess: c.Result == string(dispatch.ResultSuccess),
 	}
-	if err := c.removePidFile(info, slot); err != nil {
-		fmt.Fprintf(os.Stderr, "swarm close: warning: remove pid file failed: %v\n", err)
-	}
-	if err := mgr.Delete(ctx, slot, rev); err != nil {
-		// Tolerate ErrCASConflict / ErrNotFound — another close ran
-		// in parallel and we converged on the same end state.
-		if !errors.Is(err, swarm.ErrCASConflict) && !errors.Is(err, swarm.ErrNotFound) {
-			return fmt.Errorf("delete session record: %w", err)
-		}
+	if err := lease.Close(ctx, closeOpts); err != nil {
+		return fmt.Errorf("swarm close: %w", err)
 	}
 	fmt.Fprintf(os.Stderr,
 		"swarm close: slot=%s task=%s result=%s\n",
-		slot, sess.TaskID, c.Result,
+		slot, lease.TaskID(), c.Result,
 	)
 	return nil
 }
@@ -95,15 +92,41 @@ func (c *SwarmCloseCmd) validateResult() error {
 	return fmt.Errorf("--result must be success|fail|fork (got %q)", c.Result)
 }
 
-// postResult publishes a dispatch.ResultMessage onto the task thread
-// (subject derived from the task ID). Mirrors the worker side of
-// cli/tasks_dispatch.go's flow so a parent dispatch handler picks up
-// the close.
+// resolveTargetSlot mirrors the helper in swarm_commit.go: honors
+// --slot when set, otherwise infers the unique active slot via
+// Manager.List. The Manager is opened-and-closed inline; Resume
+// opens its own to read the session record.
+func (c *SwarmCloseCmd) resolveTargetSlot(
+	ctx context.Context, info workspace.Info,
+) (string, error) {
+	mgr, closeMgr, err := openSwarmManager(ctx, info)
+	if err != nil {
+		return "", err
+	}
+	defer closeMgr()
+	host, _ := os.Hostname()
+	slot, err := resolveSlot(ctx, mgr, c.Slot, host)
+	if err != nil {
+		return "", err
+	}
+	return slot, nil
+}
+
+// postResult publishes a dispatch.ResultMessage onto the task
+// thread (subject derived from the task ID). Mirrors the worker
+// side of cli/tasks_dispatch.go's flow so a parent dispatch handler
+// picks up the close.
+//
+// This stays in the CLI verb (not on Lease) because the dispatch
+// result protocol is a verb-specific concern: a `swarm close`
+// invocation is what carries the verdict (success/fail/fork +
+// summary + optional branch/rev). The lease only owns the slot
+// state transition.
 func (c *SwarmCloseCmd) postResult(
-	ctx context.Context, info workspace.Info, sess swarm.Session,
+	ctx context.Context, info workspace.Info, agentID, taskID string,
 ) error {
 	cfg := newCoordConfig(info)
-	cfg.AgentID = sess.AgentID
+	cfg.AgentID = agentID
 	cfg.ProjectPrefix = coord.DeriveProjectPrefix(info.AgentID)
 	co, err := coord.Open(ctx, cfg)
 	if err != nil {
@@ -116,64 +139,8 @@ func (c *SwarmCloseCmd) postResult(
 		Branch:  c.Branch,
 		Rev:     c.Rev,
 	}
-	thread := sess.TaskID
-	if err := co.Post(ctx, thread, []byte(dispatch.FormatResult(msg))); err != nil {
+	if err := co.Post(ctx, taskID, []byte(dispatch.FormatResult(msg))); err != nil {
 		return fmt.Errorf("post result: %w", err)
-	}
-	return nil
-}
-
-// releaseAndMaybeCloseTask re-opens the slot's leaf, takes the claim
-// just long enough to release it (and on result=success, calls
-// Leaf.Close which also closes the task in KV), then stops the leaf.
-//
-// The double-Claim/Release here looks redundant — the swarm session
-// already represents an active claim from `swarm join`. But Leaf
-// objects are per-process: this CLI invocation never saw the join's
-// *Leaf or *Claim, so it must reconstruct them. The CAS-gated holds
-// bucket lets the second Claim succeed (same agent ID = idempotent
-// renew).
-func (c *SwarmCloseCmd) releaseAndMaybeCloseTask(
-	ctx context.Context, info workspace.Info, slot string, sess swarm.Session,
-) error {
-	hubURL := c.HubURL
-	if hubURL == "" {
-		hubURL = swarm.DefaultHubFossilURL
-	}
-	swarmRoot := info.WorkspaceDir + "/.bones/swarm"
-	leaf, err := coord.OpenLeaf(ctx, coord.LeafConfig{
-		HubAddrs: coord.HubAddrs{
-			NATSClient: info.NATSURL,
-			HTTPAddr:   hubURL,
-		},
-		Workdir:    swarmRoot,
-		SlotID:     slot,
-		FossilUser: sess.AgentID,
-	})
-	if err != nil {
-		return fmt.Errorf("open leaf: %w", err)
-	}
-	defer func() { _ = leaf.Stop() }()
-
-	claim, err := leaf.Claim(ctx, coord.TaskID(sess.TaskID))
-	if err != nil {
-		// If the task is already closed the Claim returns
-		// ErrTaskAlreadyClaimed/NotFound; either way the holds are gone
-		// and we're done.
-		return fmt.Errorf("re-claim for close: %w", err)
-	}
-	if c.Result == string(dispatch.ResultSuccess) {
-		// Leaf.Close closes the task AND releases via the claim's
-		// release closure.
-		return leaf.Close(ctx, claim)
-	}
-	return claim.Release()
-}
-
-func (c *SwarmCloseCmd) removePidFile(info workspace.Info, slot string) error {
-	pidPath := swarm.SlotPidFile(info.WorkspaceDir, slot)
-	if err := os.Remove(pidPath); err != nil && !os.IsNotExist(err) {
-		return err
 	}
 	return nil
 }

--- a/cli/swarm_commit.go
+++ b/cli/swarm_commit.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/danmestas/libfossil"
 	libfossilcli "github.com/danmestas/libfossil/cli"
 
 	"github.com/danmestas/bones/internal/coord"
@@ -17,11 +16,16 @@ import (
 )
 
 // SwarmCommitCmd commits in-flight changes from the slot's worktree
-// to the slot's leaf, triggering a sync round to the hub. Heartbeats
-// the swarm session record (extends TTL via CAS).
+// to the slot's leaf, triggers a sync round to the hub, and bumps
+// the swarm session record's TTL via CAS.
 //
 // Files default to "all modified files in wt/" if no positional
 // arguments are passed.
+//
+// All the assembled scaffold (Resume the lease, claim, announce
+// holds, commit via leaf, push to hub, renew session) lives in
+// internal/swarm.Lease. This verb is flag parsing + file gathering
+// + Lease.Commit + result printing.
 type SwarmCommitCmd struct {
 	Slot    string   `name:"slot" help:"slot name (defaults to single active slot on this host)"`
 	Message string   `name:"message" short:"m" required:"" help:"commit message"`
@@ -39,152 +43,90 @@ func (c *SwarmCommitCmd) Run(g *libfossilcli.Globals) error {
 }
 
 func (c *SwarmCommitCmd) run(ctx context.Context, info workspace.Info) error {
-	mgr, closeMgr, err := openSwarmManager(ctx, info)
+	slot, err := c.resolveTargetSlot(ctx, info)
 	if err != nil {
 		return err
 	}
-	defer closeMgr()
+	hubURL := c.HubURL
+	if hubURL == "" {
+		hubURL = swarm.DefaultHubFossilURL
+	}
+	lease, err := swarm.Resume(ctx, info, slot, swarm.AcquireOpts{HubURL: hubURL})
+	if err != nil {
+		if errors.Is(err, swarm.ErrSessionNotFound) {
+			return fmt.Errorf(
+				"swarm commit: no active session for slot %q (run `bones swarm join` first)", slot)
+		}
+		return fmt.Errorf("swarm commit: %w", err)
+	}
+	defer func() { _ = lease.Release(ctx) }()
 
+	files, err := gatherCommitFiles(info, slot, c.Files, lease.WT())
+	if err != nil {
+		return err
+	}
+	res, err := lease.Commit(ctx, c.Message, files)
+	if err != nil {
+		return fmt.Errorf("swarm commit: %w", err)
+	}
+	c.emitCommitReport(slot, lease.TaskID(), files, res, hubURL)
+	return nil
+}
+
+// resolveTargetSlot picks the slot to operate on. Honors --slot
+// when set; otherwise infers the unique active slot on this host
+// via swarm.Manager.List. The Manager is opened-and-closed inline
+// because Resume opens its own to read the session record; the
+// double-dial cost is negligible for a single CLI invocation.
+func (c *SwarmCommitCmd) resolveTargetSlot(
+	ctx context.Context, info workspace.Info,
+) (string, error) {
+	mgr, closeMgr, err := openSwarmManager(ctx, info)
+	if err != nil {
+		return "", err
+	}
+	defer closeMgr()
 	host, _ := os.Hostname()
 	slot, err := resolveSlot(ctx, mgr, c.Slot, host)
 	if err != nil {
-		return err
+		return "", err
 	}
-	sess, rev, err := mgr.Get(ctx, slot)
-	if err != nil {
-		if errors.Is(err, swarm.ErrNotFound) {
-			return fmt.Errorf("no active swarm session for slot %q (run `bones swarm join`)", slot)
-		}
-		return fmt.Errorf("read session: %w", err)
-	}
-	if err := c.assertSessionLocal(sess, host); err != nil {
-		return err
-	}
-	hubURL := c.resolveHubURL(sess)
-	leaf, err := c.openLeafForCommit(ctx, info, slot, hubURL)
-	if err != nil {
-		return err
-	}
-	// leafStopped tracks whether the explicit Stop below ran so the
-	// defer doesn't call it twice (Agent.Stop is not idempotent on
-	// double-close).
-	leafStopped := false
-	defer func() {
-		if !leafStopped {
-			_ = leaf.Stop()
-		}
-	}()
+	return slot, nil
+}
 
-	files, err := c.gatherFiles(info, slot)
-	if err != nil {
-		return err
-	}
-	uuid, err := c.commitViaLeaf(ctx, leaf, sess.TaskID, files)
-	if err != nil {
-		return err
-	}
-	// Stop the leaf BEFORE pushing so the agent's libfossil.Repo
-	// handle is closed; pushSlotToHub then opens its own handle on
-	// leaf.fossil cleanly. The Leaf.Commit above broadcasts a
-	// fossil-sync NATS announce over the workspace leaf's NATS
-	// connection — but the hub's xfer subscriber lives on a
-	// separate NATS deployment, so the commit lands locally in
-	// <swarm>/<slot>/leaf.fossil only. Push it explicitly to the
-	// hub via HTTP /xfer here so `bones peek` and the hub timeline
-	// see the commit. Soft-fail: if the hub is unreachable,
-	// stderr-warn but don't roll back the local commit.
-	_ = leaf.Stop()
-	leafStopped = true
-	if res, perr := pushSlotToHub(ctx, info.WorkspaceDir, slot, sess.AgentID, hubURL); perr != nil {
+// emitCommitReport prints the UUID on stdout (machine-readable for
+// callers piping into `git apply`/etc.) and a stderr summary, plus
+// soft-error warnings for failed push or renew. The local commit
+// is durable regardless of either soft error.
+func (c *SwarmCommitCmd) emitCommitReport(
+	slot, taskID string, files []coord.File, res swarm.CommitResult, hubURL string,
+) {
+	if res.PushErr != nil {
 		fmt.Fprintf(os.Stderr,
 			"swarm commit: warning: push to hub %s failed: %v\n",
-			hubURL, perr,
-		)
-	} else if res != nil {
+			hubURL, res.PushErr)
+	} else if res.PushResult != nil {
 		fmt.Fprintf(os.Stderr,
 			"swarm commit: pushed to hub %s rounds=%d files_sent=%d bytes_sent=%d\n",
-			hubURL, res.Rounds, res.FilesSent, res.BytesSent,
+			hubURL,
+			res.PushResult.Rounds, res.PushResult.FilesSent, res.PushResult.BytesSent,
 		)
 	}
-	if err := c.renewSession(ctx, mgr, sess, rev); err != nil {
-		// Commit succeeded; failing to extend the heartbeat is a
-		// soft error — log and return non-zero so the caller knows
-		// the session may TTL out, but don't pretend the commit
-		// didn't happen.
-		fmt.Fprintf(os.Stderr, "swarm commit: warning: renew session failed: %v\n", err)
+	if res.RenewErr != nil {
+		fmt.Fprintf(os.Stderr,
+			"swarm commit: warning: renew session failed: %v\n", res.RenewErr)
 	}
-	fmt.Printf("%s\n", uuid)
+	fmt.Printf("%s\n", res.UUID)
 	fmt.Fprintf(os.Stderr,
 		"swarm commit: slot=%s task=%s files=%d\n",
-		slot, sess.TaskID, len(files))
-	return nil
+		slot, taskID, len(files),
+	)
 }
 
-// resolveHubURL picks the hub URL to use for this commit. Precedence:
-// explicit --hub-url flag > recorded session.HubURL > package default.
-// The session-recorded URL is the canonical source — it was captured
-// at join time and matches the leaf's clone origin. The flag is a
-// recovery escape hatch for sessions written before HubURL existed.
-func (c *SwarmCommitCmd) resolveHubURL(sess swarm.Session) string {
-	if c.HubURL != "" {
-		return c.HubURL
-	}
-	if sess.HubURL != "" {
-		return sess.HubURL
-	}
-	return swarm.DefaultHubFossilURL
-}
-
-// assertSessionLocal returns an error if the session's host does not
-// match this machine. Cross-host commit attempts are programmer
-// errors per ADR 0028 §"Process lifecycle and crash recovery".
-//
-// Phase 1 does NOT check leaf pid liveness: every swarm verb is a
-// self-contained CLI invocation that opens its own leaf, so the
-// session's recorded pid (the join's bones process) is naturally
-// dead by the time commit runs. Future detached-leaf work (per ADR
-// 0028 §"Process lifecycle") will reintroduce a "leaf still
-// running?" check; for now the leaf.fossil file's mere existence is
-// the cross-invocation handle.
-func (c *SwarmCommitCmd) assertSessionLocal(sess swarm.Session, host string) error {
-	if sess.Host != host {
-		return fmt.Errorf(
-			"slot %q is owned by host %q (this machine is %q) — cross-host operation refused",
-			sess.Slot, sess.Host, host,
-		)
-	}
-	return nil
-}
-
-// openLeafForCommit re-attaches to the slot's already-cloned
-// leaf.fossil. coord.OpenLeaf is idempotent on the clone (skips when
-// leaf.fossil exists), so this resumes the existing slot rather than
-// double-cloning. hubURL is resolved by the caller from --hub-url /
-// session.HubURL / package default in that order.
-func (c *SwarmCommitCmd) openLeafForCommit(
-	ctx context.Context, info workspace.Info, slot, hubURL string,
-) (*coord.Leaf, error) {
-	swarmRoot := filepath.Join(info.WorkspaceDir, ".bones", "swarm")
-	leaf, err := coord.OpenLeaf(ctx, coord.LeafConfig{
-		HubAddrs: coord.HubAddrs{
-			NATSClient: info.NATSURL,
-			HTTPAddr:   hubURL,
-		},
-		Workdir:    swarmRoot,
-		SlotID:     slot,
-		FossilUser: "slot-" + slot,
-		Autosync:   true,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("re-open leaf: %w", err)
-	}
-	return leaf, nil
-}
-
-// gatherFiles materializes the file set passed to Leaf.Commit. When
-// the caller listed files explicitly, read them from the slot's
-// worktree. Otherwise, walk the slot's wt/ for regular files and
-// commit them all (auto-discovery — ADR 0028 §"swarm commit").
+// gatherCommitFiles materializes the file set passed to Lease.Commit.
+// When the caller listed files explicitly, read them from the slot's
+// worktree. Otherwise, walk wt/ for regular files and commit them
+// all (auto-discovery — ADR 0028 §"swarm commit").
 //
 // Each File.Path is set to the absolute workspace path so the
 // holds-gate (Invariant 4 / coord.checkHolds) sees a key matching
@@ -192,13 +134,14 @@ func (c *SwarmCommitCmd) openLeafForCommit(
 // normalizeLeadingSlash trims the leading slash to derive its
 // relative-to-repo Name, so the same Path field works as both the
 // hold key and the commit target.
-func (c *SwarmCommitCmd) gatherFiles(info workspace.Info, slot string) ([]coord.File, error) {
-	wt := swarm.SlotWorktree(info.WorkspaceDir, slot)
-	if len(c.Files) == 0 {
-		return c.discoverDirtyFiles(info, wt)
+func gatherCommitFiles(
+	info workspace.Info, slot string, explicitFiles []string, wt string,
+) ([]coord.File, error) {
+	if len(explicitFiles) == 0 {
+		return discoverDirtyFiles(info, wt)
 	}
-	out := make([]coord.File, 0, len(c.Files))
-	for _, rel := range c.Files {
+	out := make([]coord.File, 0, len(explicitFiles))
+	for _, rel := range explicitFiles {
 		// Strip prefixes so callers can pass any of:
 		//   "src/foo.go"                              (rel to wt)
 		//   "wt/src/foo.go"                           (rel to slot)
@@ -209,13 +152,8 @@ func (c *SwarmCommitCmd) gatherFiles(info workspace.Info, slot string) ([]coord.
 		abs := filepath.Join(wt, clean)
 		data, err := os.ReadFile(abs)
 		if err != nil {
-			return nil, fmt.Errorf("read %s: %w", abs, err)
+			return nil, fmt.Errorf("swarm commit: read %s: %w", abs, err)
 		}
-		// Path is the holds-gate key (must be absolute per
-		// holds.assertFile); Name is what libfossil stores the file
-		// under in the repo. Without an explicit Name, Leaf.Commit
-		// would derive the repo name by stripping one leading slash
-		// off Path, dragging the workspace prefix into the commit.
 		taskPath := filepath.Join(info.WorkspaceDir, clean)
 		out = append(out, coord.File{
 			Path:    taskPath,
@@ -239,23 +177,18 @@ func (c *SwarmCommitCmd) gatherFiles(info workspace.Info, slot string) ([]coord.
 // and Leaf.Commit ships the bytes via libfossil's content-addressed
 // FileToCommit path (no checkout required).
 //
-// Skipped: anything under .fslckout / .fossil-settings (fossil
-// metadata that may appear if a future change wires checkouts in),
-// hidden directories starting with "." (common scratch dirs like
-// .git, .vscode), and non-regular files (symlinks, sockets,
-// devices). Returns ErrNothingToCommit when wt/ has no commitable
-// files so callers see a clear "nothing to commit" error rather
-// than a downstream Leaf.Commit precondition panic.
-func (c *SwarmCommitCmd) discoverDirtyFiles(
-	info workspace.Info, wt string,
-) ([]coord.File, error) {
+// Skipped: anything under .fslckout / .fossil-settings, hidden
+// directories starting with ".", and non-regular files (symlinks,
+// sockets, devices). Errors when wt/ has no commitable files so
+// callers see a clear "nothing to commit" rather than a downstream
+// Leaf.Commit precondition panic.
+func discoverDirtyFiles(info workspace.Info, wt string) ([]coord.File, error) {
 	var out []coord.File
 	err := filepath.WalkDir(wt, func(path string, d os.DirEntry, werr error) error {
 		if werr != nil {
 			return werr
 		}
 		if d.IsDir() {
-			// Skip fossil metadata + hidden dirs at any depth.
 			name := d.Name()
 			if path != wt && (name == ".fslckout" ||
 				name == ".fossil-settings" ||
@@ -267,8 +200,6 @@ func (c *SwarmCommitCmd) discoverDirtyFiles(
 		if !d.Type().IsRegular() {
 			return nil
 		}
-		// Belt-and-suspenders: also skip the .fslckout database file
-		// itself if it ever appears as a file rather than a dir.
 		if d.Name() == ".fslckout" {
 			return nil
 		}
@@ -280,9 +211,6 @@ func (c *SwarmCommitCmd) discoverDirtyFiles(
 		if err != nil {
 			return fmt.Errorf("rel %s: %w", path, err)
 		}
-		// Same path convention as the explicit-files branch: Path is
-		// the workspace-absolute holds-gate key, Name is the
-		// wt-relative repo path libfossil uses inside leaf.fossil.
 		taskPath := filepath.Join(info.WorkspaceDir, rel)
 		out = append(out, coord.File{
 			Path:    taskPath,
@@ -292,110 +220,10 @@ func (c *SwarmCommitCmd) discoverDirtyFiles(
 		return nil
 	})
 	if err != nil {
-		return nil, fmt.Errorf("scan wt %s: %w", wt, err)
+		return nil, fmt.Errorf("swarm commit: scan wt %s: %w", wt, err)
 	}
 	if len(out) == 0 {
 		return nil, fmt.Errorf("swarm commit: nothing to commit (wt %s is empty)", wt)
 	}
 	return out, nil
-}
-
-// commitViaLeaf re-claims the active task on the freshly-opened
-// *Leaf so Leaf.Commit's hold-gate sees the claim, then commits and
-// releases (the session record keeps the swarm hold across processes
-// on the bones-holds bucket — claim-release here only undoes the
-// re-claim we just took, not the underlying session ownership).
-//
-// Before Commit we also AnnounceHolds for every file's path, so
-// commits succeed even when the task was created with --slot=X but
-// no --files=. The slot owns its wt/ — files inside that dir are
-// commitable territory whether or not the task record listed them
-// up front. AnnounceHolds is idempotent for files this slot already
-// holds (e.g. via the task's pre-populated Files list at Claim
-// time), so this is safe to call unconditionally.
-func (c *SwarmCommitCmd) commitViaLeaf(
-	ctx context.Context, leaf *coord.Leaf, taskID string, files []coord.File,
-) (string, error) {
-	claim, err := leaf.Claim(ctx, coord.TaskID(taskID))
-	if err != nil {
-		return "", fmt.Errorf("re-claim task %q: %w", taskID, err)
-	}
-	defer func() { _ = claim.Release() }()
-	paths := make([]string, 0, len(files))
-	for _, f := range files {
-		paths = append(paths, f.Path)
-	}
-	releaseHolds, err := leaf.AnnounceHolds(ctx, paths)
-	if err != nil {
-		return "", fmt.Errorf("announce holds: %w", err)
-	}
-	defer releaseHolds()
-	uuid, err := leaf.Commit(ctx, claim, files, coord.WithMessage(c.Message))
-	if err != nil {
-		return "", fmt.Errorf("leaf commit: %w", err)
-	}
-	return uuid, nil
-}
-
-// renewSession bumps LastRenewed via CAS so the bucket TTL extends.
-// CAS conflict means a sibling renewer raced ours — we treat that as
-// success because the other writer's update already extended the
-// bucket TTL.
-func (c *SwarmCommitCmd) renewSession(
-	ctx context.Context, mgr *swarm.Manager, sess swarm.Session, rev uint64,
-) error {
-	sess.LastRenewed = timeNow()
-	if err := mgr.Update(ctx, sess, rev); err != nil {
-		if errors.Is(err, swarm.ErrCASConflict) {
-			return nil
-		}
-		return err
-	}
-	return nil
-}
-
-// pushSlotToHub HTTP-pushes the slot's leaf.fossil to the hub via
-// libfossil's /xfer transport. Mirrors what raw `fossil sync push`
-// does and what the original swarm-demo used; bones swarm wraps it so
-// commits made through `bones swarm commit` propagate to hub.fossil
-// without depending on the workspace leaf's NATS announce reaching
-// the hub's NATS subscriber (the two NATS deployments are separate by
-// design — see ADR 0028 retro for the bug this fixes).
-//
-// The fossilUser is the hub login the push authenticates as. Slot
-// users (created at join time by ensureSlotUser) have caps that
-// include "i" (check-in), so the hub accepts the push. Anonymous
-// "nobody" pushes would be rejected because hubs only grant "g" /
-// "h" / "o" by default — checkin requires authenticated identity.
-//
-// Errors propagate; the caller decides whether a hub-unreachable
-// failure is fatal (commit success keeps the data locally either way).
-func pushSlotToHub(
-	ctx context.Context, workspaceDir, slot, fossilUser, hubURL string,
-) (*libfossil.SyncResult, error) {
-	leafRepoPath := filepath.Join(swarm.SlotDir(workspaceDir, slot), "leaf.fossil")
-	leafRepo, err := libfossil.Open(leafRepoPath)
-	if err != nil {
-		return nil, fmt.Errorf("open leaf repo: %w", err)
-	}
-	defer func() { _ = leafRepo.Close() }()
-	// project-code is required for the login-card nonce; libfossil
-	// panics in computeLogin if it's blank. Read it from the cloned
-	// leaf repo (same code as the hub since clone copies the
-	// project-code config row).
-	projectCode, err := leafRepo.Config("project-code")
-	if err != nil {
-		return nil, fmt.Errorf("read project-code: %w", err)
-	}
-	transport := libfossil.NewHTTPTransport(hubURL)
-	res, err := leafRepo.Sync(ctx, transport, libfossil.SyncOpts{
-		Push:        true,
-		Pull:        false,
-		User:        fossilUser,
-		ProjectCode: projectCode,
-	})
-	if err != nil {
-		return res, fmt.Errorf("sync push: %w", err)
-	}
-	return res, nil
 }

--- a/internal/swarm/lease.go
+++ b/internal/swarm/lease.go
@@ -69,6 +69,15 @@ var ErrSessionForeignHost = errors.New(
 	"swarm: session owned by another host — refusing cross-host takeover",
 )
 
+// ErrCrossHostOperation is returned by Resume when the session
+// record's Host field doesn't match this machine's hostname.
+// Cross-host commit / close / status operations would manipulate
+// a leaf process bones can't reach; the right answer is for the
+// operator to run the verb on the owning host.
+var ErrCrossHostOperation = errors.New(
+	"swarm: cross-host operation refused — run the verb on the slot's owning host",
+)
+
 // AcquireOpts tunes AcquireFresh and Resume. Zero-value defaults are
 // production-correct: HubURL → DefaultHubFossilURL, Caps →
 // DefaultCaps, NATSConn dialed from info.NATSURL, Now →
@@ -168,6 +177,13 @@ func AcquireFresh(
 	assert.NotEmpty(info.WorkspaceDir, "swarm.AcquireFresh: info.WorkspaceDir is empty")
 
 	now, hubURL, caps := defaultAcquireOpts(opts)
+	if opts.HubURL == "" && opts.Hub != nil {
+		// In-process hub override (test path): stamp the test hub's
+		// actual HTTP address into the session record so post-commit
+		// pushes land at the live port instead of the production
+		// default.
+		hubURL = opts.Hub.HTTPAddr()
+	}
 	fossilUser := "slot-" + slot
 
 	if err := ensureSlotUser(info.WorkspaceDir, fossilUser, caps); err != nil {
@@ -304,10 +320,15 @@ func writeSessionAndPid(
 // exists in KV. Used by every swarm verb other than join.
 //
 // Resume does NOT re-take the claim — verbs that need a claim
-// (commit, close) re-acquire via Lease.Commit / Lease.Close. This
+// (Lease.Commit / Lease.Close) re-acquire it themselves. This
 // mirrors today's CLI behavior: claim holds have a TTL that
-// outlives a single verb only when bumped by a commit, and the
-// record's LastRenewed is the durable liveness signal.
+// outlives a single verb only when bumped, and the record's
+// LastRenewed is the durable liveness signal.
+//
+// Resume refuses cross-host operations: if the session record's
+// Host field doesn't match this machine, returns
+// ErrCrossHostOperation. The leaf process bones can manipulate
+// lives on the owning host, so the verb has to run there.
 //
 // Returns ErrSessionNotFound if the slot has no record. Returns the
 // underlying NATS / Fossil errors otherwise.
@@ -319,10 +340,7 @@ func Resume(
 	assert.NotEmpty(slot, "swarm.Resume: slot is empty")
 	assert.NotEmpty(info.WorkspaceDir, "swarm.Resume: info.WorkspaceDir is empty")
 
-	now := opts.Now
-	if now == nil {
-		now = func() time.Time { return time.Now().UTC() }
-	}
+	now, _, _ := defaultAcquireOpts(opts)
 
 	mgr, nc, ownsConn, err := openLeaseManager(ctx, info, opts.NATSConn)
 	if err != nil {
@@ -342,6 +360,12 @@ func Resume(
 			return nil, ErrSessionNotFound
 		}
 		return nil, fmt.Errorf("swarm.Resume: read session: %w", err)
+	}
+	host, _ := os.Hostname()
+	if sess.Host != host {
+		cleanup()
+		return nil, fmt.Errorf("%w (slot=%q owner=%q this=%q)",
+			ErrCrossHostOperation, slot, sess.Host, host)
 	}
 
 	hubURL := sess.HubURL
@@ -401,32 +425,251 @@ func (l *Lease) Release(ctx context.Context) error {
 	return nil
 }
 
-// Close terminates the lease and deletes the session record via a
-// CAS gate against the revision the lease holds. Idempotent — a
-// second Close after a successful first is a no-op. After Close,
-// the slot is available for a fresh AcquireFresh.
+// CloseOpts tunes Lease.Close. Zero value is the conservative
+// release-and-cleanup behavior; CloseTaskOnSuccess transitions the
+// lease's task to closed in the bones-tasks bucket.
+type CloseOpts struct {
+	// CloseTaskOnSuccess, when true, calls coord.Leaf.Close on the
+	// re-claimed task — closing the task in the bones-tasks bucket
+	// in addition to releasing the claim hold. False just releases
+	// the claim, leaving the task open for retry by the parent
+	// dispatch. swarm close --result=success sets this true; fail
+	// and fork leave it false.
+	CloseTaskOnSuccess bool
+}
+
+// Close terminates the lease, removes the host-local pid file, and
+// deletes the session record via a CAS gate against the revision
+// the lease holds. When CloseOpts.CloseTaskOnSuccess is true the
+// underlying task is also transitioned to closed in the
+// bones-tasks bucket via Leaf.Close. Idempotent — a second Close
+// after a successful first is a no-op.
 //
-// `bones swarm close` calls this. The CAS gate ensures we don't
-// delete a record some other process renewed; if it raced us, the
-// caller sees ErrCASConflict and can decide whether to re-Resume
-// and retry.
-func (l *Lease) Close(ctx context.Context) error {
+// Steps, in order:
+//
+//  1. Re-claim the lease's task (Resume did not claim it).
+//  2. If CloseTaskOnSuccess: Leaf.Close — closes the task and
+//     releases the claim hold in one operation. Otherwise just
+//     release the claim.
+//  3. Stop the leaf.
+//  4. Remove the host-local pid file.
+//  5. CAS-delete the session record.
+//  6. Tear down the swarm.Manager + NATS connection.
+//
+// `bones swarm close` calls this. The CAS gate on step 5 ensures
+// we don't delete a record some other process renewed; if it raced
+// us, the caller sees the underlying ErrCASConflict and can decide
+// whether to re-Resume and retry.
+func (l *Lease) Close(ctx context.Context, opts CloseOpts) error {
 	assert.NotNil(l, "swarm.Lease.Close: receiver is nil")
 	assert.NotNil(ctx, "swarm.Lease.Close: ctx is nil")
 	if l.released {
 		return nil
 	}
+	if err := l.closeTaskAndReleaseClaim(ctx, opts.CloseTaskOnSuccess); err != nil {
+		_ = l.releaseUnderlying()
+		return err
+	}
+	if l.leaf != nil {
+		_ = l.leaf.Stop()
+		l.leaf = nil
+	}
+	if err := os.Remove(SlotPidFile(l.info.WorkspaceDir, l.slot)); err != nil &&
+		!os.IsNotExist(err) {
+		_ = l.releaseUnderlying()
+		return fmt.Errorf("swarm.Lease.Close: remove pid file: %w", err)
+	}
 	if l.mgr != nil && l.rev != 0 {
 		if err := l.mgr.Delete(ctx, l.slot, l.rev); err != nil &&
-			!errors.Is(err, ErrNotFound) {
-			// Best-effort cleanup of the underlying resources even on
-			// CAS failure; the caller decides whether to retry the
-			// delete after re-Resume.
+			!errors.Is(err, ErrNotFound) && !errors.Is(err, ErrCASConflict) {
 			_ = l.releaseUnderlying()
 			return fmt.Errorf("swarm.Lease.Close: delete record: %w", err)
 		}
 	}
 	return l.releaseUnderlying()
+}
+
+// closeTaskAndReleaseClaim acquires a claim on the lease's task
+// (or reuses the one AcquireFresh already took) and either closes
+// the task (success) or releases the claim (fail/fork). Pulled out
+// so Close stays under the funlen lint cap.
+//
+// AcquireFresh leaves an active claim on the lease so AcquireFresh
+// → Close in a single CLI invocation reuses it; Resume → Close
+// (the more common path) re-claims here.
+func (l *Lease) closeTaskAndReleaseClaim(ctx context.Context, closeTask bool) error {
+	if l.leaf == nil {
+		return nil
+	}
+	claim := l.claim
+	if claim == nil {
+		c, err := l.leaf.Claim(ctx, coord.TaskID(l.taskID))
+		if err != nil {
+			return fmt.Errorf("swarm.Lease.Close: re-claim for close: %w", err)
+		}
+		claim = c
+	}
+	l.claim = nil // ownership transfers to the close-or-release call below
+	if closeTask {
+		if err := l.leaf.Close(ctx, claim); err != nil {
+			return fmt.Errorf("swarm.Lease.Close: leaf close: %w", err)
+		}
+		return nil
+	}
+	if err := claim.Release(); err != nil {
+		return fmt.Errorf("swarm.Lease.Close: release claim: %w", err)
+	}
+	return nil
+}
+
+// CommitResult is the outcome of Lease.Commit. UUID is set on every
+// successful local commit. PushResult is set when the post-commit
+// HTTP push to the hub succeeded; PushErr is set when it failed
+// (the local commit lands either way). RenewErr is set when the
+// session-record CAS-bump failed (the commit succeeded but the
+// session may TTL out before the next verb runs). Callers should
+// print warnings for the soft errors but should not roll back the
+// local commit on either of them.
+type CommitResult struct {
+	UUID       string
+	PushResult *libfossil.SyncResult
+	PushErr    error
+	RenewErr   error
+}
+
+// Commit takes a fresh claim on the lease's task, announces holds
+// for the file paths, commits the bytes via the underlying
+// coord.Leaf, releases the claim, stops the leaf, HTTP-pushes the
+// slot's leaf.fossil to the hub via /xfer, and CAS-bumps
+// LastRenewed on the session record.
+//
+// Returns CommitResult with the local-commit UUID always set on
+// success. PushResult / PushErr report the hub-push outcome; the
+// hub may be unreachable without rolling back the local commit.
+// RenewErr reports the session-record CAS bump; CAS conflicts are
+// silently treated as success (a sibling renewer raced and bumped
+// the TTL on our behalf).
+//
+// After Commit returns, the lease's underlying coord.Leaf has been
+// stopped — the push path needs an exclusive libfossil.Repo handle
+// on leaf.fossil. The lease can still be Released or Closed; doing
+// other verb work on the lease's leaf after Commit is undefined
+// and would have to re-Resume.
+func (l *Lease) Commit(
+	ctx context.Context, message string, files []coord.File,
+) (CommitResult, error) {
+	assert.NotNil(l, "swarm.Lease.Commit: receiver is nil")
+	assert.NotNil(ctx, "swarm.Lease.Commit: ctx is nil")
+	if l.leaf == nil {
+		return CommitResult{}, fmt.Errorf("swarm.Lease.Commit: leaf already stopped")
+	}
+	uuid, err := commitViaLeaf(ctx, l.leaf, l.taskID, message, files)
+	if err != nil {
+		return CommitResult{}, err
+	}
+	// Stop the leaf BEFORE pushing so the agent's libfossil.Repo
+	// handle is closed; pushLeafFossil opens its own handle on
+	// leaf.fossil cleanly.
+	_ = l.leaf.Stop()
+	l.leaf = nil
+
+	pushRes, pushErr := pushLeafFossil(ctx, l.info.WorkspaceDir, l.slot, l.fossilUser, l.hubURL)
+	renewErr := l.renewSessionAfterCommit(ctx)
+
+	return CommitResult{
+		UUID:       uuid,
+		PushResult: pushRes,
+		PushErr:    pushErr,
+		RenewErr:   renewErr,
+	}, nil
+}
+
+// renewSessionAfterCommit bumps LastRenewed via CAS so the bucket
+// TTL extends beyond the next slot heartbeat window. CAS conflict
+// is treated as success — a sibling commit raced ours and the
+// other writer's update already extended the TTL.
+func (l *Lease) renewSessionAfterCommit(ctx context.Context) error {
+	if l.mgr == nil || l.rev == 0 {
+		return nil
+	}
+	sess, rev, err := l.mgr.Get(ctx, l.slot)
+	if err != nil {
+		return fmt.Errorf("swarm.Lease.Commit: re-read session for renew: %w", err)
+	}
+	sess.LastRenewed = l.now()
+	if err := l.mgr.Update(ctx, sess, rev); err != nil {
+		if errors.Is(err, ErrCASConflict) {
+			return nil
+		}
+		return fmt.Errorf("swarm.Lease.Commit: renew session: %w", err)
+	}
+	l.rev = rev + 1 // best-effort; next Get re-syncs anyway
+	return nil
+}
+
+// commitViaLeaf re-claims the lease's task on the freshly-Resumed
+// leaf, announces holds for the file paths, commits, and releases.
+// Mirrors what cli/swarm_commit.go::commitViaLeaf used to do
+// directly — pulled into the swarm package so the CLI verb is just
+// flag-parsing + Lease.Commit.
+func commitViaLeaf(
+	ctx context.Context, leaf *coord.Leaf, taskID, message string, files []coord.File,
+) (string, error) {
+	claim, err := leaf.Claim(ctx, coord.TaskID(taskID))
+	if err != nil {
+		return "", fmt.Errorf("swarm.Lease.Commit: re-claim task %q: %w", taskID, err)
+	}
+	defer func() { _ = claim.Release() }()
+	paths := make([]string, 0, len(files))
+	for _, f := range files {
+		paths = append(paths, f.Path)
+	}
+	releaseHolds, err := leaf.AnnounceHolds(ctx, paths)
+	if err != nil {
+		return "", fmt.Errorf("swarm.Lease.Commit: announce holds: %w", err)
+	}
+	defer releaseHolds()
+	uuid, err := leaf.Commit(ctx, claim, files, coord.WithMessage(message))
+	if err != nil {
+		return "", fmt.Errorf("swarm.Lease.Commit: leaf commit: %w", err)
+	}
+	return uuid, nil
+}
+
+// pushLeafFossil HTTP-pushes the slot's leaf.fossil to the hub via
+// libfossil's /xfer transport. The two NATS deployments are
+// separate by design (hub NATS vs. workspace leaf NATS), so the
+// post-commit announce doesn't reach the hub's /xfer subscriber —
+// the explicit HTTP push here is what makes the commit visible to
+// `bones peek` and the hub timeline.
+//
+// Soft-fail-friendly: returns SyncResult and error separately so
+// the caller can warn on push failure without rolling back the
+// local commit.
+func pushLeafFossil(
+	ctx context.Context, workspaceDir, slot, fossilUser, hubURL string,
+) (*libfossil.SyncResult, error) {
+	leafRepoPath := filepath.Join(SlotDir(workspaceDir, slot), "leaf.fossil")
+	leafRepo, err := libfossil.Open(leafRepoPath)
+	if err != nil {
+		return nil, fmt.Errorf("swarm: open leaf repo for push: %w", err)
+	}
+	defer func() { _ = leafRepo.Close() }()
+	projectCode, err := leafRepo.Config("project-code")
+	if err != nil {
+		return nil, fmt.Errorf("swarm: read project-code: %w", err)
+	}
+	transport := libfossil.NewHTTPTransport(hubURL)
+	res, err := leafRepo.Sync(ctx, transport, libfossil.SyncOpts{
+		Push:        true,
+		Pull:        false,
+		User:        fossilUser,
+		ProjectCode: projectCode,
+	})
+	if err != nil {
+		return res, fmt.Errorf("swarm: sync push: %w", err)
+	}
+	return res, nil
 }
 
 // releaseUnderlying tears down the leaf + claim + manager + NATS
@@ -473,23 +716,11 @@ func (l *Lease) WT() string {
 	return l.leaf.WT()
 }
 
-// Leaf returns the underlying coord.Leaf. ESCAPE HATCH —
-// deprecated on arrival. Present so cli/swarm_commit.go and
-// cli/swarm_close.go can be migrated to use Lease in PR B and C
-// without porting their full code in PR A. Will be removed once
-// all swarm verbs use Lease's typed methods.
-func (l *Lease) Leaf() *coord.Leaf { return l.leaf }
-
 // SessionRevision returns the JetStream KV revision the lease
-// captured at acquisition. Callers that want to do their own CAS
-// updates against the session record (e.g. a future commit-without-
-// claim path) can pass this to swarm.Manager.Update.
+// captured at acquisition. Test-only utility — callers that want
+// to inspect the underlying record can pair this with a separate
+// swarm.Manager.Get; production verbs go through Commit / Close.
 func (l *Lease) SessionRevision() uint64 { return l.rev }
-
-// Manager returns the lease's swarm.Manager. Same escape-hatch
-// caveat as Leaf — used during migration; will be encapsulated
-// once Lease.Commit / Lease.Close cover all swarm verbs.
-func (l *Lease) Manager() *Manager { return l.mgr }
 
 // ensureSlotUser creates the slot's fossil user on the hub repo
 // if missing. The role-guard for "workspace not bootstrapped" lives

--- a/internal/swarm/lease_test.go
+++ b/internal/swarm/lease_test.go
@@ -140,9 +140,10 @@ func TestAcquireFresh_SuccessAndRelease(t *testing.T) {
 		t.Errorf("SessionRevision: zero")
 	}
 
-	// Session record must be visible on the manager.
-	mgr := lease.Manager()
-	got, _, err := mgr.Get(ctx, "rendering")
+	// Session record must be visible on a manager separate from
+	// the one Lease owns internally.
+	verifyMgr := openVerifyManager(t, f)
+	got, _, err := verifyMgr.Get(ctx, "rendering")
 	if err != nil {
 		t.Fatalf("post-acquire Get: %v", err)
 	}
@@ -164,7 +165,6 @@ func TestAcquireFresh_SuccessAndRelease(t *testing.T) {
 	if err := lease.Release(ctx); err != nil {
 		t.Fatalf("Release: %v", err)
 	}
-	verifyMgr := openVerifyManager(t, f)
 	if _, _, err := verifyMgr.Get(ctx, "rendering"); err != nil {
 		t.Errorf("session record gone after Release (expected to persist): %v", err)
 	}
@@ -264,11 +264,11 @@ func TestResume_AfterAcquireFresh(t *testing.T) {
 	}
 }
 
-// TestClose_DeletesRecord pins the Close contract: removes the
-// session record (CAS-gated against the lease's revision) and
-// stops the underlying leaf. After Close, AcquireFresh on the
+// TestClose_DeletesRecordAndPidFile pins the Close contract:
+// removes the session record (CAS-gated), removes the host-local
+// pid file, and stops the leaf. After Close, AcquireFresh on the
 // same slot must succeed without --force.
-func TestClose_DeletesRecord(t *testing.T) {
+func TestClose_DeletesRecordAndPidFile(t *testing.T) {
 	f := newLeaseFixture(t)
 	holdPath := filepath.Join(f.dir, "audio", "hello.txt")
 	taskID := string(f.createTask(t, "audio-task-1", holdPath))
@@ -280,8 +280,15 @@ func TestClose_DeletesRecord(t *testing.T) {
 	if err != nil {
 		t.Fatalf("first AcquireFresh: %v", err)
 	}
-	if err := first.Close(ctx); err != nil {
+	pidPath := SlotPidFile(f.dir, "audio")
+	if _, err := os.Stat(pidPath); err != nil {
+		t.Fatalf("pre-Close pid file missing: %v", err)
+	}
+	if err := first.Close(ctx, CloseOpts{CloseTaskOnSuccess: true}); err != nil {
 		t.Fatalf("Close: %v", err)
+	}
+	if _, err := os.Stat(pidPath); !os.IsNotExist(err) {
+		t.Errorf("pid file should be gone after Close: err=%v", err)
 	}
 
 	// Second acquire on same slot without --force should now succeed.
@@ -292,4 +299,118 @@ func TestClose_DeletesRecord(t *testing.T) {
 		t.Fatalf("post-Close AcquireFresh: %v", err)
 	}
 	t.Cleanup(func() { _ = second.Release(ctx) })
+}
+
+// TestCommit_SuccessUpdatesTrunkAndRenewsSession covers the happy
+// path: claim → AnnounceHolds → Leaf.Commit → release → leaf stop
+// → push to hub → renew session. UUID is non-empty, push result
+// is set (in-process hub accepts the HTTP /xfer push), the
+// session record's LastRenewed bumps.
+func TestCommit_SuccessUpdatesTrunkAndRenewsSession(t *testing.T) {
+	f := newLeaseFixture(t)
+	holdPath := filepath.Join(f.dir, "render", "hello.txt")
+	taskID := string(f.createTask(t, "render-commit-1", holdPath))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	lease, err := AcquireFresh(ctx, f.info, "render", taskID, AcquireOpts{Hub: f.hub})
+	if err != nil {
+		t.Fatalf("AcquireFresh: %v", err)
+	}
+	if err := lease.Release(ctx); err != nil {
+		t.Fatalf("Release after AcquireFresh: %v", err)
+	}
+
+	// Capture the pre-commit LastRenewed so we can compare.
+	verifyMgr := openVerifyManager(t, f)
+	preSess, _, err := verifyMgr.Get(ctx, "render")
+	if err != nil {
+		t.Fatalf("pre-commit Get: %v", err)
+	}
+	preRenewed := preSess.LastRenewed
+
+	// Sleep a single tick so LastRenewed is observably newer.
+	time.Sleep(10 * time.Millisecond)
+
+	resumed, err := Resume(ctx, f.info, "render", AcquireOpts{Hub: f.hub})
+	if err != nil {
+		t.Fatalf("Resume: %v", err)
+	}
+	wt := resumed.WT()
+	if err := os.WriteFile(filepath.Join(wt, "hello.txt"), []byte("world"), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	files := []coord.File{{
+		Path:    holdPath,
+		Name:    "hello.txt",
+		Content: []byte("world"),
+	}}
+	res, err := resumed.Commit(ctx, "test commit", files)
+	if err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	if res.UUID == "" {
+		t.Errorf("Commit: empty UUID")
+	}
+	if res.PushErr != nil {
+		t.Errorf("Commit: PushErr=%v (in-process hub should accept push)", res.PushErr)
+	}
+	if res.PushResult == nil {
+		t.Errorf("Commit: PushResult nil")
+	}
+	if res.RenewErr != nil {
+		t.Errorf("Commit: RenewErr=%v", res.RenewErr)
+	}
+
+	// Verify session record's LastRenewed bumped.
+	postSess, _, err := verifyMgr.Get(ctx, "render")
+	if err != nil {
+		t.Fatalf("post-commit Get: %v", err)
+	}
+	if !postSess.LastRenewed.After(preRenewed) {
+		t.Errorf("LastRenewed did not advance: pre=%v post=%v", preRenewed, postSess.LastRenewed)
+	}
+
+	if err := resumed.Release(ctx); err != nil {
+		t.Errorf("Release: %v", err)
+	}
+}
+
+// TestResume_RefusesCrossHost pins the new Resume cross-host
+// guard. A session whose Host field doesn't match this machine
+// must be rejected with ErrCrossHostOperation rather than
+// reconstructing a leaf the caller can't actually drive.
+func TestResume_RefusesCrossHost(t *testing.T) {
+	f := newLeaseFixture(t)
+	holdPath := filepath.Join(f.dir, "ghosthost", "hello.txt")
+	taskID := string(f.createTask(t, "ghosthost-task-1", holdPath))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// AcquireFresh writes the session record stamped with the local
+	// host. Manually rewrite Host to a foreign hostname to simulate
+	// the cross-host case without standing up a second machine.
+	first, err := AcquireFresh(ctx, f.info, "ghosthost", taskID, AcquireOpts{Hub: f.hub})
+	if err != nil {
+		t.Fatalf("AcquireFresh: %v", err)
+	}
+	if err := first.Release(ctx); err != nil {
+		t.Fatalf("Release: %v", err)
+	}
+	verifyMgr := openVerifyManager(t, f)
+	sess, rev, err := verifyMgr.Get(ctx, "ghosthost")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	sess.Host = "definitely-not-this-machine.invalid"
+	if err := verifyMgr.Update(ctx, sess, rev); err != nil {
+		t.Fatalf("Update with foreign host: %v", err)
+	}
+
+	_, err = Resume(ctx, f.info, "ghosthost", AcquireOpts{Hub: f.hub})
+	if !errors.Is(err, ErrCrossHostOperation) {
+		t.Fatalf("Resume: want ErrCrossHostOperation, got %v", err)
+	}
 }


### PR DESCRIPTION
## Summary
PRs **B + C + D** from ADR 0031, consolidated into one PR. Completes the Lease-as-runtime-view-of-a-slot migration started by #61.

## What lands

### \`internal/swarm/lease.go\`
- **\`Resume\` cross-host guard.** Returns \`ErrCrossHostOperation\` when the session record's \`Host\` field doesn't match this machine. The old per-verb \`assertSessionLocal\` check is now centralized in Resume.
- **New \`Lease.Commit\` method.** Claim → AnnounceHolds → \`Leaf.Commit\` → release → stop leaf → push leaf.fossil to hub via \`/xfer\` → CAS-bump \`LastRenewed\`. Returns \`CommitResult{UUID, PushResult, PushErr, RenewErr}\` so callers can warn on soft errors but the local commit lands either way.
- **Extended \`Lease.Close\`.** New \`CloseOpts{CloseTaskOnSuccess bool}\` governs whether the task transitions to closed in the bones-tasks bucket (success path) or just the claim is released (fail/fork). Close also removes the host-local pid file. Reuses any AcquireFresh-held claim so an \`Acquire + Close\` in one process doesn't re-claim and deadlock on \"task already claimed\".
- **In-process hub URL fix.** \`AcquireFresh\` now stamps \`opts.Hub.HTTPAddr()\` when \`opts.Hub\` is set and \`HubURL\` is empty, so test-path commits push to the live test hub port instead of the production default.
- **Dropped \`Leaf()\` / \`Manager()\` escape hatches** (PR D). No callers remained after the CLI migrations.

### \`cli/swarm_commit.go\` (401 → ~220 LoC)
Flag parsing, slot inference, walk wt/ for dirty files, \`Lease.Commit\`, result reporting. The push/claim/announce-holds/renew code that used to live here is now in \`swarm.Lease.Commit\`.

### \`cli/swarm_close.go\` (180 → ~150 LoC)
\`Resume\`, post the dispatch \`ResultMessage\` (verb-specific protocol stays in CLI), \`Lease.Close\` with \`CloseOpts\`. The re-open-leaf, re-claim, pid-file removal, and session-record CAS-delete code is now in \`swarm.Lease.Close\`.

## Tests (real NATS + real Fossil per ADR 0030)
- \`TestCommit_SuccessUpdatesTrunkAndRenewsSession\` — commit lands, push succeeds against in-process hub, LastRenewed advances.
- \`TestClose_DeletesRecordAndPidFile\` — Close removes both KV record and pid file; subsequent \`AcquireFresh\` succeeds.
- \`TestResume_RefusesCrossHost\` — rewrite a session record's Host to a foreign hostname, Resume returns \`ErrCrossHostOperation\`.
- Existing \`AcquireFresh\` / \`Resume\` tests updated for new Close signature.

## Behavior preservation
Operator-facing surface unchanged: same CLI output, same exit codes, same error messages. The role-leak guard from PR #54 and the autosync linearization from PR #61 remain pinned. \`TestCLI_SwarmJoin_RefusesBootstrapFromLeafContext\` still passes against the new code paths.

## Verbs not migrated (out of scope)
\`swarm status\` walks \`Manager.List\` directly — no Lease needed. \`swarm cwd\` is pure path computation. \`swarm fan-in\` is orchestrator-side and doesn't fit the per-slot Lease shape.

## Test plan
- [x] \`make check\` clean (fmt, vet, lint, race, todo)
- [x] \`go test ./...\` clean (full suite, including integration)
- [x] \`internal/swarm/lease_test.go\` — 8 tests, all real-substrate
- [x] \`TestCLI_SwarmJoin_RefusesBootstrapFromLeafContext\` still pins the role-guard end-to-end