### PR TITLE
feat(updatecheck): once-a-day notice when bones is behind

### DIFF
--- a/cmd/bones/main.go
+++ b/cmd/bones/main.go
@@ -15,6 +15,8 @@ import (
 
 	"github.com/alecthomas/kong"
 	_ "github.com/danmestas/libfossil/db/driver/modernc"
+
+	"github.com/danmestas/bones/internal/updatecheck"
 )
 
 // Build-time variables, populated via -ldflags by GoReleaser.
@@ -25,6 +27,12 @@ var (
 )
 
 func main() {
+	// Once-per-day update check. Best-effort; runs the network refresh
+	// in a goroutine and prints a one-line stderr notice based on
+	// cached state. Suppressed by BONES_UPDATE_CHECK=0 and skipped on
+	// "dev" builds (i.e. anything not built by GoReleaser).
+	updatecheck.Check(version)
+
 	// Handle --version / -V at the top level. Done before Kong.Parse so
 	// it doesn't collide with sub-flags like `bones repo extract --version`.
 	if len(os.Args) == 2 && (os.Args[1] == "--version" || os.Args[1] == "-V") {

--- a/internal/updatecheck/updatecheck.go
+++ b/internal/updatecheck/updatecheck.go
@@ -1,0 +1,230 @@
+// Package updatecheck queries GitHub for the latest bones release tag
+// and emits a one-line stderr notice when the running binary is
+// behind. Best-effort and rate-limited (once per 24h cached on
+// disk). Called from cmd/bones/main.go at process start.
+//
+// Design notes:
+//
+//   - The notice is printed synchronously from the on-disk cache. The
+//     network refresh runs asynchronously and may not finish before
+//     a short-lived CLI process exits — that's OK; the next long-
+//     enough invocation picks up the new latest.
+//   - "dev" builds (no version embedded) skip the check entirely so
+//     local hacking never triggers a network call.
+//   - Suppressed by env var BONES_UPDATE_CHECK=0.
+//   - All errors are silent: an update check that fails must never
+//     interfere with the verb the user actually ran.
+package updatecheck
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// LatestReleaseURL is the GitHub API endpoint queried for the latest
+// release tag. Exported so tests can override it without monkey-patching.
+var LatestReleaseURL = "https://api.github.com/repos/danmestas/bones/releases/latest"
+
+// CacheTTL is the minimum interval between network refreshes.
+// Exported for tests; production callers leave it at 24h.
+var CacheTTL = 24 * time.Hour
+
+// FetchTimeout caps how long the async refresh waits for GitHub.
+var FetchTimeout = 3 * time.Second
+
+// UpgradeHint is the user-facing instruction appended to every notice.
+// One-line so the notice fits on a single stderr row.
+var UpgradeHint = "brew upgrade danmestas/tap/bones"
+
+type cacheEntry struct {
+	LastCheck time.Time `json:"last_check"`
+	Latest    string    `json:"latest"`
+}
+
+// Check is the public entry point. Reads the cache, prints a notice
+// to stderr if the running binary is behind, and spawns an async
+// refresh when the cache is stale. Never blocks the caller for the
+// network round-trip.
+func Check(currentVersion string) {
+	if shouldSkip(currentVersion) {
+		return
+	}
+	cachePath, err := cacheFile()
+	if err != nil {
+		return
+	}
+
+	entry := readCache(cachePath)
+	if entry.Latest != "" && Newer(entry.Latest, currentVersion) {
+		printNotice(os.Stderr, currentVersion, entry.Latest)
+	}
+
+	if time.Since(entry.LastCheck) < CacheTTL {
+		return
+	}
+
+	go refresh(cachePath)
+}
+
+// shouldSkip returns true when the update check must not run: dev
+// builds, opt-out env var, or empty version.
+func shouldSkip(currentVersion string) bool {
+	if currentVersion == "" || currentVersion == "dev" {
+		return true
+	}
+	if os.Getenv("BONES_UPDATE_CHECK") == "0" {
+		return true
+	}
+	return false
+}
+
+// cacheFile resolves the on-disk path used to memoize the latest
+// observed release tag. Uses os.UserCacheDir per platform conventions.
+func cacheFile() (string, error) {
+	dir, err := os.UserCacheDir()
+	if err != nil {
+		return "", err
+	}
+	bonesDir := filepath.Join(dir, "bones")
+	if err := os.MkdirAll(bonesDir, 0o700); err != nil {
+		return "", err
+	}
+	return filepath.Join(bonesDir, "version-check.json"), nil
+}
+
+// readCache loads the cache entry from path. A missing or malformed
+// cache returns a zero-value entry; callers treat it as "never
+// checked, no known latest."
+func readCache(path string) cacheEntry {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return cacheEntry{}
+	}
+	var e cacheEntry
+	if err := json.Unmarshal(data, &e); err != nil {
+		return cacheEntry{}
+	}
+	return e
+}
+
+// writeCache persists the entry. Errors are intentionally ignored —
+// a failed write means the next invocation will refresh again, which
+// is the correct behavior.
+func writeCache(path string, entry cacheEntry) {
+	data, err := json.Marshal(entry)
+	if err != nil {
+		return
+	}
+	_ = os.WriteFile(path, data, 0o600)
+}
+
+// refresh fetches the latest release tag from GitHub and writes the
+// cache. Runs in its own goroutine; never returns errors visibly.
+// On fetch failure the cache is unchanged so the next invocation
+// will retry.
+func refresh(cachePath string) {
+	ctx, cancel := context.WithTimeout(context.Background(), FetchTimeout)
+	defer cancel()
+	latest, err := fetchLatest(ctx)
+	if err != nil {
+		return
+	}
+	writeCache(cachePath, cacheEntry{LastCheck: time.Now(), Latest: latest})
+}
+
+// fetchLatest queries GitHub's "latest release" endpoint and returns
+// the tag_name string ("v0.2.0"). Exposed for tests.
+func fetchLatest(ctx context.Context) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, LatestReleaseURL, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("github: status %d", resp.StatusCode)
+	}
+	var body struct {
+		TagName string `json:"tag_name"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return "", err
+	}
+	if body.TagName == "" {
+		return "", fmt.Errorf("github: empty tag_name")
+	}
+	return body.TagName, nil
+}
+
+// printNotice formats and emits the one-line stderr update notice.
+// Both versions are normalized to a leading "v" so the message reads
+// "v0.2.0 → v0.3.0" regardless of which form GoReleaser injected.
+func printNotice(w *os.File, current, latest string) {
+	_, _ = fmt.Fprintf(w,
+		"bones: update available: %s → %s (run: %s)\n",
+		normalizeVersion(current), normalizeVersion(latest), UpgradeHint,
+	)
+}
+
+// normalizeVersion ensures the string starts with "v".
+func normalizeVersion(v string) string {
+	if v == "" {
+		return v
+	}
+	if v[0] == 'v' {
+		return v
+	}
+	return "v" + v
+}
+
+// Newer reports whether latest is a strictly newer semver than
+// current. Both inputs may carry a leading "v"; non-numeric
+// suffixes (pre-releases) cause Newer to return false to avoid
+// spurious notices.
+func Newer(latest, current string) bool {
+	lMaj, lMin, lPatch, ok := parseSemver(latest)
+	if !ok {
+		return false
+	}
+	cMaj, cMin, cPatch, ok := parseSemver(current)
+	if !ok {
+		return false
+	}
+	if lMaj != cMaj {
+		return lMaj > cMaj
+	}
+	if lMin != cMin {
+		return lMin > cMin
+	}
+	return lPatch > cPatch
+}
+
+// parseSemver extracts (major, minor, patch) from a vX.Y.Z string.
+// Returns ok=false on any parsing failure (including pre-release
+// suffixes like "v0.2.0-rc1") so the caller errs on the side of
+// silence.
+func parseSemver(v string) (major, minor, patch int, ok bool) {
+	v = strings.TrimPrefix(v, "v")
+	parts := strings.Split(v, ".")
+	if len(parts) != 3 {
+		return 0, 0, 0, false
+	}
+	maj, err1 := strconv.Atoi(parts[0])
+	min, err2 := strconv.Atoi(parts[1])
+	pat, err3 := strconv.Atoi(parts[2])
+	if err1 != nil || err2 != nil || err3 != nil {
+		return 0, 0, 0, false
+	}
+	return maj, min, pat, true
+}

--- a/internal/updatecheck/updatecheck_test.go
+++ b/internal/updatecheck/updatecheck_test.go
@@ -1,0 +1,167 @@
+package updatecheck
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestNewer(t *testing.T) {
+	cases := []struct {
+		latest, current string
+		want            bool
+	}{
+		{"v0.2.0", "v0.1.0", true},
+		{"v0.2.0", "0.1.0", true},
+		{"0.2.0", "v0.1.0", true},
+		{"v1.0.0", "v0.99.99", true},
+		{"v0.2.1", "v0.2.0", true},
+		{"v0.2.0", "v0.2.0", false},
+		{"v0.1.0", "v0.2.0", false},
+		// Bad inputs should NOT trigger notices — return false
+		// rather than guess.
+		{"vNotASemver", "v0.1.0", false},
+		{"v0.2.0", "garbage", false},
+		{"v0.2.0-rc1", "v0.1.0", false},
+	}
+	for _, c := range cases {
+		got := Newer(c.latest, c.current)
+		if got != c.want {
+			t.Errorf("Newer(%q, %q): got %v, want %v",
+				c.latest, c.current, got, c.want)
+		}
+	}
+}
+
+func TestShouldSkip(t *testing.T) {
+	t.Setenv("BONES_UPDATE_CHECK", "")
+	cases := []struct {
+		version string
+		want    bool
+	}{
+		{"", true},
+		{"dev", true},
+		{"v0.2.0", false},
+		{"0.2.0", false},
+	}
+	for _, c := range cases {
+		if got := shouldSkip(c.version); got != c.want {
+			t.Errorf("shouldSkip(%q): got %v, want %v",
+				c.version, got, c.want)
+		}
+	}
+}
+
+func TestShouldSkip_OptOutEnv(t *testing.T) {
+	t.Setenv("BONES_UPDATE_CHECK", "0")
+	if !shouldSkip("v0.2.0") {
+		t.Error("BONES_UPDATE_CHECK=0 should skip even on real version")
+	}
+}
+
+func TestCacheRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "version-check.json")
+
+	// Empty file: returns zero value.
+	got := readCache(path)
+	if got.Latest != "" || !got.LastCheck.IsZero() {
+		t.Errorf("empty cache: got %+v", got)
+	}
+
+	// Round-trip.
+	want := cacheEntry{
+		LastCheck: time.Now().UTC().Truncate(time.Second),
+		Latest:    "v0.3.0",
+	}
+	writeCache(path, want)
+
+	got = readCache(path)
+	if got.Latest != want.Latest {
+		t.Errorf("Latest: got %q, want %q", got.Latest, want.Latest)
+	}
+	if !got.LastCheck.Equal(want.LastCheck) {
+		t.Errorf("LastCheck: got %v, want %v", got.LastCheck, want.LastCheck)
+	}
+
+	// Malformed cache: returns zero value, no panic.
+	if err := os.WriteFile(path, []byte("{not json"), 0o600); err != nil {
+		t.Fatalf("write malformed: %v", err)
+	}
+	got = readCache(path)
+	if got.Latest != "" {
+		t.Errorf("malformed cache should return zero value, got %+v", got)
+	}
+}
+
+func TestNormalizeVersion(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"", ""},
+		{"v0.2.0", "v0.2.0"},
+		{"0.2.0", "v0.2.0"},
+	}
+	for _, c := range cases {
+		if got := normalizeVersion(c.in); got != c.want {
+			t.Errorf("normalizeVersion(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestFetchLatest(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]string{"tag_name": "v0.99.0"})
+	}))
+	defer srv.Close()
+
+	prev := LatestReleaseURL
+	LatestReleaseURL = srv.URL
+	defer func() { LatestReleaseURL = prev }()
+
+	tag, err := fetchLatest(context.Background())
+	if err != nil {
+		t.Fatalf("fetchLatest: %v", err)
+	}
+	if tag != "v0.99.0" {
+		t.Errorf("tag = %q, want v0.99.0", tag)
+	}
+}
+
+func TestFetchLatest_HTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	prev := LatestReleaseURL
+	LatestReleaseURL = srv.URL
+	defer func() { LatestReleaseURL = prev }()
+
+	if _, err := fetchLatest(context.Background()); err == nil {
+		t.Error("expected error on 500 response")
+	}
+}
+
+func TestPrintNotice(t *testing.T) {
+	// Verify formatting end-to-end through a bytes.Buffer disguised as
+	// an *os.File via a temp pipe. Simpler: test the format string
+	// directly.
+	want := fmt.Sprintf(
+		"bones: update available: v0.1.0 → v0.2.0 (run: %s)\n",
+		UpgradeHint,
+	)
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf,
+		"bones: update available: %s → %s (run: %s)\n",
+		normalizeVersion("v0.1.0"), normalizeVersion("0.2.0"), UpgradeHint,
+	)
+	if buf.String() != want {
+		t.Errorf("notice format drift: got %q, want %q", buf.String(), want)
+	}
+}


### PR DESCRIPTION
## Summary

Implements option A from the brew-update-check brainstorm: \`bones\` checks GitHub Releases at most once per 24h and prints a one-line stderr notice when the running binary is older than the latest tag.

**Format:**
\`\`\`
bones: update available: v0.1.0 → v0.2.0 (run: brew upgrade danmestas/tap/bones)
\`\`\`

## Design

- **Non-blocking.** The notice prints synchronously from the on-disk cache (zero-latency); the network refresh runs in a goroutine that may finish after a short-lived CLI process exits. Next long-enough invocation picks up the new \`latest\`.
- **Rate-limited** to once per 24h via \`os.UserCacheDir/bones/version-check.json\`.
- **Best-effort silent.** Every error path is silent — a failed update check must never interfere with the verb the user actually ran.
- **Dev builds skip.** When \`main.version == "dev"\` (i.e., not a GoReleaser build) the check is suppressed entirely. Local hacking never triggers a network call.
- **Opt-out** via \`BONES_UPDATE_CHECK=0\`.
- **Pre-releases ignored.** Tags like \`v0.2.0-rc1\` parse as not-newer rather than triggering spurious notices.

## Test plan

- [x] \`make check\` — green (vet, lint, race, todo-check, fmt-check)
- [x] \`go build -tags=otel ./...\` — green
- [x] \`go test -tags=otel -short ./...\` — green
- [x] **Manual smoke test**:
  - \`v0.1.0\` binary with cached \`v0.5.0\` → notice fires
  - Same with \`BONES_UPDATE_CHECK=0\` → silent
  - \`dev\` build → silent

## Notes

- The check fires before \`Kong.Parse\` so even \`bones --version\` and parse-error paths get the notice.
- Cache directory is \`os.UserCacheDir()\` — \`~/Library/Caches/bones/\` on macOS, \`~/.cache/bones/\` on Linux.
- HTTP timeout is 3s. After 3s with no response, the cache stays unchanged so the next invocation will retry.