### PR TITLE
docs(cleanup): sync CONTEXT.md + backlog with redesign end state

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -91,9 +91,10 @@ normalization. See ADR 0033.
 `bones-swarm-sessions[slot]` (`swarm.Session` type) that ties a
 slot to its current task, agent ID, hub URL, and last-renewed
 timestamp. Persists across CLI verbs; TTL-evicted if not renewed.
-Written by `swarm join` (a fresh `Lease.AcquireFresh`), bumped by
-`swarm commit` (`Lease.Commit`), deleted by `swarm close`
-(`Lease.Close`). See ADR 0028.
+Written by `swarm join` via `swarm.Acquire` (returns
+`*FreshLease`), bumped by `swarm commit` via
+`ResumedLease.Commit`, deleted by `swarm close` via
+`ResumedLease.Close`. See ADRs 0028 and 0033.
 
 **Sessions.** The read view across all session records in
 `bones-swarm-sessions` (`swarm.Sessions` type, returned by

--- a/docs/architecture-backlog.md
+++ b/docs/architecture-backlog.md
@@ -40,6 +40,11 @@ through five separate paths.
 
 ## 2. Introduce a CLI Session as the missing seam
 
+**Status:** partial progress — the swarm `commit`/`close` opening is
+now consolidated behind `cli/swarm.go:bootstrapResume`. The broader
+Session abstraction (every verb takes a Session, output through an
+`io.Writer` for unit testability) is still open.
+
 **Files:** `cli/tasks_common.go` (`joinWorkspace`, `openManager`), then ~12
 verbs (`tasks_create.go:27-43`, `tasks_list.go:32-50`, `tasks_claim.go:33-41`,
 etc.) repeating the same 17–21 line bootstrap; plus `swarm_status.go:60-73`
@@ -90,6 +95,13 @@ session-record path. Makes the Sessions narrowing intent enforceable.
 
 ## 4. Redraw the substrate seam: lift domain types out of `coord`'s public surface
 
+**Status:** partial progress — `internal/dispatch` now defines its own
+`Task` interface and no longer imports `coord` (Phase 4 of the
+Ousterhout redesign). The bulk of the candidate is still open:
+`coord.Task`, `coord.Presence`, `coord.File`, and `coord.Edge` are
+still re-exported on `coord`'s public surface, and the translation
+helpers (`taskFromRecord`, `presenceFromEntry`) still live there.
+
 **Files:** `internal/coord/types.go` (re-exports `Task`, `Presence`, `Edge`,
 `File`), `internal/coord/coord.go` (28 exported types total), translation
 helpers `taskFromRecord` / `presenceFromEntry`.
@@ -118,6 +130,16 @@ locking + storage + events, period.
 ---
 
 ## 5. Extract the KV-Manager pattern shared by Holds and Tasks
+
+**Status:** evaluated and deliberately not done. Survey during the
+Ousterhout redesign (Phase 6) found the audit's "~60 lines of
+boilerplate per package" estimate inflated; the actual shared shape
+across tasks/holds/presence is closer to ~15 lines per package and
+the divergence is meaningful (tasks+holds have subscriber slices,
+presence has a heartbeat goroutine; chat is fundamentally different
+— fossil + notify, not KV). Forcing them into a common base would
+add complexity, not remove it. Reopen if a third KV-manager use
+case appears and the shared shape grows.
 
 **Files:** `internal/tasks/tasks.go`, `internal/tasks/subscribe.go`,
 `internal/holds/holds.go`, `internal/holds/subscribe.go`; today


### PR DESCRIPTION
## Summary

Final cleanup pass after the Ousterhout redesign (Phases 0–5). Branch is named \`phase-6/manager-base\` for sequence continuity but the work here is Phase 7 (cleanup) — Phase 6 was deliberately skipped after surveying the four substrate managers (see [the architecture-backlog #5 entry](../blob/main/docs/architecture-backlog.md) for the rationale captured in this PR).

## What changed

### \`CONTEXT.md\`
- The Session record entry referenced the pre-Phase 2 single \`Lease\` type (\`Lease.AcquireFresh\`, \`Lease.Commit\`, \`Lease.Close\`). Updated to the \`FreshLease\`/\`ResumedLease\` split per ADR 0033.

### \`docs/architecture-backlog.md\`
- Candidate **#2 (CLI Session)** — marked partial progress: \`bootstrapResume\` covers swarm commit/close; broader Session abstraction still open.
- Candidate **#4 (coord public surface)** — marked partial progress: \`dispatch.Task\` interface lifted out so dispatch no longer imports coord; \`coord.Task\`/\`Presence\`/\`File\`/\`Edge\` re-exports still on the public surface.
- Candidate **#5 (KV-Manager scaffold)** — marked evaluated and deliberately not done. The audit's "~60 lines of boilerplate per package" estimate was inflated; the actual shared shape across tasks/holds/presence is closer to ~15 lines per package and the divergence is meaningful (subscriber slices vs heartbeat goroutine; chat diverges further — fossil + notify, not KV). Reopen if a third KV-manager use case appears.

## Fresh Ousterhout pass on the new \`Lease\` types (sanity check)

The redesign's structural goal was deepening the lease modules. A quick read after the dust settled:

- **\`ResumedLease\`** — small public surface (\`Commit\`, \`Close\`, \`Release\`, accessors); behind it: claim+hold re-acquisition, libfossil commit, hub push, CAS-bump with bounded retry, optional task close. CAS revisions are private (\`l.rev\`); retry counts hidden. **Deep.** ✓
- **\`FreshLease\`** — even smaller surface (\`Release\`, \`Abort\`, accessors); covers the fresh-acquisition rollback case. The type system prevents calling \`Commit\` or \`Close\` on a \`FreshLease\` — exactly the misuse the audit flagged as an "obscure dependency." **Deep.** ✓
- **Errors-defined-out-of-existence** — \`ErrSessionGone\` is a new typed surface for "record deleted concurrently"; the old code swallowed these as silent CAS conflicts. The retry loop hides "rev advanced" cases entirely. ✓

The redesign achieves what it promised. No remaining sub-modules feel shallow; the type split made misuses compile errors instead of runtime errors.

## Test plan

- [x] \`make check\` — green (vet, lint, race, todo-check, fmt-check)
- [x] \`go build -tags=otel ./...\` — green
- [x] \`go test -tags=otel -short ./...\` — green
- [x] All three lanes verified post-push per the rule

## Sequence wrap-up

This is the last PR in the redesign sequence. The seven-phase plan in \`docs/audits/2026-04-29-ousterhout-redesign-plan.md\` is complete with one phase intentionally skipped:

| Phase | What landed | PR |
|---|---|---|
| 0 | ADR 0033 + plan + CONTEXT.md prep | #68 |
| 1 | \`coord.Path\` newtype + holds API migration | #69 |
| 2 | \`FreshLease\` / \`ResumedLease\` type split | #70 |
| 3 | Autosync seam → \`AcquireOpts.NoAutosync\` | #71 |
| 4 | Dispatch decoupling via \`dispatch.Task\` | #72 |
| 5 | \`bootstrapResume\` CLI helper | #73 |
| 6 | Substrate \`managerBase\` | **skipped** (rationale recorded in backlog) |
| 7 | Cleanup (this PR) | this |