### PR TITLE
feat: prime on session boundaries (ADR 0036)

### DIFF
--- a/cli/orchestrator.go
+++ b/cli/orchestrator.go
@@ -103,6 +103,12 @@ func mergeSettings(path string) error {
 		hooks = map[string]any{}
 	}
 
+	// Prime first so task context lands in the agent's window before any
+	// other hook output. coord.Prime is the only thing that survives
+	// session boundaries — specs written outside `bones tasks` evaporate
+	// at the next compaction, which keeps planners filing atomic work
+	// rather than bypassing the tracker with freeform docs.
+	addHook(hooks, "SessionStart", "bones tasks prime --json")
 	addHook(hooks, "SessionStart", "bash .orchestrator/scripts/hub-bootstrap.sh")
 	migrateStopToSessionEnd(hooks)
 	addHook(hooks, "SessionEnd", "bash .orchestrator/scripts/hub-shutdown.sh")

--- a/cli/orchestrator.go
+++ b/cli/orchestrator.go
@@ -110,6 +110,7 @@ func mergeSettings(path string) error {
 	// rather than bypassing the tracker with freeform docs.
 	addHook(hooks, "SessionStart", "bones tasks prime --json")
 	addHook(hooks, "SessionStart", "bash .orchestrator/scripts/hub-bootstrap.sh")
+	addHook(hooks, "PreCompact", "bones tasks prime --json")
 	migrateStopToSessionEnd(hooks)
 	addHook(hooks, "SessionEnd", "bash .orchestrator/scripts/hub-shutdown.sh")
 

--- a/cli/orchestrator_test.go
+++ b/cli/orchestrator_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -254,12 +255,9 @@ func TestScaffoldOrchestrator_SessionStartIncludesPrime(t *testing.T) {
 	}
 	cmds := hookCommandsFor(readSettings(t, dir), "SessionStart")
 	want := "bones tasks prime --json"
-	for _, c := range cmds {
-		if c == want {
-			return
-		}
+	if !slices.Contains(cmds, want) {
+		t.Fatalf("SessionStart hooks missing %q; got %v", want, cmds)
 	}
-	t.Fatalf("SessionStart hooks missing %q; got %v", want, cmds)
 }
 
 // TestScaffoldOrchestrator_PreCompactIncludesPrime asserts the
@@ -273,12 +271,30 @@ func TestScaffoldOrchestrator_PreCompactIncludesPrime(t *testing.T) {
 	}
 	cmds := hookCommandsFor(readSettings(t, dir), "PreCompact")
 	want := "bones tasks prime --json"
-	for _, c := range cmds {
-		if c == want {
-			return
+	if !slices.Contains(cmds, want) {
+		t.Fatalf("PreCompact hooks missing %q; got %v", want, cmds)
+	}
+}
+
+// TestScaffoldOrchestrator_PrimeHookIdempotent asserts that re-running
+// `bones up` does not duplicate the prime entries. Locks in the
+// addHook dedup contract — without it, a downstream user who runs
+// `bones up --reinstall-hooks` repeatedly would accumulate multiple
+// prime calls per event.
+func TestScaffoldOrchestrator_PrimeHookIdempotent(t *testing.T) {
+	dir := t.TempDir()
+	for i := range 3 {
+		if err := scaffoldOrchestrator(dir); err != nil {
+			t.Fatalf("scaffold pass %d: %v", i+1, err)
 		}
 	}
-	t.Fatalf("PreCompact hooks missing %q; got %v", want, cmds)
+	settings := readSettings(t, dir)
+	const cmd = "bones tasks prime --json"
+	for _, event := range []string{"SessionStart", "PreCompact"} {
+		if got := countHookCommand(settings, event, cmd); got != 1 {
+			t.Errorf("%s prime entry count = %d, want 1", event, got)
+		}
+	}
 }
 
 func verifyHooks(t *testing.T, path string) {

--- a/cli/orchestrator_test.go
+++ b/cli/orchestrator_test.go
@@ -262,6 +262,25 @@ func TestScaffoldOrchestrator_SessionStartIncludesPrime(t *testing.T) {
 	t.Fatalf("SessionStart hooks missing %q; got %v", want, cmds)
 }
 
+// TestScaffoldOrchestrator_PreCompactIncludesPrime asserts the
+// PreCompact event runs `bones tasks prime --json`. Compaction is the
+// longer-horizon failure mode for narrative drift — wiring SessionStart
+// alone leaves a multi-hour window where freeform context can win.
+func TestScaffoldOrchestrator_PreCompactIncludesPrime(t *testing.T) {
+	dir := t.TempDir()
+	if err := scaffoldOrchestrator(dir); err != nil {
+		t.Fatalf("scaffoldOrchestrator: %v", err)
+	}
+	cmds := hookCommandsFor(readSettings(t, dir), "PreCompact")
+	want := "bones tasks prime --json"
+	for _, c := range cmds {
+		if c == want {
+			return
+		}
+	}
+	t.Fatalf("PreCompact hooks missing %q; got %v", want, cmds)
+}
+
 func verifyHooks(t *testing.T, path string) {
 	t.Helper()
 	data, err := os.ReadFile(path)

--- a/cli/orchestrator_test.go
+++ b/cli/orchestrator_test.go
@@ -193,6 +193,75 @@ func TestScaffoldOrchestrator_PreservesUnrelatedStopHook(t *testing.T) {
 	}
 }
 
+// readSettings parses .claude/settings.json from the workspace root.
+func readSettings(t *testing.T, root string) map[string]any {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(root, ".claude", "settings.json"))
+	if err != nil {
+		t.Fatalf("read settings: %v", err)
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("parse settings: %v\n%s", err, data)
+	}
+	return parsed
+}
+
+// hookCommandsFor returns every "command" string in settings.hooks[event].
+func hookCommandsFor(settings map[string]any, event string) []string {
+	hooks, _ := settings["hooks"].(map[string]any)
+	groups, _ := hooks[event].([]any)
+	var out []string
+	for _, g := range groups {
+		gm, ok := g.(map[string]any)
+		if !ok {
+			continue
+		}
+		entries, _ := gm["hooks"].([]any)
+		for _, e := range entries {
+			em, ok := e.(map[string]any)
+			if !ok {
+				continue
+			}
+			if c, _ := em["command"].(string); c != "" {
+				out = append(out, c)
+			}
+		}
+	}
+	return out
+}
+
+func countHookCommand(settings map[string]any, event, cmd string) int {
+	n := 0
+	for _, c := range hookCommandsFor(settings, event) {
+		if c == cmd {
+			n++
+		}
+	}
+	return n
+}
+
+// TestScaffoldOrchestrator_SessionStartIncludesPrime asserts that the
+// scaffold injects `bones tasks prime --json` into SessionStart so a
+// fresh agent's context boots from the tasks substrate. Without this,
+// freeform specs written outside `bones tasks` survive session
+// boundaries on equal footing with filed tasks, which removes the
+// "tasks-as-survivor" pressure that keeps planners filing atomic work.
+func TestScaffoldOrchestrator_SessionStartIncludesPrime(t *testing.T) {
+	dir := t.TempDir()
+	if err := scaffoldOrchestrator(dir); err != nil {
+		t.Fatalf("scaffoldOrchestrator: %v", err)
+	}
+	cmds := hookCommandsFor(readSettings(t, dir), "SessionStart")
+	want := "bones tasks prime --json"
+	for _, c := range cmds {
+		if c == want {
+			return
+		}
+	}
+	t.Fatalf("SessionStart hooks missing %q; got %v", want, cmds)
+}
+
 func verifyHooks(t *testing.T, path string) {
 	t.Helper()
 	data, err := os.ReadFile(path)

--- a/docs/adr/0036-prime-on-session-boundaries.md
+++ b/docs/adr/0036-prime-on-session-boundaries.md
@@ -1,0 +1,41 @@
+# ADR 0036: Prime on session boundaries
+
+## Context
+
+bones already has the primitives for tasks-as-survivor: `coord.Prime` returns a snapshot of the workspace's open/ready/claimed tasks plus chat threads and live peers (`internal/coord/prime.go`), and `bones tasks prime --json` serializes that snapshot stably (`cli/tasks_prime.go`, schema in `cli/tasks_format.go`). What was missing was the wiring: nothing in the `bones up` scaffold called Prime at session boundaries, so an agent's working context booted from whatever the harness happened to surface — including freeform spec files in the workspace.
+
+The asymmetry that keeps planners filing atomic tasks rather than freeform specs is auto-injection of prime at SessionStart and PreCompact. With prime injected at both events, only the tasks substrate survives session and compaction boundaries; any narrative written outside `bones tasks` evaporates and stops being a viable side channel. Without prime, a `spec.md` in the workspace rides on equal footing with filed tasks, and the tracker stops being the path of least resistance.
+
+ADR 0034 chose the workspace scaffold (`scaffoldOrchestrator` in `cli/orchestrator.go`) as the seam for hook installation — that is where the SessionStart hub-bootstrap line and the `.git/hooks/pre-commit` install already land. The same seam is the natural place to wire prime injection.
+
+## Decision
+
+The `bones up` scaffold writes `bones tasks prime --json` into both the SessionStart and PreCompact hook arrays of the workspace's `.claude/settings.json`. SessionStart prime runs before the hub bootstrap script so task context lands in the agent's window before any other hook output. PreCompact prime runs as the only hook on that event.
+
+The wiring is two `addHook` calls in `mergeSettings`:
+
+```go
+addHook(hooks, "SessionStart", "bones tasks prime --json")
+addHook(hooks, "PreCompact",   "bones tasks prime --json")
+```
+
+`addHook` already dedupes by command, so re-running `bones up` does not duplicate either entry. The dedup contract is locked in by `TestScaffoldOrchestrator_PrimeHookIdempotent`.
+
+## Consequences
+
+- Specs written outside `bones tasks` do not survive session boundaries on equal footing with filed tasks. Planners face structural pressure to file atomic work via `bones tasks create` rather than dropping a freeform spec and walking away.
+- Every Claude Code session in a bones workspace pays one Prime call at start and one at each compaction. `coord.Prime` is a single client-side filter over the tasks KV bucket (ADR 0005); cost is bounded by the workspace's task count.
+- The Prime JSON output (`{open_tasks, ready_tasks, claimed_tasks, threads, peers}`) becomes part of the consumer-visible surface. Schema stability is governed by `cli/tasks_format.go`'s `primeResultJSON` and is part of the `bones tasks prime --json` contract; future schema changes require the same forward-only migration discipline ADR 0005 established for task records themselves.
+- Sits orthogonal to ADR 0034: the pre-commit hook prevents *commits* from bypassing the substrate; prime injection prevents *planning context* from bypassing the substrate. Neither subsumes the other.
+
+## Alternatives considered
+
+**Inject prime at the leaf-RPC layer rather than the workspace scaffold.** Considered for the same reason ADR 0034 considered fossil-layer gating. Rejected for the same reason: the scaffold is the natural seam — it knows the workspace context and can be replaced or extended without touching coord internals. A consumer who wants prime at a different boundary (a custom hook event, a wrapper command) can edit `.claude/settings.json` directly; the scaffold writes a baseline, not a lock.
+
+**SessionStart only, skip PreCompact.** Rejected. Compaction is the longer-horizon failure mode for narrative drift. SessionStart alone leaves a multi-hour window in which freeform context written mid-session rides compaction unchanged — exactly the scenario this ADR exists to prevent.
+
+**Surface Prime via the SessionStart hook protocol's structured-output mode rather than as plain stdout JSON.** The hook protocol accepts structured JSON responses keyed by event type. Rejected because the plain-stdout path composes with every other hook in `.claude/settings.json` (all of which dump text to stdout), and it lets the scaffold stay schema-agnostic about hook output formats. A future ADR may revisit if the structured-output path proves materially better for context recovery.
+
+## Status
+
+Accepted, 2026-04-29.


### PR DESCRIPTION
## Summary

- `bones up` scaffold now writes `bones tasks prime --json` into both the SessionStart and PreCompact hook arrays of `.claude/settings.json` so the tasks substrate is the only thing that survives session and compaction boundaries.
- ADR 0036 documents the architectural decision: sits orthogonal to ADR 0034 (pre-commit prevents commit-bypass; prime injection prevents planning-context bypass).
- `addHook` already dedupes by command, so re-running `bones up` does not duplicate either entry. Locked in by `TestScaffoldOrchestrator_PrimeHookIdempotent`.

## Why

bones already had `coord.Prime` and `bones tasks prime --json` shipped — the scaffold just wasn't wiring them. Without prime at session boundaries, freeform spec files in the workspace ride on equal footing with filed tasks, which removes the structural pressure for planners to file atomic work via `bones tasks create`. With prime injected at SessionStart and PreCompact, only the tasks substrate survives — specs written outside the tracker evaporate at the next compaction.

## Test plan

- [x] `go test ./cli/ -v -run TestScaffoldOrchestrator` — three new tests pass alongside existing scaffold suite
- [x] `make check` — fmt-check, vet, lint, race, todo-check all green
- [x] `go test -tags=otel -short ./...` — full CI-equivalent run green
- [x] Manual smoke: built binary, ran `bones init && bones orchestrator` in a scratch dir, verified `.claude/settings.json` contains prime entries under both events
- [x] Manual idempotence: re-ran `bones orchestrator`, confirmed exactly one prime entry per event