### PR TITLE
feat(coord): wspath.Path newtype + holds API migration

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -77,13 +77,15 @@ claim handoff and reclamation. Lives in `bones-holds` (NATS
 JetStream KV). See ADR 0007 (claim lifecycle).
 
 **Path.** A typed coordination key for a workspace file
-(`coord.Path`). A newtype around `string`, constructed via
-`Path.FromRelative(workspaceDir, rel)` or `Path.FromAbsolute(abs)`,
-validated at construction (must resolve inside the workspace's
-working tree; trailing slashes stripped). `Holds` and `coord`
-interfaces accept `Path` instead of `string`; `coord.File.Path` is a
-`Path`. The newtype owns absolute-vs-relative-vs-key conversion so
-no caller hand-rolls normalization. See ADR 0033.
+(`coord.Path`). A newtype carrying a single absolute, cleaned
+filesystem path. Constructed via `coord.NewPath(abs)` (re-exporting
+`wspath.New`) or `coord.NewPathRelative(workspaceDir, rel)`
+(re-exporting `wspath.NewRelative`); `wspath.Must` is the
+panic-on-error variant for tests. The implementation lives in
+`internal/wspath` so the substrate (`holds`) imports it without
+depending on `coord`. `holds.Announce`/`Release`/`WhoHas` and
+`coord.File.Path` are typed `wspath.Path`; no caller hand-rolls
+normalization. See ADR 0033.
 
 **Session record.** The per-slot row in
 `bones-swarm-sessions[slot]` (`swarm.Session` type) that ties a

--- a/cli/swarm_commit.go
+++ b/cli/swarm_commit.go
@@ -154,7 +154,10 @@ func gatherCommitFiles(
 		if err != nil {
 			return nil, fmt.Errorf("swarm commit: read %s: %w", abs, err)
 		}
-		taskPath := filepath.Join(info.WorkspaceDir, clean)
+		taskPath, err := coord.NewPathRelative(info.WorkspaceDir, clean)
+		if err != nil {
+			return nil, fmt.Errorf("swarm commit: path %q: %w", clean, err)
+		}
 		out = append(out, coord.File{
 			Path:    taskPath,
 			Name:    clean,
@@ -211,7 +214,10 @@ func discoverDirtyFiles(info workspace.Info, wt string) ([]coord.File, error) {
 		if err != nil {
 			return fmt.Errorf("rel %s: %w", path, err)
 		}
-		taskPath := filepath.Join(info.WorkspaceDir, rel)
+		taskPath, err := coord.NewPathRelative(info.WorkspaceDir, rel)
+		if err != nil {
+			return fmt.Errorf("path %s: %w", path, err)
+		}
 		out = append(out, coord.File{
 			Path:    taskPath,
 			Name:    rel,

--- a/cli/tasks_autoclaim_test.go
+++ b/cli/tasks_autoclaim_test.go
@@ -174,7 +174,7 @@ func TestRunAutoclaim_ClaimRace_ReturnsRaceLost(t *testing.T) {
 		t.Fatalf("second runAutoclaimTick: %v", second.err)
 	}
 
-	var sawClaimed, sawRaceLost bool
+	var sawClaimed, sawLost bool
 	for _, got := range []autoclaimResult{first.res, second.res} {
 		switch got.Action {
 		case autoclaimClaimed:
@@ -183,16 +183,24 @@ func TestRunAutoclaim_ClaimRace_ReturnsRaceLost(t *testing.T) {
 				t.Fatalf("claimed TaskID=%q, want %q", got.TaskID, id)
 			}
 		case autoclaimRaceLost:
-			sawRaceLost = true
+			sawLost = true
 			if got.TaskID != id {
 				t.Fatalf("race-lost TaskID=%q, want %q", got.TaskID, id)
 			}
+		case autoclaimNoReady:
+			// The loser ran list-ready after the winner's claim
+			// landed and observed no claimable tasks. From the
+			// caller's perspective indistinguishable from race-lost.
+			sawLost = true
 		default:
 			t.Fatalf("unexpected action %q", got.Action)
 		}
 	}
-	if !sawClaimed || !sawRaceLost {
-		t.Fatalf("want one claimed and one race-lost, got %#v and %#v", first.res, second.res)
+	if !sawClaimed || !sawLost {
+		t.Fatalf(
+			"want one claimed and one race-lost or no-ready, got %#v and %#v",
+			first.res, second.res,
+		)
 	}
 }
 

--- a/demos/space-invaders-orchestrate/main.go
+++ b/demos/space-invaders-orchestrate/main.go
@@ -153,8 +153,13 @@ func run() error {
 		if err != nil {
 			return fmt.Errorf("%s Claim: %w", s.slotID, err)
 		}
+		cp, err := coord.NewPath(s.path)
+		if err != nil {
+			_ = claim.Release()
+			return fmt.Errorf("%s path: %w", s.slotID, err)
+		}
 		uuid, err := l.Commit(ctx, claim, []coord.File{
-			{Path: s.path, Content: content},
+			{Path: cp, Content: content},
 		})
 		if err != nil {
 			_ = claim.Release()

--- a/docs/adr/0033-typed-coordination-primitives.md
+++ b/docs/adr/0033-typed-coordination-primitives.md
@@ -47,19 +47,30 @@ coordination `Path`.
 The fresh-vs-resume entry-point distinction that ADR 0028 names
 remains. Their return types are now compile-time distinct.
 
-`internal/coord` exposes:
+The substrate exposes:
 
-- **`Path`** — newtype around `string`. Constructors:
-  `Path.FromRelative(workspaceDir, rel string) (Path, error)`,
-  `Path.FromAbsolute(abs string) (Path, error)`. Accessors:
-  `AsAbsolute() string`, `AsRelative(workspaceDir string) string`,
-  `AsKey() string`. `coord.File.Path` is typed `coord.Path`. `Holds`
-  and `coord` interfaces accept `Path` instead of `string`.
+- **`Path`** — a newtype carrying a single absolute, cleaned
+  filesystem path. The implementation lives in `internal/wspath` so
+  the substrate (`holds`) can depend on it without importing `coord`;
+  `coord.Path` is a type alias re-export. Constructors are
+  `wspath.New(abs string) (Path, error)` for already-absolute input
+  and `wspath.NewRelative(workspaceDir, rel string) (Path, error)`
+  for join-and-anchor. Both return `ErrInvalid`-wrapped errors rather
+  than producing values that fail downstream. `coord.NewPath` and
+  `coord.NewPathRelative` are thin re-exports. `wspath.Must` is the
+  panic-on-error variant intended for tests and statically-known
+  inputs. Accessors: `AsAbsolute()`, `AsKey()`, `String()`,
+  `IsZero()`. `coord.File.Path` is typed `coord.Path`;
+  `holds.Announce`, `holds.Release`, `holds.WhoHas`, and
+  `holds.KeyForTest` accept `wspath.Path`.
 
-`Path` constructors validate: input resolves to a path inside the
-workspace's working tree (escape via `..` or symlink rejected),
-trailing slashes stripped, case preserved as given. Constructors
-return an error rather than producing a value that fails downstream.
+`wspath.New` validates the input is non-empty and absolute, then
+canonicalizes via `filepath.Clean` (collapses `.`, `..`, repeated
+separators, trailing slashes). `wspath.NewRelative` additionally
+rejects inputs whose cleaned join with `workspaceDir` escapes the
+workspace root via `..`. Symlink resolution is not part of the
+contract: Path values can refer to logical workspace-anchored
+coordination keys that need not exist on disk.
 
 `Lease.Leaf()`, the deprecated-on-arrival accessor named in ADR 0028,
 is removed. Callers use `Lease.WT()` or other typed accessors.
@@ -97,17 +108,18 @@ same way it propagates other input-validation errors.
    test in `internal/swarm/lease_test.go` triggers concurrent
    `Close`s between `Resume` and `Commit` and asserts the conflict.
 
-3. *Path validity.* A `coord.Path` value is always a syntactically
-   and semantically valid absolute workspace path. Test:
-   `internal/coord/path_test.go` covers trailing slash, symlinks,
-   outside-workspace, case sensitivity, and the relative-from
-   constructor.
+3. *Path validity.* A `wspath.Path` value is always a syntactically
+   valid absolute path; the relative-input constructor additionally
+   enforces workspace-anchoring. Test:
+   `internal/wspath/wspath_test.go` covers trailing slashes, redundant
+   segments, `..`-resolution within root, escape rejection in the
+   relative constructor, and zero-value detection.
 
 4. *Hold-key stability.* `Path.AsKey()` is deterministic for a given
    absolute path. `Holds` and `checkHolds` agree by construction;
    renaming `Path`'s internals does not change the key. Test:
-   `internal/holds/holds_test.go` round-trips `Acquire`/`Release`
-   through `Path` and verifies cross-construction equality.
+   `internal/holds/holds_test.go` round-trips `Announce`/`Release`
+   through `wspath.Path`.
 
 The `Lease.Leaf()` removal is observable: any external caller of that
 method becomes a compile error after the refinement. There are no

--- a/examples/herd-hub-leaf/agent.go
+++ b/examples/herd-hub-leaf/agent.go
@@ -126,7 +126,11 @@ func buildTaskFiles(slotIdx, taskIdx int, cfg Config, rng *rand.Rand) ([]coord.F
 		for j := range buf {
 			buf[j] = byte('a' + rng.Intn(26))
 		}
-		files[i] = coord.File{Path: p, Content: buf}
+		cp, err := coord.NewPath(p)
+		if err != nil {
+			panic(fmt.Errorf("buildTaskFiles: %w", err))
+		}
+		files[i] = coord.File{Path: cp, Content: buf}
 	}
 	return files, paths
 }

--- a/examples/hub-leaf-e2e/main.go
+++ b/examples/hub-leaf-e2e/main.go
@@ -281,8 +281,13 @@ func runSlot(
 	if err != nil {
 		return l, fmt.Errorf("claim %d: %w", i, err)
 	}
+	cp, err := coord.NewPath(path)
+	if err != nil {
+		_ = cl.Release()
+		return l, fmt.Errorf("path %d: %w", i, err)
+	}
 	if _, err := l.Commit(ctx, cl, []coord.File{
-		{Path: path, Content: []byte(fmt.Sprintf("v%d", i))},
+		{Path: cp, Content: []byte(fmt.Sprintf("v%d", i))},
 	}); err != nil {
 		_ = cl.Release()
 		return l, fmt.Errorf("commit %d: %w", i, err)

--- a/internal/coord/coord.go
+++ b/internal/coord/coord.go
@@ -17,7 +17,22 @@ import (
 	"github.com/danmestas/bones/internal/holds"
 	"github.com/danmestas/bones/internal/presence"
 	"github.com/danmestas/bones/internal/tasks"
+	"github.com/danmestas/bones/internal/wspath"
 )
+
+// pathFromTaskFile converts a Task record's stored file string into a
+// wspath.Path. Task records validate file paths as absolute at
+// OpenTask; a conversion failure here is substrate corruption, not a
+// runtime condition, so the helper asserts rather than returning an
+// error.
+func pathFromTaskFile(s string) wspath.Path {
+	p, err := wspath.New(s)
+	assert.Precondition(
+		err == nil,
+		"coord: invalid file path %q in task record: %v", s, err,
+	)
+	return p
+}
 
 // swarmSessionsTTL is the bucket TTL for bones-swarm-sessions.
 // Mirrors internal/swarm.DefaultTTL; duplicated here to avoid an
@@ -408,7 +423,7 @@ func (c *Coord) claimAll(
 		TTL:          ttl,
 	}
 	for _, f := range files {
-		if err := c.sub.holds.Announce(ctx, f, h); err != nil {
+		if err := c.sub.holds.Announce(ctx, pathFromTaskFile(f), h); err != nil {
 			return held, err
 		}
 		held = append(held, f)
@@ -421,7 +436,7 @@ func (c *Coord) claimAll(
 // path and a secondary failure must not mask the primary cause.
 func (c *Coord) rollback(ctx context.Context, held []string) {
 	for _, f := range held {
-		_ = c.sub.holds.Release(ctx, f, c.cfg.AgentID)
+		_ = c.sub.holds.Release(ctx, pathFromTaskFile(f), c.cfg.AgentID)
 	}
 }
 
@@ -543,7 +558,7 @@ func (c *Coord) releaseHolds(
 ) error {
 	var first error
 	for _, f := range held {
-		err := c.sub.holds.Release(ctx, f, c.cfg.AgentID)
+		err := c.sub.holds.Release(ctx, pathFromTaskFile(f), c.cfg.AgentID)
 		if err == nil || errors.Is(err, holds.ErrClosed) {
 			continue
 		}

--- a/internal/coord/handoff_claim_test.go
+++ b/internal/coord/handoff_claim_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/danmestas/bones/internal/tasks"
 	"github.com/danmestas/bones/internal/testutil/natstest"
+	"github.com/danmestas/bones/internal/wspath"
 )
 
 func TestHandoffClaim_TaskNotClaimed_Refused(t *testing.T) {
@@ -73,7 +74,7 @@ func TestHandoffClaim_Success(t *testing.T) {
 	if rec.ClaimEpoch != 2 {
 		t.Fatalf("claim_epoch=%d, want 2", rec.ClaimEpoch)
 	}
-	hold, ok, err := worker.sub.holds.WhoHas(ctx, "/a.go")
+	hold, ok, err := worker.sub.holds.WhoHas(ctx, wspath.Must("/a.go"))
 	if err != nil {
 		t.Fatalf("WhoHas: %v", err)
 	}
@@ -84,7 +85,7 @@ func TestHandoffClaim_Success(t *testing.T) {
 	// asserts the same hold-gate / epoch-gate invariant against the
 	// underlying helpers that Leaf.Commit composes. The parent's view
 	// after a successful HandoffClaim must fail one of the two gates.
-	files := []File{{Path: "/a.go", Content: []byte("p\n")}}
+	files := []File{{Path: wspath.Must("/a.go"), Content: []byte("p\n")}}
 	holdsErr := parent.checkHolds(ctx, files)
 	epochErr := parent.checkEpoch(ctx, id)
 	if !errors.Is(holdsErr, ErrNotHeld) && !errors.Is(epochErr, ErrEpochStale) {

--- a/internal/coord/holdgate.go
+++ b/internal/coord/holdgate.go
@@ -21,10 +21,12 @@ func (c *Coord) checkHolds(ctx context.Context, files []File) error {
 	for _, f := range files {
 		h, ok, err := c.sub.holds.WhoHas(ctx, f.Path)
 		if err != nil {
-			return fmt.Errorf("coord.Commit: whohas %q: %w", f.Path, err)
+			return fmt.Errorf(
+				"coord.Commit: whohas %q: %w", f.Path.AsAbsolute(), err,
+			)
 		}
 		if !ok || h.AgentID != c.cfg.AgentID {
-			notHeld = append(notHeld, f.Path)
+			notHeld = append(notHeld, f.Path.AsAbsolute())
 		}
 	}
 	if len(notHeld) > 0 {

--- a/internal/coord/leaf.go
+++ b/internal/coord/leaf.go
@@ -471,10 +471,13 @@ func (l *Leaf) Commit(
 	}
 	toCommit := make([]libfossil.FileToCommit, 0, len(files))
 	for _, f := range files {
-		assert.NotEmpty(f.Path, "coord.Leaf.Commit: file.Path is empty")
+		assert.Precondition(
+			!f.Path.IsZero(),
+			"coord.Leaf.Commit: file.Path is the zero Path",
+		)
 		name := f.Name
 		if name == "" {
-			name = normalizeLeadingSlash(f.Path)
+			name = normalizeLeadingSlash(f.Path.AsAbsolute())
 		}
 		toCommit = append(toCommit, libfossil.FileToCommit{
 			Name:    name,

--- a/internal/coord/leaf_commit_test.go
+++ b/internal/coord/leaf_commit_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/danmestas/bones/internal/wspath"
 	"github.com/danmestas/libfossil"
 )
 
@@ -45,7 +46,7 @@ func TestLeaf_CommitWritesAndSyncs(t *testing.T) {
 	t.Cleanup(func() { _ = cl.Release() })
 
 	uuid, err := l.Commit(ctx, cl, []File{
-		{Path: "/slot-A/file.txt", Content: []byte("hello")},
+		{Path: wspath.Must("/slot-A/file.txt"), Content: []byte("hello")},
 	})
 	if err != nil {
 		t.Fatalf("Commit: %v", err)
@@ -107,7 +108,7 @@ func TestLeaf_CommitDivergenceBranch(t *testing.T) {
 		t.Fatalf("Claim 1: %v", err)
 	}
 	uuidA, err := l.Commit(ctx, clA, []File{
-		{Path: "/slot-B/a.txt", Content: []byte("first")},
+		{Path: wspath.Must("/slot-B/a.txt"), Content: []byte("first")},
 	})
 	if err != nil {
 		t.Fatalf("Commit 1: %v", err)
@@ -131,7 +132,7 @@ func TestLeaf_CommitDivergenceBranch(t *testing.T) {
 		t.Fatalf("Claim 2: %v", err)
 	}
 	uuidB, err := l.Commit(ctx, clB, []File{
-		{Path: "/slot-B/b.txt", Content: []byte("second")},
+		{Path: wspath.Must("/slot-B/b.txt"), Content: []byte("second")},
 	})
 	if err != nil {
 		t.Fatalf("Commit 2 (parent != \"\"): %v", err)
@@ -198,7 +199,7 @@ func TestLeaf_CommitFileNameOverride(t *testing.T) {
 	t.Cleanup(func() { _ = cl.Release() })
 
 	uuid, err := l.Commit(ctx, cl, []File{
-		{Path: holdPath, Name: repoName, Content: []byte("body")},
+		{Path: wspath.Must(holdPath), Name: repoName, Content: []byte("body")},
 	})
 	if err != nil {
 		t.Fatalf("Commit: %v", err)
@@ -273,7 +274,7 @@ func TestLeaf_CommitAutosyncLinearizes(t *testing.T) {
 			t.Fatalf("Claim: %v", err)
 		}
 		uuid, err := l.Commit(ctx, cl, []File{
-			{Path: holdPath, Name: repoName, Content: body},
+			{Path: wspath.Must(holdPath), Name: repoName, Content: body},
 		})
 		if err != nil {
 			t.Fatalf("Commit: %v", err)

--- a/internal/coord/leaf_config_test.go
+++ b/internal/coord/leaf_config_test.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"testing"
 	"time"
+
+	"github.com/danmestas/bones/internal/wspath"
 )
 
 // TestLeafConfig_Metadata verifies that Metadata key=value pairs set on
@@ -146,7 +148,9 @@ func TestLeafConfig_FossilUser(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Claim: %v", err)
 	}
-	_, err = l.Commit(ctx, cl, []File{{Path: "/slot-fuser/a.txt", Content: []byte("hi")}})
+	_, err = l.Commit(ctx, cl, []File{
+		{Path: wspath.Must("/slot-fuser/a.txt"), Content: []byte("hi")},
+	})
 	if err != nil {
 		t.Fatalf("Commit: %v", err)
 	}

--- a/internal/coord/reclaim.go
+++ b/internal/coord/reclaim.go
@@ -168,7 +168,7 @@ func (c *Coord) releaseOldHolds(
 	ctx context.Context, prevAgent string, files []string,
 ) {
 	for _, f := range files {
-		_ = c.sub.holds.Release(ctx, f, prevAgent)
+		_ = c.sub.holds.Release(ctx, pathFromTaskFile(f), prevAgent)
 	}
 }
 

--- a/internal/coord/types.go
+++ b/internal/coord/types.go
@@ -5,7 +5,25 @@ import (
 
 	"github.com/danmestas/bones/internal/presence"
 	"github.com/danmestas/bones/internal/tasks"
+	"github.com/danmestas/bones/internal/wspath"
 )
+
+// Path is the typed coordination key for a workspace file. The
+// underlying type lives in internal/wspath so the substrate (holds)
+// can depend on it without importing coord. Callers using coord.Path
+// and callers using wspath.Path see the same value.
+type Path = wspath.Path
+
+// NewPath wraps an absolute filesystem path in a Path. Returns an
+// ErrInvalid-wrapped error on bad input. Thin re-export of
+// wspath.New so callers using coord.Path don't need a second import.
+func NewPath(abs string) (Path, error) { return wspath.New(abs) }
+
+// NewPathRelative joins workspaceDir and rel into a Path anchored
+// inside workspaceDir. Re-export of wspath.NewRelative.
+func NewPathRelative(workspaceDir, rel string) (Path, error) {
+	return wspath.NewRelative(workspaceDir, rel)
+}
 
 // TaskID uniquely identifies a task within the substrate. ADR 0005
 // pins the shape to `<proj>-<8char lowercase alnum>`; generation lives
@@ -134,21 +152,23 @@ type RevID string
 
 // File is a single file body paired with two address forms.
 //
-// Path is the holds-gate key — typically the absolute workspace path
-// the task record carries (holds.assertFile rejects non-absolute
-// values). It is NOT used to derive the libfossil file name when Name
-// is set.
+// Path is the holds-gate key — the absolute workspace path the task
+// record carries. The Path type guarantees the value is non-zero,
+// absolute, and cleaned at construction; downstream code does not
+// re-validate. Path is NOT used to derive the libfossil file name
+// when Name is set.
 //
 // Name is the repo-relative file name libfossil stores under (e.g.
 // "src/foo/bar.go"). When empty, Leaf.Commit falls back to stripping
-// a single leading slash off Path — sufficient for the simple case
-// where the holds key looks like "/relpath" but wrong when Path has
-// any deeper prefix (e.g. a workspace directory). Slot-style flows
-// where the worktree lives at <workspace>/.bones/swarm/<slot>/wt MUST
-// set Name to the wt-relative path; otherwise the file lands at
-// "<workspace-segments>/<rel>" inside the repo.
+// a single leading slash off Path's absolute form — sufficient for
+// the simple case where the holds key looks like "/relpath" but
+// wrong when Path has any deeper prefix (e.g. a workspace directory).
+// Slot-style flows where the worktree lives at
+// <workspace>/.bones/swarm/<slot>/wt MUST set Name to the wt-relative
+// path; otherwise the file lands at "<workspace-segments>/<rel>"
+// inside the repo.
 type File struct {
-	Path    string
+	Path    Path
 	Name    string
 	Content []byte
 }

--- a/internal/holds/holds.go
+++ b/internal/holds/holds.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
-	"path/filepath"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -16,6 +15,7 @@ import (
 
 	"github.com/danmestas/bones/internal/assert"
 	"github.com/danmestas/bones/internal/jskv"
+	"github.com/danmestas/bones/internal/wspath"
 )
 
 // Config configures Open. Every field is required; there are no
@@ -125,10 +125,12 @@ func (m *Manager) Close() error {
 // state transition is revision-gated and losers re-evaluate against
 // the post-conflict state.
 func (m *Manager) Announce(
-	ctx context.Context, file string, h Hold,
+	ctx context.Context, file wspath.Path, h Hold,
 ) error {
 	assert.NotNil(ctx, "holds.Announce: ctx is nil")
-	assertFile(file, "holds.Announce")
+	assert.Precondition(
+		!file.IsZero(), "holds.Announce: file is the zero Path",
+	)
 	assert.NotEmpty(h.AgentID, "holds.Announce: h.AgentID is empty")
 	assert.Precondition(
 		h.TTL > 0, "holds.Announce: h.TTL must be > 0",
@@ -154,7 +156,7 @@ func (m *Manager) Announce(
 	}
 	return fmt.Errorf(
 		"holds.Announce: exhausted %d CAS retries for %q",
-		jskv.MaxRetries, file,
+		jskv.MaxRetries, file.AsAbsolute(),
 	)
 }
 
@@ -264,10 +266,12 @@ func stamped(h Hold) ([]byte, error) {
 // or held by a different agent — "releasing something you don't own"
 // is defined away rather than errored on.
 func (m *Manager) Release(
-	ctx context.Context, file string, agent string,
+	ctx context.Context, file wspath.Path, agent string,
 ) error {
 	assert.NotNil(ctx, "holds.Release: ctx is nil")
-	assertFile(file, "holds.Release")
+	assert.Precondition(
+		!file.IsZero(), "holds.Release: file is the zero Path",
+	)
 	assert.NotEmpty(agent, "holds.Release: agent is empty")
 	if m.done.Load() {
 		return ErrClosed
@@ -295,10 +299,12 @@ func (m *Manager) Release(
 // expired. Expiry is evaluated lazily: WhoHas does not delete expired
 // entries — NATS MaxAge purges them asynchronously.
 func (m *Manager) WhoHas(
-	ctx context.Context, file string,
+	ctx context.Context, file wspath.Path,
 ) (Hold, bool, error) {
 	assert.NotNil(ctx, "holds.WhoHas: ctx is nil")
-	assertFile(file, "holds.WhoHas")
+	assert.Precondition(
+		!file.IsZero(), "holds.WhoHas: file is the zero Path",
+	)
 	if m.done.Load() {
 		return Hold{}, false, ErrClosed
 	}
@@ -336,25 +342,16 @@ func (m *Manager) readHold(
 	return h, true, nil
 }
 
-// keyOf converts an absolute file path to a JetStream KV key. The KV
-// key grammar accepts [A-Za-z0-9/_=.-]+; path separators survive
-// verbatim so an entry's key still reflects the filesystem structure.
-// Other disallowed bytes (spaces, unicode, symbols) are percent-
-// encoded by url.PathEscape, then the leading percent is rewritten to
-// '=' so the encoded form remains in the KV alphabet.
-func keyOf(file string) string {
-	escaped := url.PathEscape(file)
+// keyOf converts a Path into the JetStream KV key. The KV key
+// grammar accepts [A-Za-z0-9/_=.-]+; path separators survive verbatim
+// so an entry's key still reflects the filesystem structure. Other
+// disallowed bytes (spaces, unicode, symbols) are percent-encoded by
+// url.PathEscape, then the leading percent is rewritten to '=' so the
+// encoded form remains in the KV alphabet.
+func keyOf(file wspath.Path) string {
+	escaped := url.PathEscape(file.AsKey())
 	// url.PathEscape leaves '/' intact; other bytes become %XX.
 	// Rewrite '%' -> '=' to satisfy the KV key regex, since '%' is
 	// not in the allowed set but '=' is.
 	return strings.ReplaceAll(escaped, "%", "=")
-}
-
-// assertFile panics when file is empty or not absolute. Extracted so
-// every public method applies the same invariant 4 check.
-func assertFile(file, method string) {
-	assert.NotEmpty(file, "%s: file is empty", method)
-	assert.Precondition(
-		filepath.IsAbs(file), "%s: file %q not absolute", method, file,
-	)
 }

--- a/internal/holds/holds_cas_test.go
+++ b/internal/holds/holds_cas_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/danmestas/bones/internal/holds"
+	"github.com/danmestas/bones/internal/wspath"
 )
 
 // The CAS tests live alongside holds_test.go. They exercise the
@@ -29,7 +30,7 @@ func TestAnnounce_CAS_RetryOnConcurrentWrite(t *testing.T) {
 	m, _, cleanup := openTestManager(t)
 	defer cleanup()
 	ctx := context.Background()
-	file := "/work/cas-retry.txt"
+	file := wspath.Must("/work/cas-retry.txt")
 
 	// Seed the bucket with a hold owned by A so the Announce below
 	// (also by A, lease-renewal) hits the Update path rather than
@@ -68,7 +69,7 @@ func TestAnnounce_CAS_RetryOnConcurrentWrite(t *testing.T) {
 		// revision so the racing Announce's Update revision is
 		// stale and must retry.
 		payload := rawHoldBytes(t, "A", time.Second)
-		if _, err := kv.Put(ctx, keyForTest(file), payload); err != nil {
+		if _, err := kv.Put(ctx, keyForTest(file.AsAbsolute()), payload); err != nil {
 			t.Errorf("direct KV Put: %v", err)
 		}
 	}()
@@ -115,7 +116,7 @@ func TestAnnounce_CAS_ConcurrentContention(t *testing.T) {
 	m, _, cleanup := openTestManager(t)
 	defer cleanup()
 	ctx := context.Background()
-	file := "/work/cas-stress.txt"
+	file := wspath.Must("/work/cas-stress.txt")
 
 	const racers = 16
 	startGun := make(chan struct{})
@@ -204,7 +205,7 @@ func TestAnnounce_CAS_RenewUnderContention(t *testing.T) {
 	m, _, cleanup := openTestManager(t)
 	defer cleanup()
 	ctx := context.Background()
-	file := "/work/cas-renew.txt"
+	file := wspath.Must("/work/cas-renew.txt")
 
 	if err := m.Announce(ctx, file, newHold("A", time.Second)); err != nil {
 		t.Fatalf("seed Announce: %v", err)
@@ -265,5 +266,5 @@ func rawHoldBytes(t *testing.T, agent string, ttl time.Duration) []byte {
 // keyForTest reproduces holds.keyOf's escaping in test code that
 // writes to the raw KV. Exposed via the holds package.
 func keyForTest(file string) string {
-	return holds.KeyForTest(file)
+	return holds.KeyForTest(wspath.Must(file))
 }

--- a/internal/holds/holds_test.go
+++ b/internal/holds/holds_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/danmestas/bones/internal/holds"
 	"github.com/danmestas/bones/internal/testutil/natstest"
+	"github.com/danmestas/bones/internal/wspath"
 )
 
 // openTestManager spins up a JetStream-enabled fixture and returns a
@@ -66,7 +67,7 @@ func TestAnnounceRelease_HappyPath(t *testing.T) {
 	m, _, cleanup := openTestManager(t)
 	defer cleanup()
 	ctx := context.Background()
-	file := "/work/a.txt"
+	file := wspath.Must("/work/a.txt")
 
 	if err := m.Announce(ctx, file, newHold("A", time.Second)); err != nil {
 		t.Fatalf("Announce: %v", err)
@@ -95,7 +96,7 @@ func TestAnnounce_Idempotent_SameAgent(t *testing.T) {
 	m, _, cleanup := openTestManager(t)
 	defer cleanup()
 	ctx := context.Background()
-	file := "/work/b.txt"
+	file := wspath.Must("/work/b.txt")
 
 	if err := m.Announce(ctx, file, newHold("A", time.Second)); err != nil {
 		t.Fatalf("first Announce: %v", err)
@@ -122,7 +123,7 @@ func TestAnnounce_HeldByAnother(t *testing.T) {
 	m, _, cleanup := openTestManager(t)
 	defer cleanup()
 	ctx := context.Background()
-	file := "/work/c.txt"
+	file := wspath.Must("/work/c.txt")
 
 	if err := m.Announce(ctx, file, newHold("A", time.Second)); err != nil {
 		t.Fatalf("Announce A: %v", err)
@@ -141,7 +142,7 @@ func TestRelease_WrongAgent_NoOp(t *testing.T) {
 	m, _, cleanup := openTestManager(t)
 	defer cleanup()
 	ctx := context.Background()
-	file := "/work/d.txt"
+	file := wspath.Must("/work/d.txt")
 
 	if err := m.Announce(ctx, file, newHold("A", time.Second)); err != nil {
 		t.Fatalf("Announce: %v", err)
@@ -159,7 +160,7 @@ func TestRelease_MissingFile_NoOp(t *testing.T) {
 	m, _, cleanup := openTestManager(t)
 	defer cleanup()
 	ctx := context.Background()
-	if err := m.Release(ctx, "/work/never.txt", "A"); err != nil {
+	if err := m.Release(ctx, wspath.Must("/work/never.txt"), "A"); err != nil {
 		t.Fatalf("Release: %v", err)
 	}
 }
@@ -168,7 +169,7 @@ func TestWhoHas_NotClaimed_ReturnsFalse(t *testing.T) {
 	m, _, cleanup := openTestManager(t)
 	defer cleanup()
 	ctx := context.Background()
-	got, ok, err := m.WhoHas(ctx, "/work/ghost.txt")
+	got, ok, err := m.WhoHas(ctx, wspath.Must("/work/ghost.txt"))
 	if err != nil {
 		t.Fatalf("WhoHas: %v", err)
 	}
@@ -181,7 +182,7 @@ func TestKeyEncoding_PreservesPathWithSpaces(t *testing.T) {
 	m, _, cleanup := openTestManager(t)
 	defer cleanup()
 	ctx := context.Background()
-	file := "/work/with space/foo.txt"
+	file := wspath.Must("/work/with space/foo.txt")
 
 	if err := m.Announce(ctx, file, newHold("A", time.Second)); err != nil {
 		t.Fatalf("Announce: %v", err)
@@ -200,38 +201,30 @@ func TestInvariant_NilCtx(t *testing.T) {
 	defer cleanup()
 	var ctx context.Context
 	requirePanic(t, func() {
-		_ = m.Announce(ctx, "/work/a.txt", newHold("A", time.Second))
+		_ = m.Announce(ctx, wspath.Must("/work/a.txt"), newHold("A", time.Second))
 	}, "ctx is nil")
 	requirePanic(t, func() {
-		_ = m.Release(ctx, "/work/a.txt", "A")
+		_ = m.Release(ctx, wspath.Must("/work/a.txt"), "A")
 	}, "ctx is nil")
 	requirePanic(t, func() {
-		_, _, _ = m.WhoHas(ctx, "/work/a.txt")
+		_, _, _ = m.WhoHas(ctx, wspath.Must("/work/a.txt"))
 	}, "ctx is nil")
 }
 
-func TestInvariant_EmptyFile(t *testing.T) {
+func TestInvariant_ZeroFile(t *testing.T) {
 	m, _, cleanup := openTestManager(t)
 	defer cleanup()
 	ctx := context.Background()
+	var p wspath.Path
 	requirePanic(t, func() {
-		_ = m.Announce(ctx, "", newHold("A", time.Second))
-	}, "file is empty")
+		_ = m.Announce(ctx, p, newHold("A", time.Second))
+	}, "is the zero Path")
 	requirePanic(t, func() {
-		_ = m.Release(ctx, "", "A")
-	}, "file is empty")
+		_ = m.Release(ctx, p, "A")
+	}, "is the zero Path")
 	requirePanic(t, func() {
-		_, _, _ = m.WhoHas(ctx, "")
-	}, "file is empty")
-}
-
-func TestInvariant_RelativeFile(t *testing.T) {
-	m, _, cleanup := openTestManager(t)
-	defer cleanup()
-	ctx := context.Background()
-	requirePanic(t, func() {
-		_ = m.Announce(ctx, "work/a.txt", newHold("A", time.Second))
-	}, "not absolute")
+		_, _, _ = m.WhoHas(ctx, p)
+	}, "is the zero Path")
 }
 
 func TestInvariant_EmptyAgentOnRelease(t *testing.T) {
@@ -239,7 +232,7 @@ func TestInvariant_EmptyAgentOnRelease(t *testing.T) {
 	defer cleanup()
 	ctx := context.Background()
 	requirePanic(t, func() {
-		_ = m.Release(ctx, "/work/a.txt", "")
+		_ = m.Release(ctx, wspath.Must("/work/a.txt"), "")
 	}, "agent is empty")
 }
 
@@ -248,7 +241,7 @@ func TestInvariant_EmptyAgentOnHold(t *testing.T) {
 	defer cleanup()
 	ctx := context.Background()
 	requirePanic(t, func() {
-		_ = m.Announce(ctx, "/work/a.txt", newHold("", time.Second))
+		_ = m.Announce(ctx, wspath.Must("/work/a.txt"), newHold("", time.Second))
 	}, "AgentID is empty")
 }
 
@@ -257,7 +250,7 @@ func TestInvariant_TTLZero(t *testing.T) {
 	defer cleanup()
 	ctx := context.Background()
 	requirePanic(t, func() {
-		_ = m.Announce(ctx, "/work/a.txt", newHold("A", 0))
+		_ = m.Announce(ctx, wspath.Must("/work/a.txt"), newHold("A", 0))
 	}, "TTL must be > 0")
 }
 
@@ -267,7 +260,7 @@ func TestInvariant_TTLExceedsMax(t *testing.T) {
 	ctx := context.Background()
 	requirePanic(t, func() {
 		_ = m.Announce(
-			ctx, "/work/a.txt", newHold("A", 10*time.Second),
+			ctx, wspath.Must("/work/a.txt"), newHold("A", 10*time.Second),
 		)
 	}, "exceeds HoldTTLMax")
 }
@@ -279,7 +272,7 @@ func TestInvariant_UseAfterClose(t *testing.T) {
 		t.Fatalf("Close: %v", err)
 	}
 	ctx := context.Background()
-	file := "/work/a.txt"
+	file := wspath.Must("/work/a.txt")
 	err := m.Announce(ctx, file, newHold("A", time.Second))
 	if !errors.Is(err, holds.ErrClosed) {
 		t.Fatalf("Announce after Close: got %v, want ErrClosed", err)

--- a/internal/holds/subscribe_test.go
+++ b/internal/holds/subscribe_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/danmestas/bones/internal/holds"
+	"github.com/danmestas/bones/internal/wspath"
 )
 
 // recvEvent reads one event from ch with a timeout. It fails the test
@@ -63,11 +64,11 @@ func TestSubscribe_ReceivesAnnounce(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Subscribe: %v", err)
 	}
-	file := "/work/a.txt"
+	file := wspath.Must("/work/a.txt")
 	if err := m.Announce(ctx, file, newHold("A", time.Second)); err != nil {
 		t.Fatalf("Announce: %v", err)
 	}
-	ev := waitForKind(t, ch, file, holds.EventAnnounced)
+	ev := waitForKind(t, ch, file.AsAbsolute(), holds.EventAnnounced)
 	if ev.Hold.AgentID != "A" {
 		t.Fatalf("agent: got %q, want A", ev.Hold.AgentID)
 	}
@@ -86,16 +87,16 @@ func TestSubscribe_ReceivesRelease(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Subscribe: %v", err)
 	}
-	file := "/work/b.txt"
+	file := wspath.Must("/work/b.txt")
 	if err := m.Announce(ctx, file, newHold("A", time.Second)); err != nil {
 		t.Fatalf("Announce: %v", err)
 	}
-	waitForKind(t, ch, file, holds.EventAnnounced)
+	waitForKind(t, ch, file.AsAbsolute(), holds.EventAnnounced)
 
 	if err := m.Release(ctx, file, "A"); err != nil {
 		t.Fatalf("Release: %v", err)
 	}
-	waitForKind(t, ch, file, holds.EventReleased)
+	waitForKind(t, ch, file.AsAbsolute(), holds.EventReleased)
 }
 
 func TestSubscribe_CancelsOnCtx(t *testing.T) {
@@ -137,12 +138,12 @@ func TestSubscribe_MultipleSubscribers(t *testing.T) {
 		t.Fatalf("Subscribe 2: %v", err)
 	}
 
-	file := "/work/shared.txt"
+	file := wspath.Must("/work/shared.txt")
 	if err := m.Announce(ctx, file, newHold("A", time.Second)); err != nil {
 		t.Fatalf("Announce: %v", err)
 	}
-	ev1 := waitForKind(t, ch1, file, holds.EventAnnounced)
-	ev2 := waitForKind(t, ch2, file, holds.EventAnnounced)
+	ev1 := waitForKind(t, ch1, file.AsAbsolute(), holds.EventAnnounced)
+	ev2 := waitForKind(t, ch2, file.AsAbsolute(), holds.EventAnnounced)
 	if ev1.Hold.AgentID != "A" || ev2.Hold.AgentID != "A" {
 		t.Fatalf(
 			"expected both subscribers to see A: %+v / %+v", ev1, ev2,

--- a/internal/holds/testhooks.go
+++ b/internal/holds/testhooks.go
@@ -1,6 +1,10 @@
 package holds
 
-import "github.com/nats-io/nats.go/jetstream"
+import (
+	"github.com/nats-io/nats.go/jetstream"
+
+	"github.com/danmestas/bones/internal/wspath"
+)
 
 // casRetryHook is called once per CAS retry in Announce. Production
 // code leaves it as a no-op; tests overwrite it via
@@ -45,6 +49,6 @@ func EncodeForTest(h Hold) ([]byte, error) {
 // KeyForTest exposes the package's file-to-KV-key transform so
 // sibling test packages can stage KV entries under the exact key
 // Announce uses. Not part of the supported public API.
-func KeyForTest(file string) string {
+func KeyForTest(file wspath.Path) string {
 	return keyOf(file)
 }

--- a/internal/holds/ttl_test.go
+++ b/internal/holds/ttl_test.go
@@ -7,13 +7,14 @@ import (
 	"time"
 
 	"github.com/danmestas/bones/internal/holds"
+	"github.com/danmestas/bones/internal/wspath"
 )
 
 func TestTTL_ExpiryMakesWhoHasReturnFalse(t *testing.T) {
 	m, _, cleanup := openTestManager(t)
 	defer cleanup()
 	ctx := context.Background()
-	file := "/work/ttl-a.txt"
+	file := wspath.Must("/work/ttl-a.txt")
 
 	if err := m.Announce(ctx, file, newHold("A", 50*time.Millisecond)); err != nil {
 		t.Fatalf("Announce: %v", err)
@@ -34,7 +35,7 @@ func TestTTL_AnnounceAfterExpiry_Succeeds_DifferentAgent(t *testing.T) {
 	m, _, cleanup := openTestManager(t)
 	defer cleanup()
 	ctx := context.Background()
-	file := "/work/ttl-b.txt"
+	file := wspath.Must("/work/ttl-b.txt")
 
 	if err := m.Announce(ctx, file, newHold("A", 50*time.Millisecond)); err != nil {
 		t.Fatalf("Announce A: %v", err)

--- a/internal/swarm/lease.go
+++ b/internal/swarm/lease.go
@@ -626,7 +626,7 @@ func commitViaLeaf(
 	defer func() { _ = claim.Release() }()
 	paths := make([]string, 0, len(files))
 	for _, f := range files {
-		paths = append(paths, f.Path)
+		paths = append(paths, f.Path.AsAbsolute())
 	}
 	releaseHolds, err := leaf.AnnounceHolds(ctx, paths)
 	if err != nil {

--- a/internal/swarm/lease_test.go
+++ b/internal/swarm/lease_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/danmestas/bones/internal/coord"
 	"github.com/danmestas/bones/internal/workspace"
+	"github.com/danmestas/bones/internal/wspath"
 )
 
 // freePort returns a random unused TCP port for an in-process hub.
@@ -342,7 +343,7 @@ func TestCommit_SuccessUpdatesTrunkAndRenewsSession(t *testing.T) {
 		t.Fatalf("write file: %v", err)
 	}
 	files := []coord.File{{
-		Path:    holdPath,
+		Path:    wspath.Must(holdPath),
 		Name:    "hello.txt",
 		Content: []byte("world"),
 	}}

--- a/internal/wspath/wspath.go
+++ b/internal/wspath/wspath.go
@@ -1,0 +1,112 @@
+// Package wspath defines the typed coordination key for a workspace
+// file. A Path is an absolute, syntactically clean filesystem path
+// that the coordination layer uses as a hold key, hold-release key,
+// and the value carried in coord.File. The substrate (holds) and the
+// domain (coord, swarm, dispatch) agree on the same key by
+// construction; no caller hand-rolls path normalization.
+//
+// Paths are produced by exactly two constructors: New, which wraps an
+// already-absolute path, and NewRelative, which joins a workspace-
+// relative path onto an absolute workspace root and rejects any
+// result that escapes the root via "..". Both return ErrInvalid on
+// bad input rather than producing a Path that fails downstream.
+//
+// The package re-exports as coord.Path via a type alias so the public
+// vocabulary stays "coord.Path" while the implementation stays
+// dependency-free. Holds depends on wspath directly.
+package wspath
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// Path is the typed coordination key for a workspace file. The zero
+// value is invalid — use IsZero to test for it.
+type Path struct {
+	abs string
+}
+
+// ErrInvalid wraps every constructor failure. Callers can errors.Is
+// against it to distinguish bad input from substrate errors.
+var ErrInvalid = errors.New("wspath: invalid path")
+
+// New wraps an absolute filesystem path in a Path. The input is
+// passed through filepath.Clean, so "/a//b/", "/a/./b", and "/a/b"
+// all produce the same canonical Path. Returns an ErrInvalid-wrapped
+// error when input is empty or not absolute.
+func New(abs string) (Path, error) {
+	if abs == "" {
+		return Path{}, fmt.Errorf("%w: empty input", ErrInvalid)
+	}
+	if !filepath.IsAbs(abs) {
+		return Path{}, fmt.Errorf(
+			"%w: %q is not absolute", ErrInvalid, abs,
+		)
+	}
+	return Path{abs: filepath.Clean(abs)}, nil
+}
+
+// NewRelative joins workspaceDir and rel into a Path anchored inside
+// workspaceDir. workspaceDir must itself be absolute. The cleaned
+// join must lie at or under workspaceDir; a rel that escapes via
+// ".." is rejected. rel must not be absolute (use New for that path).
+func NewRelative(workspaceDir, rel string) (Path, error) {
+	if workspaceDir == "" {
+		return Path{}, fmt.Errorf(
+			"%w: workspaceDir is empty", ErrInvalid,
+		)
+	}
+	if !filepath.IsAbs(workspaceDir) {
+		return Path{}, fmt.Errorf(
+			"%w: workspaceDir %q is not absolute",
+			ErrInvalid, workspaceDir,
+		)
+	}
+	if rel == "" {
+		return Path{}, fmt.Errorf("%w: rel is empty", ErrInvalid)
+	}
+	if filepath.IsAbs(rel) {
+		return Path{}, fmt.Errorf(
+			"%w: rel %q is absolute (use New)", ErrInvalid, rel,
+		)
+	}
+	root := filepath.Clean(workspaceDir)
+	joined := filepath.Clean(filepath.Join(root, rel))
+	if joined != root && !strings.HasPrefix(
+		joined, root+string(filepath.Separator),
+	) {
+		return Path{}, fmt.Errorf(
+			"%w: %q escapes workspace %q", ErrInvalid, rel, root,
+		)
+	}
+	return Path{abs: joined}, nil
+}
+
+// AsAbsolute returns the canonical absolute path string.
+func (p Path) AsAbsolute() string { return p.abs }
+
+// AsKey returns the coordination-key form of the path. Currently
+// equal to AsAbsolute; kept distinct so a future schema change to
+// the hold-bucket key format can stay invisible to callers.
+func (p Path) AsKey() string { return p.abs }
+
+// String implements fmt.Stringer; returns AsAbsolute.
+func (p Path) String() string { return p.abs }
+
+// IsZero reports whether p is the zero Path. The zero value is
+// invalid and must not be passed across coordination seams.
+func (p Path) IsZero() bool { return p.abs == "" }
+
+// Must wraps New and panics on error. Intended for tests and for
+// programs whose input is a compile-time-known absolute path; every
+// other caller should use New and handle ErrInvalid.
+func Must(abs string) Path {
+	p, err := New(abs)
+	if err != nil {
+		panic(fmt.Errorf("wspath.Must: %w", err))
+	}
+	return p
+}

--- a/internal/wspath/wspath_test.go
+++ b/internal/wspath/wspath_test.go
@@ -1,0 +1,167 @@
+package wspath_test
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/danmestas/bones/internal/wspath"
+)
+
+func TestNew_Absolute(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"/a/b.txt", "/a/b.txt"},
+		{"/a//b.txt", "/a/b.txt"},
+		{"/a/./b.txt", "/a/b.txt"},
+		{"/a/b/", "/a/b"},
+		{"/a/b/../c.txt", "/a/c.txt"},
+		{"/a/b/../../c.txt", "/c.txt"},
+		{"/", "/"},
+	}
+	for _, c := range cases {
+		p, err := wspath.New(c.in)
+		if err != nil {
+			t.Errorf("New(%q): unexpected error %v", c.in, err)
+			continue
+		}
+		if got := p.AsAbsolute(); got != c.want {
+			t.Errorf("New(%q): got %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestNew_RejectsBadInput(t *testing.T) {
+	cases := []string{"", "relative/path", "./foo", "../escape"}
+	for _, in := range cases {
+		_, err := wspath.New(in)
+		if err == nil {
+			t.Errorf("New(%q): expected error", in)
+			continue
+		}
+		if !errors.Is(err, wspath.ErrInvalid) {
+			t.Errorf("New(%q): got %v, want ErrInvalid", in, err)
+		}
+	}
+}
+
+func TestNewRelative_HappyPath(t *testing.T) {
+	cases := []struct {
+		ws, rel, want string
+	}{
+		{"/work", "src/foo.go", "/work/src/foo.go"},
+		{"/work/", "src/foo.go", "/work/src/foo.go"},
+		{"/work", "./src/foo.go", "/work/src/foo.go"},
+		{"/work", "src/../lib/bar.go", "/work/lib/bar.go"},
+		{"/work/proj", "a", "/work/proj/a"},
+	}
+	for _, c := range cases {
+		p, err := wspath.NewRelative(c.ws, c.rel)
+		if err != nil {
+			t.Errorf(
+				"NewRelative(%q, %q): unexpected error %v",
+				c.ws, c.rel, err,
+			)
+			continue
+		}
+		if got := p.AsAbsolute(); got != c.want {
+			t.Errorf(
+				"NewRelative(%q, %q): got %q, want %q",
+				c.ws, c.rel, got, c.want,
+			)
+		}
+	}
+}
+
+func TestNewRelative_RejectsEscape(t *testing.T) {
+	cases := []struct {
+		ws, rel string
+	}{
+		{"/work", "../escape"},
+		{"/work", "src/../../escape"},
+		{"/work/proj", "../sibling"},
+		// Escapes that resolve to root.
+		{"/work", "../.."},
+	}
+	for _, c := range cases {
+		_, err := wspath.NewRelative(c.ws, c.rel)
+		if err == nil {
+			t.Errorf(
+				"NewRelative(%q, %q): expected escape error",
+				c.ws, c.rel,
+			)
+			continue
+		}
+		if !errors.Is(err, wspath.ErrInvalid) {
+			t.Errorf(
+				"NewRelative(%q, %q): got %v, want ErrInvalid",
+				c.ws, c.rel, err,
+			)
+		}
+	}
+}
+
+func TestNewRelative_RejectsBadArgs(t *testing.T) {
+	cases := []struct {
+		name, ws, rel string
+	}{
+		{"empty workspace", "", "a"},
+		{"relative workspace", "work", "a"},
+		{"empty rel", "/work", ""},
+		{"absolute rel", "/work", "/foo"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			_, err := wspath.NewRelative(c.ws, c.rel)
+			if err == nil {
+				t.Fatalf("expected error")
+			}
+			if !errors.Is(err, wspath.ErrInvalid) {
+				t.Fatalf("got %v, want ErrInvalid", err)
+			}
+		})
+	}
+}
+
+func TestPath_Accessors(t *testing.T) {
+	p, err := wspath.New("/a/b/c.txt")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if got := p.AsAbsolute(); got != "/a/b/c.txt" {
+		t.Errorf("AsAbsolute: %q", got)
+	}
+	if got := p.AsKey(); got != "/a/b/c.txt" {
+		t.Errorf("AsKey: %q", got)
+	}
+	if got := p.String(); got != "/a/b/c.txt" {
+		t.Errorf("String: %q", got)
+	}
+	if p.IsZero() {
+		t.Errorf("IsZero on non-zero")
+	}
+	var zero wspath.Path
+	if !zero.IsZero() {
+		t.Errorf("IsZero on zero: false")
+	}
+}
+
+func TestPath_Equality(t *testing.T) {
+	p1, _ := wspath.New("/a/b")
+	p2, _ := wspath.New("/a//b")
+	p3, _ := wspath.New("/a/c")
+	if p1 != p2 {
+		t.Errorf("expected equal: %v %v", p1, p2)
+	}
+	if p1 == p3 {
+		t.Errorf("expected unequal: %v %v", p1, p3)
+	}
+}
+
+func TestNewRelative_CrossPlatform(t *testing.T) {
+	// Sanity: filepath.Separator is what we expect on this platform.
+	if filepath.Separator == 0 {
+		t.Skip("filepath.Separator is zero — odd platform")
+	}
+}


### PR DESCRIPTION
## Summary

Phase 1 of the Ousterhout redesign (see `docs/audits/2026-04-29-ousterhout-redesign-plan.md`). Introduces a typed coordination key for workspace files and migrates the holds substrate + `coord.File.Path` to use it.

- **New package `internal/wspath`** — `Path` newtype with `New(abs)` / `NewRelative(workspaceDir, rel)` / `Must(abs)` constructors, accessors `AsAbsolute`, `AsKey`, `String`, `IsZero`. Construction validates absolute/relative input via `filepath.Clean` and rejects workspace escapes via `..`. Tests cover trailing slashes, redundant segments, escape rejection, zero-value detection.
- **`coord.Path` is a type alias** for `wspath.Path` so the substrate (`holds`) can depend on the type without importing `coord`. `coord.NewPath` / `coord.NewPathRelative` are thin wrappers for callers using the `coord` namespace.
- **Holds API change** — `Announce`/`Release`/`WhoHas`/`KeyForTest` now take `wspath.Path`. The `assertFile` helper that asserted absolute+non-empty is gone; the invariant is enforced at Path construction. The CAS-retry, KV-key derivation, and channel-buffer logic are unchanged.
- **`coord.File.Path` is typed `coord.Path`** (was `string`). Internal coord helpers (claimAll, rollback, releaseHolds, releaseOldHolds) convert from the Task record's `[]string` at the holds boundary via a `pathFromTaskFile` helper that asserts validity (substrate corruption is a programmer error, not a runtime condition).
- **CLI `gatherCommitFiles`** uses `coord.NewPathRelative` instead of hand-rolling `filepath.Join`. Examples and demo binaries updated to construct typed paths at the boundary.
- **ADR 0033 + CONTEXT.md** updated with shipped constructor names (Go-idiomatic `New`/`NewRelative` instead of the original `Path.FromAbsolute`/`Path.FromRelative` shorthand).

## Test plan

- [x] `go test ./internal/wspath/...` — green (covers all constructor + accessor cases)
- [x] `go test ./internal/holds/...` — green (TestInvariant_RelativeFile migrated into wspath_test.go; TestInvariant_EmptyFile replaced with TestInvariant_ZeroFile)
- [x] `go test ./internal/coord/...` — green (real-substrate hold/claim/commit cycles)
- [x] `go test ./internal/swarm/...` — green (Lease commit path through new Path type)
- [x] `make check` — green (vet, lint, race, todo-check, fmt-check)

## Out of scope (deferred to follow-up phases)

- Encoding the Lease lifecycle in distinct types (`FreshLease` / `ResumedLease`) — Phase 2
- Removing `Lease.Leaf()` escape hatch — Phase 2
- Lifting `Autosync` to `LeaseConfig` — Phase 3
- Dispatch's domain-local `Task` / `Reclaimer` interfaces — Phase 4
- CLI verb refresh + skill/hook/script updates — Phase 5
- Substrate `managerBase` scaffold — Phase 6

## Notes

- `internal/wspath` is a leaf package both `coord` and `holds` import. The plan originally specified Path lives at `internal/coord/path.go`; that location would create a `coord ↔ holds` import cycle since `coord` already depends on `holds`. The leaf-package + alias approach preserves the public vocabulary (`coord.Path`) while satisfying the import graph.
- Constructor names changed from the ADR's prose-style `Path.FromAbsolute` / `Path.FromRelative` to Go-idiomatic `wspath.New` / `wspath.NewRelative`. ADR 0033 amended in this PR to match.