### PR TITLE
feat(swarm): split Lease into FreshLease and ResumedLease types

### DIFF
--- a/cli/swarm.go
+++ b/cli/swarm.go
@@ -34,7 +34,8 @@ type SwarmCmd struct {
 //
 // Pulled into a helper because every read-only swarm verb opens the
 // Sessions handle the same way and the verbs are otherwise small.
-// Mutating verbs go through swarm.Lease (ADR 0028).
+// Mutating verbs go through swarm.FreshLease / swarm.ResumedLease
+// (ADRs 0028, 0033).
 func openSwarmSessions(
 	ctx context.Context, info workspace.Info,
 ) (*swarm.Sessions, func(), error) {

--- a/cli/swarm_commit.go
+++ b/cli/swarm_commit.go
@@ -24,8 +24,8 @@ import (
 //
 // All the assembled scaffold (Resume the lease, claim, announce
 // holds, commit via leaf, push to hub, renew session) lives in
-// internal/swarm.Lease. This verb is flag parsing + file gathering
-// + Lease.Commit + result printing.
+// internal/swarm.ResumedLease. This verb is flag parsing + file
+// gathering + ResumedLease.Commit + result printing.
 type SwarmCommitCmd struct {
 	Slot    string   `name:"slot" help:"slot name (defaults to single active slot on this host)"`
 	Message string   `name:"message" short:"m" required:"" help:"commit message"`

--- a/cli/swarm_join.go
+++ b/cli/swarm_join.go
@@ -23,8 +23,8 @@ import (
 //
 // All the assembly (workspace check, fossil-user creation, KV
 // session record CAS, leaf open/claim) lives in
-// internal/swarm.Lease (ADR 0028). This verb is a thin adapter
-// from CLI flags to AcquireFresh + Release.
+// internal/swarm (ADR 0028). This verb is a thin adapter from CLI
+// flags to swarm.Acquire + FreshLease.Release.
 type SwarmJoinCmd struct {
 	Slot          string `name:"slot" required:"" help:"slot name (matches plan [slot: X])"`
 	TaskID        string `name:"task-id" required:"" help:"open task id to claim"`
@@ -34,10 +34,10 @@ type SwarmJoinCmd struct {
 }
 
 // Run drives the join flow per ADR 0028 §"swarm join", via
-// swarm.Lease: open workspace, AcquireFresh (which does
-// the role-guard check, ensures the slot user, CAS-writes the
-// session record, opens the leaf, claims the task, writes the pid
-// file), emit the report, Release.
+// swarm.Acquire: open workspace, Acquire (which does the role-guard
+// check, ensures the slot user, CAS-writes the session record, opens
+// the leaf, claims the task, writes the pid file), emit the report,
+// FreshLease.Release.
 func (c *SwarmJoinCmd) Run(g *libfossilcli.Globals) error {
 	ctx, stop, info, err := joinWorkspace()
 	if err != nil {
@@ -52,7 +52,7 @@ func (c *SwarmJoinCmd) run(ctx context.Context, info workspace.Info) error {
 	if hubURL == "" {
 		hubURL = swarm.DefaultHubFossilURL
 	}
-	lease, err := swarm.AcquireFresh(ctx, info, c.Slot, c.TaskID, swarm.AcquireOpts{
+	lease, err := swarm.Acquire(ctx, info, c.Slot, c.TaskID, swarm.AcquireOpts{
 		HubURL:        hubURL,
 		Caps:          c.Caps,
 		ForceTakeover: c.ForceTakeover,
@@ -71,7 +71,7 @@ func (c *SwarmJoinCmd) run(ctx context.Context, info workspace.Info) error {
 // emitJoinReport prints the BONES_SLOT_WT line on stdout (consumed
 // by `eval $(bones swarm join ...)` patterns in shells) and a
 // human-readable summary on stderr.
-func (c *SwarmJoinCmd) emitJoinReport(lease *swarm.Lease) {
+func (c *SwarmJoinCmd) emitJoinReport(lease *swarm.FreshLease) {
 	wt := lease.WT()
 	fmt.Printf("BONES_SLOT_WT=%s\n", wt)
 	fmt.Fprintf(

--- a/docs/adr/0028-bones-swarm-verbs.md
+++ b/docs/adr/0028-bones-swarm-verbs.md
@@ -46,54 +46,78 @@ A subagent prompt collapses to ~5 swarm verbs from the ~12 raw
 Every verb touches the same scaffold: locate workspace, ensure slot
 user exists, open the swarm-sessions KV bucket, read or write the
 per-slot session record under CAS, open a `coord.Leaf`, do the
-verb's work, stop the leaf, update KV. **`internal/swarm.Lease`** is
-that assembled view — workspace + fossil-user precondition +
-session-record + open `coord.Leaf` in one place.
+verb's work, stop the leaf, update KV. The lease abstraction in
+`internal/swarm` is that assembled view — workspace + fossil-user
+precondition + session-record + open `coord.Leaf` in one place.
+Following ADR 0033 it is split into two compile-time-distinct
+types so the lifecycle is encoded in the type system rather than
+runtime preconditions.
 
 ### Lifetime
 
-Lease and its underlying `coord.Leaf` share a lifetime: the lease
+A lease and its underlying `coord.Leaf` share a lifetime: the lease
 opens the leaf at acquire time and stops it at close time. There is
 no long-running per-slot leaf process to coordinate across CLI
 invocations. The persistent state across verbs is the **session
 record** in `bones-swarm-sessions[slot]` (`swarm.Session`), not the
 leaf itself. `swarm join` writes the record; `swarm commit` and
-`swarm close` re-acquire the lease against that existing record.
+`swarm close` re-acquire a fresh lease against that existing record.
 
-### Two acquisition modes
+### Two-type lifecycle
 
-- **`AcquireFresh(ctx, info, slot, taskID, opts) (*Lease, error)`** —
-  for `swarm join`. Creates the session record via CAS-PutIfAbsent
+The lease lifecycle is encoded in two distinct types so that the
+verb-to-state-machine mapping is enforced by the compiler:
+
+- **`FreshLease`**, returned by
+  `swarm.Acquire(ctx, info, slot, taskID, opts) (*FreshLease, error)`
+  — for `swarm join`. Creates the session record via CAS-PutIfAbsent
   (or `--force`-overwrites a stale one), opens the leaf, claims the
-  task. The "refusing to bootstrap from a leaf context" role-guard is
-  a precondition inside `AcquireFresh`, not a free-standing CLI
-  check.
+  task. The "refusing to bootstrap from a leaf context" role-guard
+  is a precondition inside `Acquire`, not a free-standing CLI check.
 
-- **`Resume(ctx, info, slot, opts) (*Lease, error)`** — for every
-  other verb. Reads the existing session record, reconstructs the
-  leaf using the recorded hub URL and slot user, fails with
-  `ErrSessionNotFound` if no record exists.
+- **`ResumedLease`**, returned by
+  `swarm.Resume(ctx, info, slot, opts) (*ResumedLease, error)` —
+  for every other verb. Reads the existing session record,
+  reconstructs the leaf using the recorded hub URL and slot user,
+  fails with `ErrSessionNotFound` if no record exists.
 
-### Methods (closed verb set)
+### Methods (closed verb set per type)
 
-`Lease` exposes methods mirroring the verbs that operate on an open
-lease:
+**`FreshLease`** — graceful-exit and rollback only:
 
-- `Commit(ctx, files ...File) (uuid, error)` — claim →
-  `coord.Leaf.Commit` → bump `LastRenewed` via CAS, atomic from the
-  caller's view.
-- `Close(ctx, result, summary string) error` — delete the session
-  record via CAS, stop the leaf.
-- `Release(ctx) error` — release the claim hold and stop the leaf
-  *without* deleting the session record. The path `swarm join`
-  takes after writing the record; the lease stays "live" in KV
-  until a later verb closes it.
-- `Slot()`, `TaskID()`, `WT()` — accessors. `Leaf() *coord.Leaf` is
-  a deprecated-on-arrival escape hatch, scheduled for removal once
-  no caller uses it.
+- `Release(ctx) error` — release the claim, stop the leaf, close
+  the session handle. Session record persists in KV for later
+  `Resume`. The path `swarm join` takes after writing the record.
+- `Abort(ctx) error` — release the claim, stop the leaf, CAS-delete
+  the session record, remove the pid file. The rollback path used
+  when the join verb's downstream work fails after `Acquire`
+  succeeded.
+- `Slot()`, `TaskID()`, `WT()`, `HubURL()`, `FossilUser()`,
+  `SessionRevision()` — accessors.
 
-`Renew` is deliberately not a method — `Commit` already bumps
+**`ResumedLease`** — work-doing and graceful-exit:
+
+- `Commit(ctx, message, files) (CommitResult, error)` — re-claim
+  → `coord.Leaf.Commit` → push to hub → CAS-bump `LastRenewed`,
+  atomic from the caller's view. The session-record CAS retries on
+  conflict up to `jskv.MaxRetries` and surfaces `ErrSessionGone`
+  if the record was deleted between `Resume` and the bump.
+- `Close(ctx, opts CloseOpts) error` — re-claim and either close
+  the task (success) or release the claim (fail/fork), then stop
+  the leaf, remove the pid file, and CAS-delete the session record
+  (retrying on rev advance from concurrent commits).
+- `Release(ctx) error` — close handles without deleting the
+  record, used by `swarm commit` after the commit completes.
+- `Slot()`, `TaskID()`, `WT()`, `HubURL()`, `FossilUser()`,
+  `SessionRevision()` — accessors.
+
+A `Renew` method is deliberately absent — `Commit` already bumps
 `LastRenewed` and is the only path that needs heartbeating today.
+
+The type split makes the obvious misuses compile errors:
+`FreshLease` has no `Commit` (no current rev to CAS against),
+`ResumedLease` has no `Abort` (it didn't write the record), and
+neither has the other's `Close`/`Abort` distinction.
 
 ## Lifecycle and state
 
@@ -138,27 +162,31 @@ path directly without consulting KV.
 
 **`swarm join`** — flags `--slot`, `--task-id` (required), `--caps`
 (default `oih`), `--force` (recovery-only takeover). Calls
-`Lease.AcquireFresh` (ensure slot user → verify no live session →
-open `coord.Leaf` at `.bones/swarm/<slot>/` as `slot-<name>` → claim
-task with 60s hold → CAS-write session record with 5-min TTL), emits
-`BONES_SLOT_WT=<path>`, then `Release` (stops the leaf, leaves the
-session record live in KV).
+`swarm.Acquire` (ensure slot user → verify no live session → open
+`coord.Leaf` at `.bones/swarm/<slot>/` as `slot-<name>` → claim task
+with 60s hold → CAS-write session record with 5-min TTL), emits
+`BONES_SLOT_WT=<path>`, then `FreshLease.Release` (stops the leaf,
+leaves the session record live in KV). On any failure between
+`Acquire` and emission the verb falls back to `FreshLease.Abort`
+to roll the record back.
 
 **`swarm commit`** — flags `--slot` (defaults to single active
 slot), `-m` (required); positional file args optional. Calls
-`Lease.Resume` then `Lease.Commit(files...)` (claim → libfossil
-commit with slot-user identity → autosync to hub → bump
-`LastRenewed` via CAS). Prints new commit hash. The agent NEVER calls
-`fossil up`; concurrent slot work appears on the hub as forks (the
-way fossil itself models it), invisible to this slot's lineage.
+`swarm.Resume` then `ResumedLease.Commit(message, files)` (claim →
+libfossil commit with slot-user identity → autosync to hub → bump
+`LastRenewed` via CAS, retrying on conflict). Prints new commit
+hash. The agent NEVER calls `fossil up`; concurrent slot work
+appears on the hub as forks (the way fossil itself models it),
+invisible to this slot's lineage.
 
 **`swarm close`** — flags `--slot`, `--result`
 (`success|fail|fork`), `--summary`, `--branch`/`--rev` (forks only).
-Calls `Lease.Resume`, posts a `dispatch.ResultMessage` to
+Calls `swarm.Resume`, posts a `dispatch.ResultMessage` to
 `<proj>.tasks.<taskID>.result` so the dispatch parent (ADR 0021)
-picks it up. On success, `Lease.Close` (releases the claim, closes
-the task in NATS KV, deletes the session record via CAS, stops the
-leaf); on fail/fork, release claim only — task stays open for human
+picks it up. On success, `ResumedLease.Close` with
+`CloseTaskOnSuccess=true` (releases the claim, closes the task in
+NATS KV, deletes the session record via CAS, stops the leaf); on
+fail/fork, releases the claim only — task stays open for human
 inspection. `wt/` and `leaf.fossil` stay for forensics until
 explicit `bones swarm prune <slot>`.
 
@@ -206,15 +234,19 @@ list.
   via `bones doctor`, and future multi-machine swarms for free.
   Cost: one more substrate-side bucket to provision at `coord.Open`,
   consistent with existing buckets.
-- **`AcquireFresh` / `Resume` split vs. a single `Lease`
-  constructor.** Caller intent (start vs. continue) is explicit in
-  the type signature, role-guard preconditions are scoped to fresh
-  acquisition, error handling is unambiguous. Cost: two
-  constructors, slightly more API surface.
-- **Lease accessors vs. `Leaf()` escape hatch.** Methods pin the
-  lifetime invariant in the type and constrain callers to the closed
-  verb set. The deprecated-on-arrival `Leaf()` accessor exists only
-  to allow incremental verb migration; its removal is the end-state.
+- **`Acquire` / `Resume` returning compile-time-distinct types vs.
+  a single `Lease` constructor.** Caller intent (start vs.
+  continue) is encoded in the return type, role-guard preconditions
+  are scoped to fresh acquisition, and the methods that only make
+  sense on a fresh record (`Abort`) or a resumed one (`Commit`,
+  `Close`) are not callable on the wrong type. Cost: two types
+  share an embedded `leaseBase` for accessors and teardown.
+- **CAS retries inside `Commit` and `Close` vs. caller-visible
+  conflicts.** The lease implementation absorbs the rev-advance
+  retry loop and surfaces only `ErrSessionGone` (record deleted
+  concurrently) as a typed signal. CLI verbs do not see transient
+  CAS failures. Cost: a stuck CAS loop is bounded by
+  `jskv.MaxRetries` rather than retried indefinitely.
 
 ## Migration
 

--- a/internal/swarm/lease.go
+++ b/internal/swarm/lease.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"sync/atomic"
 	"time"
 
 	"github.com/danmestas/libfossil"
@@ -14,32 +15,32 @@ import (
 
 	"github.com/danmestas/bones/internal/assert"
 	"github.com/danmestas/bones/internal/coord"
+	"github.com/danmestas/bones/internal/jskv"
 	"github.com/danmestas/bones/internal/workspace"
 )
 
 // DefaultHubFossilURL is the hub fossil HTTP URL bones writes when
 // `bones up` brings a hub to default ports. Mirrors the constant in
-// cli/swarm_join.go so AcquireFresh callers don't have to plumb the
-// URL through the CLI flag layer.
+// cli/swarm_join.go so Acquire callers don't have to plumb the URL
+// through the CLI flag layer.
 const DefaultHubFossilURL = "http://127.0.0.1:8765"
 
-// DefaultCaps is the fossil capability string granted to a slot
-// user when the caller doesn't override. Matches cli/swarm_join.go.
+// DefaultCaps is the fossil capability string granted to a slot user
+// when the caller doesn't override. Matches cli/swarm_join.go.
 const DefaultCaps = "oih"
 
 // activeThresholdSec is the seconds-since-LastRenewed cutoff between
 // "active" and "stale" sessions, mirroring cli/swarm_status.go. Lives
-// here too so AcquireFresh can apply the same active-on-this-host
-// rule when refusing to take over a non-stale record.
+// here too so Acquire can apply the same active-on-this-host rule
+// when refusing to take over a non-stale record.
 const activeThresholdSec = 90
 
-// ErrWorkspaceNotBootstrapped is returned by AcquireFresh when
+// ErrWorkspaceNotBootstrapped is returned by Acquire when
 // `<workspace>/.orchestrator/hub.fossil` is missing. The role-leak
 // guard from PR #54 lives here: a leaf must NEVER read the error as
-// "run `bones up`" — bootstrap is the orchestrator's job. The
-// error string deliberately omits the `bones up` phrase so a
-// subagent reading stderr can't be misled into bootstrapping its
-// own context.
+// "run `bones up`" — bootstrap is the orchestrator's job. The error
+// string deliberately omits the `bones up` phrase so a subagent
+// reading stderr can't be misled into bootstrapping its own context.
 var ErrWorkspaceNotBootstrapped = errors.New(
 	"swarm: workspace not bootstrapped — the orchestrator must " +
 		"bring up the hub before leaves can join; refusing to " +
@@ -53,32 +54,41 @@ var ErrSessionNotFound = errors.New(
 	"swarm: session record not found — run `bones swarm join` first",
 )
 
-// ErrSessionAlreadyLive is returned by AcquireFresh when a live
-// session record exists for the slot on this host and ForceTakeover
-// is false. Callers that want to overwrite it must set
+// ErrSessionGone is returned by ResumedLease.Commit and
+// ResumedLease.Close when the session record was deleted between
+// Resume and the operation — usually because a concurrent close on
+// another agent ran. Distinct from ErrSessionNotFound so callers can
+// distinguish "never existed" from "deleted under us mid-flight".
+var ErrSessionGone = errors.New(
+	"swarm: session record was deleted concurrently",
+)
+
+// ErrSessionAlreadyLive is returned by Acquire when a live session
+// record exists for the slot on this host and ForceTakeover is
+// false. Callers that want to overwrite must set
 // AcquireOpts.ForceTakeover.
 var ErrSessionAlreadyLive = errors.New(
 	"swarm: live session already on this slot — pass --force to take over",
 )
 
-// ErrSessionForeignHost is returned by AcquireFresh when the
-// existing session record was written by a different host. Cross-
-// host takeover is refused unconditionally; the operator must run
-// the takeover from the owning host.
+// ErrSessionForeignHost is returned by Acquire when the existing
+// session record was written by a different host. Cross-host takeover
+// is refused unconditionally; the operator must run the takeover
+// from the owning host.
 var ErrSessionForeignHost = errors.New(
 	"swarm: session owned by another host — refusing cross-host takeover",
 )
 
 // ErrCrossHostOperation is returned by Resume when the session
 // record's Host field doesn't match this machine's hostname.
-// Cross-host commit / close / status operations would manipulate
-// a leaf process bones can't reach; the right answer is for the
-// operator to run the verb on the owning host.
+// Cross-host commit/close/status operations would manipulate a leaf
+// process bones can't reach; the right answer is for the operator to
+// run the verb on the owning host.
 var ErrCrossHostOperation = errors.New(
 	"swarm: cross-host operation refused — run the verb on the slot's owning host",
 )
 
-// AcquireOpts tunes AcquireFresh and Resume. Zero-value defaults are
+// AcquireOpts tunes Acquire and Resume. Zero-value defaults are
 // production-correct: HubURL → DefaultHubFossilURL, Caps →
 // DefaultCaps, NATSConn dialed from info.NATSURL, Now →
 // time.Now().UTC.
@@ -96,18 +106,18 @@ type AcquireOpts struct {
 	Hub *coord.Hub
 
 	// Caps overrides fossil capabilities for the slot user on
-	// AcquireFresh. Resume ignores this. Empty → DefaultCaps.
+	// Acquire. Resume ignores this. Empty → DefaultCaps.
 	Caps string
 
-	// ForceTakeover lets AcquireFresh CAS-delete an existing same-
-	// host session record on the slot. Recovery only — the typical
-	// path is an explicit operator decision after `bones doctor`.
+	// ForceTakeover lets Acquire CAS-delete an existing same-host
+	// session record on the slot. Recovery only — the typical path
+	// is an explicit operator decision after `bones doctor`.
 	ForceTakeover bool
 
-	// NATSConn is a pre-connected NATS connection. If nil, the
-	// lease dials info.NATSURL itself and the resulting connection
-	// is closed when the lease is released. When set, the caller
-	// owns the connection's lifetime.
+	// NATSConn is a pre-connected NATS connection. If nil, the lease
+	// dials info.NATSURL itself and the resulting connection is
+	// closed when the lease is released. When set, the caller owns
+	// the connection's lifetime.
 	NATSConn *nats.Conn
 
 	// Now is the time source for StartedAt and LastRenewed. nil →
@@ -115,25 +125,37 @@ type AcquireOpts struct {
 	Now func() time.Time
 }
 
-// Lease is a single CLI invocation's grip on a slot. A Lease owns
-// the per-slot coord.Leaf, an optional claim hold, and the
-// JetStream KV session record for the duration of one CLI verb.
-//
-// Acquired fresh by `bones swarm join` (which CAS-creates the
-// session record), resumed by every other swarm verb (which read
-// the existing record and reconstruct the leaf). Per-CLI-invocation
-// lifetime — the leaf and claim die with the lease; the persistent
-// state across verbs is the session record in
-// bones-swarm-sessions[slot], not the lease itself.
-//
-// Lease is the only legal mutator of the session record. The narrow
-// public surface on swarm.Sessions (Get/List public, put/update/delete
-// unexported) enforces this at compile time.
-//
-// See ADR 0028 for the design and the rationale for the
-// AcquireFresh / Resume split. Tests against Lease use real NATS +
-// real Fossil rather than mocks.
-type Lease struct {
+// CommitResult is the outcome of ResumedLease.Commit. UUID is set on
+// every successful local commit. PushResult is set when the
+// post-commit HTTP push to the hub succeeded; PushErr is set when it
+// failed (the local commit lands either way). RenewErr is set when
+// the session-record CAS bump exhausted retries or saw an
+// unrecoverable error. Callers should print warnings for the soft
+// errors but should not roll back the local commit.
+type CommitResult struct {
+	UUID       string
+	PushResult *libfossil.SyncResult
+	PushErr    error
+	RenewErr   error
+}
+
+// CloseOpts tunes ResumedLease.Close. Zero value is the conservative
+// release-and-cleanup behavior; CloseTaskOnSuccess transitions the
+// underlying task to closed in the bones-tasks bucket.
+type CloseOpts struct {
+	// CloseTaskOnSuccess, when true, calls coord.Leaf.Close on the
+	// re-claimed task — closing the task in the bones-tasks bucket
+	// in addition to releasing the claim hold. False just releases
+	// the claim, leaving the task open for retry by the parent
+	// dispatch. swarm close --result=success sets this true; fail
+	// and fork leave it false.
+	CloseTaskOnSuccess bool
+}
+
+// leaseBase holds the fields shared by FreshLease and ResumedLease.
+// Embedded into both types so the accessors and teardown logic
+// live in one place.
+type leaseBase struct {
 	info       workspace.Info
 	slot       string
 	taskID     string
@@ -141,18 +163,86 @@ type Lease struct {
 	hubURL     string
 	now        func() time.Time
 
-	leaf  *coord.Leaf
-	claim *coord.Claim
+	leaf *coord.Leaf
 
 	sessions     *Sessions
 	natsConn     *nats.Conn
 	ownsNATSConn bool
 	rev          uint64
 
-	released bool
+	released atomic.Bool
 }
 
-// AcquireFresh opens a Lease for a slot that has no live session
+// Slot returns the slot name this lease is bound to.
+func (b *leaseBase) Slot() string { return b.slot }
+
+// TaskID returns the task ID stamped into the lease's session record.
+func (b *leaseBase) TaskID() string { return b.taskID }
+
+// HubURL returns the hub fossil HTTP URL the lease's leaf is peered
+// against.
+func (b *leaseBase) HubURL() string { return b.hubURL }
+
+// FossilUser returns the slot's fossil user (e.g. "slot-rendering").
+func (b *leaseBase) FossilUser() string { return b.fossilUser }
+
+// WT returns the slot's worktree path. Returns the empty string
+// after the leaf has been stopped (e.g. post-Commit).
+func (b *leaseBase) WT() string {
+	if b.leaf == nil {
+		return ""
+	}
+	return b.leaf.WT()
+}
+
+// SessionRevision returns the JetStream KV revision the lease last
+// observed. Bumped internally by Commit on each successful CAS.
+// Test-only utility — production verbs go through Commit / Close.
+func (b *leaseBase) SessionRevision() uint64 { return b.rev }
+
+// teardown stops the leaf and closes the Sessions handle and the
+// owned NATS connection. Caller is responsible for sequencing claim
+// release before this. Idempotent.
+func (b *leaseBase) teardown() {
+	if b.leaf != nil {
+		_ = b.leaf.Stop()
+		b.leaf = nil
+	}
+	if b.sessions != nil {
+		_ = b.sessions.Close()
+	}
+	if b.ownsNATSConn && b.natsConn != nil {
+		b.natsConn.Close()
+	}
+}
+
+// FreshLease is a slot session created by Acquire. It owns an active
+// claim taken at acquisition time. FreshLease.Release is the graceful
+// exit (record persists for later Resume); FreshLease.Abort is the
+// rollback path (record deleted).
+//
+// FreshLease has neither Commit nor Close — those operate on a
+// resumed lease with the latest record revision. Callers that need
+// to commit after acquiring should Release the FreshLease and Resume
+// in a separate operation.
+type FreshLease struct {
+	leaseBase
+	claim *coord.Claim
+}
+
+// ResumedLease is a slot session reconstructed from an existing
+// record by Resume. It does NOT hold a claim; Commit and Close
+// re-acquire as needed. CAS revision on the session record is
+// tracked internally; Commit advances it on every successful
+// LastRenewed bump.
+//
+// ResumedLease has Commit, Close, and Release. No Abort — fresh
+// records are the only thing that gets rolled back.
+type ResumedLease struct {
+	leaseBase
+}
+
+// Acquire opens a FreshLease for a slot that has no live session
 // record yet. Used by `bones swarm join`. Steps, in order, with any
 // partial work cleaned up on error:
 //
@@ -168,17 +258,17 @@ type Lease struct {
 //  5. Open coord.Leaf with Autosync=true and claim the task.
 //  6. Put the session record (CAS create) and write the pid file.
 //
-// Returns a live Lease the caller MUST Release (when the session
-// record should persist for later verbs) or Close (when the slot's
-// work is done and the record should be deleted).
-func AcquireFresh(
+// The returned FreshLease holds the claim. Callers MUST call
+// Release (record persists) or Abort (record deleted as rollback)
+// exactly once.
+func Acquire(
 	ctx context.Context, info workspace.Info,
 	slot, taskID string, opts AcquireOpts,
-) (*Lease, error) {
-	assert.NotNil(ctx, "swarm.AcquireFresh: ctx is nil")
-	assert.NotEmpty(slot, "swarm.AcquireFresh: slot is empty")
-	assert.NotEmpty(taskID, "swarm.AcquireFresh: taskID is empty")
-	assert.NotEmpty(info.WorkspaceDir, "swarm.AcquireFresh: info.WorkspaceDir is empty")
+) (*FreshLease, error) {
+	assert.NotNil(ctx, "swarm.Acquire: ctx is nil")
+	assert.NotEmpty(slot, "swarm.Acquire: slot is empty")
+	assert.NotEmpty(taskID, "swarm.Acquire: taskID is empty")
+	assert.NotEmpty(info.WorkspaceDir, "swarm.Acquire: info.WorkspaceDir is empty")
 
 	now, hubURL, caps := defaultAcquireOpts(opts)
 	if opts.HubURL == "" && opts.Hub != nil {
@@ -225,121 +315,41 @@ func AcquireFresh(
 		return nil, err
 	}
 
-	return &Lease{
-		info:         info,
-		slot:         slot,
-		taskID:       taskID,
-		fossilUser:   fossilUser,
-		hubURL:       hubURL,
-		now:          now,
-		leaf:         leaf,
-		claim:        claim,
-		sessions:     sessions,
-		natsConn:     nc,
-		ownsNATSConn: ownsConn,
-		rev:          rev,
+	return &FreshLease{
+		leaseBase: leaseBase{
+			info:         info,
+			slot:         slot,
+			taskID:       taskID,
+			fossilUser:   fossilUser,
+			hubURL:       hubURL,
+			now:          now,
+			leaf:         leaf,
+			sessions:     sessions,
+			natsConn:     nc,
+			ownsNATSConn: ownsConn,
+			rev:          rev,
+		},
+		claim: claim,
 	}, nil
 }
 
-// defaultAcquireOpts returns the (now, hubURL, caps) triple after
-// substituting package defaults for any zero-valued fields. Pulled
-// out so AcquireFresh and Resume share the defaulting logic and so
-// AcquireFresh fits under the funlen lint cap.
-func defaultAcquireOpts(opts AcquireOpts) (func() time.Time, string, string) {
-	now := opts.Now
-	if now == nil {
-		now = func() time.Time { return time.Now().UTC() }
-	}
-	hubURL := opts.HubURL
-	if hubURL == "" {
-		hubURL = DefaultHubFossilURL
-	}
-	caps := opts.Caps
-	if caps == "" {
-		caps = DefaultCaps
-	}
-	return now, hubURL, caps
-}
-
-// openLeafAndClaim opens the per-slot coord.Leaf and acquires a
-// claim on the named task. On error, any partially-opened leaf is
-// stopped before return.
-func openLeafAndClaim(
-	ctx context.Context, info workspace.Info,
-	slot, fossilUser, hubURL, taskID string, hub *coord.Hub,
-) (*coord.Leaf, *coord.Claim, error) {
-	leaf, err := openLeaf(ctx, info, slot, fossilUser, hubURL, hub)
-	if err != nil {
-		return nil, nil, fmt.Errorf("swarm.AcquireFresh: open leaf: %w", err)
-	}
-	if err := os.MkdirAll(leaf.WT(), 0o755); err != nil {
-		_ = leaf.Stop()
-		return nil, nil, fmt.Errorf("swarm.AcquireFresh: mkdir worktree: %w", err)
-	}
-	claim, err := leaf.Claim(ctx, coord.TaskID(taskID))
-	if err != nil {
-		_ = leaf.Stop()
-		return nil, nil, fmt.Errorf("swarm.AcquireFresh: claim task: %w", err)
-	}
-	return leaf, claim, nil
-}
-
-// writeSessionAndPid CAS-creates the session record and writes the
-// host-local pid file. Returns the post-put KV revision so the
-// Lease can CAS against it during Close. On pid-file failure the
-// session record is best-effort deleted before return so the slot
-// stays clean for the next AcquireFresh.
-func writeSessionAndPid(
-	ctx context.Context, sessions *Sessions,
-	workspaceDir, slot, taskID, fossilUser, hubURL string,
-	now func() time.Time,
-) (uint64, error) {
-	host, _ := os.Hostname()
-	t := now()
-	sess := Session{
-		Slot:        slot,
-		TaskID:      taskID,
-		AgentID:     fossilUser,
-		Host:        host,
-		LeafPID:     os.Getpid(),
-		HubURL:      hubURL,
-		StartedAt:   t,
-		LastRenewed: t,
-	}
-	if err := sessions.put(ctx, sess); err != nil {
-		return 0, fmt.Errorf("swarm.AcquireFresh: write session record: %w", err)
-	}
-	if err := writePidFile(workspaceDir, slot); err != nil {
-		_ = sessions.delete(ctx, slot, 0)
-		return 0, fmt.Errorf("swarm.AcquireFresh: %w", err)
-	}
-	_, rev, err := sessions.Get(ctx, slot)
-	if err != nil {
-		return 0, fmt.Errorf("swarm.AcquireFresh: re-read session: %w", err)
-	}
-	return rev, nil
-}
-
-// Resume opens a Lease for a slot whose session record already
-// exists in KV. Used by every swarm verb other than join.
+// Resume opens a ResumedLease for a slot whose session record
+// already exists in KV. Used by every swarm verb other than join.
 //
 // Resume does NOT re-take the claim — verbs that need a claim
-// (Lease.Commit / Lease.Close) re-acquire it themselves. This
-// mirrors today's CLI behavior: claim holds have a TTL that
-// outlives a single verb only when bumped, and the record's
-// LastRenewed is the durable liveness signal.
+// (Commit, Close) re-acquire it themselves. This mirrors today's
+// CLI behavior: claim holds have a TTL that outlives a single verb
+// only when bumped, and the record's LastRenewed is the durable
+// liveness signal.
 //
 // Resume refuses cross-host operations: if the session record's
 // Host field doesn't match this machine, returns
-// ErrCrossHostOperation. The leaf process bones can manipulate
-// lives on the owning host, so the verb has to run there.
-//
-// Returns ErrSessionNotFound if the slot has no record. Returns the
-// underlying NATS / Fossil errors otherwise.
+// ErrCrossHostOperation. Returns ErrSessionNotFound if the slot has
+// no record.
 func Resume(
 	ctx context.Context, info workspace.Info,
 	slot string, opts AcquireOpts,
-) (*Lease, error) {
+) (*ResumedLease, error) {
 	assert.NotNil(ctx, "swarm.Resume: ctx is nil")
 	assert.NotEmpty(slot, "swarm.Resume: slot is empty")
 	assert.NotEmpty(info.WorkspaceDir, "swarm.Resume: info.WorkspaceDir is empty")
@@ -383,96 +393,59 @@ func Resume(
 		return nil, fmt.Errorf("swarm.Resume: open leaf: %w", err)
 	}
 
-	return &Lease{
-		info:         info,
-		slot:         slot,
-		taskID:       sess.TaskID,
-		fossilUser:   sess.AgentID,
-		hubURL:       hubURL,
-		now:          now,
-		leaf:         leaf,
-		claim:        nil, // Resume does not take a claim
-		sessions:     sessions,
-		natsConn:     nc,
-		ownsNATSConn: ownsConn,
-		rev:          rev,
+	return &ResumedLease{
+		leaseBase: leaseBase{
+			info:         info,
+			slot:         slot,
+			taskID:       sess.TaskID,
+			fossilUser:   sess.AgentID,
+			hubURL:       hubURL,
+			now:          now,
+			leaf:         leaf,
+			sessions:     sessions,
+			natsConn:     nc,
+			ownsNATSConn: ownsConn,
+			rev:          rev,
+		},
 	}, nil
 }
 
-// Release closes the lease without deleting the session record.
-// Stops the leaf, releases any held claim, closes the swarm
-// Sessions handle, and (if the lease owns the NATS connection)
-// closes that too. Idempotent.
+// Release closes the FreshLease without deleting the session record.
+// Releases the claim, stops the leaf, closes the swarm.Sessions
+// handle, and (if the lease owns the NATS connection) closes that
+// too. Idempotent.
 //
-// `bones swarm join` calls Release after writing the session
-// record so subsequent verbs can Resume against it. `bones swarm
-// close` calls Close instead, which also deletes the record.
-func (l *Lease) Release(ctx context.Context) error {
-	assert.NotNil(l, "swarm.Lease.Release: receiver is nil")
-	if l.released {
+// `bones swarm join` calls Release after writing the session record
+// so subsequent verbs can Resume against it.
+func (l *FreshLease) Release(ctx context.Context) error {
+	assert.NotNil(l, "swarm.FreshLease.Release: receiver is nil")
+	if !l.released.CompareAndSwap(false, true) {
 		return nil
 	}
-	l.released = true
 	if l.claim != nil {
 		_ = l.claim.Release()
+		l.claim = nil
 	}
-	if l.leaf != nil {
-		_ = l.leaf.Stop()
-	}
-	if l.sessions != nil {
-		_ = l.sessions.Close()
-	}
-	if l.ownsNATSConn && l.natsConn != nil {
-		l.natsConn.Close()
-	}
-	_ = ctx // ctx kept for symmetry with Close; cleanup is local
+	l.teardown()
+	_ = ctx
 	return nil
 }
 
-// CloseOpts tunes Lease.Close. Zero value is the conservative
-// release-and-cleanup behavior; CloseTaskOnSuccess transitions the
-// lease's task to closed in the bones-tasks bucket.
-type CloseOpts struct {
-	// CloseTaskOnSuccess, when true, calls coord.Leaf.Close on the
-	// re-claimed task — closing the task in the bones-tasks bucket
-	// in addition to releasing the claim hold. False just releases
-	// the claim, leaving the task open for retry by the parent
-	// dispatch. swarm close --result=success sets this true; fail
-	// and fork leave it false.
-	CloseTaskOnSuccess bool
-}
-
-// Close terminates the lease, removes the host-local pid file, and
-// deletes the session record via a CAS gate against the revision
-// the lease holds. When CloseOpts.CloseTaskOnSuccess is true the
-// underlying task is also transitioned to closed in the
-// bones-tasks bucket via Leaf.Close. Idempotent — a second Close
-// after a successful first is a no-op.
-//
-// Steps, in order:
-//
-//  1. Re-claim the lease's task (Resume did not claim it).
-//  2. If CloseTaskOnSuccess: Leaf.Close — closes the task and
-//     releases the claim hold in one operation. Otherwise just
-//     release the claim.
-//  3. Stop the leaf.
-//  4. Remove the host-local pid file.
-//  5. CAS-delete the session record.
-//  6. Tear down the swarm.Sessions handle + NATS connection.
-//
-// `bones swarm close` calls this. The CAS gate on step 5 ensures
-// we don't delete a record some other process renewed; if it raced
-// us, the caller sees the underlying ErrCASConflict and can decide
-// whether to re-Resume and retry.
-func (l *Lease) Close(ctx context.Context, opts CloseOpts) error {
-	assert.NotNil(l, "swarm.Lease.Close: receiver is nil")
-	assert.NotNil(ctx, "swarm.Lease.Close: ctx is nil")
-	if l.released {
+// Abort rolls back the fresh acquisition: releases the claim, stops
+// the leaf, CAS-deletes the session record, removes the host-local
+// pid file, and tears down the Sessions handle and NATS connection.
+// Used when join's downstream work fails after Acquire succeeded —
+// the caller wants to leave the slot in the same state Acquire saw.
+// Idempotent.
+func (l *FreshLease) Abort(ctx context.Context) error {
+	assert.NotNil(l, "swarm.FreshLease.Abort: receiver is nil")
+	assert.NotNil(ctx, "swarm.FreshLease.Abort: ctx is nil")
+	if !l.released.CompareAndSwap(false, true) {
 		return nil
 	}
-	if err := l.closeTaskAndReleaseClaim(ctx, opts.CloseTaskOnSuccess); err != nil {
-		_ = l.releaseUnderlying()
-		return err
+	if l.claim != nil {
+		_ = l.claim.Release()
+		l.claim = nil
 	}
 	if l.leaf != nil {
 		_ = l.leaf.Stop()
@@ -480,92 +453,46 @@ func (l *Lease) Close(ctx context.Context, opts CloseOpts) error {
 	}
 	if err := os.Remove(SlotPidFile(l.info.WorkspaceDir, l.slot)); err != nil &&
 		!os.IsNotExist(err) {
-		_ = l.releaseUnderlying()
-		return fmt.Errorf("swarm.Lease.Close: remove pid file: %w", err)
+		// Best-effort: pid removal failure shouldn't block KV
+		// rollback. The pid file is host-local cosmetics.
+		_ = err
 	}
+	var first error
 	if l.sessions != nil && l.rev != 0 {
 		if err := l.sessions.delete(ctx, l.slot, l.rev); err != nil &&
 			!errors.Is(err, ErrNotFound) && !errors.Is(err, ErrCASConflict) {
-			_ = l.releaseUnderlying()
-			return fmt.Errorf("swarm.Lease.Close: delete record: %w", err)
+			first = fmt.Errorf("swarm.FreshLease.Abort: delete record: %w", err)
 		}
 	}
-	return l.releaseUnderlying()
+	l.teardown()
+	return first
 }
 
-// closeTaskAndReleaseClaim acquires a claim on the lease's task
-// (or reuses the one AcquireFresh already took) and either closes
-// the task (success) or releases the claim (fail/fork). Pulled out
-// so Close stays under the funlen lint cap.
-//
-// AcquireFresh leaves an active claim on the lease so AcquireFresh
-// → Close in a single CLI invocation reuses it; Resume → Close
-// (the more common path) re-claims here.
-func (l *Lease) closeTaskAndReleaseClaim(ctx context.Context, closeTask bool) error {
-	if l.leaf == nil {
-		return nil
-	}
-	claim := l.claim
-	if claim == nil {
-		c, err := l.leaf.Claim(ctx, coord.TaskID(l.taskID))
-		if err != nil {
-			return fmt.Errorf("swarm.Lease.Close: re-claim for close: %w", err)
-		}
-		claim = c
-	}
-	l.claim = nil // ownership transfers to the close-or-release call below
-	if closeTask {
-		if err := l.leaf.Close(ctx, claim); err != nil {
-			return fmt.Errorf("swarm.Lease.Close: leaf close: %w", err)
-		}
-		return nil
-	}
-	if err := claim.Release(); err != nil {
-		return fmt.Errorf("swarm.Lease.Close: release claim: %w", err)
-	}
-	return nil
-}
-
-// CommitResult is the outcome of Lease.Commit. UUID is set on every
-// successful local commit. PushResult is set when the post-commit
-// HTTP push to the hub succeeded; PushErr is set when it failed
-// (the local commit lands either way). RenewErr is set when the
-// session-record CAS-bump failed (the commit succeeded but the
-// session may TTL out before the next verb runs). Callers should
-// print warnings for the soft errors but should not roll back the
-// local commit on either of them.
-type CommitResult struct {
-	UUID       string
-	PushResult *libfossil.SyncResult
-	PushErr    error
-	RenewErr   error
-}
-
-// Commit takes a fresh claim on the lease's task, announces holds
-// for the file paths, commits the bytes via the underlying
-// coord.Leaf, releases the claim, stops the leaf, HTTP-pushes the
-// slot's leaf.fossil to the hub via /xfer, and CAS-bumps
-// LastRenewed on the session record.
+// Commit re-claims the lease's task, announces holds for the file
+// paths, commits the bytes via the underlying coord.Leaf, releases
+// the claim, stops the leaf, HTTP-pushes the slot's leaf.fossil to
+// the hub via /xfer, and CAS-bumps LastRenewed on the session record.
 //
 // Returns CommitResult with the local-commit UUID always set on
 // success. PushResult / PushErr report the hub-push outcome; the
 // hub may be unreachable without rolling back the local commit.
-// RenewErr reports the session-record CAS bump; CAS conflicts are
-// silently treated as success (a sibling renewer raced and bumped
-// the TTL on our behalf).
+// RenewErr reports the session-record CAS bump; transient CAS
+// conflicts retry up to jskv.MaxRetries times. ErrSessionGone
+// surfaces as RenewErr if the session record was deleted between
+// Resume and now.
 //
 // After Commit returns, the lease's underlying coord.Leaf has been
 // stopped — the push path needs an exclusive libfossil.Repo handle
 // on leaf.fossil. The lease can still be Released or Closed; doing
-// other verb work on the lease's leaf after Commit is undefined
-// and would have to re-Resume.
-func (l *Lease) Commit(
+// other verb work on the lease's leaf after Commit is undefined and
+// would have to re-Resume.
+func (l *ResumedLease) Commit(
 	ctx context.Context, message string, files []coord.File,
 ) (CommitResult, error) {
-	assert.NotNil(l, "swarm.Lease.Commit: receiver is nil")
-	assert.NotNil(ctx, "swarm.Lease.Commit: ctx is nil")
+	assert.NotNil(l, "swarm.ResumedLease.Commit: receiver is nil")
+	assert.NotNil(ctx, "swarm.ResumedLease.Commit: ctx is nil")
 	if l.leaf == nil {
-		return CommitResult{}, fmt.Errorf("swarm.Lease.Commit: leaf already stopped")
+		return CommitResult{}, fmt.Errorf("swarm.ResumedLease.Commit: leaf already stopped")
 	}
 	uuid, err := commitViaLeaf(ctx, l.leaf, l.taskID, message, files)
 	if err != nil {
@@ -578,7 +505,7 @@ func (l *Lease) Commit(
 	l.leaf = nil
 
 	pushRes, pushErr := pushLeafFossil(ctx, l.info.WorkspaceDir, l.slot, l.fossilUser, l.hubURL)
-	renewErr := l.renewSessionAfterCommit(ctx)
+	renewErr := l.bumpLastRenewed(ctx)
 
 	return CommitResult{
 		UUID:       uuid,
@@ -588,40 +515,250 @@ func (l *Lease) Commit(
 	}, nil
 }
 
-// renewSessionAfterCommit bumps LastRenewed via CAS so the bucket
-// TTL extends beyond the next slot heartbeat window. CAS conflict
-// is treated as success — a sibling commit raced ours and the
-// other writer's update already extended the TTL.
-func (l *Lease) renewSessionAfterCommit(ctx context.Context) error {
+// bumpLastRenewed CAS-updates LastRenewed on the session record so
+// the bucket TTL extends. On CAS conflict (rev advanced — sibling
+// commit raced ours) the loop re-reads and tries again. On
+// ErrNotFound (record deleted concurrently) returns ErrSessionGone
+// so the caller can distinguish unrecoverable state from a transient
+// failure.
+func (l *ResumedLease) bumpLastRenewed(ctx context.Context) error {
+	if l.sessions == nil {
+		return nil
+	}
+	for attempt := 0; attempt < jskv.MaxRetries; attempt++ {
+		sess, rev, err := l.sessions.Get(ctx, l.slot)
+		if err != nil {
+			if errors.Is(err, ErrNotFound) {
+				return ErrSessionGone
+			}
+			return fmt.Errorf("swarm.ResumedLease.Commit: re-read session: %w", err)
+		}
+		sess.LastRenewed = l.now()
+		if err := l.sessions.update(ctx, sess, rev); err != nil {
+			if errors.Is(err, ErrCASConflict) {
+				// Another writer raced ours; loop and re-read.
+				continue
+			}
+			return fmt.Errorf("swarm.ResumedLease.Commit: renew session: %w", err)
+		}
+		l.rev = rev + 1
+		return nil
+	}
+	return fmt.Errorf(
+		"swarm.ResumedLease.Commit: exhausted %d CAS retries on session bump",
+		jskv.MaxRetries,
+	)
+}
+
+// Close terminates the ResumedLease, removes the host-local pid
+// file, and CAS-deletes the session record. When CloseOpts.
+// CloseTaskOnSuccess is true the underlying task is also transitioned
+// to closed in the bones-tasks bucket via Leaf.Close. Idempotent.
+//
+// Steps, in order:
+//
+//  1. Re-claim the lease's task (Resume did not claim it).
+//  2. If CloseTaskOnSuccess: Leaf.Close — closes the task and
+//     releases the claim hold in one operation. Otherwise just
+//     release the claim.
+//  3. Stop the leaf.
+//  4. Remove the host-local pid file.
+//  5. CAS-delete the session record, retrying on rev advance from a
+//     concurrent commit.
+//  6. Tear down the swarm.Sessions handle + NATS connection.
+//
+// CAS conflict on step 5 (sibling commit bumped LastRenewed) re-reads
+// the rev and retries — the operator wants to close, regardless of
+// transient renewals. ErrSessionGone surfaces if the record is
+// missing on first read; the close is otherwise idempotent.
+func (l *ResumedLease) Close(ctx context.Context, opts CloseOpts) error {
+	assert.NotNil(l, "swarm.ResumedLease.Close: receiver is nil")
+	assert.NotNil(ctx, "swarm.ResumedLease.Close: ctx is nil")
+	if !l.released.CompareAndSwap(false, true) {
+		return nil
+	}
+	if err := l.closeTaskAndReleaseClaim(ctx, opts.CloseTaskOnSuccess); err != nil {
+		l.teardown()
+		return err
+	}
+	if l.leaf != nil {
+		_ = l.leaf.Stop()
+		l.leaf = nil
+	}
+	if err := os.Remove(SlotPidFile(l.info.WorkspaceDir, l.slot)); err != nil &&
+		!os.IsNotExist(err) {
+		l.teardown()
+		return fmt.Errorf("swarm.ResumedLease.Close: remove pid file: %w", err)
+	}
+	if err := l.deleteSessionRecord(ctx); err != nil {
+		l.teardown()
+		return err
+	}
+	l.teardown()
+	return nil
+}
+
+// deleteSessionRecord CAS-deletes the session record, retrying on
+// rev advance from a concurrent commit. Treats ErrNotFound as success
+// (the record was already gone — close is idempotent).
+func (l *ResumedLease) deleteSessionRecord(ctx context.Context) error {
 	if l.sessions == nil || l.rev == 0 {
 		return nil
 	}
-	sess, rev, err := l.sessions.Get(ctx, l.slot)
-	if err != nil {
-		return fmt.Errorf("swarm.Lease.Commit: re-read session for renew: %w", err)
-	}
-	sess.LastRenewed = l.now()
-	if err := l.sessions.update(ctx, sess, rev); err != nil {
-		if errors.Is(err, ErrCASConflict) {
+	for attempt := 0; attempt < jskv.MaxRetries; attempt++ {
+		err := l.sessions.delete(ctx, l.slot, l.rev)
+		if err == nil {
 			return nil
 		}
-		return fmt.Errorf("swarm.Lease.Commit: renew session: %w", err)
+		if errors.Is(err, ErrNotFound) {
+			return nil
+		}
+		if errors.Is(err, ErrCASConflict) {
+			_, rev, getErr := l.sessions.Get(ctx, l.slot)
+			if errors.Is(getErr, ErrNotFound) {
+				return nil
+			}
+			if getErr != nil {
+				return fmt.Errorf(
+					"swarm.ResumedLease.Close: re-read session: %w", getErr,
+				)
+			}
+			l.rev = rev
+			continue
+		}
+		return fmt.Errorf("swarm.ResumedLease.Close: delete record: %w", err)
 	}
-	l.rev = rev + 1 // best-effort; next Get re-syncs anyway
+	return fmt.Errorf(
+		"swarm.ResumedLease.Close: exhausted %d CAS retries on session delete",
+		jskv.MaxRetries,
+	)
+}
+
+// closeTaskAndReleaseClaim acquires a claim on the lease's task and
+// either closes the task (success) or releases the claim
+// (fail/fork). Pulled out so Close stays under the funlen lint cap.
+func (l *ResumedLease) closeTaskAndReleaseClaim(ctx context.Context, closeTask bool) error {
+	if l.leaf == nil {
+		return nil
+	}
+	claim, err := l.leaf.Claim(ctx, coord.TaskID(l.taskID))
+	if err != nil {
+		return fmt.Errorf("swarm.ResumedLease.Close: re-claim for close: %w", err)
+	}
+	if closeTask {
+		if err := l.leaf.Close(ctx, claim); err != nil {
+			return fmt.Errorf("swarm.ResumedLease.Close: leaf close: %w", err)
+		}
+		return nil
+	}
+	if err := claim.Release(); err != nil {
+		return fmt.Errorf("swarm.ResumedLease.Close: release claim: %w", err)
+	}
 	return nil
+}
+
+// Release closes the ResumedLease without deleting the session
+// record. Stops the leaf, closes the Sessions handle, and (if the
+// lease owns the NATS connection) closes that too. Idempotent.
+//
+// `bones swarm commit` calls Release after Commit so the record
+// stays live for later verbs.
+func (l *ResumedLease) Release(ctx context.Context) error {
+	assert.NotNil(l, "swarm.ResumedLease.Release: receiver is nil")
+	if !l.released.CompareAndSwap(false, true) {
+		return nil
+	}
+	l.teardown()
+	_ = ctx
+	return nil
+}
+
+// defaultAcquireOpts returns the (now, hubURL, caps) triple after
+// substituting package defaults for any zero-valued fields. Pulled
+// out so Acquire and Resume share the defaulting logic.
+func defaultAcquireOpts(opts AcquireOpts) (func() time.Time, string, string) {
+	now := opts.Now
+	if now == nil {
+		now = func() time.Time { return time.Now().UTC() }
+	}
+	hubURL := opts.HubURL
+	if hubURL == "" {
+		hubURL = DefaultHubFossilURL
+	}
+	caps := opts.Caps
+	if caps == "" {
+		caps = DefaultCaps
+	}
+	return now, hubURL, caps
+}
+
+// openLeafAndClaim opens the per-slot coord.Leaf and acquires a
+// claim on the named task. On error, any partially-opened leaf is
+// stopped before return.
+func openLeafAndClaim(
+	ctx context.Context, info workspace.Info,
+	slot, fossilUser, hubURL, taskID string, hub *coord.Hub,
+) (*coord.Leaf, *coord.Claim, error) {
+	leaf, err := openLeaf(ctx, info, slot, fossilUser, hubURL, hub)
+	if err != nil {
+		return nil, nil, fmt.Errorf("swarm.Acquire: open leaf: %w", err)
+	}
+	if err := os.MkdirAll(leaf.WT(), 0o755); err != nil {
+		_ = leaf.Stop()
+		return nil, nil, fmt.Errorf("swarm.Acquire: mkdir worktree: %w", err)
+	}
+	claim, err := leaf.Claim(ctx, coord.TaskID(taskID))
+	if err != nil {
+		_ = leaf.Stop()
+		return nil, nil, fmt.Errorf("swarm.Acquire: claim task: %w", err)
+	}
+	return leaf, claim, nil
+}
+
+// writeSessionAndPid CAS-creates the session record and writes the
+// host-local pid file. Returns the post-put KV revision so the lease
+// can CAS against it during Close. On pid-file failure the session
+// record is best-effort deleted before return so the slot stays
+// clean for the next Acquire.
+func writeSessionAndPid(
+	ctx context.Context, sessions *Sessions,
+	workspaceDir, slot, taskID, fossilUser, hubURL string,
+	now func() time.Time,
+) (uint64, error) {
+	host, _ := os.Hostname()
+	t := now()
+	sess := Session{
+		Slot:        slot,
+		TaskID:      taskID,
+		AgentID:     fossilUser,
+		Host:        host,
+		LeafPID:     os.Getpid(),
+		HubURL:      hubURL,
+		StartedAt:   t,
+		LastRenewed: t,
+	}
+	if err := sessions.put(ctx, sess); err != nil {
+		return 0, fmt.Errorf("swarm.Acquire: write session record: %w", err)
+	}
+	if err := writePidFile(workspaceDir, slot); err != nil {
+		_ = sessions.delete(ctx, slot, 0)
+		return 0, fmt.Errorf("swarm.Acquire: %w", err)
+	}
+	_, rev, err := sessions.Get(ctx, slot)
+	if err != nil {
+		return 0, fmt.Errorf("swarm.Acquire: re-read session: %w", err)
+	}
+	return rev, nil
 }
 
 // commitViaLeaf re-claims the lease's task on the freshly-Resumed
 // leaf, announces holds for the file paths, commits, and releases.
-// Mirrors what cli/swarm_commit.go::commitViaLeaf used to do
-// directly — pulled into the swarm package so the CLI verb is just
-// flag-parsing + Lease.Commit.
 func commitViaLeaf(
 	ctx context.Context, leaf *coord.Leaf, taskID, message string, files []coord.File,
 ) (string, error) {
 	claim, err := leaf.Claim(ctx, coord.TaskID(taskID))
 	if err != nil {
-		return "", fmt.Errorf("swarm.Lease.Commit: re-claim task %q: %w", taskID, err)
+		return "", fmt.Errorf("swarm.ResumedLease.Commit: re-claim task %q: %w", taskID, err)
 	}
 	defer func() { _ = claim.Release() }()
 	paths := make([]string, 0, len(files))
@@ -630,26 +767,26 @@ func commitViaLeaf(
 	}
 	releaseHolds, err := leaf.AnnounceHolds(ctx, paths)
 	if err != nil {
-		return "", fmt.Errorf("swarm.Lease.Commit: announce holds: %w", err)
+		return "", fmt.Errorf("swarm.ResumedLease.Commit: announce holds: %w", err)
 	}
 	defer releaseHolds()
 	uuid, err := leaf.Commit(ctx, claim, files, coord.WithMessage(message))
 	if err != nil {
-		return "", fmt.Errorf("swarm.Lease.Commit: leaf commit: %w", err)
+		return "", fmt.Errorf("swarm.ResumedLease.Commit: leaf commit: %w", err)
 	}
 	return uuid, nil
 }
 
 // pushLeafFossil HTTP-pushes the slot's leaf.fossil to the hub via
-// libfossil's /xfer transport. The two NATS deployments are
-// separate by design (hub NATS vs. workspace leaf NATS), so the
-// post-commit announce doesn't reach the hub's /xfer subscriber —
-// the explicit HTTP push here is what makes the commit visible to
-// `bones peek` and the hub timeline.
+// libfossil's /xfer transport. The two NATS deployments are separate
+// by design (hub NATS vs. workspace leaf NATS), so the post-commit
+// announce doesn't reach the hub's /xfer subscriber — the explicit
+// HTTP push here is what makes the commit visible to `bones peek`
+// and the hub timeline.
 //
-// Soft-fail-friendly: returns SyncResult and error separately so
-// the caller can warn on push failure without rolling back the
-// local commit.
+// Soft-fail-friendly: returns SyncResult and error separately so the
+// caller can warn on push failure without rolling back the local
+// commit.
 func pushLeafFossil(
 	ctx context.Context, workspaceDir, slot, fossilUser, hubURL string,
 ) (*libfossil.SyncResult, error) {
@@ -676,62 +813,12 @@ func pushLeafFossil(
 	return res, nil
 }
 
-// releaseUnderlying tears down the leaf + claim + Sessions handle +
-// NATS connection. Shared by Release and Close so the cleanup
-// ordering stays in one place.
-func (l *Lease) releaseUnderlying() error {
-	l.released = true
-	if l.claim != nil {
-		_ = l.claim.Release()
-	}
-	if l.leaf != nil {
-		_ = l.leaf.Stop()
-	}
-	if l.sessions != nil {
-		_ = l.sessions.Close()
-	}
-	if l.ownsNATSConn && l.natsConn != nil {
-		l.natsConn.Close()
-	}
-	return nil
-}
-
-// Slot returns the slot this lease holds.
-func (l *Lease) Slot() string { return l.slot }
-
-// TaskID returns the task ID bound to the lease's session record.
-func (l *Lease) TaskID() string { return l.taskID }
-
-// HubURL returns the hub fossil HTTP URL the lease's leaf is
-// peered against.
-func (l *Lease) HubURL() string { return l.hubURL }
-
-// FossilUser returns the slot's fossil user (e.g. "slot-rendering").
-func (l *Lease) FossilUser() string { return l.fossilUser }
-
-// WT returns the slot's worktree path. Equivalent to
-// l.Leaf().WT() during the deprecated-on-arrival escape-hatch
-// window; will outlive Leaf() once swarm_commit and swarm_close
-// migrate.
-func (l *Lease) WT() string {
-	if l.leaf == nil {
-		return ""
-	}
-	return l.leaf.WT()
-}
-
-// SessionRevision returns the JetStream KV revision the lease
-// captured at acquisition. Test-only utility — callers that want
-// to inspect the underlying record can pair this with a separate
-// swarm.Sessions.Get; production verbs go through Commit / Close.
-func (l *Lease) SessionRevision() uint64 { return l.rev }
-
-// ensureSlotUser creates the slot's fossil user on the hub repo
-// if missing. The role-guard for "workspace not bootstrapped" lives
-// here: if `<workspace>/.orchestrator/hub.fossil` is absent,
-// returns ErrWorkspaceNotBootstrapped without trying to create
-// anything. Bootstrap is the orchestrator's job; a leaf must never
-// fix it (PR #54).
+// ensureSlotUser creates the slot's fossil user on the hub repo if
+// missing. The role-guard for "workspace not bootstrapped" lives
+// here: if `<workspace>/.orchestrator/hub.fossil` is absent, returns
+// ErrWorkspaceNotBootstrapped without trying to create anything.
+// Bootstrap is the orchestrator's job; a leaf must never fix it
+// (PR #54).
 func ensureSlotUser(workspaceDir, login, caps string) error {
 	hubRepoPath := filepath.Join(workspaceDir, ".orchestrator", "hub.fossil")
 	if _, err := os.Stat(hubRepoPath); err != nil {
@@ -791,7 +878,7 @@ func openLeaseSessions(
 }
 
 // clearExistingRecord enforces the "one live session per slot" rule
-// before AcquireFresh writes a new record. Returns nil if no record
+// before Acquire writes a new record. Returns nil if no record
 // exists or the existing record was successfully cleared. Returns
 // ErrSessionAlreadyLive if the existing record is active on this
 // host and force is false; ErrSessionForeignHost if it lives on a
@@ -825,9 +912,9 @@ func clearExistingRecord(
 }
 
 // openLeaf opens the per-slot coord.Leaf rooted at
-// `<workspace>/.bones/swarm`. When opts.Hub is set, opens against
-// the in-process hub directly (test path). Otherwise uses HubAddrs
-// with the workspace's NATS URL and the supplied hub HTTP URL.
+// `<workspace>/.bones/swarm`. When opts.Hub is set, opens against the
+// in-process hub directly (test path). Otherwise uses HubAddrs with
+// the workspace's NATS URL and the supplied hub HTTP URL.
 func openLeaf(
 	ctx context.Context, info workspace.Info,
 	slot, fossilUser, hubURL string, hub *coord.Hub,
@@ -855,8 +942,8 @@ func openLeaf(
 }
 
 // writePidFile writes the slot's host-local pid tracker. Mirrors
-// cli/swarm_join.go::writePidFile so `kill $(cat ...)` works
-// without a NATS round-trip.
+// cli/swarm_join.go::writePidFile so `kill $(cat ...)` works without
+// a NATS round-trip.
 func writePidFile(workspaceDir, slot string) error {
 	pidPath := SlotPidFile(workspaceDir, slot)
 	if err := os.MkdirAll(filepath.Dir(pidPath), 0o755); err != nil {

--- a/internal/swarm/lease_test.go
+++ b/internal/swarm/lease_test.go
@@ -30,7 +30,7 @@ func freePort(t *testing.T) string {
 
 // leaseFixture brings up a workspace dir + an in-process hub
 // (writing hub.fossil under .orchestrator) and returns the
-// workspace.Info shape AcquireFresh / Resume consume. Per ADR
+// workspace.Info shape Acquire / Resume consume. Per ADR
 // 0030 this uses real NATS + real Fossil — no mocks.
 type leaseFixture struct {
 	dir  string
@@ -62,12 +62,12 @@ func newLeaseFixture(t *testing.T) *leaseFixture {
 	}
 }
 
-// createTask inserts an open task on the hub so AcquireFresh has
+// createTask inserts an open task on the hub so Acquire has
 // something to claim. Uses a temporary fixture leaf to call
 // coord.Leaf.OpenTask — same path the bones tasks-create CLI verb
 // takes — so the substrate sees a fully-formed task record. The
 // fixture leaf is closed before returning; the lease under test
-// opens its own leaf inside AcquireFresh.
+// opens its own leaf inside Acquire.
 func (f *leaseFixture) createTask(t *testing.T, title, holdPath string) coord.TaskID {
 	t.Helper()
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -88,19 +88,19 @@ func (f *leaseFixture) createTask(t *testing.T, title, holdPath string) coord.Ta
 	return taskID
 }
 
-// TestAcquireFresh_RefusesWithoutHubFossil pins the role-leak
+// TestAcquire_RefusesWithoutHubFossil pins the role-leak
 // guard from PR #54. A workspace dir with no
-// `.orchestrator/hub.fossil` MUST cause AcquireFresh to return
+// `.orchestrator/hub.fossil` MUST cause Acquire to return
 // ErrWorkspaceNotBootstrapped without attempting any other work.
 // The error string MUST NOT contain "run `bones up`" — that
 // guidance is for orchestrators, not leaves.
-func TestAcquireFresh_RefusesWithoutHubFossil(t *testing.T) {
+func TestAcquire_RefusesWithoutHubFossil(t *testing.T) {
 	dir := t.TempDir() // no .orchestrator/hub.fossil
 	info := workspace.Info{WorkspaceDir: dir, NATSURL: "nats://127.0.0.1:1"}
 
-	_, err := AcquireFresh(context.Background(), info, "demo", "task-x", AcquireOpts{})
+	_, err := Acquire(context.Background(), info, "demo", "task-x", AcquireOpts{})
 	if !errors.Is(err, ErrWorkspaceNotBootstrapped) {
-		t.Fatalf("AcquireFresh: want ErrWorkspaceNotBootstrapped, got %v", err)
+		t.Fatalf("Acquire: want ErrWorkspaceNotBootstrapped, got %v", err)
 	}
 	msg := err.Error()
 	if !strings.Contains(msg, "refusing to bootstrap from a leaf context") {
@@ -111,10 +111,10 @@ func TestAcquireFresh_RefusesWithoutHubFossil(t *testing.T) {
 	}
 }
 
-// TestAcquireFresh_SuccessAndRelease covers the happy path: fresh
+// TestAcquire_SuccessAndRelease covers the happy path: fresh
 // acquire writes the session record + opens the leaf + claims the
 // task; Release tears down the leaf without deleting the record.
-func TestAcquireFresh_SuccessAndRelease(t *testing.T) {
+func TestAcquire_SuccessAndRelease(t *testing.T) {
 	f := newLeaseFixture(t)
 	holdPath := filepath.Join(f.dir, "rendering", "hello.txt")
 	taskID := string(f.createTask(t, "rendering-task-1", holdPath))
@@ -122,11 +122,11 @@ func TestAcquireFresh_SuccessAndRelease(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	lease, err := AcquireFresh(ctx, f.info, "rendering", taskID, AcquireOpts{
+	lease, err := Acquire(ctx, f.info, "rendering", taskID, AcquireOpts{
 		Hub: f.hub,
 	})
 	if err != nil {
-		t.Fatalf("AcquireFresh: %v", err)
+		t.Fatalf("Acquire: %v", err)
 	}
 	if lease.Slot() != "rendering" {
 		t.Errorf("Slot: got %q want %q", lease.Slot(), "rendering")
@@ -142,7 +142,7 @@ func TestAcquireFresh_SuccessAndRelease(t *testing.T) {
 	}
 
 	// Session record must be visible on a Sessions handle separate
-	// from the one Lease owns internally.
+	// from the one FreshLease owns internally.
 	verifySess := openVerifySessions(t, f)
 	got, _, err := verifySess.Get(ctx, "rendering")
 	if err != nil {
@@ -190,10 +190,10 @@ func openVerifySessions(t *testing.T, f *leaseFixture) *Sessions {
 	return sess
 }
 
-// TestAcquireFresh_RefusesActiveLiveSession pins the
+// TestAcquire_RefusesActiveLiveSession pins the
 // ErrSessionAlreadyLive path: a live session on the same host
 // without --force must be rejected.
-func TestAcquireFresh_RefusesActiveLiveSession(t *testing.T) {
+func TestAcquire_RefusesActiveLiveSession(t *testing.T) {
 	f := newLeaseFixture(t)
 	holdPath := filepath.Join(f.dir, "physics", "hello.txt")
 	taskID := string(f.createTask(t, "physics-task-1", holdPath))
@@ -201,16 +201,16 @@ func TestAcquireFresh_RefusesActiveLiveSession(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	first, err := AcquireFresh(ctx, f.info, "physics", taskID, AcquireOpts{Hub: f.hub})
+	first, err := Acquire(ctx, f.info, "physics", taskID, AcquireOpts{Hub: f.hub})
 	if err != nil {
-		t.Fatalf("first AcquireFresh: %v", err)
+		t.Fatalf("first Acquire: %v", err)
 	}
 	t.Cleanup(func() { _ = first.Release(ctx) })
 
 	// Without --force, second acquire must refuse.
-	_, err = AcquireFresh(ctx, f.info, "physics", taskID, AcquireOpts{Hub: f.hub})
+	_, err = Acquire(ctx, f.info, "physics", taskID, AcquireOpts{Hub: f.hub})
 	if !errors.Is(err, ErrSessionAlreadyLive) {
-		t.Fatalf("second AcquireFresh: want ErrSessionAlreadyLive, got %v", err)
+		t.Fatalf("second Acquire: want ErrSessionAlreadyLive, got %v", err)
 	}
 }
 
@@ -229,9 +229,9 @@ func TestResume_FailsWithoutSession(t *testing.T) {
 	}
 }
 
-// TestResume_AfterAcquireFresh confirms Resume reconstructs a
-// usable lease from the session record AcquireFresh wrote.
-func TestResume_AfterAcquireFresh(t *testing.T) {
+// TestResume_AfterAcquire confirms Resume reconstructs a
+// usable lease from the session record Acquire wrote.
+func TestResume_AfterAcquire(t *testing.T) {
 	f := newLeaseFixture(t)
 	holdPath := filepath.Join(f.dir, "ui", "hello.txt")
 	taskID := string(f.createTask(t, "ui-task-1", holdPath))
@@ -239,9 +239,9 @@ func TestResume_AfterAcquireFresh(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	first, err := AcquireFresh(ctx, f.info, "ui", taskID, AcquireOpts{Hub: f.hub})
+	first, err := Acquire(ctx, f.info, "ui", taskID, AcquireOpts{Hub: f.hub})
 	if err != nil {
-		t.Fatalf("AcquireFresh: %v", err)
+		t.Fatalf("Acquire: %v", err)
 	}
 	if err := first.Release(ctx); err != nil {
 		t.Fatalf("Release: %v", err)
@@ -267,8 +267,13 @@ func TestResume_AfterAcquireFresh(t *testing.T) {
 
 // TestClose_DeletesRecordAndPidFile pins the Close contract:
 // removes the session record (CAS-gated), removes the host-local
-// pid file, and stops the leaf. After Close, AcquireFresh on the
+// pid file, and stops the leaf. After Close, Acquire on the
 // same slot must succeed without --force.
+//
+// Under the FreshLease/ResumedLease split, Close is a ResumedLease
+// method, so the flow is Acquire → Release (record persists) →
+// Resume → Close, mirroring the new CLI invocation shape (acquire
+// in one call, close in a separate call).
 func TestClose_DeletesRecordAndPidFile(t *testing.T) {
 	f := newLeaseFixture(t)
 	holdPath := filepath.Join(f.dir, "audio", "hello.txt")
@@ -277,15 +282,23 @@ func TestClose_DeletesRecordAndPidFile(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	first, err := AcquireFresh(ctx, f.info, "audio", taskID, AcquireOpts{Hub: f.hub})
+	first, err := Acquire(ctx, f.info, "audio", taskID, AcquireOpts{Hub: f.hub})
 	if err != nil {
-		t.Fatalf("first AcquireFresh: %v", err)
+		t.Fatalf("first Acquire: %v", err)
 	}
 	pidPath := SlotPidFile(f.dir, "audio")
 	if _, err := os.Stat(pidPath); err != nil {
 		t.Fatalf("pre-Close pid file missing: %v", err)
 	}
-	if err := first.Close(ctx, CloseOpts{CloseTaskOnSuccess: true}); err != nil {
+	if err := first.Release(ctx); err != nil {
+		t.Fatalf("Release after Acquire: %v", err)
+	}
+
+	resumed, err := Resume(ctx, f.info, "audio", AcquireOpts{Hub: f.hub})
+	if err != nil {
+		t.Fatalf("Resume: %v", err)
+	}
+	if err := resumed.Close(ctx, CloseOpts{CloseTaskOnSuccess: true}); err != nil {
 		t.Fatalf("Close: %v", err)
 	}
 	if _, err := os.Stat(pidPath); !os.IsNotExist(err) {
@@ -295,9 +308,9 @@ func TestClose_DeletesRecordAndPidFile(t *testing.T) {
 	// Second acquire on same slot without --force should now succeed.
 	holdPath2 := filepath.Join(f.dir, "audio", "v2.txt")
 	taskID2 := string(f.createTask(t, "audio-task-2", holdPath2))
-	second, err := AcquireFresh(ctx, f.info, "audio", taskID2, AcquireOpts{Hub: f.hub})
+	second, err := Acquire(ctx, f.info, "audio", taskID2, AcquireOpts{Hub: f.hub})
 	if err != nil {
-		t.Fatalf("post-Close AcquireFresh: %v", err)
+		t.Fatalf("post-Close Acquire: %v", err)
 	}
 	t.Cleanup(func() { _ = second.Release(ctx) })
 }
@@ -315,12 +328,12 @@ func TestCommit_SuccessUpdatesTrunkAndRenewsSession(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	lease, err := AcquireFresh(ctx, f.info, "render", taskID, AcquireOpts{Hub: f.hub})
+	lease, err := Acquire(ctx, f.info, "render", taskID, AcquireOpts{Hub: f.hub})
 	if err != nil {
-		t.Fatalf("AcquireFresh: %v", err)
+		t.Fatalf("Acquire: %v", err)
 	}
 	if err := lease.Release(ctx); err != nil {
-		t.Fatalf("Release after AcquireFresh: %v", err)
+		t.Fatalf("Release after Acquire: %v", err)
 	}
 
 	// Capture the pre-commit LastRenewed so we can compare.
@@ -390,12 +403,12 @@ func TestResume_RefusesCrossHost(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	// AcquireFresh writes the session record stamped with the local
+	// Acquire writes the session record stamped with the local
 	// host. Manually rewrite Host to a foreign hostname to simulate
 	// the cross-host case without standing up a second machine.
-	first, err := AcquireFresh(ctx, f.info, "ghosthost", taskID, AcquireOpts{Hub: f.hub})
+	first, err := Acquire(ctx, f.info, "ghosthost", taskID, AcquireOpts{Hub: f.hub})
 	if err != nil {
-		t.Fatalf("AcquireFresh: %v", err)
+		t.Fatalf("Acquire: %v", err)
 	}
 	if err := first.Release(ctx); err != nil {
 		t.Fatalf("Release: %v", err)


### PR DESCRIPTION
## Summary

Phase 2 of the Ousterhout redesign — the largest PR in the sequence. Encodes the lease lifecycle in **two compile-time-distinct types** per ADR 0033, absorbing the CAS-retry loops for session-record updates inside the lease implementation.

### Type split

- **\`swarm.Acquire\`** returns \`*FreshLease\`.
  - Methods: \`Release(ctx)\` (record persists), \`Abort(ctx)\` (record CAS-deleted, rollback), accessors.
  - **No \`Commit\`, no \`Close\`** — those operate on a resumed lease with a current rev.
- **\`swarm.Resume\`** returns \`*ResumedLease\`.
  - Methods: \`Commit(ctx, msg, files)\`, \`Close(ctx, opts)\`, \`Release(ctx)\`, accessors.
  - **No \`Abort\`** — fresh records are the only thing that gets rolled back.
- Both types embed a private \`leaseBase\` for shared fields, accessors, and teardown.

### CAS-retry hardening (the audit's \"obscure dependency\" findings)

- \`ResumedLease.Commit\` now retries the \`LastRenewed\` CAS bump up to \`jskv.MaxRetries\` times. Surfaces a typed \`ErrSessionGone\` when the record was deleted between \`Resume\` and the bump (rather than treating the delete as silent success).
- \`ResumedLease.Close\` retries the session-record delete on rev-advance from a concurrent commit, re-reading rev between attempts. Idempotent on \`ErrNotFound\`.
- The old \`renewSessionAfterCommit\` that swallowed CAS conflicts is gone; the new path distinguishes "rev advanced (retry)" from "record deleted (surface)".

### CLI verb migration

| Verb | Before | After |
|---|---|---|
| \`swarm join\` | \`AcquireFresh\` → \`Lease.Release\` | \`Acquire\` → \`FreshLease.Release\` (or \`.Abort\` on rollback) |
| \`swarm commit\` | \`Resume\` → \`Lease.Commit\` → \`Lease.Release\` | \`Resume\` → \`ResumedLease.Commit\` → \`ResumedLease.Release\` |
| \`swarm close\` | \`Resume\` → \`Lease.Close\` | \`Resume\` → \`ResumedLease.Close\` |

### ADR + test updates

- ADR 0028 rewritten around the two-type lifecycle. Retains the verb shapes, session-record schema, and architectural invariants unchanged.
- ADR 0033's \"Refined by\" pointer in 0028's header preserved (bidirectional cross-reference).
- \`internal/swarm/lease_test.go\` migrated by a general-purpose subagent: 9 \`AcquireFresh\` → \`Acquire\` rewrites; tests that previously chained \`Acquire\`→\`Close\` updated to \`Acquire\`→\`Release\`→\`Resume\`→\`Close\` (mirrors the actual CLI invocation split).

## Test plan

- [x] \`go test ./internal/swarm/...\` — green (real-substrate fixtures, no mocks per ADR 0030)
- [x] \`go test ./cli/...\` — green (verbs migrated to new types)
- [x] \`make check\` — green (vet, lint, race, todo-check, fmt-check)
- [x] All four affected packages tested through their public APIs

## Out of scope (deferred to follow-up phases)

- Lifting \`Autosync\` to \`LeaseConfig\` — Phase 3
- Dispatch's domain-local \`Task\` / \`Reclaimer\` interfaces — Phase 4
- CLI verb refresh + skill/hook/script updates — Phase 5
- Substrate \`managerBase\` scaffold — Phase 6

## Notes

- \`FreshLease.Resume()\` (mentioned in ADR 0033 as a possible method) is intentionally NOT in this PR. Use case is unclear (no current verb does Acquire-then-Commit in one invocation), and adding it later is non-breaking. ADR 0033's mention can stand as aspirational.
- ADR 0028 originally referenced \`Leaf() *coord.Leaf\` as a "deprecated-on-arrival escape hatch." That accessor never actually existed as a public method — the comment in the old code described an aspirational migration window. The new types simply don't expose it, matching the original intent.
- The old behavior of swallowing CAS conflicts in \`renewSessionAfterCommit\` was a workaround for sibling commits racing each other (both bumping LastRenewed). The new retry loop keeps that intent (one of the two writes wins, both succeed) but additionally distinguishes "record deleted" from "rev advanced."