### PR TITLE
chore: bump EdgeSync v0.0.5 → v0.0.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.0
 
 require (
 	github.com/alecthomas/kong v1.15.0
-	github.com/danmestas/EdgeSync v0.0.5
+	github.com/danmestas/EdgeSync v0.0.7
 	github.com/danmestas/EdgeSync/leaf v0.0.3
 	github.com/danmestas/libfossil v0.4.5
 	github.com/danmestas/libfossil/db/driver/modernc v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1x
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/danmestas/EdgeSync v0.0.5 h1:1n3gchTMbwwjnvj2JAZKeJPkxxsQMwBLWmDvo/TmVHw=
-github.com/danmestas/EdgeSync v0.0.5/go.mod h1:hn3kZDNaXr6VhigCIkInXTh2i8XRqesXnuANf2BGRkw=
+github.com/danmestas/EdgeSync v0.0.7 h1:e6rr7ld4tgEBfz4UI7TyWuyK7klltCkiwh7kuPnPah8=
+github.com/danmestas/EdgeSync v0.0.7/go.mod h1:AklrgWrlzzDzIlruYuUrr2NNCxFD4lIz2lLi/wzeP4w=
 github.com/danmestas/EdgeSync/bridge v0.0.2 h1:ZsRC/Uk/zXkLIlhSDYqpzg3C7/N2QNPuO1w4i+AnP2g=
 github.com/danmestas/EdgeSync/bridge v0.0.2/go.mod h1:UlSJUXr34HzxYvwgVROWDZgVrQ4zq79DRJfYYoYV40E=
 github.com/danmestas/EdgeSync/leaf v0.0.3 h1:uJf9j6K2Eg5ljgaDidWLgd8oPfzxXmkUpflSm4xIv/0=


### PR DESCRIPTION
## Summary

Bumps \`github.com/danmestas/EdgeSync\` from v0.0.5 to v0.0.7. EdgeSync v0.0.7 carries the libfossil v0.4.5 bump (matching bones' own direct require from #85) plus accumulated tooling, LICENSE, README, and GoReleaser changes since v0.0.5.

bones imports \`github.com/danmestas/EdgeSync/cli\` from the root module. After this bump:

- Dep graph is clean — both bones' direct libfossil require and EdgeSync's transitive require land at v0.4.5
- EdgeSync's internal libfossil-using paths (within the cli surface bones consumes) exercise v0.4.5 instead of v0.4.3
- No bones source changes required

The leaf submodule (\`github.com/danmestas/EdgeSync/leaf\`) is still pinned at \`leaf/v0.0.3\` — that submodule has the libfossil bump in its go.mod but hasn't been retagged. A leaf-side bump can follow once that's published; until then, MVS still picks libfossil v0.4.5 via bones' direct require, so the binary is unaffected.

## Test plan

- [x] \`go get github.com/danmestas/EdgeSync@v0.0.7 && go mod tidy\` — clean
- [x] \`make check\` (fmt, vet, lint, race, todo-check) — green
- [x] \`go test -tags=otel -short ./...\` — green