### PR TITLE
ADR 0033: typed coordination primitives + redesign plan

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -61,7 +61,12 @@ claim hold, and the session record. Acquired fresh by `swarm join`
 (creates the session record), resumed by `swarm commit` and
 `swarm close` (read existing record). One lease per CLI invocation;
 the persistent state across invocations is the session record in
-`bones-swarm-sessions[slot]`, not the lease itself. See ADR 0028.
+`bones-swarm-sessions[slot]`, not the lease itself. The lifecycle is
+encoded in two compile-time-distinct types: **`FreshLease`** (returned
+by `swarm.Acquire`, used by `swarm join`) and **`ResumedLease`**
+(returned by `swarm.Resume`, used by every other verb). Each lifecycle
+transition consumes the receiver; double-acquire, post-close use, and
+`Close`-without-`Resume` are compile errors. See ADRs 0028 and 0033.
 
 **Claim.** An exclusive bind between an agent and a task. Backed by
 a fossil-recorded ownership marker plus a hold. Released when the
@@ -70,6 +75,15 @@ task is closed or the lease ends. See ADR 0007.
 **Hold.** A scoped exclusive resource lock with a TTL, used to gate
 claim handoff and reclamation. Lives in `bones-holds` (NATS
 JetStream KV). See ADR 0007 (claim lifecycle).
+
+**Path.** A typed coordination key for a workspace file
+(`coord.Path`). A newtype around `string`, constructed via
+`Path.FromRelative(workspaceDir, rel)` or `Path.FromAbsolute(abs)`,
+validated at construction (must resolve inside the workspace's
+working tree; trailing slashes stripped). `Holds` and `coord`
+interfaces accept `Path` instead of `string`; `coord.File.Path` is a
+`Path`. The newtype owns absolute-vs-relative-vs-key conversion so
+no caller hand-rolls normalization. See ADR 0033.
 
 **Session record.** The per-slot row in
 `bones-swarm-sessions[slot]` (`swarm.Session` type) that ties a

--- a/docs/adr/0028-bones-swarm-verbs.md
+++ b/docs/adr/0028-bones-swarm-verbs.md
@@ -1,6 +1,7 @@
 # ADR 0028 — Bones swarm: verbs and lease
 
 **Status:** Accepted (2026-04-28, lease merge 2026-04-29)
+**Refined by:** ADR 0033 — Lease lifecycle encoded in two compile-time-distinct types (`FreshLease`, `ResumedLease`); `coord.Path` newtype
 
 ## Context
 

--- a/docs/adr/0033-typed-coordination-primitives.md
+++ b/docs/adr/0033-typed-coordination-primitives.md
@@ -1,0 +1,142 @@
+# ADR 0033 — Typed coordination primitives
+
+**Status:** Accepted (2026-04-29)
+**Refines:** ADR 0028 (bones swarm: verbs and lease)
+
+## Context
+
+`internal/swarm.Lease` (ADR 0028) holds a four-step lifecycle —
+acquire, resume, commit, close — whose ordering is documented in
+comments and enforced at runtime. `Resume` on a slot with no session
+record fails with `ErrSessionNotFound`. Calling `Release` after
+`Close`, or `Close` twice, succeeds quietly. The session-record CAS
+revision is held inside the lease and never threaded through the call
+sites — concurrent `Close`s between `Resume` and `Commit` can produce
+a local fossil commit that the session record never bumps to. These
+are obscure dependencies in the Ousterhout sense: methods that work
+only if invoked in a specific order, with no compile-time fence
+preventing misuse.
+
+`coord.File.Path` carries two contracts in one `string` field: the
+absolute-workspace path used as a hold key by `coord.checkHolds`, and
+the relative path consumed by libfossil at commit time. Path
+normalization happens hand-rolled in
+`cli/swarm_commit.go:gatherCommitFiles` and is assumed downstream;
+trailing-slash, symlink, and outside-workspace cases are not centrally
+handled. No module owns "file path as a coordination key."
+
+## Decision
+
+Encode the Lease lifecycle in two distinct types and add a typed
+coordination `Path`.
+
+`internal/swarm` exposes:
+
+- **`FreshLease`** — returned only by
+  `swarm.Acquire(ctx, slot, taskID)`. Owns fresh session-record
+  creation (CAS-PutIfAbsent), claim acquisition, hold acquisition.
+  Methods: `Resume() ResumedLease`, `Abort(ctx) error`. Either method
+  consumes the receiver.
+- **`ResumedLease`** — returned by `swarm.Resume(ctx, slot)` or by
+  `FreshLease.Resume()`. Methods: `Commit(ctx, []coord.Path) (Commit,
+  ResumedLease, error)`, `Close(ctx) error`, accessors `Slot()`,
+  `TaskID()`, `WT()`. CAS revision is private; `Commit` returns a
+  fresh `ResumedLease` whose rev is valid at commit time. `Close`
+  consumes the receiver.
+
+The fresh-vs-resume entry-point distinction that ADR 0028 names
+remains. Their return types are now compile-time distinct.
+
+`internal/coord` exposes:
+
+- **`Path`** — newtype around `string`. Constructors:
+  `Path.FromRelative(workspaceDir, rel string) (Path, error)`,
+  `Path.FromAbsolute(abs string) (Path, error)`. Accessors:
+  `AsAbsolute() string`, `AsRelative(workspaceDir string) string`,
+  `AsKey() string`. `coord.File.Path` is typed `coord.Path`. `Holds`
+  and `coord` interfaces accept `Path` instead of `string`.
+
+`Path` constructors validate: input resolves to a path inside the
+workspace's working tree (escape via `..` or symlink rejected),
+trailing slashes stripped, case preserved as given. Constructors
+return an error rather than producing a value that fails downstream.
+
+`Lease.Leaf()`, the deprecated-on-arrival accessor named in ADR 0028,
+is removed. Callers use `Lease.WT()` or other typed accessors.
+
+## Consequences
+
+**Pulled-down complexity.** Callers stop tracking the session-record
+revision; CAS retries live inside the Lease implementation and surface
+conflicts as a typed `ErrSessionConflict`. CLI verbs no longer
+hand-roll path normalization. The `FreshLease`/`ResumedLease` split
+makes double-acquire, post-close use, and `Close`-without-`Resume`
+compile errors. The largest class of obscure-dependency bugs in the
+swarm verbs becomes structurally impossible.
+
+**Pushed-up complexity.** Callers that mutate a `ResumedLease` thread
+the value returned by `Commit` instead of mutating in place — a single
+variable rebind per CLI verb. `Path` constructors return an error;
+CLI gathers files once at verb start and propagates the error the
+same way it propagates other input-validation errors.
+
+**Invariants and where they're enforced.**
+
+1. *Lease state machine.* `FreshLease.Resume` and `FreshLease.Abort`
+   each consume the receiver. `ResumedLease.Close` consumes the
+   receiver. `Commit` returns a fresh `ResumedLease`. Enforced by Go
+   value semantics plus return-only types (no public constructors
+   beyond the named entry points). Test:
+   `internal/swarm/lease_test.go` exercises the transitions against
+   an embedded NATS hub.
+
+2. *CAS revision freshness.* Every `ResumedLease` instance holds a
+   rev valid at construction. `Commit` returns a `ResumedLease` whose
+   rev is valid at commit time. Stale-rev conflicts surface as
+   `ErrSessionConflict` from `Commit`/`Close`. Test: a real-substrate
+   test in `internal/swarm/lease_test.go` triggers concurrent
+   `Close`s between `Resume` and `Commit` and asserts the conflict.
+
+3. *Path validity.* A `coord.Path` value is always a syntactically
+   and semantically valid absolute workspace path. Test:
+   `internal/coord/path_test.go` covers trailing slash, symlinks,
+   outside-workspace, case sensitivity, and the relative-from
+   constructor.
+
+4. *Hold-key stability.* `Path.AsKey()` is deterministic for a given
+   absolute path. `Holds` and `checkHolds` agree by construction;
+   renaming `Path`'s internals does not change the key. Test:
+   `internal/holds/holds_test.go` round-trips `Acquire`/`Release`
+   through `Path` and verifies cross-construction equality.
+
+The `Lease.Leaf()` removal is observable: any external caller of that
+method becomes a compile error after the refinement. There are no
+external callers (`internal/` package).
+
+## Out of scope
+
+- Verb surface decisions — verb names, flag set, output formats,
+  `--json` schema. Settled by a later ADR alongside the
+  bootstrap-helper consolidation.
+- Substrate manager scaffold (`managerBase`). Orthogonal to the
+  Lease type split; covered by an update to ADR 0025.
+- `dispatch`'s domain-local `Task` and `Reclaimer` interfaces, and
+  the `coord.TaskSubject` newtype that supports them. Orthogonal to
+  this ADR.
+
+## References
+
+- ADR 0007 — claim semantics. The claim+hold protocol moves entirely
+  behind the Lease seam; Lease implementations call into
+  `coord.Claim` and `holds.Acquire` privately.
+- ADR 0023 — hub-and-leaf orchestrator. Lease remains the runtime
+  view of a slot.
+- ADR 0028 — bones swarm verbs and lease. The two-type split refines
+  the fresh-vs-resume distinction described there; the verb set, the
+  session-record schema, and the architectural invariants in 0028
+  stand unchanged.
+- ADR 0030 — real-substrate tests over mocks. New Lease and `Path`
+  tests follow the same discipline.
+- ADR 0032 — package boundary criteria. `coord.Path` keeps `coord`
+  as its package because `Path` belongs with the substrate primitives,
+  not because it justifies a new package.

--- a/docs/audits/2026-04-29-ousterhout-redesign-plan.md
+++ b/docs/audits/2026-04-29-ousterhout-redesign-plan.md
@@ -1,0 +1,249 @@
+# Ousterhout Redesign Plan
+
+Sequenced plan to absorb the 7 architecture-review candidates and 11 Ousterhout
+findings from the 2026-04-29 audit. End state: deeper Lease, type-enforced
+lifecycle, typed Path, decoupled Dispatch, shared substrate manager scaffold,
+shared CLI verb bootstrap, and a verb surface scrubbed for clarity.
+
+## Decisions baked in (no further discussion needed)
+
+- **Lease state machine encoded in types.** Two types — `FreshLease`
+  (returned by `Acquire`) and `ResumedLease` (returned by `Resume`). `Commit`
+  and `Close` exist only on `ResumedLease`; double-close and double-acquire
+  become compile errors. _Why_: eliminates the largest class of obscure
+  dependencies.
+- **`Sessions` stays a read-only view.** `Get`/`List`/`Close` keep their
+  current narrow surface for `bones swarm status` and `bones doctor`.
+  All mutators stay private to the swarm package; only the Lease types
+  may invoke them.
+- **`coord.Path` is a newtype.** `coord.File` keeps its current name but
+  its `Path` field becomes `coord.Path`. Constructors:
+  `Path.FromRelative(workspaceDir, rel)` and `Path.FromAbsolute(abs)`. Holds
+  and Coord interfaces accept `Path`.
+- **Autosync stays a knob; default ON.** Lifted from `LeafConfig` to
+  `LeaseConfig`. CLI verbs accept `--no-autosync` for the cases the user
+  flagged ("there may be reasons to branch but I don't know when"). The
+  Leaf project-code cache contract gets documented.
+- **Dispatch defines its own `Task` and `Reclaimer` interfaces.** Coord
+  satisfies them. Justified by testability + locality — does not contradict
+  ADR 0025 (which permits domain → substrate imports) but reduces concrete
+  coupling. A `coord.TaskSubject` newtype prevents subject-format drift.
+- **Substrate managers compose a `managerBase`.** Embedding (Go-idiomatic),
+  not composition. Owns ctx/NC validation, bucket creation, channel-buffer
+  defaults, idempotent Close, done-atom race-fence.
+- **CLI verb names are open for renaming.** No external consumers; full
+  rename pass authorized. Skills, hooks, and scripts updated atomically
+  in the same PR as each rename.
+- **Real-substrate tests required.** Every new seam gets at least one
+  test that runs against embedded NATS + libfossil. Mocks remain
+  forbidden for substrate behavior (CONTEXT.md "Tests" section).
+
+## Phases
+
+Each phase = one PR unless noted. Phase boundaries respect dependencies;
+phases marked **parallelizable** can land in any order relative to one
+another once their predecessors are in.
+
+### Phase 0 — Prep
+
+Single small PR that lands before the redesign starts.
+
+- Add `Path`, `FreshLease`, `ResumedLease`, `Reclaimer`, `TaskSubject`,
+  `managerBase` to `CONTEXT.md` under existing sections (Topology / Coordination
+  / Layering as appropriate).
+- Add ADR `0033-typed-coordination-primitives.md` capturing the
+  type-encoded Lease lifecycle decision and the `Path` newtype rationale.
+  Architecture only — no migration prose, no PR refs (per ADR style memory).
+- Mark ADR 0028 with a forward pointer to 0033 in its header. Don't rewrite
+  it yet; that happens in Phase 2.
+
+### Phase 1 — `coord.Path` newtype
+
+Independent. Lands before Phase 2 so the Lease redesign uses `Path` from
+day one.
+
+- New `internal/coord/path.go` with `Path` newtype + constructors.
+- `coord.File.Path` field changes from `string` to `Path`.
+- `internal/holds/holds.go`: `Acquire`/`Release` take `[]coord.Path` instead
+  of `[]string`. Internal KV key derived via `Path.AsKey()`.
+- `internal/coord/coord.go`: `checkHolds` takes `[]coord.Path`.
+- `cli/swarm_commit.go:gatherCommitFiles` becomes ~10 lines: walk inputs,
+  call `Path.FromRelative` once each, return `[]coord.Path`.
+- Real-substrate tests covering: trailing slash, symlinked paths, paths
+  outside the workspace (rejected at construction), case-sensitivity on
+  case-insensitive filesystems.
+- Remove inline normalization comments from `coord/types.go`,
+  `swarm_commit.go`, `holdgate.go` — replaced by `Path` doc.
+
+### Phase 2 — Lease redesign (big-bang)
+
+The largest PR. Bundles candidates #1–3 from the architecture review and
+the Lease-related Ousterhout findings.
+
+- **Type split**:
+  - `FreshLease` — returned by `swarm.Acquire(ctx, slot, taskID)`. Owns
+    fresh session record creation, claim acquisition, hold acquisition.
+    Methods: `Resume() ResumedLease`, `Abort()`. No `Commit`, no `Close`.
+  - `ResumedLease` — returned by `swarm.Resume(ctx, slot)` or `FreshLease.Resume()`.
+    Methods: `Commit(ctx, []Path) (Commit, error)`, `Close(ctx) error`,
+    `WT() string`. Internally holds the fossil leaf, claim, holds, session
+    rev. CAS rev is private; `Commit` returns a new `ResumedLease` with
+    fresh rev, forcing the caller to thread it.
+- **Closer** absorbs all teardown ordering. `Close` is the only public
+  release path; double-close is a no-op (idempotent) but the type system
+  prevents post-close use because `Close` consumes the receiver
+  (returns nothing usable).
+- **Claim+Hold orchestrator** lives inside the Lease implementation as a
+  private helper invoked from `Acquire` and `Close`. Not exported. Real-substrate
+  tests target it through the Lease interface.
+- **Session mutator** is a private struct used by both Lease types. Owns
+  CAS retry on conflict, validates field consistency (TaskID without
+  AgentID = error at compile-impossible / runtime-rejected), surfaces
+  conflicts to the caller via a typed `ErrSessionConflict`.
+- **Delete** `Lease.Leaf()`. `swarm_commit.go` and `swarm_close.go` migrate
+  to `lease.WT()` in this same PR.
+- **`Sessions` audit**: confirm `Get`/`List` are read-only and stay
+  exported; remove anything else from the surface. Document that mutators
+  are intentionally unexported and only `Lease` may invoke them.
+- **ADR 0028 rewrite**: re-cast around the two-type model. Architecture
+  end state only — no migration narrative.
+- **ADR 0007 update**: tighten claim-lifecycle wording to reflect that
+  the Lease module owns the protocol; remove the "subagent must release
+  the claim" prescription where the Lease now guarantees it.
+
+### Phase 3 — Autosync seam
+
+Small PR. Lands after Phase 2 so `LeaseConfig` exists.
+
+- Add `LeaseConfig.Autosync bool` (default true). Plumb through
+  `Acquire`/`Resume`.
+- Remove `LeafConfig.Autosync`; `OpenLeaf` callers stop setting it.
+- `Leaf.Commit` doc gains a sentence describing the hub round-trip
+  performed when autosync is enabled.
+- `Leaf` project-code cache: add `Leaf.RefreshMetadata(ctx)` and document
+  the cache lifetime. Lease config gets `RefreshOnCommit` (default false)
+  for the rare case mid-session repo metadata changes.
+- `bones swarm join` and `bones swarm commit` get `--no-autosync` flags
+  with help text explaining the performance/safety trade-off.
+
+### Phase 4 — Dispatch decoupling — _parallelizable with Phase 5_
+
+Independent of Lease changes.
+
+- New file `internal/dispatch/task.go`: domain-local `Task`, `Reclaimer`
+  interfaces.
+- `BuildSpec` takes `Task` (the dispatch-local interface) instead of `coord.Task`.
+- `monitor.go:ReclaimClaim` takes `Reclaimer`.
+- `coord.TaskSubject` newtype in `internal/coord/types.go`. Constructed
+  only from a `coord.TaskID`. `cli/swarm_close.go:postResult` takes
+  `TaskSubject`.
+- Coord adapter (`internal/coord/dispatch_adapter.go`) implements
+  `dispatch.Task` and `dispatch.Reclaimer`. CLI/orchestrator wires it.
+- Dispatch tests drop the embedded-NATS dependency where possible
+  (still required for end-to-end paths; unit-level dispatch logic can
+  use minimal in-memory fakes against the new domain interfaces).
+
+### Phase 5 — CLI verb refresh — _parallelizable with Phase 4_
+
+Comes after Phase 2. Largest doc impact.
+
+- New helper `cli/swarm_bootstrap.go` exporting `BootstrapVerb(ctx, name,
+  preferredSlot string, work func(ResumedLease) error) error`. Owns:
+  workspace open, sessions handle, slot resolution, `Resume`, error
+  wrapping, deferred close.
+- All swarm verbs (`join`, `commit`, `close`, `status`, `list`, ...) migrate
+  to either the bootstrapper (verbs that need a lease) or a thinner
+  `BootstrapReadOnly` (verbs that need only `Sessions`).
+- `resolveSlot` consolidated to one function in `cli/swarm_helpers.go`.
+- **Rename pass.** Catalog every `bones` verb, flag, env var, JSON output
+  field, hook script. Apply renames where clarity wins:
+  - Audit candidates so far: `bones validate-plan` → `bones plan validate`;
+    `bones up` → keep; `bones doctor` → keep; status output formatting
+    pass for `--json` consistency across verbs.
+  - Final list decided in-PR; the rule is "rename only when the new
+    name materially clarifies."
+- `--json` flag pass: every verb that prints structured output supports
+  `--json` with a stable, documented schema.
+- **Skills, hooks, scripts updated atomically**:
+  - `.claude/skills/orchestrator` — invocations of any renamed verb.
+  - `.claude/skills/subagent` — same.
+  - Hook scripts scaffolded by `bones up` (find via
+    `grep -r "bones " .orchestrator/ scripts/`).
+  - `cmd/bones-up/` templates — the source of the scaffolded scripts.
+  - `Makefile` recipes that invoke `bones`.
+  - `README.md`, `GETTING_STARTED.md`, `AGENTS.md` — verb names anywhere
+    in narrative docs.
+  - `docs/adr/` — refs to old verb names get updated where cited as
+    architecture (not where cited as historical context).
+- New ADR `0034-cli-verb-surface.md` capturing the verb naming and
+  `--json` schema rules. Architecture only.
+
+### Phase 6 — Substrate manager scaffold
+
+Independent. Lands last to avoid churn against in-flight phases.
+
+- `internal/coord/managerbase.go` — `managerBase` struct with the shared
+  shape: ctx validation, NC handle, bucket open, channel buffers,
+  done atom, idempotent close.
+- Migrate `tasks.Manager`, `holds.Manager`, `presence.Manager`,
+  `chat.Manager` to embed `*managerBase`. Each loses ~60 lines of
+  boilerplate.
+- Real-substrate tests: a single `manager_test.go` in `internal/coord/`
+  exercising the close-race invariant once for the base; per-package
+  tests retain their domain-specific coverage.
+- `presence.Entry` JSON schema versioning: add `SchemaVersion int` field
+  with explicit invariant, or document the freeze in a comment + add a
+  test that fails if any field tag changes. Recommend the latter — less
+  ceremony, same effect.
+- ADR 0025 update: mention the manager base as the canonical substrate
+  manager shape. No new ADR needed.
+
+### Phase 7 — Cleanup
+
+Small final PR. Catches leftovers.
+
+- Verify CONTEXT.md is fully synchronized with the final code.
+- Audit ADRs for stale verb names, type names, function names.
+- Delete any `// deprecated-on-arrival` comments that should now be gone.
+- Run a fresh Ousterhout pass on the new Lease types — sanity check
+  that the redesign actually deepened the modules and didn't just move
+  shallow modules around.
+- Update `docs/architecture-backlog.md` (if relevant items now closed) or
+  delete entries that are subsumed.
+
+## Test strategy across phases
+
+- **No new mocks for substrate behavior.** Every new seam gets a
+  real-substrate test using `internal/testutil/natstest` and the
+  in-process hub helpers in `internal/coord`.
+- **Type-level tests where possible.** The `FreshLease`/`ResumedLease`
+  split is enforced by the compiler; add one test per type that
+  asserts the methods that should/shouldn't exist (compile-time guard
+  via `var _ interface{ ... } = FreshLease{}`).
+- **Concurrency tests** — the autosync linearization property
+  (15 commits across 5 slots, zero forks; CONTEXT.md autosync entry)
+  must continue to hold. Re-run that test after Phase 3.
+
+## ADR end state
+
+After Phase 7, the ADR set looks like:
+
+- 0007 — claim semantics, updated to reference Lease as the protocol owner.
+- 0023 — hub-leaf-orchestrator, updated for the new Lease types.
+- 0025 — substrate vs. domain, updated to reference `managerBase`.
+- 0028 — bones swarm verbs, rewritten around the two-type Lease model.
+- 0033 (new) — typed coordination primitives (Lease split, Path newtype).
+- 0034 (new) — CLI verb surface (naming rules, `--json` schema).
+
+No ADR is deleted. Superseded sections are marked, not stripped.
+
+## Out of scope
+
+The audit surfaced two items deliberately deferred:
+
+- **`Sessions` merge into `Lease`.** Decision: keep `Sessions` as a
+  read view; rich coupling to `Lease` is unnecessary for the read paths
+  that consume it (`status`, `doctor`).
+- **`presence.Entry` explicit schema versioning.** A test fence is
+  cheaper than a versioning protocol and catches the same drift.
+  Revisit only if a wire-incompatible change becomes necessary.


### PR DESCRIPTION
## Summary

- Adds **ADR 0033** — encodes the `swarm.Lease` lifecycle in two compile-time-distinct types (`FreshLease`, `ResumedLease`) and introduces `coord.Path` as a typed coordination key. Refines ADR 0028.
- Updates `CONTEXT.md`: amends the Lease entry to name both types and the consume-on-transition rule; adds a new **Path** entry under Coordination primitives.
- Adds a "**Refined by**" pointer in ADR 0028's header so the bidirectional ADR cross-link discipline holds.
- Lands the **seven-phase Ousterhout redesign plan** at `docs/audits/2026-04-29-ousterhout-redesign-plan.md`. This PR is Phase 0 (prep). Follow-up PRs: `coord.Path` (P1), Lease split (P2), Autosync seam (P3), Dispatch decoupling (P4, parallelizable), CLI verb refresh (P5, parallelizable), substrate `managerBase` (P6), cleanup pass (P7).

## Test plan

- [ ] ADR 0033 reads as architecture-only (no migration narrative, no PR refs, no audit dates in body)
- [ ] CONTEXT.md Lease entry names `FreshLease` / `ResumedLease` and the consume-on-transition rule
- [ ] CONTEXT.md Path entry explains absolute / relative / key conversion as the newtype's contract
- [ ] ADR 0028 header's "Refined by" line points to ADR 0033
- [ ] No code changes in this PR — doc-only

## Out of scope (deferred to follow-up phases)

- Implementing `coord.Path` (Phase 1)
- Implementing `FreshLease`/`ResumedLease` and removing `Lease.Leaf()` (Phase 2)
- Lifting `Autosync` to `LeaseConfig` (Phase 3)
- Dispatch's domain-local `Task`/`Reclaimer`, `coord.TaskSubject` (Phase 4)
- CLI verb rename pass + bootstrap helper + skill/hook/script updates (Phase 5)
- Substrate `managerBase` scaffold (Phase 6)