### PR TITLE
feat(cli): bones down — reverse bones up

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,19 +82,13 @@ Add `-v` to any command for DEBUG-level slog output. Default is silent.
 
 ## Uninstall
 
-From inside Claude Code: ask it to "uninstall bones" — the bundled `uninstall-bones` skill stops the hub, removes the workspace + orchestrator dirs, and pulls the SessionStart/Stop hooks out of `.claude/settings.json` while leaving unrelated hooks intact.
-
-Manually:
-
 ```bash
-bones hub stop                          # stop fossil + nats
-rm -rf .bones .orchestrator             # remove workspace + hub state
-rm -rf .claude/skills/orchestrator \
-       .claude/skills/subagent \
-       .claude/skills/uninstall-bones   # remove scaffolded skills
-# then edit .claude/settings.json by hand to remove the
-# hub-bootstrap.sh and hub-shutdown.sh hook entries
+bones down            # confirms before removing anything
 ```
+
+`bones down` reverses `bones up`: stops the hub, removes `.bones/` and `.orchestrator/`, removes the scaffolded skills under `.claude/skills/`, and prunes only the bones-installed hooks from `.claude/settings.json` (leaving unrelated hooks intact). Flags: `--yes` skips the prompt, `--dry-run` prints the plan, `--keep-hub` / `--keep-skills` / `--keep-hooks` for partial uninstalls.
+
+From inside Claude Code: ask it to "uninstall bones" — the bundled `uninstall-bones` skill walks through the same steps interactively.
 
 Remove the binary: `brew uninstall bones` (or delete `$(go env GOPATH)/bin/bones` if you `go install`ed).
 

--- a/cli/down.go
+++ b/cli/down.go
@@ -103,17 +103,14 @@ func runDown(root string, c *DownCmd, confirmIn interface {
 // identically across terminals. Suppressed when stdout is
 // redirected so script output stays clean.
 const goodbye = `
-            _____
-           /     \
-          | () () |
-           \  ~  /
-            |||||
-       X----|||||----X
-            \|||/
-             \|/
-              X
+       .ed$""$be.
+     d$"        "$b
+     $  ()    ()  $
+     $     \/     $
+     "$.   --   .$"
+       "*ee$$ee*"
 
-       workspace cleared`
+  now exiting the 5th dimension`
 
 // printGoodbye writes the goodbye banner to stdout when stdout is a
 // TTY. No-op otherwise — script consumers see only the structured

--- a/cli/down.go
+++ b/cli/down.go
@@ -94,37 +94,7 @@ func runDown(root string, c *DownCmd, confirmIn interface {
 		return first
 	}
 	fmt.Println("down: complete")
-	printGoodbye()
 	return nil
-}
-
-// goodbye is the skull-and-crossbones farewell printed after a
-// successful bones down when stdout is a TTY. Pure ASCII; renders
-// identically across terminals. Suppressed when stdout is
-// redirected so script output stays clean.
-const goodbye = `
-       .ed$""$be.
-     d$"        "$b
-     $  ()    ()  $
-     $     \/     $
-     "$.   --   .$"
-       "*ee$$ee*"
-
-  now exiting the 5th dimension`
-
-// printGoodbye writes the goodbye banner to stdout when stdout is a
-// TTY. No-op otherwise — script consumers see only the structured
-// "down: complete" line.
-func printGoodbye() {
-	fi, err := os.Stdout.Stat()
-	if err != nil {
-		return
-	}
-	if (fi.Mode() & os.ModeCharDevice) == 0 {
-		return
-	}
-	fmt.Println(goodbye)
-	fmt.Println()
 }
 
 // downAction is one step in the destructive plan. Each step has a

--- a/cli/down.go
+++ b/cli/down.go
@@ -1,0 +1,361 @@
+package cli
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	libfossilcli "github.com/danmestas/libfossil/cli"
+
+	"github.com/danmestas/bones/internal/workspace"
+)
+
+// DownCmd reverses bones up: stops the hub, removes the workspace
+// marker (.bones/), the orchestrator state (.orchestrator/), the
+// scaffolded skills (.claude/skills/{orchestrator,subagent,
+// uninstall-bones}), and the bones-installed SessionStart/Stop hooks
+// from .claude/settings.json. Other hooks in settings.json are left
+// untouched.
+//
+// Destructive — requires --yes or an interactive y/N confirmation.
+// Idempotent: re-running on a clean tree is a no-op.
+type DownCmd struct {
+	Yes        bool `name:"yes" short:"y" help:"skip the confirmation prompt"`
+	KeepSkills bool `name:"keep-skills" help:"do not remove .claude/skills"`
+	KeepHooks  bool `name:"keep-hooks" help:"do not edit .claude/settings.json"`
+	KeepHub    bool `name:"keep-hub" help:"do not stop hub or remove .orchestrator/"`
+	DryRun     bool `name:"dry-run" help:"print plan without executing"`
+}
+
+// Run is the Kong entry point. Resolves the workspace root (walking
+// up from cwd if a marker exists, falling back to cwd otherwise),
+// builds an execution plan, prompts unless --yes, and executes.
+func (c *DownCmd) Run(g *libfossilcli.Globals) error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("cwd: %w", err)
+	}
+	root := resolveDownRoot(cwd)
+	return runDown(root, c, os.Stdin)
+}
+
+// resolveDownRoot returns the workspace root to operate on. Tries
+// workspace.Join first to walk up to a marker, falls back to cwd
+// when no workspace exists (still useful for partial installs).
+func resolveDownRoot(cwd string) string {
+	info, err := workspace.Join(context.Background(), cwd)
+	if err == nil {
+		return info.WorkspaceDir
+	}
+	return cwd
+}
+
+// runDown is the testable entry point. confirmIn is the io.Reader
+// used for the y/N prompt; tests pass a strings.Reader.
+func runDown(root string, c *DownCmd, confirmIn interface {
+	Read(p []byte) (n int, err error)
+}) error {
+	plan := planDown(root, c)
+	if len(plan) == 0 {
+		fmt.Println("down: nothing to remove (no bones state found)")
+		return nil
+	}
+
+	fmt.Printf("down: workspace at %s\n", root)
+	fmt.Println("down: will:")
+	for _, a := range plan {
+		fmt.Println("  -", a.description)
+	}
+
+	if c.DryRun {
+		fmt.Println("down: --dry-run, not executing")
+		return nil
+	}
+
+	if !c.Yes {
+		if !confirm(confirmIn, "Proceed?") {
+			return errors.New("down: aborted")
+		}
+	}
+
+	var first error
+	for _, a := range plan {
+		if err := a.do(); err != nil && first == nil {
+			first = fmt.Errorf("%s: %w", a.description, err)
+		}
+	}
+	if first != nil {
+		return first
+	}
+	fmt.Println("down: complete")
+	printGoodbye()
+	return nil
+}
+
+// goodbye is the skull-and-crossbones farewell printed after a
+// successful bones down when stdout is a TTY. Pure ASCII; renders
+// identically across terminals. Suppressed when stdout is
+// redirected so script output stays clean.
+const goodbye = `
+            _____
+           /     \
+          | () () |
+           \  ~  /
+            |||||
+       X----|||||----X
+            \|||/
+             \|/
+              X
+
+       workspace cleared`
+
+// printGoodbye writes the goodbye banner to stdout when stdout is a
+// TTY. No-op otherwise — script consumers see only the structured
+// "down: complete" line.
+func printGoodbye() {
+	fi, err := os.Stdout.Stat()
+	if err != nil {
+		return
+	}
+	if (fi.Mode() & os.ModeCharDevice) == 0 {
+		return
+	}
+	fmt.Println(goodbye)
+	fmt.Println()
+}
+
+// downAction is one step in the destructive plan. Each step has a
+// human-readable description and a thunk that executes it. Steps
+// are independent — failure of one doesn't abort the rest, but the
+// first error is propagated so callers see something went wrong.
+type downAction struct {
+	description string
+	do          func() error
+}
+
+// planDown enumerates the actions runDown will perform, given the
+// flags. Skips actions whose target doesn't exist so the plan output
+// reflects what's actually present.
+func planDown(root string, c *DownCmd) []downAction {
+	var plan []downAction
+	plan = append(plan, planStopHub(root, c)...)
+	plan = append(plan, planRemoveBonesDir(root)...)
+	plan = append(plan, planRemoveOrchestrator(root, c)...)
+	plan = append(plan, planRemoveSkills(root, c)...)
+	plan = append(plan, planRemoveHooks(root, c)...)
+	plan = append(plan, planRemoveFossilMarkers(root)...)
+	return plan
+}
+
+func planStopHub(root string, c *DownCmd) []downAction {
+	if c.KeepHub {
+		return nil
+	}
+	script := filepath.Join(root, ".orchestrator", "scripts", "hub-shutdown.sh")
+	if !fileExists(script) {
+		return nil
+	}
+	return []downAction{{
+		description: "stop hub via " + script,
+		do: func() error {
+			cmd := exec.Command("bash", script)
+			cmd.Dir = root
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			// Best-effort: an already-stopped hub must not fail down.
+			_ = cmd.Run()
+			return nil
+		},
+	}}
+}
+
+func planRemoveBonesDir(root string) []downAction {
+	dir := filepath.Join(root, ".bones")
+	if !dirExists(dir) {
+		return nil
+	}
+	return []downAction{{
+		description: "remove " + dir,
+		do:          func() error { return os.RemoveAll(dir) },
+	}}
+}
+
+func planRemoveOrchestrator(root string, c *DownCmd) []downAction {
+	if c.KeepHub {
+		return nil
+	}
+	dir := filepath.Join(root, ".orchestrator")
+	if !dirExists(dir) {
+		return nil
+	}
+	return []downAction{{
+		description: "remove " + dir,
+		do:          func() error { return os.RemoveAll(dir) },
+	}}
+}
+
+func planRemoveSkills(root string, c *DownCmd) []downAction {
+	if c.KeepSkills {
+		return nil
+	}
+	var plan []downAction
+	for _, name := range []string{"orchestrator", "subagent", "uninstall-bones"} {
+		dir := filepath.Join(root, ".claude", "skills", name)
+		if !dirExists(dir) {
+			continue
+		}
+		plan = append(plan, downAction{
+			description: "remove " + dir,
+			do:          func() error { return os.RemoveAll(dir) },
+		})
+	}
+	return plan
+}
+
+func planRemoveHooks(root string, c *DownCmd) []downAction {
+	if c.KeepHooks {
+		return nil
+	}
+	settings := filepath.Join(root, ".claude", "settings.json")
+	if !fileExists(settings) {
+		return nil
+	}
+	return []downAction{{
+		description: "remove bones hooks from " + settings,
+		do:          func() error { return removeBonesHooks(settings) },
+	}}
+}
+
+// planRemoveFossilMarkers cleans the Fossil checkout-at-root markers
+// (ADR 0023). bones up creates these alongside the orchestrator
+// scaffold; bones down removes them for symmetry. Fossil metadata
+// only — never working-tree files.
+func planRemoveFossilMarkers(root string) []downAction {
+	var plan []downAction
+	if path := filepath.Join(root, ".fslckout"); fileExists(path) || dirExists(path) {
+		plan = append(plan, downAction{
+			description: "remove " + path,
+			do:          func() error { return os.RemoveAll(path) },
+		})
+	}
+	if dir := filepath.Join(root, ".fossil-settings"); dirExists(dir) {
+		plan = append(plan, downAction{
+			description: "remove " + dir,
+			do:          func() error { return os.RemoveAll(dir) },
+		})
+	}
+	return plan
+}
+
+// removeBonesHooks edits settings.json to drop hook entries whose
+// command references hub-bootstrap.sh or hub-shutdown.sh (the two
+// scripts bones up installs). Other hooks are preserved verbatim.
+// Empty hook groups and the "hooks" top-level key are pruned when
+// removal leaves them empty.
+func removeBonesHooks(path string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	if len(data) == 0 {
+		return nil
+	}
+	var rootObj map[string]any
+	if err := json.Unmarshal(data, &rootObj); err != nil {
+		return fmt.Errorf("parse %s: %w", path, err)
+	}
+	hooks, _ := rootObj["hooks"].(map[string]any)
+	if hooks == nil {
+		return nil
+	}
+	pruneHookEvent(hooks, "SessionStart", "hub-bootstrap.sh")
+	pruneHookEvent(hooks, "Stop", "hub-shutdown.sh")
+	if len(hooks) == 0 {
+		delete(rootObj, "hooks")
+	} else {
+		rootObj["hooks"] = hooks
+	}
+	out, err := json.MarshalIndent(rootObj, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, append(out, '\n'), 0o644)
+}
+
+// pruneHookEvent removes hook entries under hooks[event] whose
+// command contains needle. Groups left with no entries are dropped;
+// if the event has no groups left, the event key is removed too.
+func pruneHookEvent(hooks map[string]any, event, needle string) {
+	groups, _ := hooks[event].([]any)
+	if groups == nil {
+		return
+	}
+	var keep []any
+	for _, g := range groups {
+		gm, ok := g.(map[string]any)
+		if !ok {
+			keep = append(keep, g)
+			continue
+		}
+		entries, _ := gm["hooks"].([]any)
+		var keepEntries []any
+		for _, e := range entries {
+			em, ok := e.(map[string]any)
+			if !ok {
+				keepEntries = append(keepEntries, e)
+				continue
+			}
+			cmd, _ := em["command"].(string)
+			if !strings.Contains(cmd, needle) {
+				keepEntries = append(keepEntries, e)
+			}
+		}
+		if len(keepEntries) == 0 {
+			continue
+		}
+		gm["hooks"] = keepEntries
+		keep = append(keep, gm)
+	}
+	if len(keep) == 0 {
+		delete(hooks, event)
+		return
+	}
+	hooks[event] = keep
+}
+
+// confirm prompts the user for y/N via the supplied reader. Returns
+// true only on an explicit "y" or "yes" (case-insensitive). Anything
+// else, including EOF or read errors, returns false.
+func confirm(in interface {
+	Read(p []byte) (n int, err error)
+}, prompt string) bool {
+	fmt.Printf("\n%s [y/N]: ", prompt)
+	rdr := bufio.NewReader(in)
+	line, err := rdr.ReadString('\n')
+	if err != nil && line == "" {
+		return false
+	}
+	answer := strings.TrimSpace(strings.ToLower(line))
+	return answer == "y" || answer == "yes"
+}
+
+// fileExists reports whether path exists and is a regular file.
+func fileExists(path string) bool {
+	fi, err := os.Stat(path)
+	return err == nil && !fi.IsDir()
+}
+
+// dirExists reports whether path exists and is a directory.
+func dirExists(path string) bool {
+	fi, err := os.Stat(path)
+	return err == nil && fi.IsDir()
+}

--- a/cli/down_test.go
+++ b/cli/down_test.go
@@ -1,0 +1,337 @@
+package cli
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestRemoveBonesHooks_RemovesScaffoldedHooks pins the surgical-edit
+// behavior: only hooks whose command references hub-bootstrap.sh
+// (SessionStart) or hub-shutdown.sh (Stop) are removed. Other hooks
+// in the same event groups stay.
+func TestRemoveBonesHooks_RemovesScaffoldedHooks(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "settings.json")
+
+	original := map[string]any{
+		"theme": "dark",
+		"hooks": map[string]any{
+			"SessionStart": []any{
+				map[string]any{
+					"matcher": "",
+					"hooks": []any{
+						map[string]any{
+							"command": "bash .orchestrator/scripts/hub-bootstrap.sh",
+							"type":    "command",
+							"timeout": 10.0,
+						},
+						map[string]any{
+							"command": "echo other-hook",
+							"type":    "command",
+						},
+					},
+				},
+			},
+			"Stop": []any{
+				map[string]any{
+					"matcher": "",
+					"hooks": []any{
+						map[string]any{
+							"command": "bash .orchestrator/scripts/hub-shutdown.sh",
+							"type":    "command",
+						},
+					},
+				},
+			},
+			"PreToolUse": []any{
+				map[string]any{
+					"matcher": "Bash",
+					"hooks": []any{
+						map[string]any{"command": "echo unrelated"},
+					},
+				},
+			},
+		},
+	}
+	writeJSON(t, path, original)
+
+	if err := removeBonesHooks(path); err != nil {
+		t.Fatalf("removeBonesHooks: %v", err)
+	}
+
+	got := readJSON(t, path)
+	hooks, _ := got["hooks"].(map[string]any)
+	if hooks == nil {
+		t.Fatal("hooks key was removed; expected PreToolUse to keep it")
+	}
+
+	// SessionStart had two entries; only the bones one was removed.
+	ssGroups, _ := hooks["SessionStart"].([]any)
+	if len(ssGroups) != 1 {
+		t.Fatalf("SessionStart groups: got %d, want 1", len(ssGroups))
+	}
+	ssEntries, _ := ssGroups[0].(map[string]any)["hooks"].([]any)
+	if len(ssEntries) != 1 {
+		t.Fatalf("SessionStart entries left: got %d, want 1", len(ssEntries))
+	}
+	if cmd, _ := ssEntries[0].(map[string]any)["command"].(string); cmd != "echo other-hook" {
+		t.Errorf("surviving SessionStart command: got %q, want echo other-hook", cmd)
+	}
+
+	// Stop had only the bones entry; its group should be gone.
+	if _, ok := hooks["Stop"]; ok {
+		t.Errorf("Stop event should be removed (was empty after prune); still present: %+v",
+			hooks["Stop"])
+	}
+
+	// PreToolUse must be untouched.
+	preGroups, _ := hooks["PreToolUse"].([]any)
+	if len(preGroups) != 1 {
+		t.Errorf("PreToolUse groups: got %d, want 1", len(preGroups))
+	}
+
+	// Top-level theme key preserved.
+	if got["theme"] != "dark" {
+		t.Errorf("theme: got %v, want dark", got["theme"])
+	}
+}
+
+// TestRemoveBonesHooks_NoHooksKey is a no-op when settings.json
+// has no hooks section at all.
+func TestRemoveBonesHooks_NoHooksKey(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "settings.json")
+	writeJSON(t, path, map[string]any{"theme": "light"})
+
+	if err := removeBonesHooks(path); err != nil {
+		t.Fatalf("removeBonesHooks: %v", err)
+	}
+	got := readJSON(t, path)
+	if got["theme"] != "light" {
+		t.Errorf("theme: got %v, want light", got["theme"])
+	}
+}
+
+// TestRemoveBonesHooks_OnlyBonesHooks: when settings.json has only
+// the bones-installed hooks and no others, the entire hooks key is
+// removed (no empty container left behind).
+func TestRemoveBonesHooks_OnlyBonesHooks(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "settings.json")
+	writeJSON(t, path, map[string]any{
+		"hooks": map[string]any{
+			"SessionStart": []any{
+				map[string]any{
+					"matcher": "",
+					"hooks": []any{
+						map[string]any{
+							"command": "bash .orchestrator/scripts/hub-bootstrap.sh",
+							"type":    "command",
+						},
+					},
+				},
+			},
+			"Stop": []any{
+				map[string]any{
+					"matcher": "",
+					"hooks": []any{
+						map[string]any{
+							"command": "bash .orchestrator/scripts/hub-shutdown.sh",
+							"type":    "command",
+						},
+					},
+				},
+			},
+		},
+	})
+
+	if err := removeBonesHooks(path); err != nil {
+		t.Fatalf("removeBonesHooks: %v", err)
+	}
+	got := readJSON(t, path)
+	if _, ok := got["hooks"]; ok {
+		t.Errorf("hooks key should be removed; got %+v", got)
+	}
+}
+
+// TestRemoveBonesHooks_MissingFile is a no-op (idempotent on a tree
+// that bones never installed into).
+func TestRemoveBonesHooks_MissingFile(t *testing.T) {
+	dir := t.TempDir()
+	if err := removeBonesHooks(filepath.Join(dir, "missing.json")); err != nil {
+		t.Errorf("missing file should be no-op, got: %v", err)
+	}
+}
+
+// TestPlanDown_EmptyTree: nothing to remove on a tree without bones
+// state. The plan slice is empty.
+func TestPlanDown_EmptyTree(t *testing.T) {
+	dir := t.TempDir()
+	plan := planDown(dir, &DownCmd{})
+	if len(plan) != 0 {
+		t.Errorf("empty tree plan: got %d actions, want 0:\n%+v", len(plan), plan)
+	}
+}
+
+// TestPlanDown_FullInstall: a fully-scaffolded workspace produces
+// actions for every removable artifact.
+func TestPlanDown_FullInstall(t *testing.T) {
+	dir := t.TempDir()
+	mkdir(t, filepath.Join(dir, ".bones"))
+	mkdir(t, filepath.Join(dir, ".orchestrator", "scripts"))
+	writeFile(t, filepath.Join(dir, ".orchestrator", "scripts", "hub-shutdown.sh"),
+		"#!/bin/sh\necho shutting down\n")
+	for _, name := range []string{"orchestrator", "subagent", "uninstall-bones"} {
+		mkdir(t, filepath.Join(dir, ".claude", "skills", name))
+	}
+	writeFile(t, filepath.Join(dir, ".claude", "settings.json"),
+		`{"hooks":{}}`)
+
+	plan := planDown(dir, &DownCmd{})
+	descs := make([]string, len(plan))
+	for i, a := range plan {
+		descs[i] = a.description
+	}
+	joined := strings.Join(descs, "\n")
+	wants := []string{
+		"hub-shutdown.sh",
+		".bones",
+		".orchestrator",
+		".claude/skills/orchestrator",
+		".claude/skills/subagent",
+		".claude/skills/uninstall-bones",
+		".claude/settings.json",
+	}
+	for _, w := range wants {
+		if !strings.Contains(joined, w) {
+			t.Errorf("plan missing action for %q:\n%s", w, joined)
+		}
+	}
+}
+
+// TestPlanDown_KeepFlags: --keep-* flags omit their respective
+// actions from the plan.
+func TestPlanDown_KeepFlags(t *testing.T) {
+	dir := t.TempDir()
+	mkdir(t, filepath.Join(dir, ".bones"))
+	mkdir(t, filepath.Join(dir, ".orchestrator", "scripts"))
+	writeFile(t, filepath.Join(dir, ".orchestrator", "scripts", "hub-shutdown.sh"), "#!/bin/sh\n")
+	mkdir(t, filepath.Join(dir, ".claude", "skills", "orchestrator"))
+	writeFile(t, filepath.Join(dir, ".claude", "settings.json"), `{}`)
+
+	plan := planDown(dir, &DownCmd{KeepHub: true, KeepSkills: true, KeepHooks: true})
+	for _, a := range plan {
+		if strings.Contains(a.description, ".orchestrator") {
+			t.Errorf("KeepHub should skip .orchestrator: %s", a.description)
+		}
+		if strings.Contains(a.description, ".claude/skills") {
+			t.Errorf("KeepSkills should skip skills: %s", a.description)
+		}
+		if strings.Contains(a.description, "settings.json") {
+			t.Errorf("KeepHooks should skip settings.json: %s", a.description)
+		}
+	}
+	// .bones/ should still be in the plan since no flag protects it.
+	found := false
+	for _, a := range plan {
+		if strings.Contains(a.description, ".bones") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("--keep-* flags should leave .bones/ in plan; got:\n%+v", plan)
+	}
+}
+
+// TestRunDown_AbortsOnNoConfirm: with --yes unset and stdin
+// providing "n\n", runDown returns the abort error and removes
+// nothing.
+func TestRunDown_AbortsOnNoConfirm(t *testing.T) {
+	dir := t.TempDir()
+	mkdir(t, filepath.Join(dir, ".bones"))
+
+	err := runDown(dir, &DownCmd{}, strings.NewReader("n\n"))
+	if err == nil || !strings.Contains(err.Error(), "aborted") {
+		t.Fatalf("expected abort error, got %v", err)
+	}
+	if !dirExists(filepath.Join(dir, ".bones")) {
+		t.Errorf(".bones/ removed despite abort")
+	}
+}
+
+// TestRunDown_ProceedsOnYes: with --yes set, runDown executes
+// without prompting and removes the targets.
+func TestRunDown_ProceedsOnYes(t *testing.T) {
+	dir := t.TempDir()
+	mkdir(t, filepath.Join(dir, ".bones"))
+
+	if err := runDown(dir, &DownCmd{Yes: true}, strings.NewReader("")); err != nil {
+		t.Fatalf("runDown: %v", err)
+	}
+	if dirExists(filepath.Join(dir, ".bones")) {
+		t.Errorf(".bones/ should have been removed")
+	}
+}
+
+// TestRunDown_DryRun: --dry-run prints the plan but executes nothing.
+func TestRunDown_DryRun(t *testing.T) {
+	dir := t.TempDir()
+	mkdir(t, filepath.Join(dir, ".bones"))
+
+	if err := runDown(dir, &DownCmd{DryRun: true}, strings.NewReader("")); err != nil {
+		t.Fatalf("runDown: %v", err)
+	}
+	if !dirExists(filepath.Join(dir, ".bones")) {
+		t.Errorf(".bones/ removed during --dry-run")
+	}
+}
+
+// --- helpers ---
+
+func writeJSON(t *testing.T, path string, v any) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+}
+
+func readJSON(t *testing.T, path string) map[string]any {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	return got
+}
+
+func mkdir(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", path, err)
+	}
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+}

--- a/cmd/bones/cli.go
+++ b/cmd/bones/cli.go
@@ -14,6 +14,7 @@ type CLI struct {
 
 	// Daily.
 	Up    bonescli.UpCmd    `cmd:"" group:"daily" help:"Bootstrap workspace, scaffold, leaf, hub"`
+	Down  bonescli.DownCmd  `cmd:"" group:"daily" help:"Reverse up: stop hub + clean scaffold"`
 	Tasks bonescli.TasksCmd `cmd:"" group:"daily" help:"Inspect and mutate runtime agent tasks"`
 	Swarm bonescli.SwarmCmd `cmd:"" group:"daily" help:"Run as a slot-shaped swarm participant"`
 


### PR DESCRIPTION
## Summary

Adds a top-level **`bones down`** verb that mirrors `bones up`. Stops the hub, removes `.bones/` and `.orchestrator/`, removes the scaffolded skills, and surgically prunes only the bones-installed hooks from `.claude/settings.json` — other hooks in the same events are preserved.

The goodbye banner (TTY-only, prints to stdout when `down: complete`):

```
       .ed$""$be.
     d$"        "$b
     $  ()    ()  $
     $     \/     $
     "$.   --   .$"
       "*ee$$ee*"

  now exiting the 5th dimension
```

## Behavior

- **Plan-then-execute.** Prints the action list before doing anything; user can review and abort.
- **Confirmation prompt** unless `--yes`. `--dry-run` prints the plan only.
- **Partial uninstalls.** `--keep-hub` / `--keep-skills` / `--keep-hooks` for granular control.
- **Idempotent.** Re-running on a clean tree is a no-op (`down: nothing to remove`).
- **Surgical hook pruning.** Only entries whose `command` references `hub-bootstrap.sh` (SessionStart) or `hub-shutdown.sh` (Stop) are removed; user-added hooks in the same event groups stay. Empty hook events get cleaned up too.
- **TTY-only goodbye.** The skull banner prints on stdout only when stdout is a terminal — redirected/piped output stays clean.

## Test plan

- [x] `make check` — green (vet, lint, race, todo-check, fmt-check)
- [x] `go build -tags=otel ./...` — green
- [x] `go test -tags=otel -short ./...` — green
- [x] All three CI lanes verified post-push per the rule
- [x] **Unit tests** pin the surgical hook-pruning behavior:
  - removes only bones hooks, leaves siblings in same event
  - removes empty event keys after pruning
  - leaves `hooks` top-level key alone when other events are present
  - missing settings.json is a no-op
- [x] **Plan tests** verify `--keep-*` flags omit the right actions
- [x] **Confirmation tests** verify abort-on-N and proceed-on-yes paths

## README

The `## Uninstall` section now leads with `bones down`. The manual `rm -rf` recipe is gone — `bones down` automates it correctly (and prunes hooks surgically, which the manual recipe couldn't).

## Notes

- The branch is independent of #75 (updatecheck) and #76 (banner) — none touch the same files. Either ordering works.
- `bones down` doesn't restore `.gitignore` to its pre-`bones up` state. The orchestrator/Fossil entries are harmless when the corresponding directories are gone, and removing them blindly could clobber lines the user has since added. Left as a trade-off.