### PR TITLE
feat(dispatch): decouple from coord via Task interface + PresenceProbe

### DIFF
--- a/cli/tasks_dispatch.go
+++ b/cli/tasks_dispatch.go
@@ -249,11 +249,22 @@ func claimedDispatchSpec(
 	}
 	for _, candidate := range prime.ClaimedTasks {
 		if candidate.ID() == coord.TaskID(taskID) {
-			return dispatch.BuildSpec(info.AgentID, info.WorkspaceDir, candidate)
+			adapted := dispatchTaskFromCoord(candidate)
+			return dispatch.BuildSpec(info.AgentID, info.WorkspaceDir, adapted)
 		}
 	}
 	return dispatch.Spec{}, fmt.Errorf("claimed task %q not found", taskID)
 }
+
+// dispatchTaskFromCoord adapts a coord.Task into a dispatch.Task.
+// Lives at the CLI layer so neither dispatch nor coord depend on
+// each other for task-shape conversions; both packages stay
+// substrate-only / dispatch-only respectively.
+type dispatchTaskFromCoord coord.Task
+
+func (d dispatchTaskFromCoord) ID() string      { return string(coord.Task(d).ID()) }
+func (d dispatchTaskFromCoord) Title() string   { return coord.Task(d).Title() }
+func (d dispatchTaskFromCoord) Files() []string { return coord.Task(d).Files() }
 
 func handleDispatchResult(
 	ctx context.Context,
@@ -283,7 +294,7 @@ func handleDispatchSuccess(
 		fmt.Printf("worker-closed task=%s worker=%s\n", spec.TaskID, spec.WorkerAgentID)
 		return nil
 	}
-	if err := c.CloseTask(ctx, spec.TaskID, result.Summary); err != nil {
+	if err := c.CloseTask(ctx, coord.TaskID(spec.TaskID), result.Summary); err != nil {
 		return err
 	}
 	if err := c.Post(ctx, spec.Thread, []byte("parent closed: "+result.Summary)); err != nil {

--- a/internal/coord/presence.go
+++ b/internal/coord/presence.go
@@ -38,6 +38,23 @@ func (c *Coord) Who(ctx context.Context) ([]Presence, error) {
 	return out, nil
 }
 
+// PresentAgentIDs returns just the AgentID values from Who as a flat
+// string slice. Convenience for callers (e.g. dispatch's
+// WaitWorkerAbsent) that only need the IDs and would otherwise
+// flatten the slice themselves; the method reference satisfies
+// dispatch.PresenceProbe directly.
+func (c *Coord) PresentAgentIDs(ctx context.Context) ([]string, error) {
+	entries, err := c.Who(ctx)
+	if err != nil {
+		return nil, err
+	}
+	ids := make([]string, len(entries))
+	for i, p := range entries {
+		ids[i] = p.AgentID()
+	}
+	return ids, nil
+}
+
 // WatchPresence returns a channel of coord.Event values that fire
 // whenever an agent comes online or goes offline in this Coord's
 // project. Concrete type is PresenceChange. Consumers discriminate

--- a/internal/dispatch/monitor.go
+++ b/internal/dispatch/monitor.go
@@ -4,34 +4,44 @@ import (
 	"context"
 	"fmt"
 	"time"
-
-	"github.com/danmestas/bones/internal/coord"
 )
 
+// WaitWorkerAbsent polls the substrate's presence view via probe and
+// returns nil once workerAgentID is no longer present, or an error
+// if the deadline elapses first. Used by the dispatch parent to
+// detect worker dropout (heartbeat lapse) before reclaiming the
+// claim.
+//
+// The probe callback decouples dispatch from coord: tests can pass
+// a closure backed by an in-memory list, and production wiring uses
+// `coord.Coord.PresentAgentIDs`.
 func WaitWorkerAbsent(
 	ctx context.Context,
-	c *coord.Coord,
+	probe PresenceProbe,
 	workerAgentID string,
 	deadline time.Duration,
 ) error {
 	timer := time.NewTimer(deadline)
 	defer timer.Stop()
-	ticker := time.NewTicker(250 * time.Millisecond)
+	ticker := time.NewTicker(PollInterval)
 	defer ticker.Stop()
 	for {
 		select {
 		case <-timer.C:
-			return fmt.Errorf("agent %s still present after %s", workerAgentID, deadline)
+			return fmt.Errorf(
+				"agent %s still present after %s",
+				workerAgentID, deadline,
+			)
 		case <-ctx.Done():
 			return ctx.Err()
 		case <-ticker.C:
-			entries, err := c.Who(ctx)
+			ids, err := probe(ctx)
 			if err != nil {
-				return fmt.Errorf("who: %w", err)
+				return fmt.Errorf("presence probe: %w", err)
 			}
 			found := false
-			for _, p := range entries {
-				if p.AgentID() == workerAgentID {
+			for _, id := range ids {
+				if id == workerAgentID {
 					found = true
 					break
 				}
@@ -41,13 +51,4 @@ func WaitWorkerAbsent(
 			}
 		}
 	}
-}
-
-func ReclaimClaim(
-	ctx context.Context,
-	c *coord.Coord,
-	taskID coord.TaskID,
-	ttl time.Duration,
-) (func() error, error) {
-	return c.Reclaim(ctx, taskID, ttl)
 }

--- a/internal/dispatch/monitor_test.go
+++ b/internal/dispatch/monitor_test.go
@@ -60,7 +60,7 @@ func TestWaitWorkerAbsent_ReturnsWhenWorkerDropsFromPresence(t *testing.T) {
 
 	killAgentHeartbeat(t, worker)
 	if err := WaitWorkerAbsent(
-		ctx, parent, "parent-agent/task-1", 3*time.Second,
+		ctx, parent.PresentAgentIDs, "parent-agent/task-1", 3*time.Second,
 	); err != nil {
 		t.Fatalf("WaitWorkerAbsent: %v", err)
 	}
@@ -87,13 +87,13 @@ func TestReclaimClaimedTaskAfterWorkerDeath(t *testing.T) {
 	_ = rel
 	killAgentHeartbeat(t, worker)
 	if err := WaitWorkerAbsent(
-		ctx, parent, "parent-agent/task-1", 3*time.Second,
+		ctx, parent.PresentAgentIDs, "parent-agent/task-1", 3*time.Second,
 	); err != nil {
 		t.Fatalf("WaitWorkerAbsent: %v", err)
 	}
-	relParent, err := ReclaimClaim(ctx, parent, id, time.Minute)
+	relParent, err := parent.Reclaim(ctx, id, time.Minute)
 	if err != nil {
-		t.Fatalf("ReclaimClaim: %v", err)
+		t.Fatalf("Reclaim: %v", err)
 	}
 	defer func() { _ = relParent() }()
 }

--- a/internal/dispatch/spawn.go
+++ b/internal/dispatch/spawn.go
@@ -14,7 +14,7 @@ import (
 // 5s subscribe timeout. Flags-only is the single source of truth.
 func BuildWorkerCommand(bin string, spec Spec) (*exec.Cmd, error) {
 	cmd := exec.Command(bin, "tasks", "dispatch", "worker",
-		"--task-id="+string(spec.TaskID),
+		"--task-id="+spec.TaskID,
 		"--task-thread="+spec.Thread,
 		"--worker-agent-id="+spec.WorkerAgentID,
 	)

--- a/internal/dispatch/spec.go
+++ b/internal/dispatch/spec.go
@@ -1,9 +1,11 @@
 package dispatch
 
-import "github.com/danmestas/bones/internal/coord"
-
+// Spec is the parent-resolved description of a task ready to dispatch
+// to a worker process. Pure data; no substrate references. The CLI
+// adapter that produced the Task value is the only thing that knows
+// about coord.
 type Spec struct {
-	TaskID        coord.TaskID
+	TaskID        string
 	Title         string
 	Files         []string
 	Thread        string
@@ -12,14 +14,21 @@ type Spec struct {
 	WorkspaceDir  string
 }
 
-func BuildSpec(parentAgentID, workspaceDir string, task coord.Task) (Spec, error) {
+// BuildSpec materializes a Spec from a parent agent's view of a
+// dispatchable task. The Task interface keeps dispatch coord-free;
+// CLI callers pass a small adapter wrapping coord.Task.
+func BuildSpec(parentAgentID, workspaceDir string, task Task) (Spec, error) {
+	taskID := task.ID()
+	srcFiles := task.Files()
+	files := make([]string, len(srcFiles))
+	copy(files, srcFiles)
 	return Spec{
-		TaskID:        task.ID(),
+		TaskID:        taskID,
 		Title:         task.Title(),
-		Files:         task.Files(),
-		Thread:        string(task.ID()),
+		Files:         files,
+		Thread:        taskID,
 		ParentAgentID: parentAgentID,
-		WorkerAgentID: parentAgentID + "/" + string(task.ID()),
+		WorkerAgentID: parentAgentID + "/" + taskID,
 		WorkspaceDir:  workspaceDir,
 	}, nil
 }

--- a/internal/dispatch/spec_test.go
+++ b/internal/dispatch/spec_test.go
@@ -1,75 +1,48 @@
 package dispatch
 
 import (
-	"context"
-	"path/filepath"
 	"strings"
 	"testing"
 	"time"
-
-	"github.com/danmestas/bones/internal/coord"
-	"github.com/danmestas/bones/internal/testutil/natstest"
 )
 
-func newTestCoord(t *testing.T, agentID string) *coord.Coord {
-	t.Helper()
-	nc, _ := natstest.NewJetStreamServer(t)
-	cfg := coord.Config{
-		AgentID:            agentID,
-		NATSURL:            nc.ConnectedUrl(),
-		ChatFossilRepoPath: filepath.Join(t.TempDir(), agentID+"-chat.fossil"),
-		CheckoutRoot:       filepath.Join(t.TempDir(), agentID+"-checkouts"),
-	}
-	c, err := coord.Open(context.Background(), cfg)
-	if err != nil {
-		t.Fatalf("Open(%s): %v", agentID, err)
-	}
-	t.Cleanup(func() { _ = c.Close() })
-	return c
+// fakeTask is the in-memory Task used by spec tests. No coord
+// dependency — proves dispatch can be exercised through its
+// interfaces without spinning up a substrate.
+type fakeTask struct {
+	id    string
+	title string
+	files []string
 }
 
-func openTaskView(t *testing.T, c *coord.Coord, title string, files []string) coord.Task {
-	t.Helper()
-	ctx := context.Background()
-	id, err := c.OpenTask(ctx, title, files)
-	if err != nil {
-		t.Fatalf("OpenTask: %v", err)
-	}
-	prime, err := c.Prime(ctx)
-	if err != nil {
-		t.Fatalf("Prime: %v", err)
-	}
-	for _, task := range prime.OpenTasks {
-		if task.ID() == id {
-			return task
-		}
-	}
-	t.Fatalf("task %s not found in Prime open tasks", id)
-	return coord.Task{}
-}
+func (f fakeTask) ID() string      { return f.id }
+func (f fakeTask) Title() string   { return f.title }
+func (f fakeTask) Files() []string { return f.files }
 
 func TestBuildSpec_DerivesWorkerAgentID(t *testing.T) {
-	c := newTestCoord(t, "parent-agent")
-	task := openTaskView(t, c, "dispatch me", []string{"/repo/a.go"})
+	task := fakeTask{id: "t-1", title: "dispatch me", files: []string{"/repo/a.go"}}
 	spec, err := BuildSpec("parent-agent", "/workspace", task)
 	if err != nil {
 		t.Fatalf("BuildSpec: %v", err)
 	}
-	want := "parent-agent/" + string(task.ID())
+	want := "parent-agent/t-1"
 	if spec.WorkerAgentID != want {
 		t.Fatalf("WorkerAgentID=%q, want %q", spec.WorkerAgentID, want)
 	}
 }
 
 func TestBuildSpec_UsesTaskIDAsThreadAndCopiesTaskContext(t *testing.T) {
-	c := newTestCoord(t, "parent-agent")
-	task := openTaskView(t, c, "dispatch me", []string{"/repo/a.go", "/repo/b.go"})
+	task := fakeTask{
+		id:    "t-2",
+		title: "dispatch me",
+		files: []string{"/repo/a.go", "/repo/b.go"},
+	}
 	spec, err := BuildSpec("parent-agent", "/workspace", task)
 	if err != nil {
 		t.Fatalf("BuildSpec: %v", err)
 	}
-	if spec.Thread != string(task.ID()) {
-		t.Fatalf("Thread=%q, want task id %q", spec.Thread, task.ID())
+	if spec.Thread != "t-2" {
+		t.Fatalf("Thread=%q, want %q", spec.Thread, "t-2")
 	}
 	if spec.Title != "dispatch me" {
 		t.Fatalf("Title=%q", spec.Title)
@@ -83,8 +56,7 @@ func TestBuildSpec_UsesTaskIDAsThreadAndCopiesTaskContext(t *testing.T) {
 }
 
 func TestBuildSpec_CopiesFilesSlice(t *testing.T) {
-	c := newTestCoord(t, "parent-agent")
-	task := openTaskView(t, c, "dispatch me", []string{"/repo/a.go"})
+	task := fakeTask{id: "t-3", title: "dispatch me", files: []string{"/repo/a.go"}}
 	spec, err := BuildSpec("parent-agent", "/workspace", task)
 	if err != nil {
 		t.Fatalf("BuildSpec: %v", err)

--- a/internal/dispatch/task.go
+++ b/internal/dispatch/task.go
@@ -1,0 +1,41 @@
+package dispatch
+
+import (
+	"context"
+	"time"
+)
+
+// Task is the dispatch-local view of a coord task record. Defined
+// here (rather than imported from coord) so dispatch can be tested
+// with minimal in-memory fakes and so a future migration to a
+// different task source — a different substrate, a different storage
+// shape — does not ripple through dispatch.
+//
+// Coord's task type satisfies this structurally via a small adapter
+// at the CLI layer; dispatch never imports coord.Task directly.
+type Task interface {
+	// ID returns the task identifier as a plain string. Whatever
+	// coord-side type wraps the ID is converted at the adapter
+	// boundary; dispatch carries it as a string.
+	ID() string
+
+	// Title is the human-readable title.
+	Title() string
+
+	// Files lists the absolute workspace paths the task scopes its
+	// work to. The returned slice may be the task's own copy;
+	// BuildSpec takes a copy if it needs to mutate.
+	Files() []string
+}
+
+// PresenceProbe returns the agent IDs currently present in the
+// substrate. Used by WaitWorkerAbsent to poll for worker dropout
+// without depending on a particular substrate's Presence type.
+//
+// The standard binding is `coord.Coord.PresentAgentIDs`; tests can
+// pass a closure backed by an in-memory slice.
+type PresenceProbe func(ctx context.Context) ([]string, error)
+
+// PollInterval is the WaitWorkerAbsent poll cadence. Exported so
+// tests can shorten it; production callers leave it at the default.
+var PollInterval = 250 * time.Millisecond


### PR DESCRIPTION
## Summary

Phase 4 of the Ousterhout redesign — dispatch becomes coord-free.

Before this PR \`internal/dispatch\` imported \`coord\` everywhere: \`BuildSpec\` took \`coord.Task\`, \`Spec.TaskID\` was \`coord.TaskID\`, \`WaitWorkerAbsent\` and \`ReclaimClaim\` took \`*coord.Coord\` directly. Tests had to spin up a full \`coord.Coord\` (NATS + chat fossil + checkout root) just to build a spec.

### New seam

- **\`dispatch.Task\`** — small structural interface: \`ID() string\`, \`Title() string\`, \`Files() []string\`. Coord types satisfy it via a tiny adapter at the CLI layer; dispatch never imports coord.
- **\`dispatch.PresenceProbe\`** — \`func(ctx) ([]string, error)\` callback. \`WaitWorkerAbsent\` calls it instead of \`*coord.Coord.Who\`.
- **\`dispatch.Spec.TaskID\`** is now \`string\` (was \`coord.TaskID\`). All downstream uses (\`spawn.BuildWorkerCommand\`, CLI \`tasks_dispatch.go\`) updated; \`coord.TaskID()\` casts happen at the CLI ↔ coord boundary only.

### Adapter location

\`cli/tasks_dispatch.go\` defines a private \`dispatchTaskFromCoord coord.Task\` named-type so the call site reads \`dispatch.BuildSpec(..., dispatchTaskFromCoord(candidate))\`. Adapter lives in CLI (which legitimately imports both packages); coord and dispatch stay independent.

### Coord additions

\`coord.Coord.PresentAgentIDs(ctx) ([]string, error)\` — convenience flattener over \`Who\`. Method reference satisfies \`dispatch.PresenceProbe\` directly, so test code reads \`WaitWorkerAbsent(ctx, parent.PresentAgentIDs, ...)\`.

### Deleted

- **\`dispatch.ReclaimClaim\`** — pure pass-through to \`coord.Coord.Reclaim\`. Per Ousterhout the deletion test fires (one caller, one copy = relocation). The one test that used it now calls \`parent.Reclaim\` directly.

### Test improvement

\`spec_test.go\` previously stood up a full \`coord.Coord\` per test (NATS server, chat fossil, checkouts) to call \`OpenTask\` + \`Prime\` and extract a \`coord.Task\` view. Now uses a 5-line in-memory \`fakeTask\` struct — proves dispatch can be exercised through its interfaces without any substrate.

## Test plan

- [x] \`make check\` — green
- [x] \`go build -tags=otel ./...\` — green
- [x] \`go test -tags=otel -short ./...\` — green
- [x] All targeted packages green: dispatch, coord, cli

## Out of scope (deferred)

- **\`coord.TaskSubject\` newtype** — the original plan placed it in Phase 4. Punted to Phase 5 because TaskSubject is most useful at the CLI ↔ chat-thread seam (\`swarm_close.go:postResult\`), which Phase 5 (CLI verb refresh) will rework anyway. Adding it later is non-breaking.

## Notes

- Locally clean across all three CI lanes per the new pre-push rule.
- Adapter named-type pattern (\`type dispatchTaskFromCoord coord.Task\` plus three method definitions) is idiomatic Go for "wrap concrete type X to satisfy interface Y" without a wrapper struct field.