### PR TITLE
fix(peek): default to a free port in 8775-8799 instead of fossil's 8080

### DIFF
--- a/cli/peek.go
+++ b/cli/peek.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"fmt"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -13,6 +14,17 @@ import (
 	"github.com/danmestas/bones/internal/workspace"
 )
 
+// peekPortRangeStart is where the auto-port scanner begins looking
+// for a free local port when --port is not specified. Sits 10 above
+// the hub's Fossil port (8765) to stay grouped with the bones port
+// range, well above the common 3000/8080 dev-server cluster.
+const peekPortRangeStart = 8775
+
+// peekPortRangeEnd caps the scan. If nothing in the preferred range
+// is free, peek falls back to letting fossil pick its own default;
+// the user can always override with --port.
+const peekPortRangeEnd = 8799
+
 // PeekCmd opens the workspace's hub Fossil repo in the system fossil
 // binary's web UI (timeline, branches, files). It is an *enhancement*,
 // not a hard dependency: when `fossil` isn't on PATH, peek prints the
@@ -22,7 +34,7 @@ import (
 // /xfer for sync) does not implement the rich Fossil web UI; peek
 // shells out to the canonical `fossil ui` for that.
 type PeekCmd struct {
-	Port int    `name:"port" help:"bind the UI on this port (default: fossil chooses)"`
+	Port int    `name:"port" help:"bind the UI on this port (default: first free in 8775-8799)"`
 	Page string `name:"page" default:"timeline?y=ci&n=50" help:"fossil page (e.g. timeline)"`
 }
 
@@ -55,18 +67,48 @@ func (c *PeekCmd) Run(g *libfossilcli.Globals) error {
 		return nil
 	}
 
+	port := c.Port
+	if port == 0 {
+		port = pickPeekPort()
+	}
+
 	args := []string{"ui", hubRepo}
-	if c.Port > 0 {
-		args = append(args, "--port", strconv.Itoa(c.Port))
+	if port > 0 {
+		args = append(args, "--port", strconv.Itoa(port))
 	}
 	if c.Page != "" {
 		args = append(args, "--page", c.Page)
 	}
 
-	fmt.Printf("peek: %s ui %s\n", fossilBin, hubRepo)
+	if port > 0 {
+		fmt.Printf("peek: %s ui %s --port %d\n", fossilBin, hubRepo, port)
+	} else {
+		fmt.Printf("peek: %s ui %s\n", fossilBin, hubRepo)
+	}
 	cmd := exec.Command(fossilBin, args...)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	return cmd.Run()
+}
+
+// pickPeekPort scans peekPortRangeStart through peekPortRangeEnd and
+// returns the first port that accepts a local listener. Returns 0
+// when none are free; the caller falls back to fossil's own default.
+//
+// The probe binds + immediately closes; there's a small window
+// between this call and fossil's bind where a competing process
+// could grab the port. That's a tradeoff: deterministic-port output
+// for the user, vs. a race that fossil's own bind would surface as
+// a clear error anyway.
+func pickPeekPort() int {
+	for p := peekPortRangeStart; p <= peekPortRangeEnd; p++ {
+		l, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", p))
+		if err != nil {
+			continue
+		}
+		_ = l.Close()
+		return p
+	}
+	return 0
 }

--- a/cli/peek_test.go
+++ b/cli/peek_test.go
@@ -1,0 +1,63 @@
+package cli
+
+import (
+	"fmt"
+	"net"
+	"testing"
+)
+
+func TestPickPeekPort_ReturnsAvailablePort(t *testing.T) {
+	got := pickPeekPort()
+	if got < peekPortRangeStart || got > peekPortRangeEnd {
+		t.Fatalf("pickPeekPort returned %d, want in [%d,%d]",
+			got, peekPortRangeStart, peekPortRangeEnd)
+	}
+	l, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", got))
+	if err != nil {
+		t.Errorf("returned port %d isn't bindable: %v", got, err)
+		return
+	}
+	_ = l.Close()
+}
+
+func TestPickPeekPort_SkipsBoundPorts(t *testing.T) {
+	// Hold the entire preferred range open. pickPeekPort must return
+	// 0 (the "let fossil pick" sentinel) rather than spuriously hand
+	// back a port we know is in use.
+	var holders []net.Listener
+	defer func() {
+		for _, l := range holders {
+			_ = l.Close()
+		}
+	}()
+	for p := peekPortRangeStart; p <= peekPortRangeEnd; p++ {
+		l, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", p))
+		if err != nil {
+			t.Skipf("port %d already in use; skipping (real env)", p)
+		}
+		holders = append(holders, l)
+	}
+
+	if got := pickPeekPort(); got != 0 {
+		t.Errorf("range full: got %d, want 0 (fallback)", got)
+	}
+}
+
+func TestPickPeekPort_PrefersLowestFree(t *testing.T) {
+	// Bind the first port. pickPeekPort should skip it and return
+	// the next free one.
+	first, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", peekPortRangeStart))
+	if err != nil {
+		t.Skipf("port %d already in use; skipping (real env)", peekPortRangeStart)
+	}
+	defer func() { _ = first.Close() }()
+
+	got := pickPeekPort()
+	if got == peekPortRangeStart {
+		t.Errorf("returned bound port %d", got)
+	}
+	if got < peekPortRangeStart+1 || got > peekPortRangeEnd {
+		t.Errorf("got %d, want in (%d,%d]",
+			got, peekPortRangeStart, peekPortRangeEnd)
+	}
+}


### PR DESCRIPTION
## Summary

\`bones peek\` shells out to \`fossil ui\`, which defaults to port 8080. That collides with the typical dev-box port cluster (webpack-dev-server, Spring, the long list of historical 8080-claimers) and surfaces as a confusing fossil-side bind error.

When \`--port\` is unset, peek now scans **8775-8799** for the first free port and passes it to \`fossil ui\` explicitly. The range sits just above the hub's 8765 (memorable bones-port grouping) and well clear of the common dev-server cluster. Explicit \`--port\` still wins; if the entire preferred range is occupied, peek falls back to fossil's own default so it never fails purely on the picker.

## Test plan

- [x] \`make check\` (fmt, vet, lint, race, todo-check) — green
- [x] \`go test -tags=otel -short ./...\` — green
- [x] New \`TestPickPeekPort_ReturnsAvailablePort\`: returns a port in range, port is bindable
- [x] New \`TestPickPeekPort_SkipsBoundPorts\`: returns 0 when range is full (skipped if real env has stuff bound)
- [x] New \`TestPickPeekPort_PrefersLowestFree\`: with port N bound, returns N+1 (skipped if real env has N bound)
- [ ] Manual: \`bones peek\` from a workspace where 8080 is in use no longer collides