### PR TITLE
feat: detect scaffold-version drift after binary upgrades (ADR 0035)

### DIFF
--- a/cli/doctor.go
+++ b/cli/doctor.go
@@ -13,7 +13,9 @@ import (
 	libfossilcli "github.com/danmestas/libfossil/cli"
 
 	"github.com/danmestas/bones/internal/githook"
+	"github.com/danmestas/bones/internal/scaffoldver"
 	"github.com/danmestas/bones/internal/swarm"
+	"github.com/danmestas/bones/internal/version"
 	"github.com/danmestas/bones/internal/workspace"
 )
 
@@ -73,6 +75,19 @@ func (c *DoctorCmd) runBypassReport() {
 		default:
 			fmt.Println("  OK    pre-commit hook installed")
 		}
+	}
+
+	stamp, err := scaffoldver.Read(cwd)
+	switch {
+	case err != nil:
+		fmt.Printf("  WARN  scaffold stamp read: %v\n", err)
+	case stamp == "":
+		fmt.Println("  INFO  no scaffold version stamp — `bones up` to write one")
+	case scaffoldver.Drifted(stamp, version.Get()):
+		fmt.Printf("  WARN  scaffold v%s, binary v%s — run `bones up` to refresh skills/hooks\n",
+			stamp, version.Get())
+	default:
+		fmt.Printf("  OK    scaffold version v%s matches binary\n", stamp)
 	}
 
 	switch tip, head, drifted := fossilDrift(cwd); {

--- a/cli/hub.go
+++ b/cli/hub.go
@@ -10,6 +10,8 @@ import (
 	libfossilcli "github.com/danmestas/libfossil/cli"
 
 	"github.com/danmestas/bones/internal/hub"
+	"github.com/danmestas/bones/internal/scaffoldver"
+	"github.com/danmestas/bones/internal/version"
 )
 
 // HubCmd is the umbrella command for the embedded Fossil + NATS hub.
@@ -49,6 +51,8 @@ func (c *HubStartCmd) Run(g *libfossilcli.Globals) error {
 		return fmt.Errorf("cwd: %w", err)
 	}
 
+	warnScaffoldDrift(cwd)
+
 	ctx, stop := signal.NotifyContext(context.Background(),
 		syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
@@ -58,6 +62,22 @@ func (c *HubStartCmd) Run(g *libfossilcli.Globals) error {
 		hub.WithNATSPort(c.NATSPort),
 		hub.WithDetach(c.Detach),
 	)
+}
+
+// warnScaffoldDrift prints a single-line stderr notice when the
+// workspace scaffold version disagrees with the running binary's
+// version. Best-effort: any read error is silent. Fires on every
+// `bones hub start`, which the SessionStart hook runs at the
+// beginning of each Claude Code session — so the operator sees it
+// the moment they start working in a stale workspace.
+func warnScaffoldDrift(cwd string) {
+	stamp, err := scaffoldver.Read(cwd)
+	if err != nil || !scaffoldver.Drifted(stamp, version.Get()) {
+		return
+	}
+	fmt.Fprintf(os.Stderr,
+		"bones: scaffold v%s, binary v%s — run `bones up` to refresh skills/hooks\n",
+		stamp, version.Get())
 }
 
 // HubStopCmd wires `bones hub stop` to hub.Stop. Idempotent.

--- a/cli/orchestrator.go
+++ b/cli/orchestrator.go
@@ -9,6 +9,9 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/danmestas/bones/internal/scaffoldver"
+	"github.com/danmestas/bones/internal/version"
 )
 
 //go:embed all:templates/orchestrator
@@ -35,6 +38,9 @@ func scaffoldOrchestrator(root string) error {
 	}
 	if err := ensureGitignoreEntries(root); err != nil {
 		return fmt.Errorf("root gitignore: %w", err)
+	}
+	if err := scaffoldver.Write(root, version.Get()); err != nil {
+		return fmt.Errorf("scaffold version stamp: %w", err)
 	}
 	return nil
 }

--- a/cli/orchestrator_test.go
+++ b/cli/orchestrator_test.go
@@ -180,6 +180,25 @@ func TestScaffoldOrchestrator_SkillHasADR0023Completion(t *testing.T) {
 	}
 }
 
+// TestScaffoldOrchestrator_StampsScaffoldVersion verifies that
+// scaffolding writes .bones/scaffold_version with the current
+// binary version, so drift detection on subsequent invocations has
+// a value to compare against.
+func TestScaffoldOrchestrator_StampsScaffoldVersion(t *testing.T) {
+	dir := t.TempDir()
+	if err := scaffoldOrchestrator(dir); err != nil {
+		t.Fatalf("scaffoldOrchestrator: %v", err)
+	}
+	stamp, err := os.ReadFile(filepath.Join(dir, ".bones", "scaffold_version"))
+	if err != nil {
+		t.Fatalf("read stamp: %v", err)
+	}
+	got := strings.TrimSpace(string(stamp))
+	if got == "" {
+		t.Errorf("stamp is empty; want a version (default \"dev\" in tests)")
+	}
+}
+
 func TestEnsureGitignoreEntries_FreshFile(t *testing.T) {
 	dir := t.TempDir()
 	if err := ensureGitignoreEntries(dir); err != nil {

--- a/cmd/bones/main.go
+++ b/cmd/bones/main.go
@@ -17,6 +17,7 @@ import (
 	_ "github.com/danmestas/libfossil/db/driver/modernc"
 
 	"github.com/danmestas/bones/internal/updatecheck"
+	bversion "github.com/danmestas/bones/internal/version"
 )
 
 // Build-time variables, populated via -ldflags by GoReleaser.
@@ -27,6 +28,11 @@ var (
 )
 
 func main() {
+	// Plumb the running binary's version into the internal/version
+	// package so cli/orchestrator can stamp it onto fresh workspaces
+	// and cli/doctor can compare against the workspace stamp.
+	bversion.Set(version)
+
 	// Once-per-day update check. Best-effort; runs the network refresh
 	// in a goroutine and prints a one-line stderr notice based on
 	// cached state. Suppressed by BONES_UPDATE_CHECK=0 and skipped on

--- a/docs/adr/0035-scaffold-version-drift.md
+++ b/docs/adr/0035-scaffold-version-drift.md
@@ -1,0 +1,66 @@
+# ADR 0035: Detect scaffold-version drift after binary upgrades
+
+## Context
+
+The bones binary and the workspace state evolve independently. `brew upgrade bones` (or `go install`) replaces the binary at `/opt/homebrew/bin/bones`, but the per-workspace artifacts written by `bones up` — `.orchestrator/scripts/`, `.claude/skills/`, `.claude/settings.json`, the `.git/hooks/pre-commit` from ADR 0034 — are unchanged. Those artifacts came from templates embedded in the *previous* binary; they only refresh when the user re-runs `bones up`.
+
+The result: a fix shipped in version N+1 (new hook semantics, new skill content, migrated hook events) does nothing in workspaces last scaffolded by version N until someone explicitly refreshes them. The 2026-04-29 incidents made this concrete — PR #79's pre-commit hook and PR #80's `Stop` → `SessionEnd` migration are both invisible until `bones up` runs again, and there is no signal telling the operator that's needed.
+
+## Decision
+
+bones will record the binary version that scaffolded each workspace and surface drift on entry to the workspace. Three small surfaces, one source of truth.
+
+### 1. Scaffold version stamp
+
+`scaffoldOrchestrator` writes `<workspace>/.bones/scaffold_version` containing the running binary's version (`internal/version.Get()`). The file is plain text, single line. Re-running `bones up` overwrites it with the current value, which is exactly the drift-clearing operation we want.
+
+A new package `internal/scaffoldver` owns Read/Write/Drifted. `Drifted(stamp, binary)` returns `false` when:
+
+- the stamp is empty (fresh workspace, nothing to compare against)
+- the binary is `"dev"` or empty (local build; suppress noise during development)
+- the values match
+
+Any other case is drift.
+
+### 2. SessionStart-path notice
+
+The Claude Code SessionStart hook runs `hub-bootstrap.sh`, which execs `bones hub start --detach`. The Go side of `bones hub start` now reads the scaffold stamp and compares it against `version.Get()` at the start of `Run`. On drift, it prints one line to stderr:
+
+> `bones: scaffold v0.3.0, binary v0.3.1 — run \`bones up\` to refresh skills/hooks`
+
+That's exactly when an agent or user starts working in the workspace. The notice is short, actionable, and doesn't block the hub from coming up — the contract is "tell me, then proceed."
+
+The shim (`hub-bootstrap.sh`) stays minimal because the check lives in Go; the test that pins the shim to ≤10 lines doesn't need to change.
+
+### 3. Doctor report
+
+`bones doctor` adds a scaffold-version line to its substrate-gates section. It surfaces:
+
+- `OK    scaffold version v0.3.1 matches binary` when aligned
+- `WARN  scaffold v0.3.0, binary v0.3.1 — run \`bones up\` to refresh skills/hooks` on drift
+- `INFO  no scaffold version stamp — \`bones up\` to write one` for workspaces that predate the stamp (also covers the bootstrap window where v0.3.1 is installed but `bones up` hasn't been re-run yet)
+
+`bones doctor` is the on-demand surface; the SessionStart notice is the every-session surface. Together they give every consumer a path to noticing drift.
+
+## Consequences
+
+- The first `bones up` after this PR ships establishes the stamp baseline. Workspaces predating it are flagged as "no stamp" rather than "drift" so the user isn't told to re-run `bones up` for an installed binary that already matches what they have.
+- `dev` binaries (local builds, tests) suppress drift warnings. Without that, every developer iteration would print a notice against itself.
+- The plumbing is small: one new package (`internal/scaffoldver`), one tiny package (`internal/version` — a settable global), one line in `cmd/bones/main.go`, one block in `cli/orchestrator.go`, one block in `cli/hub.go`, one block in `cli/doctor.go`.
+- ADR 0034's hooks and ADR 0035's stamp are independent gates: the hook prevents commit-bypass; the stamp prevents the substrate from going silently stale across upgrades.
+
+## Alternatives considered
+
+**Auto-rescaffold on drift detection.** Tempting — fixes the problem without user action. Rejected because it mutates the workspace as a side effect of unrelated commands (`bones hub start`, `bones doctor`). Side-effecting auto-mutation makes upgrades scary and breaks the predictability of `bones --version`-only changes. Better to surface drift loudly and let the operator run `bones up`.
+
+**Stamp into `.bones/config.json` rather than a separate file.** Adds a JSON read/write to a hot path that currently doesn't need to parse JSON. The standalone file is one fopen/fread; ergonomics of "read line, compare to version" beat structured parsing here.
+
+**Homebrew post-install hook to run `bones up` automatically.** Cross-workspace: a single brew upgrade can't know which workspaces exist. Also makes `brew upgrade bones` mutate user state outside its install prefix, which is exactly the kind of thing brew warns formula authors against.
+
+**Bake the version check into hub-bootstrap.sh in shell.** Means parsing `bones --version` output in bash, which is fragile to format changes. Keeping the logic in Go gives us tests and lets the version source change without touching the shim.
+
+## Status
+
+Accepted, 2026-04-29.
+
+Implementation lands in PR `feat/scaffold-version-drift`.

--- a/internal/scaffoldver/scaffoldver.go
+++ b/internal/scaffoldver/scaffoldver.go
@@ -1,0 +1,66 @@
+// Package scaffoldver tracks which bones binary version scaffolded
+// the current workspace's .bones/, .orchestrator/, and .claude/skills
+// trees. The scaffold and the binary upgrade independently — brew
+// upgrade replaces the binary but leaves the workspace state alone —
+// so we record the version each time scaffoldOrchestrator runs and
+// detect drift on subsequent invocations.
+//
+// See ADR 0035 (`docs/adr/0035-scaffold-version-drift.md`) for the
+// rationale and detection strategy.
+package scaffoldver
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// StampPath is the relative location under the workspace root where
+// the scaffold version is recorded. Plain text, single line, no
+// trailing newline-noise to fight.
+const StampPath = ".bones/scaffold_version"
+
+// Read returns the version stamped at root/.bones/scaffold_version.
+// Returns ("", nil) if the file is missing — that's the "fresh
+// workspace, no stamp yet" case, not an error. Other read failures
+// are returned verbatim.
+func Read(root string) (string, error) {
+	data, err := os.ReadFile(filepath.Join(root, StampPath))
+	if errors.Is(err, os.ErrNotExist) {
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(data)), nil
+}
+
+// Write records ver at root/.bones/scaffold_version. Creates parent
+// directories as needed. Idempotent: writing the same value twice is
+// a no-op as far as drift detection is concerned.
+func Write(root, ver string) error {
+	path := filepath.Join(root, StampPath)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(path, []byte(ver+"\n"), 0o644)
+}
+
+// Drifted reports whether the workspace stamp and the running
+// binary's version disagree. Returns false when:
+//   - the stamp is empty (fresh workspace; nothing to compare against)
+//   - the binary version is "dev" or empty (local build; suppress
+//     noise during development)
+//   - the values match
+//
+// All other cases return true. Caller decides whether to warn.
+func Drifted(stamp, binary string) bool {
+	if stamp == "" {
+		return false
+	}
+	if binary == "" || binary == "dev" {
+		return false
+	}
+	return stamp != binary
+}

--- a/internal/scaffoldver/scaffoldver_test.go
+++ b/internal/scaffoldver/scaffoldver_test.go
@@ -1,0 +1,81 @@
+package scaffoldver
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestReadMissing(t *testing.T) {
+	root := t.TempDir()
+	got, err := Read(root)
+	if err != nil {
+		t.Fatalf("Read on missing stamp: unexpected error %v", err)
+	}
+	if got != "" {
+		t.Errorf("got %q, want empty", got)
+	}
+}
+
+func TestWriteThenRead(t *testing.T) {
+	root := t.TempDir()
+	if err := Write(root, "0.3.0"); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	got, err := Read(root)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if got != "0.3.0" {
+		t.Errorf("Read: got %q, want %q", got, "0.3.0")
+	}
+}
+
+func TestWriteCreatesParentDir(t *testing.T) {
+	root := t.TempDir()
+	if err := Write(root, "0.3.1"); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, ".bones", "scaffold_version")); err != nil {
+		t.Errorf("stamp not at expected path: %v", err)
+	}
+}
+
+func TestWriteIdempotent(t *testing.T) {
+	root := t.TempDir()
+	if err := Write(root, "0.3.0"); err != nil {
+		t.Fatal(err)
+	}
+	first, _ := os.ReadFile(filepath.Join(root, ".bones", "scaffold_version"))
+	if err := Write(root, "0.3.0"); err != nil {
+		t.Fatal(err)
+	}
+	second, _ := os.ReadFile(filepath.Join(root, ".bones", "scaffold_version"))
+	if string(first) != string(second) {
+		t.Errorf("repeated write differed: %q vs %q", first, second)
+	}
+}
+
+func TestDriftedCases(t *testing.T) {
+	cases := []struct {
+		name   string
+		stamp  string
+		binary string
+		want   bool
+	}{
+		{"fresh workspace no stamp", "", "0.3.1", false},
+		{"dev binary suppresses warning", "0.3.0", "dev", false},
+		{"empty binary suppresses warning", "0.3.0", "", false},
+		{"identical version", "0.3.0", "0.3.0", false},
+		{"different version", "0.3.0", "0.3.1", true},
+		{"both empty", "", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := Drifted(tc.stamp, tc.binary); got != tc.want {
+				t.Errorf("Drifted(%q, %q) = %v, want %v",
+					tc.stamp, tc.binary, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,33 @@
+// Package version exposes the running binary's semver to other
+// packages without dragging in a dependency on cmd/bones. main.go
+// sets it via Set() at startup; everything else calls Get().
+//
+// The default ("dev") is what unset GoReleaser ldflags produce, so
+// development builds and tests see a stable value. Drift checks
+// treat "dev" specially — they do not warn against "dev" because
+// the workspace stamp would always look stale during local hacking.
+package version
+
+var current = "dev"
+
+// Set records the running binary's version. Called once from
+// cmd/bones/main.go after ldflags-injected globals are read.
+// Callers other than main should not invoke this.
+func Set(v string) {
+	if v != "" {
+		current = v
+	}
+}
+
+// Get returns the running binary's version, or "dev" if Set was
+// never called.
+func Get() string {
+	return current
+}
+
+// IsDev reports whether the running binary is an unstamped build
+// (Set was never called or was called with "dev"). Drift checks
+// suppress warnings against dev binaries.
+func IsDev() bool {
+	return current == "dev" || current == ""
+}


### PR DESCRIPTION
## Summary

\`brew upgrade bones\` replaces the binary, but the per-workspace artifacts written by \`bones up\` — scripts, skills, settings, hooks — don't update until someone reruns \`bones up\`. PR #79's pre-commit hook and PR #80's Stop→SessionEnd migration both depend on that re-run; without it, the fixes are invisible.

This PR records the binary version that scaffolded each workspace and surfaces drift on entry. Three surfaces, one source of truth:

- **Stamp** — \`scaffoldOrchestrator\` writes \`.bones/scaffold_version\` on every \`bones up\` (new \`internal/scaffoldver\` package).
- **SessionStart notice** — \`bones hub start\` reads the stamp and prints a one-line stderr warning before bringing the hub up. The \`hub-bootstrap.sh\` shim already runs at SessionStart, so operators see the notice on entry to a stale workspace.
- **\`bones doctor\`** — adds a scaffold-version check next to the ADR 0034 substrate gates: \`OK\` / \`WARN\` / \`INFO\`.

Drift checks suppress noise for \`dev\` binaries (local development) and stamp-less workspaces (which print \`INFO\` once and clear on next \`bones up\`).

A small \`internal/version\` package holds the ldflags-injected version as a settable global so non-main packages can read it without importing \`cmd/bones\`.

See \`docs/adr/0035-scaffold-version-drift.md\` for the rationale and alternatives considered (auto-rescaffold, brew post-install, etc.).

## Test plan

- [x] \`make check\` — green
- [x] \`go test -tags=otel -short ./...\` — green
- [x] \`internal/scaffoldver\` covers Read of missing/written stamps, write-creates-parent, idempotency, all six drift cases (fresh, dev binary, identical, different, both empty)
- [x] New \`TestScaffoldOrchestrator_StampsScaffoldVersion\` confirms \`bones up\` writes the stamp
- [ ] Manual: \`bones doctor\` reports \`OK    scaffold version v0.3.X matches binary\` after \`bones up\`
- [ ] Manual: simulate drift (\`echo 0.0.1 > .bones/scaffold_version\`) and confirm \`bones hub start\` prints the warning