### PR TITLE
chore: bump libfossil v0.4.4 → v0.4.5 (clone convergence fix)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/alecthomas/kong v1.15.0
 	github.com/danmestas/EdgeSync v0.0.5
 	github.com/danmestas/EdgeSync/leaf v0.0.3
-	github.com/danmestas/libfossil v0.4.4
+	github.com/danmestas/libfossil v0.4.5
 	github.com/danmestas/libfossil/db/driver/modernc v0.1.0
 	github.com/google/uuid v1.6.0
 	github.com/nats-io/nats-server/v2 v2.12.8

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,8 @@ github.com/danmestas/EdgeSync/leaf v0.0.3 h1:uJf9j6K2Eg5ljgaDidWLgd8oPfzxXmkUpfl
 github.com/danmestas/EdgeSync/leaf v0.0.3/go.mod h1:Et+E0lMUaAgk58pMLauIvSjeeMnS2+bZJeDZEkwF4h8=
 github.com/danmestas/go-sqlite3-opfs v0.2.0 h1:bO6iQYobgWCqTCQZ4NQ147x3yU2v+J+nn0Sq3y1b7sk=
 github.com/danmestas/go-sqlite3-opfs v0.2.0/go.mod h1:eAYxwG9hykpkB6oNMnsM8sSGB9HhHZv/NIN6yO9ZVQE=
-github.com/danmestas/libfossil v0.4.4 h1:VdrCxiW8YOlOHXR5WfgGdSs+DQQt0Xotz3Gc/36JVaU=
-github.com/danmestas/libfossil v0.4.4/go.mod h1:Ex+ADZ0kBLkBhSqnyrKg+KHbANVyQpKEWvVHUq8qMLc=
+github.com/danmestas/libfossil v0.4.5 h1:sDIcQCqp6cCOQgMaIGseRoopCD0mPYg2FRUrEV8P0HY=
+github.com/danmestas/libfossil v0.4.5/go.mod h1:Ex+ADZ0kBLkBhSqnyrKg+KHbANVyQpKEWvVHUq8qMLc=
 github.com/danmestas/libfossil/db/driver/modernc v0.1.0 h1:w3elyVSdXdbGNZ3Iu9xE6RP4XTz6JRlkpk0RZKBMl1Y=
 github.com/danmestas/libfossil/db/driver/modernc v0.1.0/go.mod h1:sXeYxCmAkz3Tb/zLIOo7X2CoZDelYQ1MWyoUrySD/vU=
 github.com/danmestas/libfossil/db/driver/ncruces v0.1.0 h1:GWlyrNicyBYSUi68w4G4uXL34SIqmwSFco5a8IuutY0=


### PR DESCRIPTION
## Summary

Bumps \`github.com/danmestas/libfossil\` from v0.4.4 to v0.4.5. Pulls in [libfossil#18](https://github.com/danmestas/libfossil/pull/18) which fixes [libfossil#17](https://github.com/danmestas/libfossil/issues/17) — the \`sync.Clone: exceeded 100 rounds\` failure mode observed on 2026-04-29 in serverdom (2/30 concurrent swarm joins failed when the hub was being written to during the clone window).

The fix addresses three compounding root causes inside libfossil:
- Server-side rid cap captured at session open (CookieCard \`lf-clone-cap:<rid>\`) so blobs written mid-clone don't extend the pagination queue
- Client-side \`CloneSeqNoCard\` now emitted on continuation rounds (>0)
- \`CookieCard\` round-tripping in the clone client (mirrors the existing sync-client pattern)

All libfossil-internal — \`CloneOpts\` API unchanged, no bones source changes required.

## Test plan

- [x] \`go get github.com/danmestas/libfossil@v0.4.5 && go mod tidy\` — clean
- [x] \`make check\` (fmt, vet, lint, race, todo-check) — green
- [x] \`go test -tags=otel -short ./...\` — green
- [ ] Manual verification: rerun a 30-slot swarm dispatch in serverdom against an active hub; observe whether the round-cap error reappears

Closes #84.