### PR TITLE
ADRs 0032 + 0033: keep internal/jskv, internal/dispatch, internal/hub as separate packages

### DIFF
--- a/docs/adr/0032-keep-jskv-and-dispatch-as-separate-packages.md
+++ b/docs/adr/0032-keep-jskv-and-dispatch-as-separate-packages.md
@@ -1,0 +1,120 @@
+# ADR 0032: Keep `internal/jskv` and `internal/dispatch` as separate packages
+
+**Status:** accepted
+
+**Date:** 2026-04-29
+
+## Context
+
+The 2026-04-29 architecture review (the same thread that produced
+ADRs 0030 and 0031) flagged `internal/jskv` and `internal/dispatch`
+as candidates for the deletion test on the basis of shallow metrics:
+
+- `internal/jskv` — 49 LoC, 1 impl file, 8 exports.
+- `internal/dispatch` — 153 LoC, 4 files, 16 exports.
+
+Both small enough that "delete and inline" looked plausible. The
+review's framing was "1 adapter = hypothetical seam, 2 = real seam"
+— with two slim packages it asked whether either was earning its
+keep.
+
+## Decision
+
+**Keep both packages as-is.** Closer inspection during the same
+review showed both pass the deletion test:
+
+### `internal/jskv`
+
+Exports two things only: `IsConflict(err) bool` and `MaxRetries`
+(constant = 8). `IsConflict` parses the union of NATS JetStream KV
+CAS-conflict error shapes (`jetstream.ErrKeyExists`,
+`jetstream.APIError` with the right `ErrorCode`, plus wrapped
+variants). `MaxRetries` is the shared CAS-loop bound the
+substrate's writer-loops respect.
+
+Used in four places:
+
+- `internal/swarm/swarm.go` — three `IsConflict` checks on Put /
+  Update / Delete.
+- `internal/tasks/tasks.go` — `MaxRetries` bound + `IsConflict`
+  checks in the optimistic-retry loop.
+- `internal/holds/holds.go` — same bound + `IsConflict` in
+  Announce / Release.
+- `internal/jskv/cas_test.go` — pins the parsing rules against
+  the upstream NATS error shapes that drift across versions.
+
+**Deletion test:** delete `jskv` → `IsConflict`'s parsing logic
+duplicates across `tasks`, `swarm`, `holds`. Each new copy is
+independently brittle against upstream NATS error-shape changes
+(we'd have to find and update three call sites instead of one
+when nats.go ships a new error sentinel). `MaxRetries` would be
+re-declared in each consumer.
+
+Verdict: **complexity reappears across N callers.** `jskv` is
+deep — small interface (2 exports), real leverage (CAS-conflict
+detection deduplicated; upstream-error-shape drift caught in one
+place), real locality.
+
+### `internal/dispatch`
+
+Exports a small set of related concerns:
+
+- `ResultMessage` / `FormatResult` / `ParseResult` — the
+  worker-to-parent result protocol. `swarm close` formats; the
+  parent dispatch handler in `cli/tasks_dispatch.go` parses.
+- `ResultKind` — the success/fail/fork enum.
+- `WaitWorkerAbsent` — a polling helper that waits for an agent
+  to drop off `coord.Coord.Who`.
+
+Used by exactly two CLI verbs (`tasks_dispatch` and
+`swarm_close`) but the *protocol* is shared between worker and
+parent — both must agree on the wire format.
+
+**Deletion test:** delete `dispatch` → `ResultMessage` format
+duplicates between worker (swarm_close) and parent
+(tasks_dispatch). The two halves of a wire protocol drifting in
+silence is a class of bug that took bones #51 to surface in a
+different code path; this protocol is exactly the shape that
+benefits from a single source of truth.
+
+Verdict: **earns its keep.** The two-caller count is misleading
+because the *protocol* is one concept that both halves enforce
+together; both halves importing one package is the locality
+property the package exists to provide.
+
+## Rationale
+
+Both packages were initially flagged on shallow metrics (LoC,
+export count). Closer inspection showed both have small interfaces
+that hide non-trivial concerns (NATS error parsing, wire-protocol
+agreement). The shallow-metric trap is real: small packages can
+be deep, and big packages can be shallow. Depth requires reading
+the implementation against the deletion test — not just measuring
+it.
+
+## Consequences
+
+- A future architecture review that re-pitches "merge `jskv` /
+  `dispatch` into a caller" should read this ADR first and refute
+  the deletion-test reasoning above before re-litigating.
+- Adding new shared CAS-conflict semantics: extend `jskv`. Adding
+  new dispatch-protocol fields: extend `dispatch`. Both are the
+  right home for their concern.
+
+## Out of scope
+
+- Other small packages (`internal/assert`, `internal/telemetry`)
+  weren't inspected by this ADR. The reasoning here doesn't
+  generalize — each small package needs its own deletion-test
+  read.
+
+## References
+
+- 2026-04-29 architecture review (this skill thread; same review
+  that produced ADRs 0030 and 0031).
+- `internal/jskv/cas_test.go` — pins the upstream-NATS-error
+  shapes `IsConflict` recognizes.
+- `internal/dispatch/result.go` + `result_test.go` — defines and
+  tests the worker/parent result protocol.
+- bones PR #51 (the dispatch-related fix that made the
+  protocol-locality argument concrete).

--- a/docs/adr/0033-keep-internal-hub-as-separate-package.md
+++ b/docs/adr/0033-keep-internal-hub-as-separate-package.md
@@ -1,0 +1,141 @@
+# ADR 0033: Keep `internal/hub` as a separate package
+
+**Status:** accepted
+
+**Date:** 2026-04-29
+
+## Context
+
+The 2026-04-29 architecture review (the same thread that produced
+ADRs 0030, 0031, and 0032) flagged `internal/hub` for folding into
+either `cli/` or `internal/coord` on the premise that it was "a
+wrapper around `coord.Hub`". Two `Hub` symbols in two packages
+looked redundant; the review proposed picking one canonical
+location.
+
+## Decision
+
+**Keep `internal/hub` as a separate package.** Closer inspection
+showed `internal/hub` and `coord.Hub` are different abstractions
+that solve different problems; folding either into the other
+would lose information.
+
+## The two Hub concepts
+
+### `internal/hub` — standalone-daemon supervisor
+
+504 LoC. Exports two functions: `Start(ctx, root, options...)` and
+`Stop(root)`. Used by exactly one caller, `cli/hub.go`.
+
+Owns:
+
+- Spawning an external `fossil server` subprocess via `exec.Cmd`
+  (NOT via libfossil in-process — the daemon model is
+  out-of-process so the hub survives the calling shell's exit).
+- Embedding a NATS JetStream server via
+  `nats-io/nats-server/v2/server`.
+- Fork-exec daemonization via the `BONES_HUB_FOREGROUND` env
+  variable: the parent re-execs itself in foreground mode, waits
+  for both ports to bind, then releases the child to outlive it.
+- Pid file management (`.orchestrator/pids/{fossil,nats}.pid`)
+  with idempotency: if both pid files reference live processes,
+  Start is a no-op.
+- Fresh-start detection (ADR 0024 §2): wipes stale checkout state
+  on first Start of a session.
+- Combined log redirection to `.orchestrator/hub.log` so child
+  panics surface even after the parent exits.
+
+The package is the implementation of `bones hub start --detach` —
+a shell-friendly daemon supervisor, not a library for in-process
+hub use.
+
+### `coord.Hub` — in-process embedded hub
+
+Lives in `internal/coord/hub.go`. Exports `OpenHub(ctx, workdir,
+httpAddr) (*Hub, error)` plus methods `NATSURL`, `LeafUpstream`,
+`HTTPAddr`, `NATSConn`, `Stop`. Used heavily by tests
+(`leaf_commit_test.go`, `hub_test.go`, `lease_test.go`, etc.) and
+by `examples/hub-leaf-e2e`.
+
+Owns:
+
+- Serving fossil HTTP **in-process** via libfossil (not via
+  external `fossil server`).
+- Embedding NATS in-process via the same upstream library, but
+  inside the calling process's address space.
+- Single-process lifetime: when the calling process exits, the
+  hub goes with it.
+
+The package is the implementation of "bring up a hub for the
+duration of this test" — a test fixture and an in-process
+embedding, not a daemon.
+
+## Why folding either way loses information
+
+**Folding `internal/hub` into `cli/`:** the 504 LoC of process-
+management code moves into `cli/hub_*.go` files. Same single
+caller, no callers were avoiding the dependency, complexity
+*relocates* without reducing. The package boundary documents that
+process-management is its own concern; killing the boundary
+doesn't change the code, only its address.
+
+**Folding `internal/hub` into `coord`:** would mix two
+incompatible execution models (subprocess + fork-exec vs. pure
+in-process) under one package. The two `Hub` types would have to
+unify their interfaces, but their lifecycles are fundamentally
+different (a daemon Stop signals SIGTERM to a recorded pid; an
+in-process Stop calls server.Shutdown on the embedded server).
+The "one canonical Hub" framing doesn't match the underlying
+abstractions.
+
+**Folding `coord.Hub` into `internal/hub`:** would push the
+in-process embedded hub (used heavily by tests) into a package
+whose other 90% of code is daemon supervision. Tests would import
+a daemon-supervisor package to spin up an in-process fixture.
+
+## Decision criteria for similar splits
+
+If two symbols share a name across packages and look redundant,
+check whether they share a *lifecycle and execution model* before
+proposing a fold:
+
+1. Do they run in the same process boundary? (in-process vs.
+   subprocess vs. fork-exec daemon.)
+2. Do they share the same Stop semantics? (signal-a-pid vs.
+   call-a-method.)
+3. Do they have the same set of callers? (one CLI verb vs. dozens
+   of tests + examples.)
+
+If any answer is "no", they're different abstractions wearing the
+same name. The right fix is naming clarity, not consolidation.
+
+## Consequences
+
+- A future architecture review that re-pitches "fold internal/hub"
+  should read this ADR first and refute the
+  daemon-vs-in-process distinction above before re-litigating.
+- The two `Hub` names in two packages stay. Where context is
+  ambiguous, use `coord.Hub` (the type-name disambiguates) or
+  `hub.Start` / `hub.Stop` (the functions are unique to the
+  daemon supervisor).
+
+## Out of scope
+
+- Other apparent duplications across the codebase weren't
+  inspected by this ADR. The reasoning here is specific to the
+  `Hub` case; each apparent duplication needs its own
+  same-lifecycle-and-execution-model read.
+- The `coord.Hub` interface is unchanged. If it grows further
+  (e.g. a future test needs a hub that survives a process restart
+  in-test), it stays in coord.
+
+## References
+
+- ADR 0023 (hub-leaf orchestrator topology — names "hub" and
+  "leaf" as the topology this code implements).
+- ADR 0026 (Go-implemented hub — established the
+  daemon-supervisor pattern in `internal/hub`).
+- `internal/hub/hub.go` — the daemon supervisor.
+- `internal/coord/hub.go` — the in-process embedded hub.
+- 2026-04-29 architecture review (same thread as ADRs 0030,
+  0031, 0032).


### PR DESCRIPTION
## Summary
Two ADRs from the 2026-04-29 architecture-review thread (alongside ADRs 0030 and 0031). Both record candidates that were proposed for consolidation but pass the deletion test on closer inspection — captures the load-bearing reasoning so a future review doesn't re-pitch the same shape.

## ADR 0032 — keep \`internal/jskv\` and \`internal/dispatch\`
Original flag was based on shallow metrics (LoC + export count). Closer reads:

- **\`internal/jskv\`** hides non-trivial NATS-error parsing (\`jetstream.ErrKeyExists\` + \`APIError\` + wrapped variants) behind a 2-export interface used by 3 packages. Deletion duplicates that parsing in 3 places — brittle against upstream-error-shape drift across nats.go releases.
- **\`internal/dispatch\`** carries the worker/parent result protocol (\`ResultMessage\` / \`FormatResult\` / \`ParseResult\`). Deletion splits a wire format into two halves that can drift silently — exactly the bug class bones #51 surfaced elsewhere.

## ADR 0033 — keep \`internal/hub\` as a separate package
Original framing was \"wrapper around coord.Hub\". Closer read shows two different abstractions with different lifecycles:

- **\`internal/hub\`** is a 504-LoC daemon supervisor: fork-execs an external \`fossil server\` subprocess, embeds NATS, manages pid files and \`BONES_HUB_FOREGROUND\` detach semantics. Used by exactly one CLI verb.
- **\`coord.Hub\`** is an in-process embedded hub used heavily by tests and \`examples/hub-leaf-e2e\`. Single-process lifetime, libfossil for HTTP in-process, embedded NATS in the calling process.

Different process boundary, different Stop semantics (SIGTERM-a-pid vs call-a-method), different caller sets. Folding either way loses information.

ADR 0033 also adds a reusable decision criterion: same-name symbols across packages should only be folded when they share process boundary, Stop semantics, and caller set.

## Skill-meta lesson
The original review made these calls partly on shallow metrics. The right move is reading the implementation against the deletion test — small packages can be deep, big packages can be shallow. These ADRs capture the corrective.

## Test plan
- [ ] No code changed; \`docs-only\` paths-ignore should skip CI.