### PR TITLE
swarm: narrow Manager to Sessions; unexport mutating methods (ADR 0034)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -80,6 +80,13 @@ Written by `swarm join` (a fresh `Lease.AcquireFresh`), bumped by
 `swarm commit` (`Lease.Commit`), deleted by `swarm close`
 (`Lease.Close`). See ADR 0028.
 
+**Sessions.** The read view across all session records in
+`bones-swarm-sessions` (`swarm.Sessions` type, returned by
+`swarm.Open`). Public reads — `Get`, `List`, `Close` — are consumed
+by `bones swarm status`, `bones doctor`, and CLI slot-resolution
+helpers. Mutations (`put`, `update`, `delete`) are unexported; the
+only legal mutator is `swarm.Lease`. See ADR 0034.
+
 ## Work shape
 
 **Plan.** A markdown file describing the work to do, with task

--- a/cli/doctor.go
+++ b/cli/doctor.go
@@ -60,13 +60,13 @@ func (c *DoctorCmd) runSwarmReport() error {
 		fmt.Printf("  INFO  not in a bones workspace (%v)\n", err)
 		return nil
 	}
-	mgr, closer, err := openSwarmManager(ctx, info)
+	sess, closer, err := openSwarmSessions(ctx, info)
 	if err != nil {
-		fmt.Printf("  WARN  open swarm manager: %v\n", err)
+		fmt.Printf("  WARN  open swarm sessions: %v\n", err)
 		return nil
 	}
 	defer closer()
-	sessions, err := mgr.List(ctx)
+	sessions, err := sess.List(ctx)
 	if err != nil {
 		fmt.Printf("  WARN  list sessions: %v\n", err)
 		return nil

--- a/cli/swarm.go
+++ b/cli/swarm.go
@@ -27,26 +27,29 @@ type SwarmCmd struct {
 	FanIn  SwarmFanInCmd  `cmd:"" name:"fan-in" help:"Merge open hub leaves into trunk"`
 }
 
-// openSwarmManager dials NATS for the workspace and opens a swarm
-// Manager bound to the bones-swarm-sessions bucket. Caller closes
-// the Manager and the returned closer to release the NATS conn.
+// openSwarmSessions dials NATS for the workspace and opens a swarm
+// Sessions handle bound to the bones-swarm-sessions bucket. Caller
+// invokes the returned closer to release the handle and the NATS
+// conn together.
 //
-// Pulled into a helper because every swarm verb opens the Manager
-// the same way and the verbs are otherwise small.
-func openSwarmManager(
+// Pulled into a helper because every read-only swarm verb opens the
+// Sessions handle the same way and the verbs are otherwise small.
+// Mutating verbs go through swarm.Lease (ADR 0031, narrowed in
+// ADR 0034).
+func openSwarmSessions(
 	ctx context.Context, info workspace.Info,
-) (*swarm.Manager, func(), error) {
+) (*swarm.Sessions, func(), error) {
 	nc, err := nats.Connect(info.NATSURL)
 	if err != nil {
 		return nil, nil, fmt.Errorf("nats connect: %w", err)
 	}
-	m, err := swarm.Open(ctx, swarm.Config{NATSConn: nc})
+	s, err := swarm.Open(ctx, swarm.Config{NATSConn: nc})
 	if err != nil {
 		nc.Close()
 		return nil, nil, fmt.Errorf("swarm.Open: %w", err)
 	}
-	return m, func() {
-		_ = m.Close()
+	return s, func() {
+		_ = s.Close()
 		nc.Close()
 	}, nil
 }
@@ -56,18 +59,18 @@ func openSwarmManager(
 // returns it. Otherwise, lists active sessions on this host and
 // returns the unique active slot. Errors if zero or more than one
 // session matches.
-func resolveSlot(ctx context.Context, m *swarm.Manager, flag, host string) (string, error) {
+func resolveSlot(ctx context.Context, s *swarm.Sessions, flag, host string) (string, error) {
 	if flag != "" {
 		return flag, nil
 	}
-	sessions, err := m.List(ctx)
+	sessions, err := s.List(ctx)
 	if err != nil {
 		return "", fmt.Errorf("list sessions: %w", err)
 	}
 	var matches []string
-	for _, s := range sessions {
-		if s.Host == host {
-			matches = append(matches, s.Slot)
+	for _, sess := range sessions {
+		if sess.Host == host {
+			matches = append(matches, sess.Slot)
 		}
 	}
 	if len(matches) == 0 {

--- a/cli/swarm_close.go
+++ b/cli/swarm_close.go
@@ -94,18 +94,18 @@ func (c *SwarmCloseCmd) validateResult() error {
 
 // resolveTargetSlot mirrors the helper in swarm_commit.go: honors
 // --slot when set, otherwise infers the unique active slot via
-// Manager.List. The Manager is opened-and-closed inline; Resume
-// opens its own to read the session record.
+// Sessions.List. The Sessions handle is opened-and-closed inline;
+// Resume opens its own to read the session record.
 func (c *SwarmCloseCmd) resolveTargetSlot(
 	ctx context.Context, info workspace.Info,
 ) (string, error) {
-	mgr, closeMgr, err := openSwarmManager(ctx, info)
+	sess, closeSess, err := openSwarmSessions(ctx, info)
 	if err != nil {
 		return "", err
 	}
-	defer closeMgr()
+	defer closeSess()
 	host, _ := os.Hostname()
-	slot, err := resolveSlot(ctx, mgr, c.Slot, host)
+	slot, err := resolveSlot(ctx, sess, c.Slot, host)
 	if err != nil {
 		return "", err
 	}

--- a/cli/swarm_commit.go
+++ b/cli/swarm_commit.go
@@ -75,19 +75,19 @@ func (c *SwarmCommitCmd) run(ctx context.Context, info workspace.Info) error {
 
 // resolveTargetSlot picks the slot to operate on. Honors --slot
 // when set; otherwise infers the unique active slot on this host
-// via swarm.Manager.List. The Manager is opened-and-closed inline
-// because Resume opens its own to read the session record; the
-// double-dial cost is negligible for a single CLI invocation.
+// via swarm.Sessions.List. The Sessions handle is opened-and-closed
+// inline because Resume opens its own to read the session record;
+// the double-dial cost is negligible for a single CLI invocation.
 func (c *SwarmCommitCmd) resolveTargetSlot(
 	ctx context.Context, info workspace.Info,
 ) (string, error) {
-	mgr, closeMgr, err := openSwarmManager(ctx, info)
+	sess, closeSess, err := openSwarmSessions(ctx, info)
 	if err != nil {
 		return "", err
 	}
-	defer closeMgr()
+	defer closeSess()
 	host, _ := os.Hostname()
-	slot, err := resolveSlot(ctx, mgr, c.Slot, host)
+	slot, err := resolveSlot(ctx, sess, c.Slot, host)
 	if err != nil {
 		return "", err
 	}

--- a/cli/swarm_status.go
+++ b/cli/swarm_status.go
@@ -57,12 +57,12 @@ func (c *SwarmStatusCmd) Run(g *libfossilcli.Globals) error {
 }
 
 func (c *SwarmStatusCmd) run(ctx context.Context, info workspace.Info) error {
-	mgr, closeMgr, err := openSwarmManager(ctx, info)
+	sess, closeSess, err := openSwarmSessions(ctx, info)
 	if err != nil {
 		return err
 	}
-	defer closeMgr()
-	sessions, err := mgr.List(ctx)
+	defer closeSess()
+	sessions, err := sess.List(ctx)
 	if err != nil {
 		return err
 	}

--- a/docs/adr/0031-lease-runtime-slot-view.md
+++ b/docs/adr/0031-lease-runtime-slot-view.md
@@ -13,7 +13,9 @@ fan-in`) all share the same opening scaffold:
    long-running leaf-daemon's NATS.
 2. `ensureSlotUser` — verify the workspace is bootstrapped and create
    the slot's fossil user on the hub repo if missing.
-3. `openSwarmManager` — open the swarm sessions KV bucket.
+3. `openSwarmManager` — open the swarm sessions KV bucket. (Renamed
+   to `openSwarmSessions` and the underlying `swarm.Manager` type
+   narrowed to `swarm.Sessions` in ADR 0034.)
 4. Read or write the per-slot session record (`swarm.Session` in
    `bones-swarm-sessions[slot]`) under a CAS gate.
 5. `coord.OpenLeaf` — open a fresh per-slot fossil leaf bound to the
@@ -123,7 +125,10 @@ the type.
 
 Each PR is independent; the existing CLI verbs continue to work
 between phases because the underlying `coord.Leaf` and `swarm.Manager`
-APIs are unchanged.
+APIs are unchanged. (After this ADR landed, `swarm.Manager` was
+renamed to `swarm.Sessions` with mutating methods made unexported —
+see ADR 0034. The migration phasing above is still accurate; only
+the substrate-adapter type's name and visibility changed.)
 
 ## Consequences
 

--- a/docs/adr/0034-swarm-sessions-narrowing.md
+++ b/docs/adr/0034-swarm-sessions-narrowing.md
@@ -1,0 +1,169 @@
+# ADR 0034: Narrow swarm.Manager to swarm.Sessions
+
+**Status:** accepted
+
+**Date:** 2026-04-29
+
+## Context
+
+ADR 0031 introduced `swarm.Lease` as the runtime-view-of-a-slot
+abstraction owning the assembled scaffold (workspace check, fossil-user
+creation, session-record CAS, leaf open/claim) for a single CLI
+invocation. The session record's lifecycle now flows through Lease:
+`AcquireFresh` writes it, `Lease.Commit` bumps it via CAS,
+`Lease.Close` deletes it.
+
+That left `swarm.Manager` — the JetStream-KV adapter for
+`bones-swarm-sessions` — in an awkward shape. Its public interface
+(`Get`, `List`, `Put`, `Update`, `Delete`, `Close`, `BucketName`) was
+designed before Lease existed and exposed the full read/write surface
+of the bucket. Post-Lease, two distinct consumer populations emerged:
+
+- **Lifecycle writers.** Exactly one: `swarm.Lease`, which performs
+  the CAS-gated `Put` / `Update` / `Delete` dance and tracks
+  revisions across CLI invocations.
+
+- **Read-only inspectors.** Three: `cli.resolveSlot` (slot inference
+  from active sessions), `cli.SwarmStatusCmd` (status table), and
+  `cli.DoctorCmd.runSwarmReport` (doctor's swarm-session inventory).
+  These call only `List` (and indirectly `Close`).
+
+Per the architecture-review heuristic of "one adapter, no real seam":
+Manager had a single implementation but a wide public interface
+serving two asymmetric populations. Per the deletion test: deleting
+the write methods from the public surface concentrates write logic in
+Lease (good — that's where it already lives); deleting the read methods
+would force every read consumer to open a Lease for a slot it doesn't
+yet know (bad — a workspace-level read cannot be expressed on a
+per-slot Lease).
+
+The 2026-04-29 architecture-review grilling named the missing
+discipline: the public type should expose only the read seam; mutations
+should be unexported, with `Lease` (same package) as the only legal
+mutator. Today nothing prevents another caller from writing directly
+to the bucket and bypassing Lease's host-match, claim-binding, and
+CAS-revision invariants. Compile-time enforcement is cheaper than
+documentation.
+
+## Decision
+
+Rename `swarm.Manager` to `swarm.Sessions`, and unexport the mutating
+methods.
+
+### Public surface
+
+`swarm.Sessions` exposes only read methods:
+
+- `Get(ctx, slot) (Session, rev, error)` — single-slot read, returns
+  `ErrNotFound` if missing.
+- `List(ctx) ([]Session, error)` — read across slots, capped at
+  `maxSessionEntries`.
+- `Close() error` — releases the handle (idempotent).
+- `BucketName() string` — diagnostic accessor.
+- `Validate()` (on `Config`) and the `Open` factory remain unchanged.
+
+### Unexported
+
+- `(*Sessions).put(ctx, sess) error`
+- `(*Sessions).update(ctx, sess, expectedRev) error`
+- `(*Sessions).delete(ctx, slot, expectedRev) error`
+
+These are reachable only from within `package swarm`. The only
+caller is `swarm.Lease`. Errors (`ErrCASConflict`, `ErrNotFound`,
+`ErrClosed`) remain exported so callers can react to them — the
+errors are part of the read seam too (`Get` returns `ErrNotFound`
+and `ErrClosed`).
+
+### Why one type, not two
+
+Two types (e.g. `Sessions` for reads and a separate `sessionStore`
+for writes) was rejected. Go's package-private methods give the
+same encapsulation for free: the compiler enforces "only `package
+swarm` callers can mutate." A second type would force Lease to hold
+both, doubling the field count without a corresponding gain. The
+rule of two adapters argues against splitting prematurely — there's
+still one substrate adapter, just with a narrowed external view.
+
+### Why keep Sessions public at all
+
+The deletion test argues against folding `Sessions` entirely into
+`Lease`: read-across-slots (`resolveSlot`, status, doctor) is a
+workspace-level operation that doesn't fit on a per-slot Lease. A
+hypothetical `Lease.ResolveActiveSlot(ctx, info, host)` static-style
+helper was rejected — it forces caller code to call a method on a
+type that hasn't been instantiated yet. Sessions keeps its own
+identity: the read view across all session records.
+
+## Consequences
+
+- **Compile-time invariant.** External packages physically cannot
+  mutate `bones-swarm-sessions`. Any future write consumer must
+  either live in `package swarm` or go through `Lease`. The
+  host-match, claim-binding, and CAS-revision invariants Lease
+  enforces are unbypassable from outside.
+
+- **Read seam stays explicit.** `cli.resolveSlot`,
+  `cli.SwarmStatusCmd`, and `cli.DoctorCmd` continue to consume
+  `Sessions` — just under the new type name. CLI-internal helper
+  `openSwarmManager` is renamed `openSwarmSessions`; the helper
+  signature matches.
+
+- **Test surface refines.** `internal/swarm/swarm_test.go` continues
+  to test the substrate-CAS contract directly (still inside
+  `package swarm`, so the unexported mutators stay reachable from
+  tests). Per ADR 0030, these tests run against real NATS — the
+  tests are the substrate-CAS contract pinned with real-substrate
+  semantics. `internal/swarm/lease_test.go` continues to use the
+  unexported `update` to simulate cross-host record corruption (the
+  `TestResume_RefusesCrossHost` case can't be reproduced through
+  `Lease` because Lease's writes always stamp the local hostname).
+
+- **No behavioral change.** No verb's runtime semantics change. The
+  rename is mechanical; the tests exercise the same paths.
+
+## Migration
+
+Single PR. Mechanical rename + visibility flip:
+
+1. `internal/swarm/swarm.go` — type rename, lowercase mutators.
+2. `internal/swarm/lease.go` — field rename (`mgr` → `sessions`),
+   helper rename (`openLeaseManager` → `openLeaseSessions`), method
+   call updates.
+3. `internal/swarm/{swarm,lease}_test.go` — variable + helper
+   renames.
+4. `cli/swarm.go` — `openSwarmManager` → `openSwarmSessions`,
+   `resolveSlot` parameter type narrowed.
+5. `cli/swarm_status.go`, `swarm_close.go`, `swarm_commit.go`,
+   `doctor.go` — call-site renames + comment updates.
+6. `internal/coord/coord.go` — comment update.
+7. `docs/adr/0031-lease-runtime-slot-view.md` — annotate the old
+   `swarm.Manager` references with a pointer to this ADR.
+8. `CONTEXT.md` — name `Sessions` as a domain term.
+
+## Out of scope
+
+- **Folding `swarm` into substrate.** ADR 0025 places `swarm` in
+  domain. This rename does not change layering; `Sessions` stays in
+  `internal/swarm/`.
+
+- **Symmetric narrowings in `presence` / `holds` / `tasks`.** Each
+  of those domain packages has its own `Manager` with its own
+  caller population. The same heuristic may apply but is not
+  re-litigated here — surface those in a future architecture
+  review if the friction is real.
+
+- **Watch / live-update API on `Sessions`.** Today doctor and
+  status make one-shot `List` calls. If a future TUI or
+  long-running monitor needs incremental updates, a `Watch` method
+  lands cleanly on the read seam — but the demand isn't here yet.
+
+## References
+
+- ADR 0025 (substrate vs domain layer)
+- ADR 0028 (bones swarm verbs — defines bucket schema and verb shape)
+- ADR 0030 (real-substrate tests over mocks — `Sessions` tests
+  follow this discipline)
+- ADR 0031 (introduced `swarm.Lease` — this ADR narrows the
+  Manager-now-Sessions surface that ADR left in place)
+- 2026-04-29 architecture review (this skill's grilling output;
+  candidate #1)

--- a/internal/coord/coord.go
+++ b/internal/coord/coord.go
@@ -43,12 +43,13 @@ const presenceBucket = "bones-presence"
 // swarmSessionsBucket is the JetStream KV bucket name internal/swarm
 // uses to track per-slot swarm sessions per ADR 0028. Listed here
 // for visibility alongside the other coord-managed buckets, but
-// internal/swarm.Manager.Open creates/attaches independently —
-// coord.Coord callers do NOT consume this bucket. Provisioning is
-// best-effort here so any coord.Open guarantees the bucket exists
-// before the first `bones swarm join`. Constant kept exported (in
-// effect — swarm package mirrors it as DefaultBucketName) so tests
-// can assert the same name in both layers.
+// internal/swarm.Open creates/attaches independently (the returned
+// *swarm.Sessions handle, narrowed in ADR 0034). coord.Coord callers
+// do NOT consume this bucket. Provisioning is best-effort here so
+// any coord.Open guarantees the bucket exists before the first
+// `bones swarm join`. Constant kept exported (in effect — swarm
+// package mirrors it as DefaultBucketName) so tests can assert the
+// same name in both layers.
 const swarmSessionsBucket = "bones-swarm-sessions"
 
 // Coord is the public entry point for bones. Construct one via

--- a/internal/swarm/lease.go
+++ b/internal/swarm/lease.go
@@ -48,7 +48,7 @@ var ErrWorkspaceNotBootstrapped = errors.New(
 
 // ErrSessionNotFound is returned by Resume when no session record
 // exists for the slot. Distinct from swarm.ErrNotFound so callers
-// can disambiguate "no record yet" from "Manager closed".
+// can disambiguate "no record yet" from "Sessions handle closed".
 var ErrSessionNotFound = errors.New(
 	"swarm: session record not found — run `bones swarm join` first",
 )
@@ -126,6 +126,10 @@ type AcquireOpts struct {
 // state across verbs is the session record in
 // bones-swarm-sessions[slot], not the lease itself.
 //
+// Lease is the only legal mutator of the session record. The narrow
+// public surface on swarm.Sessions (Get/List public, put/update/delete
+// unexported) enforces this at compile time; see ADR 0034.
+//
 // See ADR 0031 for the design and the rationale for the
 // AcquireFresh / Resume split. See ADR 0030 for why tests against
 // Lease use real NATS + real Fossil rather than mocks.
@@ -140,7 +144,7 @@ type Lease struct {
 	leaf  *coord.Leaf
 	claim *coord.Claim
 
-	mgr          *Manager
+	sessions     *Sessions
 	natsConn     *nats.Conn
 	ownsNATSConn bool
 	rev          uint64
@@ -156,7 +160,7 @@ type Lease struct {
 //     return ErrWorkspaceNotBootstrapped — the role-leak guard from
 //     PR #54.
 //  2. Create the slot's fossil user on the hub repo if missing.
-//  3. Open the swarm.Manager (dial NATS or reuse opts.NATSConn).
+//  3. Open the swarm.Sessions handle (dial NATS or reuse opts.NATSConn).
 //  4. Read any existing session record. Active on this host without
 //     --force → ErrSessionAlreadyLive. Different host →
 //     ErrSessionForeignHost. Stale or --force → CAS-delete and
@@ -190,18 +194,18 @@ func AcquireFresh(
 		return nil, err
 	}
 
-	mgr, nc, ownsConn, err := openLeaseManager(ctx, info, opts.NATSConn)
+	sessions, nc, ownsConn, err := openLeaseSessions(ctx, info, opts.NATSConn)
 	if err != nil {
 		return nil, err
 	}
 	cleanupConn := func() {
-		_ = mgr.Close()
+		_ = sessions.Close()
 		if ownsConn && nc != nil {
 			nc.Close()
 		}
 	}
 
-	if err := clearExistingRecord(ctx, mgr, slot, opts.ForceTakeover, now); err != nil {
+	if err := clearExistingRecord(ctx, sessions, slot, opts.ForceTakeover, now); err != nil {
 		cleanupConn()
 		return nil, err
 	}
@@ -212,7 +216,7 @@ func AcquireFresh(
 		return nil, err
 	}
 	rev, err := writeSessionAndPid(
-		ctx, mgr, info.WorkspaceDir, slot, taskID, fossilUser, hubURL, now,
+		ctx, sessions, info.WorkspaceDir, slot, taskID, fossilUser, hubURL, now,
 	)
 	if err != nil {
 		_ = claim.Release()
@@ -230,7 +234,7 @@ func AcquireFresh(
 		now:          now,
 		leaf:         leaf,
 		claim:        claim,
-		mgr:          mgr,
+		sessions:     sessions,
 		natsConn:     nc,
 		ownsNATSConn: ownsConn,
 		rev:          rev,
@@ -281,12 +285,12 @@ func openLeafAndClaim(
 }
 
 // writeSessionAndPid CAS-creates the session record and writes the
-// host-local pid file. Returns the post-Put KV revision so the
+// host-local pid file. Returns the post-put KV revision so the
 // Lease can CAS against it during Close. On pid-file failure the
 // session record is best-effort deleted before return so the slot
 // stays clean for the next AcquireFresh.
 func writeSessionAndPid(
-	ctx context.Context, mgr *Manager,
+	ctx context.Context, sessions *Sessions,
 	workspaceDir, slot, taskID, fossilUser, hubURL string,
 	now func() time.Time,
 ) (uint64, error) {
@@ -302,14 +306,14 @@ func writeSessionAndPid(
 		StartedAt:   t,
 		LastRenewed: t,
 	}
-	if err := mgr.Put(ctx, sess); err != nil {
+	if err := sessions.put(ctx, sess); err != nil {
 		return 0, fmt.Errorf("swarm.AcquireFresh: write session record: %w", err)
 	}
 	if err := writePidFile(workspaceDir, slot); err != nil {
-		_ = mgr.Delete(ctx, slot, 0)
+		_ = sessions.delete(ctx, slot, 0)
 		return 0, fmt.Errorf("swarm.AcquireFresh: %w", err)
 	}
-	_, rev, err := mgr.Get(ctx, slot)
+	_, rev, err := sessions.Get(ctx, slot)
 	if err != nil {
 		return 0, fmt.Errorf("swarm.AcquireFresh: re-read session: %w", err)
 	}
@@ -342,18 +346,18 @@ func Resume(
 
 	now, _, _ := defaultAcquireOpts(opts)
 
-	mgr, nc, ownsConn, err := openLeaseManager(ctx, info, opts.NATSConn)
+	sessions, nc, ownsConn, err := openLeaseSessions(ctx, info, opts.NATSConn)
 	if err != nil {
 		return nil, err
 	}
 	cleanup := func() {
-		_ = mgr.Close()
+		_ = sessions.Close()
 		if ownsConn && nc != nil {
 			nc.Close()
 		}
 	}
 
-	sess, rev, err := mgr.Get(ctx, slot)
+	sess, rev, err := sessions.Get(ctx, slot)
 	if err != nil {
 		cleanup()
 		if errors.Is(err, ErrNotFound) {
@@ -388,7 +392,7 @@ func Resume(
 		now:          now,
 		leaf:         leaf,
 		claim:        nil, // Resume does not take a claim
-		mgr:          mgr,
+		sessions:     sessions,
 		natsConn:     nc,
 		ownsNATSConn: ownsConn,
 		rev:          rev,
@@ -397,8 +401,8 @@ func Resume(
 
 // Release closes the lease without deleting the session record.
 // Stops the leaf, releases any held claim, closes the swarm
-// Manager, and (if the lease owns the NATS connection) closes that
-// too. Idempotent.
+// Sessions handle, and (if the lease owns the NATS connection)
+// closes that too. Idempotent.
 //
 // `bones swarm join` calls Release after writing the session
 // record so subsequent verbs can Resume against it. `bones swarm
@@ -415,8 +419,8 @@ func (l *Lease) Release(ctx context.Context) error {
 	if l.leaf != nil {
 		_ = l.leaf.Stop()
 	}
-	if l.mgr != nil {
-		_ = l.mgr.Close()
+	if l.sessions != nil {
+		_ = l.sessions.Close()
 	}
 	if l.ownsNATSConn && l.natsConn != nil {
 		l.natsConn.Close()
@@ -454,7 +458,7 @@ type CloseOpts struct {
 //  3. Stop the leaf.
 //  4. Remove the host-local pid file.
 //  5. CAS-delete the session record.
-//  6. Tear down the swarm.Manager + NATS connection.
+//  6. Tear down the swarm.Sessions handle + NATS connection.
 //
 // `bones swarm close` calls this. The CAS gate on step 5 ensures
 // we don't delete a record some other process renewed; if it raced
@@ -479,8 +483,8 @@ func (l *Lease) Close(ctx context.Context, opts CloseOpts) error {
 		_ = l.releaseUnderlying()
 		return fmt.Errorf("swarm.Lease.Close: remove pid file: %w", err)
 	}
-	if l.mgr != nil && l.rev != 0 {
-		if err := l.mgr.Delete(ctx, l.slot, l.rev); err != nil &&
+	if l.sessions != nil && l.rev != 0 {
+		if err := l.sessions.delete(ctx, l.slot, l.rev); err != nil &&
 			!errors.Is(err, ErrNotFound) && !errors.Is(err, ErrCASConflict) {
 			_ = l.releaseUnderlying()
 			return fmt.Errorf("swarm.Lease.Close: delete record: %w", err)
@@ -589,15 +593,15 @@ func (l *Lease) Commit(
 // is treated as success — a sibling commit raced ours and the
 // other writer's update already extended the TTL.
 func (l *Lease) renewSessionAfterCommit(ctx context.Context) error {
-	if l.mgr == nil || l.rev == 0 {
+	if l.sessions == nil || l.rev == 0 {
 		return nil
 	}
-	sess, rev, err := l.mgr.Get(ctx, l.slot)
+	sess, rev, err := l.sessions.Get(ctx, l.slot)
 	if err != nil {
 		return fmt.Errorf("swarm.Lease.Commit: re-read session for renew: %w", err)
 	}
 	sess.LastRenewed = l.now()
-	if err := l.mgr.Update(ctx, sess, rev); err != nil {
+	if err := l.sessions.update(ctx, sess, rev); err != nil {
 		if errors.Is(err, ErrCASConflict) {
 			return nil
 		}
@@ -672,9 +676,9 @@ func pushLeafFossil(
 	return res, nil
 }
 
-// releaseUnderlying tears down the leaf + claim + manager + NATS
-// connection. Shared by Release and Close so the cleanup ordering
-// stays in one place.
+// releaseUnderlying tears down the leaf + claim + Sessions handle +
+// NATS connection. Shared by Release and Close so the cleanup
+// ordering stays in one place.
 func (l *Lease) releaseUnderlying() error {
 	l.released = true
 	if l.claim != nil {
@@ -683,8 +687,8 @@ func (l *Lease) releaseUnderlying() error {
 	if l.leaf != nil {
 		_ = l.leaf.Stop()
 	}
-	if l.mgr != nil {
-		_ = l.mgr.Close()
+	if l.sessions != nil {
+		_ = l.sessions.Close()
 	}
 	if l.ownsNATSConn && l.natsConn != nil {
 		l.natsConn.Close()
@@ -719,7 +723,7 @@ func (l *Lease) WT() string {
 // SessionRevision returns the JetStream KV revision the lease
 // captured at acquisition. Test-only utility — callers that want
 // to inspect the underlying record can pair this with a separate
-// swarm.Manager.Get; production verbs go through Commit / Close.
+// swarm.Sessions.Get; production verbs go through Commit / Close.
 func (l *Lease) SessionRevision() uint64 { return l.rev }
 
 // ensureSlotUser creates the slot's fossil user on the hub repo
@@ -754,12 +758,13 @@ func ensureSlotUser(workspaceDir, login, caps string) error {
 	return nil
 }
 
-// openLeaseManager dials NATS (or reuses preNC) and opens a swarm.Manager.
-// Returns the manager, the NATS connection, and a flag indicating
-// whether the manager owns the connection's close.
-func openLeaseManager(
+// openLeaseSessions dials NATS (or reuses preNC) and opens a
+// swarm.Sessions handle. Returns the handle, the NATS connection,
+// and a flag indicating whether the handle owns the connection's
+// close.
+func openLeaseSessions(
 	ctx context.Context, info workspace.Info, preNC *nats.Conn,
-) (*Manager, *nats.Conn, bool, error) {
+) (*Sessions, *nats.Conn, bool, error) {
 	var (
 		nc       *nats.Conn
 		ownsConn bool
@@ -775,14 +780,14 @@ func openLeaseManager(
 		}
 		ownsConn = true
 	}
-	m, err := Open(ctx, Config{NATSConn: nc})
+	s, err := Open(ctx, Config{NATSConn: nc})
 	if err != nil {
 		if ownsConn {
 			nc.Close()
 		}
-		return nil, nil, false, fmt.Errorf("swarm: open manager: %w", err)
+		return nil, nil, false, fmt.Errorf("swarm: open sessions: %w", err)
 	}
-	return m, nc, ownsConn, nil
+	return s, nc, ownsConn, nil
 }
 
 // clearExistingRecord enforces the "one live session per slot" rule
@@ -792,9 +797,9 @@ func openLeaseManager(
 // host and force is false; ErrSessionForeignHost if it lives on a
 // different host (cross-host takeover refused unconditionally).
 func clearExistingRecord(
-	ctx context.Context, mgr *Manager, slot string, force bool, now func() time.Time,
+	ctx context.Context, sessions *Sessions, slot string, force bool, now func() time.Time,
 ) error {
-	existing, rev, err := mgr.Get(ctx, slot)
+	existing, rev, err := sessions.Get(ctx, slot)
 	if err != nil {
 		if errors.Is(err, ErrNotFound) {
 			return nil
@@ -813,7 +818,7 @@ func clearExistingRecord(
 				ErrSessionForeignHost, slot, existing.Host)
 		}
 	}
-	if err := mgr.Delete(ctx, slot, rev); err != nil && !errors.Is(err, ErrNotFound) {
+	if err := sessions.delete(ctx, slot, rev); err != nil && !errors.Is(err, ErrNotFound) {
 		return fmt.Errorf("swarm: clear stale record: %w", err)
 	}
 	return nil

--- a/internal/swarm/lease_test.go
+++ b/internal/swarm/lease_test.go
@@ -140,10 +140,10 @@ func TestAcquireFresh_SuccessAndRelease(t *testing.T) {
 		t.Errorf("SessionRevision: zero")
 	}
 
-	// Session record must be visible on a manager separate from
-	// the one Lease owns internally.
-	verifyMgr := openVerifyManager(t, f)
-	got, _, err := verifyMgr.Get(ctx, "rendering")
+	// Session record must be visible on a Sessions handle separate
+	// from the one Lease owns internally.
+	verifySess := openVerifySessions(t, f)
+	got, _, err := verifySess.Get(ctx, "rendering")
 	if err != nil {
 		t.Fatalf("post-acquire Get: %v", err)
 	}
@@ -160,12 +160,12 @@ func TestAcquireFresh_SuccessAndRelease(t *testing.T) {
 	}
 
 	// Release should NOT delete the session record. Verify by opening
-	// a fresh Manager (different from the lease's, which Release just
-	// closed) and reading the slot's record back.
+	// a fresh Sessions handle (different from the lease's, which
+	// Release just closed) and reading the slot's record back.
 	if err := lease.Release(ctx); err != nil {
 		t.Fatalf("Release: %v", err)
 	}
-	if _, _, err := verifyMgr.Get(ctx, "rendering"); err != nil {
+	if _, _, err := verifySess.Get(ctx, "rendering"); err != nil {
 		t.Errorf("session record gone after Release (expected to persist): %v", err)
 	}
 
@@ -175,18 +175,18 @@ func TestAcquireFresh_SuccessAndRelease(t *testing.T) {
 	}
 }
 
-// openVerifyManager dials NATS at the fixture hub's URL and opens a
-// swarm.Manager that the test owns the lifetime of. Used to read
-// session records the lease wrote, after the lease's own Manager
-// has been closed by Release/Close.
-func openVerifyManager(t *testing.T, f *leaseFixture) *Manager {
+// openVerifySessions dials NATS at the fixture hub's URL and opens a
+// swarm.Sessions handle that the test owns the lifetime of. Used to
+// read session records the lease wrote, after the lease's own
+// Sessions handle has been closed by Release/Close.
+func openVerifySessions(t *testing.T, f *leaseFixture) *Sessions {
 	t.Helper()
-	mgr, _, _, err := openLeaseManager(context.Background(), f.info, nil)
+	sess, _, _, err := openLeaseSessions(context.Background(), f.info, nil)
 	if err != nil {
-		t.Fatalf("openVerifyManager: %v", err)
+		t.Fatalf("openVerifySessions: %v", err)
 	}
-	t.Cleanup(func() { _ = mgr.Close() })
-	return mgr
+	t.Cleanup(func() { _ = sess.Close() })
+	return sess
 }
 
 // TestAcquireFresh_RefusesActiveLiveSession pins the
@@ -323,8 +323,8 @@ func TestCommit_SuccessUpdatesTrunkAndRenewsSession(t *testing.T) {
 	}
 
 	// Capture the pre-commit LastRenewed so we can compare.
-	verifyMgr := openVerifyManager(t, f)
-	preSess, _, err := verifyMgr.Get(ctx, "render")
+	verifySess := openVerifySessions(t, f)
+	preSess, _, err := verifySess.Get(ctx, "render")
 	if err != nil {
 		t.Fatalf("pre-commit Get: %v", err)
 	}
@@ -364,7 +364,7 @@ func TestCommit_SuccessUpdatesTrunkAndRenewsSession(t *testing.T) {
 	}
 
 	// Verify session record's LastRenewed bumped.
-	postSess, _, err := verifyMgr.Get(ctx, "render")
+	postSess, _, err := verifySess.Get(ctx, "render")
 	if err != nil {
 		t.Fatalf("post-commit Get: %v", err)
 	}
@@ -399,14 +399,14 @@ func TestResume_RefusesCrossHost(t *testing.T) {
 	if err := first.Release(ctx); err != nil {
 		t.Fatalf("Release: %v", err)
 	}
-	verifyMgr := openVerifyManager(t, f)
-	sess, rev, err := verifyMgr.Get(ctx, "ghosthost")
+	verifySess := openVerifySessions(t, f)
+	sess, rev, err := verifySess.Get(ctx, "ghosthost")
 	if err != nil {
 		t.Fatalf("Get: %v", err)
 	}
 	sess.Host = "definitely-not-this-machine.invalid"
-	if err := verifyMgr.Update(ctx, sess, rev); err != nil {
-		t.Fatalf("Update with foreign host: %v", err)
+	if err := verifySess.update(ctx, sess, rev); err != nil {
+		t.Fatalf("update with foreign host: %v", err)
 	}
 
 	_, err = Resume(ctx, f.info, "ghosthost", AcquireOpts{Hub: f.hub})

--- a/internal/swarm/swarm.go
+++ b/internal/swarm/swarm.go
@@ -27,9 +27,9 @@ const DefaultBucketName = "bones-swarm-sessions"
 // Five minutes mirrors ADR 0028's "stale after 5min no renewal" rule.
 const DefaultTTL = 5 * time.Minute
 
-// ErrClosed reports that a public method was called on a Manager whose
+// ErrClosed reports that a public method was called on a Sessions whose
 // Close has returned. Parallel to internal/presence.ErrClosed.
-var ErrClosed = errors.New("swarm: manager is closed")
+var ErrClosed = errors.New("swarm: sessions handle is closed")
 
 // ErrNotFound reports that the requested slot has no live session
 // record in the bucket. Distinct from a substrate error so callers
@@ -37,16 +37,17 @@ var ErrClosed = errors.New("swarm: manager is closed")
 // "NATS unreachable."
 var ErrNotFound = errors.New("swarm: session not found")
 
-// ErrCASConflict reports that a CAS-gated Update or Delete saw a
+// ErrCASConflict reports that a CAS-gated update or delete saw a
 // revision mismatch — another writer raced ours. Mirrors
 // internal/tasks.ErrCASConflict so callers can react identically.
 var ErrCASConflict = errors.New("swarm: CAS conflict")
 
-// Config configures a Manager. Only NATSConn is required; bucket name
-// and TTL fall back to the package defaults if zero. Defaults match
-// production; tests sometimes pass shorter TTLs to exercise expiry.
+// Config configures a Sessions handle. Only NATSConn is required;
+// bucket name and TTL fall back to the package defaults if zero.
+// Defaults match production; tests sometimes pass shorter TTLs to
+// exercise expiry.
 type Config struct {
-	// NATSConn is the live NATS connection. Manager does not dial; the
+	// NATSConn is the live NATS connection. Sessions does not dial; the
 	// caller owns connect/disconnect lifecycle. Required.
 	NATSConn *nats.Conn
 
@@ -61,7 +62,7 @@ type Config struct {
 }
 
 // Validate returns an error describing the first invalid field, or nil
-// if the config is acceptable. Manager.Open calls Validate before any
+// if the config is acceptable. Open calls Validate before any
 // substrate work so callers see config issues with no NATS round-trip.
 func (c Config) Validate() error {
 	if c.NATSConn == nil {
@@ -70,11 +71,22 @@ func (c Config) Validate() error {
 	return nil
 }
 
-// Manager owns the JetStream KV bucket holding swarm session records.
+// Sessions owns the JetStream KV bucket holding swarm session records.
+// Reads (Get, List) are public — `bones swarm status`, `bones doctor`,
+// and slot-resolution helpers in the CLI consume them directly.
+// Mutations (put, update, delete) are unexported; the only legal
+// mutator is `swarm.Lease`, which lives in the same package.
+//
+// The narrow public surface enforces the seam called out in ADR 0034:
+// the lifecycle of a session record is owned end-to-end by Lease, so
+// outside callers cannot bypass Lease's invariants (host match, CAS
+// revision tracking, claim-bound writes).
+//
 // Every public method is safe to call concurrently. Close is
-// idempotent. Unlike presence.Manager, there is no heartbeat goroutine
-// — callers (the bones swarm verbs) drive renewal via Update.
-type Manager struct {
+// idempotent. Unlike presence.Manager there is no heartbeat goroutine
+// — callers (the bones swarm verbs, via Lease) drive renewal via
+// CAS update.
+type Sessions struct {
 	cfg    Config
 	js     jetstream.JetStream
 	kv     jetstream.KeyValue
@@ -82,10 +94,10 @@ type Manager struct {
 }
 
 // Open creates (or reattaches to) the swarm sessions KV bucket and
-// returns a Manager. Caller must Close at shutdown. Open does not
-// dial NATS: the connection comes pre-wired so reconnect policy stays
-// a single-source concern (same shape as presence.Open).
-func Open(ctx context.Context, cfg Config) (*Manager, error) {
+// returns a Sessions handle. Caller must Close at shutdown. Open does
+// not dial NATS: the connection comes pre-wired so reconnect policy
+// stays a single-source concern (same shape as presence.Open).
+func Open(ctx context.Context, cfg Config) (*Sessions, error) {
 	assert.NotNil(ctx, "swarm.Open: ctx is nil")
 	if err := cfg.Validate(); err != nil {
 		return nil, err
@@ -111,128 +123,132 @@ func Open(ctx context.Context, cfg Config) (*Manager, error) {
 	}
 	cfg.BucketName = bucket
 	cfg.TTL = ttl
-	return &Manager{cfg: cfg, js: js, kv: kv}, nil
+	return &Sessions{cfg: cfg, js: js, kv: kv}, nil
 }
 
-// Close marks the Manager closed so subsequent public calls return
-// ErrClosed. Safe to call more than once. Does not delete bucket
-// contents; sessions outlive the process that wrote them (TTL
+// Close marks the Sessions handle closed so subsequent public calls
+// return ErrClosed. Safe to call more than once. Does not delete
+// bucket contents; sessions outlive the process that wrote them (TTL
 // eventually evicts).
-func (m *Manager) Close() error {
-	assert.NotNil(m, "swarm.Close: receiver is nil")
-	m.closed.Store(true)
+func (s *Sessions) Close() error {
+	assert.NotNil(s, "swarm.Sessions.Close: receiver is nil")
+	s.closed.Store(true)
 	return nil
 }
 
 // BucketName returns the bucket name in use. Useful for diagnostics
 // and for `bones doctor` to mention the right bucket in its messages.
-func (m *Manager) BucketName() string {
-	assert.NotNil(m, "swarm.BucketName: receiver is nil")
-	return m.cfg.BucketName
+func (s *Sessions) BucketName() string {
+	assert.NotNil(s, "swarm.Sessions.BucketName: receiver is nil")
+	return s.cfg.BucketName
 }
 
 // Get reads the session record for slot. Returns ErrNotFound if no
 // record exists. The returned revision is the JetStream KV sequence
-// number suitable for a follow-up CAS Update or Delete.
-func (m *Manager) Get(
+// number suitable for a follow-up CAS update or delete (callable only
+// from inside the swarm package — see ADR 0034).
+func (s *Sessions) Get(
 	ctx context.Context, slot string,
 ) (Session, uint64, error) {
-	assert.NotNil(ctx, "swarm.Get: ctx is nil")
-	assert.NotEmpty(slot, "swarm.Get: slot is empty")
-	if m.closed.Load() {
+	assert.NotNil(ctx, "swarm.Sessions.Get: ctx is nil")
+	assert.NotEmpty(slot, "swarm.Sessions.Get: slot is empty")
+	if s.closed.Load() {
 		return Session{}, 0, ErrClosed
 	}
-	kve, err := m.kv.Get(ctx, slot)
+	kve, err := s.kv.Get(ctx, slot)
 	if err != nil {
 		if errors.Is(err, jetstream.ErrKeyNotFound) {
 			return Session{}, 0, ErrNotFound
 		}
-		return Session{}, 0, fmt.Errorf("swarm.Get: %w", err)
+		return Session{}, 0, fmt.Errorf("swarm.Sessions.Get: %w", err)
 	}
 	if kve.Operation() != jetstream.KeyValuePut {
 		return Session{}, 0, ErrNotFound
 	}
-	s, err := decode(kve.Value())
+	sess, err := decode(kve.Value())
 	if err != nil {
-		return Session{}, 0, fmt.Errorf("swarm.Get: %w", err)
+		return Session{}, 0, fmt.Errorf("swarm.Sessions.Get: %w", err)
 	}
-	return s, kve.Revision(), nil
+	return sess, kve.Revision(), nil
 }
 
-// Put writes the session record for sess.Slot as a fresh entry. Fails
+// put writes the session record for sess.Slot as a fresh entry. Fails
 // (with ErrCASConflict) if a record already exists at that slot —
-// callers must Delete first to take over an abandoned slot. Mirrors
-// the create-or-update split in internal/tasks.
-func (m *Manager) Put(ctx context.Context, sess Session) error {
-	assert.NotNil(ctx, "swarm.Put: ctx is nil")
-	assert.NotEmpty(sess.Slot, "swarm.Put: sess.Slot is empty")
-	if m.closed.Load() {
+// callers must delete first to take over an abandoned slot. Mirrors
+// the create-or-update split in internal/tasks. Unexported: only
+// `swarm.Lease` is permitted to mutate session state.
+func (s *Sessions) put(ctx context.Context, sess Session) error {
+	assert.NotNil(ctx, "swarm.Sessions.put: ctx is nil")
+	assert.NotEmpty(sess.Slot, "swarm.Sessions.put: sess.Slot is empty")
+	if s.closed.Load() {
 		return ErrClosed
 	}
 	payload, err := encode(sess)
 	if err != nil {
 		return err
 	}
-	if _, err := m.kv.Create(ctx, sess.Slot, payload); err != nil {
+	if _, err := s.kv.Create(ctx, sess.Slot, payload); err != nil {
 		if jskv.IsConflict(err) {
 			return ErrCASConflict
 		}
-		return fmt.Errorf("swarm.Put: %w", err)
+		return fmt.Errorf("swarm.Sessions.put: %w", err)
 	}
 	return nil
 }
 
-// Update overwrites the session record for sess.Slot using a CAS gate
+// update overwrites the session record for sess.Slot using a CAS gate
 // against expectedRev. Returns ErrCASConflict if the bucket's current
 // revision differs from expectedRev — another writer raced ours and
 // the caller should re-Get and decide whether to retry.
 //
-// Update is the heartbeat path: `bones swarm commit` reads the
-// current session, updates LastRenewed, and CAS-writes back.
-func (m *Manager) Update(
+// update is the heartbeat path: `bones swarm commit` (via Lease) reads
+// the current session, updates LastRenewed, and CAS-writes back.
+// Unexported: only `swarm.Lease` is permitted to mutate.
+func (s *Sessions) update(
 	ctx context.Context, sess Session, expectedRev uint64,
 ) error {
-	assert.NotNil(ctx, "swarm.Update: ctx is nil")
-	assert.NotEmpty(sess.Slot, "swarm.Update: sess.Slot is empty")
-	if m.closed.Load() {
+	assert.NotNil(ctx, "swarm.Sessions.update: ctx is nil")
+	assert.NotEmpty(sess.Slot, "swarm.Sessions.update: sess.Slot is empty")
+	if s.closed.Load() {
 		return ErrClosed
 	}
 	payload, err := encode(sess)
 	if err != nil {
 		return err
 	}
-	if _, err := m.kv.Update(ctx, sess.Slot, payload, expectedRev); err != nil {
+	if _, err := s.kv.Update(ctx, sess.Slot, payload, expectedRev); err != nil {
 		if jskv.IsConflict(err) {
 			return ErrCASConflict
 		}
-		return fmt.Errorf("swarm.Update: %w", err)
+		return fmt.Errorf("swarm.Sessions.update: %w", err)
 	}
 	return nil
 }
 
-// Delete removes the session record at slot via a CAS gate against
+// delete removes the session record at slot via a CAS gate against
 // expectedRev. ErrCASConflict on revision mismatch — callers should
 // re-Get and retry only if they still want to delete the (newer)
 // record. ErrNotFound if the key was already missing.
 //
-// Delete is the close path: `bones swarm close` removes the session
-// after posting the dispatch result and stopping the leaf.
-func (m *Manager) Delete(
+// delete is the close path: `bones swarm close` (via Lease) removes
+// the session after posting the dispatch result and stopping the
+// leaf. Unexported: only `swarm.Lease` is permitted to mutate.
+func (s *Sessions) delete(
 	ctx context.Context, slot string, expectedRev uint64,
 ) error {
-	assert.NotNil(ctx, "swarm.Delete: ctx is nil")
-	assert.NotEmpty(slot, "swarm.Delete: slot is empty")
-	if m.closed.Load() {
+	assert.NotNil(ctx, "swarm.Sessions.delete: ctx is nil")
+	assert.NotEmpty(slot, "swarm.Sessions.delete: slot is empty")
+	if s.closed.Load() {
 		return ErrClosed
 	}
-	if err := m.kv.Delete(ctx, slot, jetstream.LastRevision(expectedRev)); err != nil {
+	if err := s.kv.Delete(ctx, slot, jetstream.LastRevision(expectedRev)); err != nil {
 		if jskv.IsConflict(err) {
 			return ErrCASConflict
 		}
 		if errors.Is(err, jetstream.ErrKeyNotFound) {
 			return ErrNotFound
 		}
-		return fmt.Errorf("swarm.Delete: %w", err)
+		return fmt.Errorf("swarm.Sessions.delete: %w", err)
 	}
 	return nil
 }
@@ -246,14 +262,19 @@ const maxSessionEntries = 1024
 // List returns every live session in the bucket. Order matches the
 // underlying JetStream KV list order (key-name lexicographic in
 // practice; callers that need a specific order should sort).
-func (m *Manager) List(ctx context.Context) ([]Session, error) {
-	assert.NotNil(ctx, "swarm.List: ctx is nil")
-	if m.closed.Load() {
+//
+// List is the canonical read-across-slots seam — `bones swarm status`,
+// `bones doctor`, and CLI slot-resolution helpers all consume it.
+// Per ADR 0034, this is one of the read methods that justify keeping
+// Sessions as a public type at all (versus folding into Lease).
+func (s *Sessions) List(ctx context.Context) ([]Session, error) {
+	assert.NotNil(ctx, "swarm.Sessions.List: ctx is nil")
+	if s.closed.Load() {
 		return nil, ErrClosed
 	}
-	lister, err := m.kv.ListKeys(ctx)
+	lister, err := s.kv.ListKeys(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("swarm.List: list keys: %w", err)
+		return nil, fmt.Errorf("swarm.Sessions.List: list keys: %w", err)
 	}
 	defer func() { _ = lister.Stop() }()
 	var out []Session
@@ -261,24 +282,24 @@ func (m *Manager) List(ctx context.Context) ([]Session, error) {
 	for key := range lister.Keys() {
 		assert.Precondition(
 			count < maxSessionEntries,
-			"swarm.List: scanned more than %d entries", maxSessionEntries,
+			"swarm.Sessions.List: scanned more than %d entries", maxSessionEntries,
 		)
 		count++
-		kve, err := m.kv.Get(ctx, key)
+		kve, err := s.kv.Get(ctx, key)
 		if err != nil {
 			if errors.Is(err, jetstream.ErrKeyNotFound) {
 				continue
 			}
-			return nil, fmt.Errorf("swarm.List: get %q: %w", key, err)
+			return nil, fmt.Errorf("swarm.Sessions.List: get %q: %w", key, err)
 		}
 		if kve.Operation() != jetstream.KeyValuePut {
 			continue
 		}
-		s, err := decode(kve.Value())
+		sess, err := decode(kve.Value())
 		if err != nil {
-			return nil, fmt.Errorf("swarm.List: decode %q: %w", key, err)
+			return nil, fmt.Errorf("swarm.Sessions.List: decode %q: %w", key, err)
 		}
-		out = append(out, s)
+		out = append(out, sess)
 	}
 	return out, nil
 }
@@ -292,8 +313,8 @@ func (m *Manager) List(ctx context.Context) ([]Session, error) {
 //	└── wt/                  worktree (Leaf.WT() result)
 //
 // Pure path derivation; no KV lookup. Callers can compute this
-// without opening a Manager — `bones swarm cwd` exploits exactly
-// that to avoid a NATS round-trip for a path query.
+// without opening a Sessions handle — `bones swarm cwd` exploits
+// exactly that to avoid a NATS round-trip for a path query.
 func SlotDir(workspaceDir, slot string) string {
 	assert.NotEmpty(workspaceDir, "swarm.SlotDir: workspaceDir is empty")
 	assert.NotEmpty(slot, "swarm.SlotDir: slot is empty")

--- a/internal/swarm/swarm_test.go
+++ b/internal/swarm/swarm_test.go
@@ -19,9 +19,9 @@ func uniqueBucket(t *testing.T) string {
 	return "bones-swarm-test-" + strings.ReplaceAll(t.Name(), "/", "-")
 }
 
-func openManager(t *testing.T, nc *nats.Conn) *Manager {
+func openSessions(t *testing.T, nc *nats.Conn) *Sessions {
 	t.Helper()
-	m, err := Open(context.Background(), Config{
+	s, err := Open(context.Background(), Config{
 		NATSConn:   nc,
 		BucketName: uniqueBucket(t),
 		TTL:        time.Minute,
@@ -29,8 +29,8 @@ func openManager(t *testing.T, nc *nats.Conn) *Manager {
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
-	t.Cleanup(func() { _ = m.Close() })
-	return m
+	t.Cleanup(func() { _ = s.Close() })
+	return s
 }
 
 func sampleSession(slot, taskID string) Session {
@@ -54,14 +54,14 @@ func TestConfigValidate(t *testing.T) {
 
 func TestPutGet(t *testing.T) {
 	nc, _ := natstest.NewJetStreamServer(t)
-	m := openManager(t, nc)
+	s := openSessions(t, nc)
 
 	sess := sampleSession("rendering", "task-rendering-1")
-	if err := m.Put(context.Background(), sess); err != nil {
-		t.Fatalf("Put: %v", err)
+	if err := s.put(context.Background(), sess); err != nil {
+		t.Fatalf("put: %v", err)
 	}
 
-	got, rev, err := m.Get(context.Background(), "rendering")
+	got, rev, err := s.Get(context.Background(), "rendering")
 	if err != nil {
 		t.Fatalf("Get: %v", err)
 	}
@@ -75,9 +75,9 @@ func TestPutGet(t *testing.T) {
 
 func TestGet_NotFound(t *testing.T) {
 	nc, _ := natstest.NewJetStreamServer(t)
-	m := openManager(t, nc)
+	s := openSessions(t, nc)
 
-	_, _, err := m.Get(context.Background(), "missing")
+	_, _, err := s.Get(context.Background(), "missing")
 	if !errors.Is(err, ErrNotFound) {
 		t.Fatalf("Get: want ErrNotFound, got %v", err)
 	}
@@ -85,71 +85,71 @@ func TestGet_NotFound(t *testing.T) {
 
 func TestPut_DuplicateConflict(t *testing.T) {
 	nc, _ := natstest.NewJetStreamServer(t)
-	m := openManager(t, nc)
+	s := openSessions(t, nc)
 
 	sess := sampleSession("audio", "task-audio-1")
-	if err := m.Put(context.Background(), sess); err != nil {
-		t.Fatalf("first Put: %v", err)
+	if err := s.put(context.Background(), sess); err != nil {
+		t.Fatalf("first put: %v", err)
 	}
-	if err := m.Put(context.Background(), sess); !errors.Is(err, ErrCASConflict) {
-		t.Fatalf("second Put: want ErrCASConflict, got %v", err)
+	if err := s.put(context.Background(), sess); !errors.Is(err, ErrCASConflict) {
+		t.Fatalf("second put: want ErrCASConflict, got %v", err)
 	}
 }
 
 func TestUpdate_CAS(t *testing.T) {
 	nc, _ := natstest.NewJetStreamServer(t)
-	m := openManager(t, nc)
+	s := openSessions(t, nc)
 
 	sess := sampleSession("physics", "task-physics-1")
-	if err := m.Put(context.Background(), sess); err != nil {
-		t.Fatalf("Put: %v", err)
+	if err := s.put(context.Background(), sess); err != nil {
+		t.Fatalf("put: %v", err)
 	}
-	got, rev, err := m.Get(context.Background(), "physics")
+	got, rev, err := s.Get(context.Background(), "physics")
 	if err != nil {
 		t.Fatalf("Get: %v", err)
 	}
 	got.LastRenewed = time.Now().UTC().Add(time.Minute).Truncate(time.Second)
-	if err := m.Update(context.Background(), got, rev); err != nil {
-		t.Fatalf("Update: %v", err)
+	if err := s.update(context.Background(), got, rev); err != nil {
+		t.Fatalf("update: %v", err)
 	}
 
-	// Second Update with the now-stale revision must conflict.
-	if err := m.Update(context.Background(), got, rev); !errors.Is(err, ErrCASConflict) {
-		t.Fatalf("stale Update: want ErrCASConflict, got %v", err)
+	// Second update with the now-stale revision must conflict.
+	if err := s.update(context.Background(), got, rev); !errors.Is(err, ErrCASConflict) {
+		t.Fatalf("stale update: want ErrCASConflict, got %v", err)
 	}
 }
 
 func TestDelete_CAS(t *testing.T) {
 	nc, _ := natstest.NewJetStreamServer(t)
-	m := openManager(t, nc)
+	s := openSessions(t, nc)
 
 	sess := sampleSession("ui", "task-ui-1")
-	if err := m.Put(context.Background(), sess); err != nil {
-		t.Fatalf("Put: %v", err)
+	if err := s.put(context.Background(), sess); err != nil {
+		t.Fatalf("put: %v", err)
 	}
-	_, rev, err := m.Get(context.Background(), "ui")
+	_, rev, err := s.Get(context.Background(), "ui")
 	if err != nil {
 		t.Fatalf("Get: %v", err)
 	}
-	if err := m.Delete(context.Background(), "ui", rev); err != nil {
-		t.Fatalf("Delete: %v", err)
+	if err := s.delete(context.Background(), "ui", rev); err != nil {
+		t.Fatalf("delete: %v", err)
 	}
 
-	if _, _, err := m.Get(context.Background(), "ui"); !errors.Is(err, ErrNotFound) {
+	if _, _, err := s.Get(context.Background(), "ui"); !errors.Is(err, ErrNotFound) {
 		t.Fatalf("post-delete Get: want ErrNotFound, got %v", err)
 	}
 }
 
 func TestList(t *testing.T) {
 	nc, _ := natstest.NewJetStreamServer(t)
-	m := openManager(t, nc)
+	s := openSessions(t, nc)
 
 	for _, slot := range []string{"a", "b", "c"} {
-		if err := m.Put(context.Background(), sampleSession(slot, "task-"+slot)); err != nil {
-			t.Fatalf("Put %s: %v", slot, err)
+		if err := s.put(context.Background(), sampleSession(slot, "task-"+slot)); err != nil {
+			t.Fatalf("put %s: %v", slot, err)
 		}
 	}
-	got, err := m.List(context.Background())
+	got, err := s.List(context.Background())
 	if err != nil {
 		t.Fatalf("List: %v", err)
 	}
@@ -175,12 +175,12 @@ func TestSlotDirHelpers(t *testing.T) {
 
 func TestClose_ReturnsErrClosedAfter(t *testing.T) {
 	nc, _ := natstest.NewJetStreamServer(t)
-	m := openManager(t, nc)
+	s := openSessions(t, nc)
 
-	if err := m.Close(); err != nil {
+	if err := s.Close(); err != nil {
 		t.Fatalf("Close: %v", err)
 	}
-	if _, _, err := m.Get(context.Background(), "x"); !errors.Is(err, ErrClosed) {
+	if _, _, err := s.Get(context.Background(), "x"); !errors.Is(err, ErrClosed) {
 		t.Fatalf("Get after Close: want ErrClosed, got %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

- Rename `swarm.Manager` → `swarm.Sessions`. Keep `Get`/`List`/`Close`/`BucketName` public; move `put`/`update`/`delete` to package-private.
- `swarm.Lease` (same package) remains the only legal mutator of `bones-swarm-sessions`. External packages physically cannot bypass Lease's host-match / claim-binding / CAS-revision invariants.
- Architecture rationale recorded in [ADR 0034](./docs/adr/0034-swarm-sessions-narrowing.md). [ADR 0031](./docs/adr/0031-lease-runtime-slot-view.md) annotated with forward pointer.

## Why

Post-ADR 0031, \`swarm.Manager\` had two asymmetric consumer populations:

| Population | Calls | Why |
|---|---|---|
| \`swarm.Lease\` | \`Get\` + \`Put\` + \`Update\` + \`Delete\` (CAS dance) | Only legal lifecycle owner of the session record. |
| \`cli.resolveSlot\`, \`cli.SwarmStatusCmd\`, \`cli.DoctorCmd\` | \`List\` (read-only) | Workspace-level "which slots are live?" — doesn't fit on a per-slot Lease. |

One adapter, wide public interface, two populations: per the rule of two adapters, narrowing the public surface concentrates write logic in Lease (where it already lives) without breaking the read seam.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`make check\` — fmt-check, vet, lint, race, todo-check all pass
- [x] \`go test ./internal/swarm/... -race\` — substrate-CAS contract tests still exercise lowercase \`put\`/\`update\`/\`delete\` (same-package access)
- [x] Lease integration tests (real NATS + real Fossil per ADR 0030) pass unchanged
- [x] CLI verbs (\`swarm join\`, \`swarm commit\`, \`swarm close\`, \`swarm status\`, \`bones doctor\`) continue to compile and link
- [x] Rebased onto current main (PRs #63 + #64 landed during this work; ADR renumbered 0032 → 0034 to avoid collision; CONTEXT.md merged with new "Work shape" section)
- [ ] Manual smoke: \`bones up\` → \`bones swarm join\` → \`bones swarm status\` → \`bones swarm close\` against a real workspace