### PR TITLE
fix(orchestrator): move hub teardown to SessionEnd, not Stop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ go.work.sum
 .fslckout
 .fossil-settings/
 .orchestrator/
+.bones/
 
 # Local scratch — code reviews and implementation plans (ephemeral, per-session)
 docs/code-review/

--- a/cli/down.go
+++ b/cli/down.go
@@ -266,6 +266,10 @@ func removeBonesHooks(path string) error {
 		return nil
 	}
 	pruneHookEvent(hooks, "SessionStart", "hub-bootstrap.sh")
+	// Current installs land under SessionEnd; the legacy Stop event
+	// is also pruned so workspaces installed before the migration
+	// are still cleaned up by `bones down`.
+	pruneHookEvent(hooks, "SessionEnd", "hub-shutdown.sh")
 	pruneHookEvent(hooks, "Stop", "hub-shutdown.sh")
 	if len(hooks) == 0 {
 		delete(rootObj, "hooks")

--- a/cli/down_test.go
+++ b/cli/down_test.go
@@ -10,8 +10,8 @@ import (
 
 // TestRemoveBonesHooks_RemovesScaffoldedHooks pins the surgical-edit
 // behavior: only hooks whose command references hub-bootstrap.sh
-// (SessionStart) or hub-shutdown.sh (Stop) are removed. Other hooks
-// in the same event groups stay.
+// (SessionStart) or hub-shutdown.sh (SessionEnd) are removed. Other
+// hooks in the same event groups stay.
 func TestRemoveBonesHooks_RemovesScaffoldedHooks(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "settings.json")
@@ -35,7 +35,7 @@ func TestRemoveBonesHooks_RemovesScaffoldedHooks(t *testing.T) {
 					},
 				},
 			},
-			"Stop": []any{
+			"SessionEnd": []any{
 				map[string]any{
 					"matcher": "",
 					"hooks": []any{
@@ -81,10 +81,10 @@ func TestRemoveBonesHooks_RemovesScaffoldedHooks(t *testing.T) {
 		t.Errorf("surviving SessionStart command: got %q, want echo other-hook", cmd)
 	}
 
-	// Stop had only the bones entry; its group should be gone.
-	if _, ok := hooks["Stop"]; ok {
-		t.Errorf("Stop event should be removed (was empty after prune); still present: %+v",
-			hooks["Stop"])
+	// SessionEnd had only the bones entry; its group should be gone.
+	if _, ok := hooks["SessionEnd"]; ok {
+		t.Errorf("SessionEnd event should be removed (was empty after prune); still present: %+v",
+			hooks["SessionEnd"])
 	}
 
 	// PreToolUse must be untouched.
@@ -134,7 +134,7 @@ func TestRemoveBonesHooks_OnlyBonesHooks(t *testing.T) {
 					},
 				},
 			},
-			"Stop": []any{
+			"SessionEnd": []any{
 				map[string]any{
 					"matcher": "",
 					"hooks": []any{
@@ -154,6 +154,37 @@ func TestRemoveBonesHooks_OnlyBonesHooks(t *testing.T) {
 	got := readJSON(t, path)
 	if _, ok := got["hooks"]; ok {
 		t.Errorf("hooks key should be removed; got %+v", got)
+	}
+}
+
+// TestRemoveBonesHooks_LegacyStopHook: bones down on a workspace
+// installed before the SessionEnd migration must still clean up the
+// shim that lives under the old "Stop" event.
+func TestRemoveBonesHooks_LegacyStopHook(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "settings.json")
+	writeJSON(t, path, map[string]any{
+		"hooks": map[string]any{
+			"Stop": []any{
+				map[string]any{
+					"matcher": "",
+					"hooks": []any{
+						map[string]any{
+							"command": "bash .orchestrator/scripts/hub-shutdown.sh",
+							"type":    "command",
+						},
+					},
+				},
+			},
+		},
+	})
+
+	if err := removeBonesHooks(path); err != nil {
+		t.Fatalf("removeBonesHooks: %v", err)
+	}
+	got := readJSON(t, path)
+	if _, ok := got["hooks"]; ok {
+		t.Errorf("legacy Stop hook should be cleaned up; got %+v", got)
 	}
 }
 

--- a/cli/orchestrator.go
+++ b/cli/orchestrator.go
@@ -74,6 +74,12 @@ func copyFile(fsys embed.FS, src, dst string, mode fs.FileMode) error {
 // mergeSettings idempotently adds hub-bootstrap and hub-shutdown hooks
 // to the consumer's .claude/settings.json. Creates the file if absent.
 // Preserves all existing top-level keys, hook events, and entries.
+//
+// Hub teardown is wired to SessionEnd, not Stop. Stop fires after every
+// assistant turn and was tearing the hub down constantly; SessionEnd
+// fires only when the actual session terminates. Legacy installs that
+// have the shim under "Stop" are migrated by removing the old entry
+// before the SessionEnd entry is added.
 func mergeSettings(path string) error {
 	root := map[string]any{}
 	if data, err := os.ReadFile(path); err == nil {
@@ -92,7 +98,8 @@ func mergeSettings(path string) error {
 	}
 
 	addHook(hooks, "SessionStart", "bash .orchestrator/scripts/hub-bootstrap.sh")
-	addHook(hooks, "Stop", "bash .orchestrator/scripts/hub-shutdown.sh")
+	migrateStopToSessionEnd(hooks)
+	addHook(hooks, "SessionEnd", "bash .orchestrator/scripts/hub-shutdown.sh")
 
 	root["hooks"] = hooks
 
@@ -104,6 +111,49 @@ func mergeSettings(path string) error {
 		return err
 	}
 	return os.WriteFile(path, append(out, '\n'), 0o644)
+}
+
+// migrateStopToSessionEnd removes any hub-shutdown entry under the
+// legacy "Stop" event so it can be re-added under "SessionEnd". The
+// scan is shim-specific (matches the hub-shutdown.sh command) so
+// unrelated Stop hooks the user has installed are preserved.
+func migrateStopToSessionEnd(hooks map[string]any) {
+	groups, _ := hooks["Stop"].([]any)
+	if groups == nil {
+		return
+	}
+	const needle = "hub-shutdown.sh"
+	var keep []any
+	for _, g := range groups {
+		gm, ok := g.(map[string]any)
+		if !ok {
+			keep = append(keep, g)
+			continue
+		}
+		entries, _ := gm["hooks"].([]any)
+		var keepEntries []any
+		for _, e := range entries {
+			em, ok := e.(map[string]any)
+			if !ok {
+				keepEntries = append(keepEntries, e)
+				continue
+			}
+			cmd, _ := em["command"].(string)
+			if !strings.Contains(cmd, needle) {
+				keepEntries = append(keepEntries, e)
+			}
+		}
+		if len(keepEntries) == 0 {
+			continue
+		}
+		gm["hooks"] = keepEntries
+		keep = append(keep, gm)
+	}
+	if len(keep) == 0 {
+		delete(hooks, "Stop")
+		return
+	}
+	hooks["Stop"] = keep
 }
 
 func addHook(hooks map[string]any, event, cmd string) {
@@ -167,6 +217,7 @@ func ensureGitignoreEntries(dir string) error {
 		".fslckout",
 		".fossil-settings/",
 		".orchestrator/",
+		".bones/",
 	}
 
 	existing := map[string]bool{}

--- a/cli/orchestrator_test.go
+++ b/cli/orchestrator_test.go
@@ -101,6 +101,98 @@ func TestScaffoldOrchestrator_PreservesExistingHooks(t *testing.T) {
 	}
 }
 
+// TestScaffoldOrchestrator_MigrateLegacyStopHook verifies that running
+// scaffoldOrchestrator on a workspace whose settings.json has the
+// hub-shutdown shim under the legacy Stop event migrates it to
+// SessionEnd. Older bones (≤ v0.3.0) installed under Stop, which
+// fired after every assistant turn instead of on session end.
+func TestScaffoldOrchestrator_MigrateLegacyStopHook(t *testing.T) {
+	dir := t.TempDir()
+	settingsPath := filepath.Join(dir, ".claude", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	legacy := map[string]any{
+		"hooks": map[string]any{
+			"Stop": []any{
+				map[string]any{
+					"matcher": "",
+					"hooks": []any{
+						map[string]any{
+							"command": "bash .orchestrator/scripts/hub-shutdown.sh",
+							"type":    "command",
+							"timeout": float64(10),
+						},
+					},
+				},
+			},
+		},
+	}
+	data, _ := json.MarshalIndent(legacy, "", "  ")
+	if err := os.WriteFile(settingsPath, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := scaffoldOrchestrator(dir); err != nil {
+		t.Fatalf("scaffoldOrchestrator: %v", err)
+	}
+
+	got, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal(got, &parsed); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	hooks := parsed["hooks"].(map[string]any)
+	if _, ok := hooks["Stop"]; ok {
+		t.Errorf("legacy Stop hook not migrated:\n%s", got)
+	}
+	if _, ok := hooks["SessionEnd"]; !ok {
+		t.Errorf("hub-shutdown not added under SessionEnd:\n%s", got)
+	}
+}
+
+// TestScaffoldOrchestrator_PreservesUnrelatedStopHook ensures the
+// migration only removes our shim, not other Stop hooks the user
+// installed.
+func TestScaffoldOrchestrator_PreservesUnrelatedStopHook(t *testing.T) {
+	dir := t.TempDir()
+	settingsPath := filepath.Join(dir, ".claude", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	other := map[string]any{
+		"hooks": map[string]any{
+			"Stop": []any{
+				map[string]any{
+					"matcher": "",
+					"hooks": []any{
+						map[string]any{
+							"command": "echo bye",
+							"type":    "command",
+						},
+					},
+				},
+			},
+		},
+	}
+	data, _ := json.MarshalIndent(other, "", "  ")
+	if err := os.WriteFile(settingsPath, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := scaffoldOrchestrator(dir); err != nil {
+		t.Fatalf("scaffoldOrchestrator: %v", err)
+	}
+
+	got, _ := os.ReadFile(settingsPath)
+	if !strings.Contains(string(got), "echo bye") {
+		t.Errorf("unrelated Stop hook lost:\n%s", got)
+	}
+}
+
 func verifyHooks(t *testing.T, path string) {
 	t.Helper()
 	data, err := os.ReadFile(path)
@@ -117,7 +209,14 @@ func verifyHooks(t *testing.T, path string) {
 		t.Errorf("SessionStart hub-bootstrap missing:\n%s", out)
 	}
 	if !strings.Contains(out, "hub-shutdown.sh") {
-		t.Errorf("Stop hub-shutdown missing:\n%s", out)
+		t.Errorf("SessionEnd hub-shutdown missing:\n%s", out)
+	}
+	hooks := parsed["hooks"].(map[string]any)
+	if _, ok := hooks["SessionEnd"]; !ok {
+		t.Errorf("hub-shutdown not under SessionEnd:\n%s", out)
+	}
+	if _, ok := hooks["Stop"]; ok {
+		t.Errorf("hub-shutdown leaked into Stop:\n%s", out)
 	}
 }
 


### PR DESCRIPTION
## Summary

Claude Code's \`Stop\` hook fires after every assistant turn, not on session end. As-installed, bones was tearing down the embedded NATS server every turn boundary and rebuilding it on the next user message. The v0.3.0 NATS bootstrap retry was papering over a self-inflicted cycle.

- Hub teardown now installs under \`SessionEnd\`, which fires only when the session actually terminates (\`/exit\`, window close, etc.).
- Re-running \`bones up\` on a workspace installed before the migration moves the existing \`Stop\` shim to \`SessionEnd\` automatically. Unrelated \`Stop\` hooks the user installed stay put.
- \`bones down\` prunes both \`SessionEnd\` (current) and \`Stop\` (legacy) so older installs that never re-ran \`bones up\` still clean up correctly.
- \`ensureGitignoreEntries\` adds \`.bones/\` to the workspace gitignore alongside \`.orchestrator/\`. The leaf's runtime state (config.json, leaf.pid, repo.fossil) was previously not gitignored, which made it easy to stage by accident — caught while preparing this PR.

## Test plan

- [x] \`make check\` (fmt, vet, lint, race, todo-check) — green
- [x] \`go test -tags=otel -short ./...\` — green
- [x] New \`TestScaffoldOrchestrator_MigrateLegacyStopHook\`: pre-existing \`Stop\` shim is removed and re-added under \`SessionEnd\`
- [x] New \`TestScaffoldOrchestrator_PreservesUnrelatedStopHook\`: user's own \`Stop\` hooks are preserved during migration
- [x] New \`TestRemoveBonesHooks_LegacyStopHook\`: \`bones down\` cleans up legacy \`Stop\` installs
- [x] Existing \`TestRemoveBonesHooks_OnlyBonesHooks\` updated to use \`SessionEnd\`
- [ ] Manual: serverdom \`bones up\` after this PR ships moves the shim from \`Stop\` to \`SessionEnd\`; \`echo bye\` Stop hooks survive