### PR TITLE
refactor(cli): factor swarm bootstrap into one helper

### DIFF
--- a/cli/swarm.go
+++ b/cli/swarm.go
@@ -2,7 +2,9 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"os"
 
 	"github.com/nats-io/nats.go"
 
@@ -52,6 +54,54 @@ func openSwarmSessions(
 		_ = s.Close()
 		nc.Close()
 	}, nil
+}
+
+// bootstrapResume opens the workspace, resolves the target slot
+// (using preferredSlot or falling back to single-active-on-this-host
+// inference), and resumes the lease. Returns ctx, info, the resumed
+// lease, and a stop function for the workspace context. Caller is
+// responsible for closing the lease (Release for commit-style verbs,
+// Close for close-style verbs) and calling stop().
+//
+// Errors are wrapped with verbName so the user sees the verb that
+// failed; ErrSessionNotFound passes through unwrapped so callers can
+// errors.Is-test it for verb-specific handling (swarm close converges
+// idempotently when the session is already gone).
+func bootstrapResume(
+	verbName, preferredSlot, hubURL string,
+	opts swarm.AcquireOpts,
+) (context.Context, workspace.Info, *swarm.ResumedLease, func(), error) {
+	ctx, stop, info, err := joinWorkspace()
+	if err != nil {
+		return nil, workspace.Info{}, nil, nil, err
+	}
+
+	sess, closeSess, err := openSwarmSessions(ctx, info)
+	if err != nil {
+		stop()
+		return nil, workspace.Info{}, nil, nil, err
+	}
+	host, _ := os.Hostname()
+	slot, err := resolveSlot(ctx, sess, preferredSlot, host)
+	closeSess()
+	if err != nil {
+		stop()
+		return nil, workspace.Info{}, nil, nil, err
+	}
+
+	if hubURL == "" {
+		hubURL = swarm.DefaultHubFossilURL
+	}
+	opts.HubURL = hubURL
+	lease, err := swarm.Resume(ctx, info, slot, opts)
+	if err != nil {
+		stop()
+		if errors.Is(err, swarm.ErrSessionNotFound) {
+			return nil, workspace.Info{}, nil, nil, err
+		}
+		return nil, workspace.Info{}, nil, nil, fmt.Errorf("%s: %w", verbName, err)
+	}
+	return ctx, info, lease, stop, nil
 }
 
 // resolveSlot picks the slot to operate on for verbs that allow

--- a/cli/swarm_close.go
+++ b/cli/swarm_close.go
@@ -32,35 +32,23 @@ type SwarmCloseCmd struct {
 }
 
 func (c *SwarmCloseCmd) Run(g *libfossilcli.Globals) error {
-	ctx, stop, info, err := joinWorkspace()
-	if err != nil {
-		return err
-	}
-	defer stop()
-	return c.run(ctx, info)
-}
-
-func (c *SwarmCloseCmd) run(ctx context.Context, info workspace.Info) error {
 	if err := c.validateResult(); err != nil {
 		return err
 	}
-	slot, err := c.resolveTargetSlot(ctx, info)
-	if err != nil {
-		return err
-	}
-	hubURL := c.HubURL
-	if hubURL == "" {
-		hubURL = swarm.DefaultHubFossilURL
-	}
-	lease, err := swarm.Resume(ctx, info, slot, swarm.AcquireOpts{HubURL: hubURL})
+	ctx, info, lease, stop, err := bootstrapResume(
+		"swarm close", c.Slot, c.HubURL, swarm.AcquireOpts{},
+	)
 	if err != nil {
 		if errors.Is(err, swarm.ErrSessionNotFound) {
 			fmt.Fprintf(os.Stderr,
-				"swarm close: no session for slot %q (already closed?)\n", slot)
+				"swarm close: no session for slot %q (already closed?)\n",
+				c.Slot,
+			)
 			return nil
 		}
-		return fmt.Errorf("swarm close: %w", err)
+		return err
 	}
+	defer stop()
 
 	// Post the dispatch ResultMessage on the task thread BEFORE we
 	// transition the lease to closed — once Lease.Close runs, the
@@ -68,7 +56,8 @@ func (c *SwarmCloseCmd) run(ctx context.Context, info workspace.Info) error {
 	// so the result post must happen first. Soft-fail per ADR 0028
 	// retro: a failed post is logged but not a hard error.
 	if err := c.postResult(ctx, info, lease.FossilUser(), lease.TaskID()); err != nil {
-		fmt.Fprintf(os.Stderr, "swarm close: warning: post result failed: %v\n", err)
+		fmt.Fprintf(os.Stderr,
+			"swarm close: warning: post result failed: %v\n", err)
 	}
 
 	closeOpts := swarm.CloseOpts{
@@ -79,7 +68,7 @@ func (c *SwarmCloseCmd) run(ctx context.Context, info workspace.Info) error {
 	}
 	fmt.Fprintf(os.Stderr,
 		"swarm close: slot=%s task=%s result=%s\n",
-		slot, lease.TaskID(), c.Result,
+		lease.Slot(), lease.TaskID(), c.Result,
 	)
 	return nil
 }
@@ -90,26 +79,6 @@ func (c *SwarmCloseCmd) validateResult() error {
 		return nil
 	}
 	return fmt.Errorf("--result must be success|fail|fork (got %q)", c.Result)
-}
-
-// resolveTargetSlot mirrors the helper in swarm_commit.go: honors
-// --slot when set, otherwise infers the unique active slot via
-// Sessions.List. The Sessions handle is opened-and-closed inline;
-// Resume opens its own to read the session record.
-func (c *SwarmCloseCmd) resolveTargetSlot(
-	ctx context.Context, info workspace.Info,
-) (string, error) {
-	sess, closeSess, err := openSwarmSessions(ctx, info)
-	if err != nil {
-		return "", err
-	}
-	defer closeSess()
-	host, _ := os.Hostname()
-	slot, err := resolveSlot(ctx, sess, c.Slot, host)
-	if err != nil {
-		return "", err
-	}
-	return slot, nil
 }
 
 // postResult publishes a dispatch.ResultMessage onto the task

--- a/cli/swarm_commit.go
+++ b/cli/swarm_commit.go
@@ -1,8 +1,6 @@
 package cli
 
 import (
-	"context"
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -35,37 +33,17 @@ type SwarmCommitCmd struct {
 }
 
 func (c *SwarmCommitCmd) Run(g *libfossilcli.Globals) error {
-	ctx, stop, info, err := joinWorkspace()
+	ctx, info, lease, stop, err := bootstrapResume(
+		"swarm commit", c.Slot, c.HubURL,
+		swarm.AcquireOpts{NoAutosync: c.NoAutosync},
+	)
 	if err != nil {
 		return err
 	}
 	defer stop()
-	return c.run(ctx, info)
-}
-
-func (c *SwarmCommitCmd) run(ctx context.Context, info workspace.Info) error {
-	slot, err := c.resolveTargetSlot(ctx, info)
-	if err != nil {
-		return err
-	}
-	hubURL := c.HubURL
-	if hubURL == "" {
-		hubURL = swarm.DefaultHubFossilURL
-	}
-	lease, err := swarm.Resume(ctx, info, slot, swarm.AcquireOpts{
-		HubURL:     hubURL,
-		NoAutosync: c.NoAutosync,
-	})
-	if err != nil {
-		if errors.Is(err, swarm.ErrSessionNotFound) {
-			return fmt.Errorf(
-				"swarm commit: no active session for slot %q (run `bones swarm join` first)", slot)
-		}
-		return fmt.Errorf("swarm commit: %w", err)
-	}
 	defer func() { _ = lease.Release(ctx) }()
 
-	files, err := gatherCommitFiles(info, slot, c.Files, lease.WT())
+	files, err := gatherCommitFiles(info, c.Files, lease.WT())
 	if err != nil {
 		return err
 	}
@@ -73,29 +51,12 @@ func (c *SwarmCommitCmd) run(ctx context.Context, info workspace.Info) error {
 	if err != nil {
 		return fmt.Errorf("swarm commit: %w", err)
 	}
-	c.emitCommitReport(slot, lease.TaskID(), files, res, hubURL)
+	hubURL := c.HubURL
+	if hubURL == "" {
+		hubURL = swarm.DefaultHubFossilURL
+	}
+	c.emitCommitReport(lease.Slot(), lease.TaskID(), files, res, hubURL)
 	return nil
-}
-
-// resolveTargetSlot picks the slot to operate on. Honors --slot
-// when set; otherwise infers the unique active slot on this host
-// via swarm.Sessions.List. The Sessions handle is opened-and-closed
-// inline because Resume opens its own to read the session record;
-// the double-dial cost is negligible for a single CLI invocation.
-func (c *SwarmCommitCmd) resolveTargetSlot(
-	ctx context.Context, info workspace.Info,
-) (string, error) {
-	sess, closeSess, err := openSwarmSessions(ctx, info)
-	if err != nil {
-		return "", err
-	}
-	defer closeSess()
-	host, _ := os.Hostname()
-	slot, err := resolveSlot(ctx, sess, c.Slot, host)
-	if err != nil {
-		return "", err
-	}
-	return slot, nil
 }
 
 // emitCommitReport prints the UUID on stdout (machine-readable for
@@ -127,7 +88,7 @@ func (c *SwarmCommitCmd) emitCommitReport(
 	)
 }
 
-// gatherCommitFiles materializes the file set passed to Lease.Commit.
+// gatherCommitFiles materializes the file set passed to ResumedLease.Commit.
 // When the caller listed files explicitly, read them from the slot's
 // worktree. Otherwise, walk wt/ for regular files and commit them
 // all (auto-discovery — ADR 0028 §"swarm commit").
@@ -139,7 +100,7 @@ func (c *SwarmCommitCmd) emitCommitReport(
 // relative-to-repo Name, so the same Path field works as both the
 // hold key and the commit target.
 func gatherCommitFiles(
-	info workspace.Info, slot string, explicitFiles []string, wt string,
+	info workspace.Info, explicitFiles []string, wt string,
 ) ([]coord.File, error) {
 	if len(explicitFiles) == 0 {
 		return discoverDirtyFiles(info, wt)


### PR DESCRIPTION
## Summary

Phase 5 of the Ousterhout redesign — scoped tighter than the original plan to avoid speculative work.

\`swarm commit\` and \`swarm close\` duplicated a five-step opening: \`joinWorkspace\` → \`openSwarmSessions\` → \`resolveSlot\` → \`defaultHubURL\` → \`swarm.Resume\` + error wrapping. Each verb also had its own \`resolveTargetSlot\` method as a thin wrapper around the same flow.

This PR consolidates the scaffold into one **\`bootstrapResume\`** helper in \`cli/swarm.go\`. Both verbs shrink ~30 lines; the duplicated \`resolveTargetSlot\` methods are gone.

\`ErrSessionNotFound\` passes through unwrapped so swarm close keeps its idempotent "already closed?" early-return; other errors get the \`verbName\` prefix automatically.

## What's intentionally NOT in this PR

The original plan ([docs/audits/2026-04-29-ousterhout-redesign-plan.md](../blob/main/docs/audits/2026-04-29-ousterhout-redesign-plan.md)) listed several Phase 5 items I'm dropping after closer inspection:

- **Verb rename pass.** Names (join/commit/close/status/cwd/tasks/fan-in) are clear; no rename improves clarity. Per the user's CLAUDE.md "don't add abstractions beyond what the task requires."
- **\`coord.TaskSubject\` newtype.** Audit identified it as marginal — speculative type safety guarding against a hypothetical \`TaskID\` format change. Dropped.
- **New ADR for verb surface.** Existing ADR 0028 already documents the verb contracts; the bootstrap helper is internal.
- **Skill / hook / script audits.** Verified the orchestrator and subagent skills still reference the right verb names with the right flag syntax. No drift to fix; no edits needed.
- **\`status\` / \`tasks\` / \`cwd\` / \`fan-in\` migration to bootstrap.** Those verbs don't use \`swarm.Resume\` (they're read-only or admin). Migrating them to a different bootstrap path would add code, not remove it.

## Test plan

- [x] \`make check\` — green (vet, lint, race, todo-check, fmt-check)
- [x] \`go build -tags=otel ./...\` — green
- [x] \`go test -tags=otel -short ./...\` — green
- [x] cli + swarm + coord package tests pass

## Notes

- This is the smallest PR in the sequence. The structural wins from Phases 1–4 (typed Path, typed Lease, autosync seam, dispatch decoupling) carried most of the redesign weight; Phase 5 just cleans up the leftover boilerplate.
- All three CI lanes verified locally per the new pre-push rule.