### PR TITLE
feat(swarm): lift Autosync to AcquireOpts (Phase 3)

### DIFF
--- a/cli/swarm_commit.go
+++ b/cli/swarm_commit.go
@@ -27,10 +27,11 @@ import (
 // internal/swarm.ResumedLease. This verb is flag parsing + file
 // gathering + ResumedLease.Commit + result printing.
 type SwarmCommitCmd struct {
-	Slot    string   `name:"slot" help:"slot name (defaults to single active slot on this host)"`
-	Message string   `name:"message" short:"m" required:"" help:"commit message"`
-	Files   []string `arg:"" optional:"" help:"files to commit (default: all modified)"`
-	HubURL  string   `name:"hub-url" help:"override hub fossil HTTP URL"`
+	Slot       string   `name:"slot" help:"slot name (defaults to single active slot on this host)"`
+	Message    string   `name:"message" short:"m" required:"" help:"commit message"`
+	Files      []string `arg:"" optional:"" help:"files to commit (default: all modified)"`
+	HubURL     string   `name:"hub-url" help:"override hub fossil HTTP URL"`
+	NoAutosync bool     `name:"no-autosync" help:"branch-per-slot mode (skip pre-commit hub pull)"`
 }
 
 func (c *SwarmCommitCmd) Run(g *libfossilcli.Globals) error {
@@ -51,7 +52,10 @@ func (c *SwarmCommitCmd) run(ctx context.Context, info workspace.Info) error {
 	if hubURL == "" {
 		hubURL = swarm.DefaultHubFossilURL
 	}
-	lease, err := swarm.Resume(ctx, info, slot, swarm.AcquireOpts{HubURL: hubURL})
+	lease, err := swarm.Resume(ctx, info, slot, swarm.AcquireOpts{
+		HubURL:     hubURL,
+		NoAutosync: c.NoAutosync,
+	})
 	if err != nil {
 		if errors.Is(err, swarm.ErrSessionNotFound) {
 			return fmt.Errorf(

--- a/cli/swarm_join.go
+++ b/cli/swarm_join.go
@@ -31,6 +31,7 @@ type SwarmJoinCmd struct {
 	Caps          string `name:"caps" default:"oih" help:"fossil caps for the slot user"`
 	ForceTakeover bool   `name:"force" help:"clobber an existing slot session (recovery only)"`
 	HubURL        string `name:"hub-url" help:"override hub fossil HTTP URL"`
+	NoAutosync    bool   `name:"no-autosync" help:"branch-per-slot mode (skip pre-commit hub pull)"`
 }
 
 // Run drives the join flow per ADR 0028 §"swarm join", via
@@ -56,6 +57,7 @@ func (c *SwarmJoinCmd) run(ctx context.Context, info workspace.Info) error {
 		HubURL:        hubURL,
 		Caps:          c.Caps,
 		ForceTakeover: c.ForceTakeover,
+		NoAutosync:    c.NoAutosync,
 	})
 	if err != nil {
 		// Stamp the verb name into the error so operators see which

--- a/docs/adr/0028-bones-swarm-verbs.md
+++ b/docs/adr/0028-bones-swarm-verbs.md
@@ -161,23 +161,25 @@ path directly without consulting KV.
 ## Verb contracts
 
 **`swarm join`** — flags `--slot`, `--task-id` (required), `--caps`
-(default `oih`), `--force` (recovery-only takeover). Calls
-`swarm.Acquire` (ensure slot user → verify no live session → open
-`coord.Leaf` at `.bones/swarm/<slot>/` as `slot-<name>` → claim task
-with 60s hold → CAS-write session record with 5-min TTL), emits
-`BONES_SLOT_WT=<path>`, then `FreshLease.Release` (stops the leaf,
-leaves the session record live in KV). On any failure between
-`Acquire` and emission the verb falls back to `FreshLease.Abort`
-to roll the record back.
+(default `oih`), `--force` (recovery-only takeover),
+`--no-autosync` (branch-per-slot mode; default omitted = autosync
+ON). Calls `swarm.Acquire` (ensure slot user → verify no live
+session → open `coord.Leaf` at `.bones/swarm/<slot>/` as
+`slot-<name>` → claim task with 60s hold → CAS-write session record
+with 5-min TTL), emits `BONES_SLOT_WT=<path>`, then
+`FreshLease.Release` (stops the leaf, leaves the session record
+live in KV). On any failure between `Acquire` and emission the verb
+falls back to `FreshLease.Abort` to roll the record back.
 
 **`swarm commit`** — flags `--slot` (defaults to single active
-slot), `-m` (required); positional file args optional. Calls
+slot), `-m` (required), `--no-autosync` (skip pre-commit hub pull
+for this commit only); positional file args optional. Calls
 `swarm.Resume` then `ResumedLease.Commit(message, files)` (claim →
-libfossil commit with slot-user identity → autosync to hub → bump
-`LastRenewed` via CAS, retrying on conflict). Prints new commit
-hash. The agent NEVER calls `fossil up`; concurrent slot work
-appears on the hub as forks (the way fossil itself models it),
-invisible to this slot's lineage.
+pull from hub if autosync ON → libfossil commit with slot-user
+identity → push to hub → bump `LastRenewed` via CAS, retrying on
+conflict). Prints new commit hash. The agent NEVER calls
+`fossil up`; concurrent slot work appears on the hub as forks (the
+way fossil itself models it), invisible to this slot's lineage.
 
 **`swarm close`** — flags `--slot`, `--result`
 (`success|fail|fork`), `--summary`, `--branch`/`--rev` (forks only).

--- a/internal/coord/leaf.go
+++ b/internal/coord/leaf.go
@@ -123,8 +123,17 @@ type LeafConfig struct {
 	// on the next pull cycle. A real check-in lock will land when
 	// libfossil exposes the necessary API.
 	//
+	// Project-code cache: when Autosync is true, OpenLeaf reads the
+	// repo's project-code config once at open time and caches it on
+	// the Leaf for use by every later Commit's Sync call. The
+	// project-code is immutable for the life of a fossil repository,
+	// so caching at open time is safe; mid-session repository
+	// metadata changes are not part of this contract.
+	//
 	// Default false preserves the prior branch-per-slot behavior
 	// expected by existing tests/examples that don't run a real hub.
+	// Production swarm leases default Autosync ON via
+	// AcquireOpts.NoAutosync (default false → Autosync=true).
 	Autosync bool
 }
 
@@ -412,6 +421,16 @@ func (l *Leaf) AnnounceHolds(
 
 // Commit writes files into the leaf's libfossil repo as a new checkin
 // authored by the slot, then triggers a sync round (SyncNow).
+//
+// When LeafConfig.Autosync was true at OpenLeaf time, Commit performs
+// a hub HTTP round-trip (pull /xfer) BEFORE resolving the trunk tip
+// so the new commit's parent is the latest hub-known commit. This is
+// the implementation of trunk-based development across slots: every
+// slot.Commit advances a shared trunk rather than producing a parallel
+// leaf that fan-in must collapse later. Cost is one network round-trip
+// per Commit; callers that prefer offline tolerance over linearity
+// should set Autosync=false at OpenLeaf time and accept
+// branch-per-slot semantics.
 //
 // The hold-gate (Invariant 20) and epoch-gate (Invariant 24) are
 // enforced via the leaf's Coord: every File.Path must be held by this

--- a/internal/swarm/lease.go
+++ b/internal/swarm/lease.go
@@ -123,6 +123,20 @@ type AcquireOpts struct {
 	// Now is the time source for StartedAt and LastRenewed. nil →
 	// time.Now().UTC. Tests inject a fixed clock.
 	Now func() time.Time
+
+	// NoAutosync disables the pre-commit hub pull on this lease's
+	// underlying coord.Leaf. Default (false) keeps autosync ON,
+	// which is the production default per ADR 0023's trunk-linearity
+	// promise: every commit pulls from the hub before resolving the
+	// trunk tip so the new commit's parent is the hub's-latest-tip,
+	// producing one linear chain instead of N parallel forks.
+	//
+	// Set to true (CLI flag --no-autosync on swarm join / swarm
+	// commit) when the caller has an explicit reason to operate in
+	// branch-per-slot mode: offline tolerance, single-slot work
+	// where no peer commits will race, or testing fan-in semantics.
+	// Cost: one less hub HTTP round-trip per commit.
+	NoAutosync bool
 }
 
 // CommitResult is the outcome of ResumedLease.Commit. UUID is set on
@@ -300,7 +314,9 @@ func Acquire(
 		return nil, err
 	}
 
-	leaf, claim, err := openLeafAndClaim(ctx, info, slot, fossilUser, hubURL, taskID, opts.Hub)
+	leaf, claim, err := openLeafAndClaim(
+		ctx, info, slot, fossilUser, hubURL, taskID, opts.Hub, !opts.NoAutosync,
+	)
 	if err != nil {
 		cleanupConn()
 		return nil, err
@@ -387,7 +403,7 @@ func Resume(
 		hubURL = DefaultHubFossilURL
 	}
 
-	leaf, err := openLeaf(ctx, info, slot, sess.AgentID, hubURL, opts.Hub)
+	leaf, err := openLeaf(ctx, info, slot, sess.AgentID, hubURL, opts.Hub, !opts.NoAutosync)
 	if err != nil {
 		cleanup()
 		return nil, fmt.Errorf("swarm.Resume: open leaf: %w", err)
@@ -697,9 +713,9 @@ func defaultAcquireOpts(opts AcquireOpts) (func() time.Time, string, string) {
 // stopped before return.
 func openLeafAndClaim(
 	ctx context.Context, info workspace.Info,
-	slot, fossilUser, hubURL, taskID string, hub *coord.Hub,
+	slot, fossilUser, hubURL, taskID string, hub *coord.Hub, autosync bool,
 ) (*coord.Leaf, *coord.Claim, error) {
-	leaf, err := openLeaf(ctx, info, slot, fossilUser, hubURL, hub)
+	leaf, err := openLeaf(ctx, info, slot, fossilUser, hubURL, hub, autosync)
 	if err != nil {
 		return nil, nil, fmt.Errorf("swarm.Acquire: open leaf: %w", err)
 	}
@@ -912,12 +928,14 @@ func clearExistingRecord(
 }
 
 // openLeaf opens the per-slot coord.Leaf rooted at
-// `<workspace>/.bones/swarm`. When opts.Hub is set, opens against the
+// `<workspace>/.bones/swarm`. When hub is non-nil, opens against the
 // in-process hub directly (test path). Otherwise uses HubAddrs with
-// the workspace's NATS URL and the supplied hub HTTP URL.
+// the workspace's NATS URL and the supplied hub HTTP URL. Autosync
+// flows through from the lease's AcquireOpts; default-on at the
+// AcquireOpts layer, opt-out via --no-autosync.
 func openLeaf(
 	ctx context.Context, info workspace.Info,
-	slot, fossilUser, hubURL string, hub *coord.Hub,
+	slot, fossilUser, hubURL string, hub *coord.Hub, autosync bool,
 ) (*coord.Leaf, error) {
 	swarmRoot := filepath.Join(info.WorkspaceDir, ".bones", "swarm")
 	if err := os.MkdirAll(swarmRoot, 0o755); err != nil {
@@ -927,7 +945,7 @@ func openLeaf(
 		Workdir:    swarmRoot,
 		SlotID:     slot,
 		FossilUser: fossilUser,
-		Autosync:   true,
+		Autosync:   autosync,
 	}
 	if hub != nil {
 		cfg.Hub = hub


### PR DESCRIPTION
## Summary

Phase 3 of the Ousterhout redesign — small surface change. The swarm package previously hardcoded \`LeafConfig.Autosync=true\` at every leaf open, so CLI verbs had no per-invocation way to opt out of the pre-commit hub round-trip. This PR promotes Autosync to a knob.

- **\`AcquireOpts.NoAutosync bool\`** (default false → autosync ON, matching prior production behavior). Threaded through to \`coord.LeafConfig.Autosync\`.
- **\`bones swarm join --no-autosync\`** and **\`bones swarm commit --no-autosync\`** — opt out per CLI invocation. Help text describes the trade-off.
- **\`Leaf.Commit\` docstring** — now describes the hub HTTP round-trip and project-code semantics that happen when Autosync was ON at OpenLeaf time. Previously only documented on \`LeafConfig.Autosync\`.
- **Project-code cache contract** documented on \`LeafConfig.Autosync\`: cached at OpenLeaf time, never refreshed mid-session, safe because project-code is immutable for the life of a fossil repository.

## Test plan

- [x] \`make check\` — green (vet, lint, race, todo-check, fmt-check)
- [x] All swarm + coord tests pass (real-substrate fixtures unchanged)
- [x] CLI flags compile and parse via Kong
- [x] Default behavior (autosync ON) preserved — no test changes needed

## Out of scope (deferred)

- \`Leaf.RefreshMetadata(ctx)\` — the original plan mentioned this for the rare case mid-session repo metadata changes. Skipped because project-code is immutable per fossil's design and no other LeafConfig-derived state has a refresh need today. Adding it later is non-breaking.
- A new ADR for the autosync surface — judged unnecessary; the existing ADR 0028 verb-contract update + ADR 0023's autosync description (which is unchanged in intent) cover the architectural surface. Phase 3 is a knob promotion, not a new design.

## Notes

- Default zero-value (\`NoAutosync: false\`) maps to autosync ON. The double-negative is intentional: it makes the production default the cheap zero-value and makes the opt-out an explicit caller choice. No behavior change for callers that don't set the field.
- \`swarm close\` deliberately doesn't expose \`--no-autosync\` — close doesn't normally commit through the leaf, and adding the flag would suggest it does.