### PR TITLE
feat: bones apply — fossil trunk to git materialization (ADR 0037)

### DIFF
--- a/cli/apply.go
+++ b/cli/apply.go
@@ -183,6 +183,33 @@ func bytesEqual(a, b []byte) bool {
 	return true
 }
 
+// lastAppliedFile is the path (relative to the workspace dir) where
+// bones apply records the most recently applied trunk rev.
+const lastAppliedFile = ".bones/last-applied"
+
+// readLastAppliedMarker returns the rev recorded at .bones/last-applied,
+// or "" if the marker is absent. Other I/O errors are returned as-is.
+func readLastAppliedMarker(workspaceDir string) (string, error) {
+	data, err := os.ReadFile(filepath.Join(workspaceDir, lastAppliedFile))
+	if os.IsNotExist(err) {
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(data)), nil
+}
+
+// writeLastAppliedMarker writes the rev to .bones/last-applied,
+// creating .bones/ if needed.
+func writeLastAppliedMarker(workspaceDir, rev string) error {
+	dir := filepath.Join(workspaceDir, ".bones")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(dir, "last-applied"), []byte(rev+"\n"), 0o644)
+}
+
 // manifestAtRev lists files at a specific rev (hex UUID or symbolic
 // name like "trunk"). `-r` is required so `fossil ls` runs against the
 // repo without a live checkout — without `-r`, fossil ls expects to be

--- a/cli/apply.go
+++ b/cli/apply.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"os"
@@ -126,7 +127,8 @@ func refuseIfDirty(workspaceDir string, manifest []string) error {
 		preview = preview[:3]
 	}
 	return fmt.Errorf(
-		"uncommitted changes in fossil-tracked files: %s — git stash or commit before applying",
+		"bones apply: uncommitted changes in fossil-tracked files: %s — "+
+			"git stash or commit before applying",
 		strings.Join(preview, ", "),
 	)
 }
@@ -153,9 +155,13 @@ func loadPrevManifest(pre *applyPreflight) ([]string, error) {
 	return prevManifest, nil
 }
 
+// shortRev abbreviates a fossil hex UUID to 12 characters — fossil's
+// own UI convention for displaying revs, mirrored here so apply's
+// "trunk @ <rev>" matches what `fossil info` and `fossil timeline` print.
 func shortRev(rev string) string {
-	if len(rev) >= 12 {
-		return rev[:12]
+	const fossilShortLen = 12
+	if len(rev) >= fossilShortLen {
+		return rev[:fossilShortLen]
 	}
 	return rev
 }
@@ -193,20 +199,22 @@ func runApplyPreflight(cwd string) (*applyPreflight, error) {
 	root, err := workspace.FindRoot(cwd)
 	if err != nil {
 		return nil, fmt.Errorf(
-			"workspace not found: run `bones init` or `bones up` first (%w)", err)
+			"bones apply: workspace not found — run `bones init` or `bones up` first (%w)", err)
 	}
 	hubRepo := filepath.Join(root, ".orchestrator", "hub.fossil")
 	if _, err := os.Stat(hubRepo); err != nil {
-		return nil, fmt.Errorf("hub repo not found at %s — run `bones up` first", hubRepo)
+		return nil, fmt.Errorf(
+			"bones apply: hub repo not found at %s — run `bones up` first", hubRepo)
 	}
 	if _, err := os.Stat(filepath.Join(root, ".git")); err != nil {
-		return nil, fmt.Errorf("no git repo at %s — bones apply requires git for staging", root)
+		return nil, fmt.Errorf(
+			"bones apply: no git repo at %s — apply requires git for staging", root)
 	}
 	fossilBin, err := exec.LookPath("fossil")
 	if err != nil {
 		return nil, errors.New(
-			"bones apply requires the system `fossil` binary; install via " +
-				"`brew install fossil` (or apt) and re-run",
+			"bones apply: requires the system `fossil` binary; " +
+				"install via `brew install fossil` (or apt) and re-run",
 		)
 	}
 	return &applyPreflight{
@@ -300,7 +308,7 @@ func classifyDiff(
 		if err != nil {
 			return nil, fmt.Errorf("read dest %s: %w", p, err)
 		}
-		if !bytesEqual(srcBytes, dstBytes) {
+		if !bytes.Equal(srcBytes, dstBytes) {
 			plan.Modified = append(plan.Modified, p)
 		}
 	}
@@ -321,26 +329,15 @@ func classifyDiff(
 	return plan, nil
 }
 
-func bytesEqual(a, b []byte) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
-}
-
 // applyPlanToTree writes adds/modifies from tempCheckout into projectRoot,
 // removes deleted paths, and stages everything that changed via
 // `git add -A -- <paths>`. Source-of-truth file modes are preserved
 // from tempCheckout (which fossil populated honoring its tracked mode).
 func applyPlanToTree(tempCheckout, projectRoot string, plan *applyPlan) error {
-	staging := append([]string(nil), plan.Added...)
+	staging := make([]string, 0, len(plan.Added)+len(plan.Modified)+len(plan.Deleted))
+	staging = append(staging, plan.Added...)
 	staging = append(staging, plan.Modified...)
-	for _, p := range append(plan.Added, plan.Modified...) {
+	for _, p := range staging {
 		src := filepath.Join(tempCheckout, p)
 		dst := filepath.Join(projectRoot, p)
 		data, err := os.ReadFile(src)

--- a/cli/apply.go
+++ b/cli/apply.go
@@ -183,6 +183,50 @@ func bytesEqual(a, b []byte) bool {
 	return true
 }
 
+// applyPlanToTree writes adds/modifies from tempCheckout into projectRoot,
+// removes deleted paths, and stages everything that changed via
+// `git add -A -- <paths>`. Source-of-truth file modes are preserved
+// from tempCheckout (which fossil populated honoring its tracked mode).
+func applyPlanToTree(tempCheckout, projectRoot string, plan *applyPlan) error {
+	staging := append([]string(nil), plan.Added...)
+	staging = append(staging, plan.Modified...)
+	for _, p := range append(plan.Added, plan.Modified...) {
+		src := filepath.Join(tempCheckout, p)
+		dst := filepath.Join(projectRoot, p)
+		data, err := os.ReadFile(src)
+		if err != nil {
+			return fmt.Errorf("read %s: %w", p, err)
+		}
+		info, err := os.Stat(src)
+		if err != nil {
+			return fmt.Errorf("stat %s: %w", p, err)
+		}
+		if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+			return fmt.Errorf("mkdir for %s: %w", p, err)
+		}
+		if err := os.WriteFile(dst, data, info.Mode().Perm()); err != nil {
+			return fmt.Errorf("write %s: %w", p, err)
+		}
+	}
+	for _, p := range plan.Deleted {
+		dst := filepath.Join(projectRoot, p)
+		if err := os.Remove(dst); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("remove %s: %w", p, err)
+		}
+		staging = append(staging, p)
+	}
+	if len(staging) == 0 {
+		return nil
+	}
+	args := append([]string{"add", "-A", "--"}, staging...)
+	cmd := exec.Command("git", args...)
+	cmd.Dir = projectRoot
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("git add: %w\n%s", err, out)
+	}
+	return nil
+}
+
 // lastAppliedFile is the path (relative to the workspace dir) where
 // bones apply records the most recently applied trunk rev.
 const lastAppliedFile = ".bones/last-applied"

--- a/cli/apply.go
+++ b/cli/apply.go
@@ -121,6 +121,68 @@ func dirtyTrackedPaths(workspaceDir string, manifest []string) ([]string, error)
 	return dirty, nil
 }
 
+// applyPlan describes the file ops bones apply will perform.
+type applyPlan struct {
+	Added    []string // in current manifest, missing in root
+	Modified []string // in current manifest, present in root, bytes differ
+	Deleted  []string // in prev manifest, NOT in current manifest, present in root
+}
+
+// classifyDiff computes the apply plan by comparing files in tempCheckout
+// (the source of truth — fossil's checkout at trunk tip) against
+// projectRoot (the live working tree). manifest is the trunk-tip path
+// list; prevManifest is the previously-applied path list (nil/empty
+// means "no marker yet, suppress deletions").
+func classifyDiff(tempCheckout, projectRoot string, manifest, prevManifest []string) (*applyPlan, error) {
+	plan := &applyPlan{}
+	for _, p := range manifest {
+		src := filepath.Join(tempCheckout, p)
+		dst := filepath.Join(projectRoot, p)
+		srcBytes, err := os.ReadFile(src)
+		if err != nil {
+			return nil, fmt.Errorf("read source %s: %w", p, err)
+		}
+		dstBytes, err := os.ReadFile(dst)
+		if os.IsNotExist(err) {
+			plan.Added = append(plan.Added, p)
+			continue
+		}
+		if err != nil {
+			return nil, fmt.Errorf("read dest %s: %w", p, err)
+		}
+		if !bytesEqual(srcBytes, dstBytes) {
+			plan.Modified = append(plan.Modified, p)
+		}
+	}
+	if len(prevManifest) > 0 {
+		current := make(map[string]struct{}, len(manifest))
+		for _, p := range manifest {
+			current[p] = struct{}{}
+		}
+		for _, p := range prevManifest {
+			if _, stillThere := current[p]; stillThere {
+				continue
+			}
+			if _, err := os.Stat(filepath.Join(projectRoot, p)); err == nil {
+				plan.Deleted = append(plan.Deleted, p)
+			}
+		}
+	}
+	return plan, nil
+}
+
+func bytesEqual(a, b []byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
 // manifestAtRev lists files at a specific rev (hex UUID or symbolic
 // name like "trunk"). `-r` is required so `fossil ls` runs against the
 // repo without a live checkout — without `-r`, fossil ls expects to be

--- a/cli/apply.go
+++ b/cli/apply.go
@@ -84,6 +84,43 @@ func trunkManifest(hubFossil, fossilBin string) ([]string, string, error) {
 	return paths, rev, nil
 }
 
+// dirtyTrackedPaths returns the subset of fossil-manifest paths that
+// have staged or unstaged modifications in the workspace's git tree.
+// Untracked-by-fossil files are not consulted regardless of their git
+// state — the apply contract is "refuse if fossil would clobber the
+// user's work," not "refuse if anything is dirty."
+func dirtyTrackedPaths(workspaceDir string, manifest []string) ([]string, error) {
+	if len(manifest) == 0 {
+		return nil, nil
+	}
+	manifestSet := make(map[string]struct{}, len(manifest))
+	for _, p := range manifest {
+		manifestSet[p] = struct{}{}
+	}
+	cmd := exec.Command("git", "status", "--porcelain", "--untracked-files=no")
+	cmd.Dir = workspaceDir
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("git status: %w", err)
+	}
+	var dirty []string
+	for _, line := range strings.Split(string(out), "\n") {
+		if len(line) < 4 {
+			continue
+		}
+		// Porcelain v1: "XY <path>" where X = index status, Y = worktree status.
+		path := strings.TrimSpace(line[3:])
+		// Rename lines have "old -> new"; take the new name.
+		if idx := strings.LastIndex(path, " -> "); idx >= 0 {
+			path = path[idx+4:]
+		}
+		if _, ok := manifestSet[path]; ok {
+			dirty = append(dirty, path)
+		}
+	}
+	return dirty, nil
+}
+
 // manifestAtRev lists files at a specific rev (hex UUID or symbolic
 // name like "trunk"). `-r` is required so `fossil ls` runs against the
 // repo without a live checkout — without `-r`, fossil ls expects to be

--- a/cli/apply.go
+++ b/cli/apply.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 
 	libfossilcli "github.com/danmestas/libfossil/cli"
 
@@ -67,3 +68,56 @@ func runApplyPreflight(cwd string) (*applyPreflight, error) {
 		FossilBin:    fossilBin,
 	}, nil
 }
+
+// trunkManifest returns the list of files tracked at the hub fossil's
+// trunk tip and the tip's hex rev. Shells to the system fossil binary,
+// matching the pattern in cli/swarm_fanin.go.
+func trunkManifest(hubFossil, fossilBin string) ([]string, string, error) {
+	paths, err := manifestAtRev(hubFossil, fossilBin, "trunk")
+	if err != nil {
+		return nil, "", err
+	}
+	rev, err := trunkRev(hubFossil, fossilBin)
+	if err != nil {
+		return paths, "", err
+	}
+	return paths, rev, nil
+}
+
+// manifestAtRev lists files at a specific rev (hex UUID or symbolic
+// name like "trunk"). `-r` is required so `fossil ls` runs against the
+// repo without a live checkout — without `-r`, fossil ls expects to be
+// run inside a fossil working directory.
+func manifestAtRev(hubFossil, fossilBin, rev string) ([]string, error) {
+	out, err := exec.Command(fossilBin, "ls", "-R", hubFossil, "-r", rev).Output()
+	if err != nil {
+		return nil, fmt.Errorf("fossil ls @ %s: %w", rev, err)
+	}
+	var paths []string
+	for _, line := range strings.Split(string(out), "\n") {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			paths = append(paths, line)
+		}
+	}
+	return paths, nil
+}
+
+// trunkRev returns the trunk tip's hex UUID via `fossil info`.
+// Accepts both legacy (`uuid:`) and current (`hash:`) labels.
+func trunkRev(hubFossil, fossilBin string) (string, error) {
+	out, err := exec.Command(fossilBin, "info", "-R", hubFossil, "trunk").Output()
+	if err != nil {
+		return "", fmt.Errorf("fossil info trunk: %w", err)
+	}
+	for _, line := range strings.Split(string(out), "\n") {
+		line = strings.TrimSpace(line)
+		for _, prefix := range []string{"uuid:", "hash:"} {
+			if strings.HasPrefix(line, prefix) {
+				return strings.TrimSpace(strings.TrimPrefix(line, prefix)), nil
+			}
+		}
+	}
+	return "", errors.New("could not parse trunk rev from `fossil info`")
+}
+

--- a/cli/apply.go
+++ b/cli/apply.go
@@ -2,8 +2,14 @@ package cli
 
 import (
 	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
 
 	libfossilcli "github.com/danmestas/libfossil/cli"
+
+	"github.com/danmestas/bones/internal/workspace"
 )
 
 // ApplyCmd materializes the hub fossil's trunk tip into the
@@ -20,4 +26,44 @@ type ApplyCmd struct {
 
 func (c *ApplyCmd) Run(g *libfossilcli.Globals) error {
 	return errors.New("bones apply: not yet implemented")
+}
+
+// applyPreflight is the resolved precondition state, returned by
+// runApplyPreflight when every check passes.
+type applyPreflight struct {
+	WorkspaceDir string
+	HubFossil    string
+	FossilBin    string
+}
+
+// runApplyPreflight checks that the bones workspace, hub fossil, git
+// repo, and system fossil binary are all in place. Returns the resolved
+// paths or a user-facing error suitable for direct return from Run.
+//
+// Uses workspace.FindRoot rather than workspace.Join: bones apply only
+// needs the workspace path, not a live leaf.
+func runApplyPreflight(cwd string) (*applyPreflight, error) {
+	root, err := workspace.FindRoot(cwd)
+	if err != nil {
+		return nil, fmt.Errorf("workspace not found: run `bones init` or `bones up` first (%w)", err)
+	}
+	hubRepo := filepath.Join(root, ".orchestrator", "hub.fossil")
+	if _, err := os.Stat(hubRepo); err != nil {
+		return nil, fmt.Errorf("hub repo not found at %s — run `bones up` first", hubRepo)
+	}
+	if _, err := os.Stat(filepath.Join(root, ".git")); err != nil {
+		return nil, fmt.Errorf("no git repo at %s — bones apply requires git for staging", root)
+	}
+	fossilBin, err := exec.LookPath("fossil")
+	if err != nil {
+		return nil, errors.New(
+			"bones apply requires the system `fossil` binary; install via " +
+				"`brew install fossil` (or apt) and re-run",
+		)
+	}
+	return &applyPreflight{
+		WorkspaceDir: root,
+		HubFossil:    hubRepo,
+		FossilBin:    fossilBin,
+	}, nil
 }

--- a/cli/apply.go
+++ b/cli/apply.go
@@ -1,0 +1,23 @@
+package cli
+
+import (
+	"errors"
+
+	libfossilcli "github.com/danmestas/libfossil/cli"
+)
+
+// ApplyCmd materializes the hub fossil's trunk tip into the
+// project-root git working tree and stages the changes for the user
+// to review and commit. See
+// docs/superpowers/specs/2026-04-30-bones-apply-design.md.
+//
+// bones apply never runs `git commit`. It writes files and stages with
+// `git add -A` within fossil's tracked-paths set; the user owns the
+// commit message and the commit author identity.
+type ApplyCmd struct {
+	DryRun bool `name:"dry-run" help:"show planned changes without writing or staging"`
+}
+
+func (c *ApplyCmd) Run(g *libfossilcli.Globals) error {
+	return errors.New("bones apply: not yet implemented")
+}

--- a/cli/apply.go
+++ b/cli/apply.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	libfossilcli "github.com/danmestas/libfossil/cli"
 
@@ -26,7 +27,116 @@ type ApplyCmd struct {
 }
 
 func (c *ApplyCmd) Run(g *libfossilcli.Globals) error {
-	return errors.New("bones apply: not yet implemented")
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("cwd: %w", err)
+	}
+	pre, err := runApplyPreflight(cwd)
+	if err != nil {
+		return err
+	}
+
+	tempDir := filepath.Join(pre.WorkspaceDir, ".bones",
+		fmt.Sprintf("apply-%d", time.Now().UnixNano()))
+	if err := os.MkdirAll(tempDir, 0o755); err != nil {
+		return fmt.Errorf("mkdir temp checkout: %w", err)
+	}
+	defer func() { _ = os.RemoveAll(tempDir) }()
+
+	checkoutCmd := exec.Command(pre.FossilBin, "open", "--force",
+		pre.HubFossil, "--workdir", tempDir)
+	checkoutCmd.Stdout = os.Stderr
+	checkoutCmd.Stderr = os.Stderr
+	if err := checkoutCmd.Run(); err != nil {
+		return fmt.Errorf("fossil open temp checkout: %w", err)
+	}
+	defer func() {
+		closeCmd := exec.Command(pre.FossilBin, "close", "--force")
+		closeCmd.Dir = tempDir
+		_ = closeCmd.Run()
+	}()
+
+	manifest, rev, err := trunkManifest(pre.HubFossil, pre.FossilBin)
+	if err != nil {
+		return err
+	}
+
+	dirty, err := dirtyTrackedPaths(pre.WorkspaceDir, manifest)
+	if err != nil {
+		return err
+	}
+	if len(dirty) > 0 {
+		preview := dirty
+		if len(preview) > 3 {
+			preview = preview[:3]
+		}
+		return fmt.Errorf(
+			"uncommitted changes in fossil-tracked files: %s — git stash or commit before applying",
+			strings.Join(preview, ", "))
+	}
+
+	prevRev, err := readLastAppliedMarker(pre.WorkspaceDir)
+	if err != nil {
+		return fmt.Errorf("read last-applied marker: %w", err)
+	}
+	var prevManifest []string
+	if prevRev != "" {
+		prevManifest, err = manifestAtRev(pre.HubFossil, pre.FossilBin, prevRev)
+		if err != nil {
+			fmt.Fprintf(os.Stderr,
+				"bones apply: previous rev %s not found in hub fossil; suppressing deletions\n",
+				prevRev)
+			prevManifest = nil
+		}
+	}
+
+	plan, err := classifyDiff(tempDir, pre.WorkspaceDir, manifest, prevManifest)
+	if err != nil {
+		return err
+	}
+
+	total := len(plan.Added) + len(plan.Modified) + len(plan.Deleted)
+	if total == 0 {
+		fmt.Printf("bones apply: already up to date at %s\n", shortRev(rev))
+		return writeLastAppliedMarker(pre.WorkspaceDir, rev)
+	}
+
+	if c.DryRun {
+		printApplyDryRun(plan, rev)
+		return nil
+	}
+
+	if err := applyPlanToTree(tempDir, pre.WorkspaceDir, plan); err != nil {
+		return err
+	}
+	if err := writeLastAppliedMarker(pre.WorkspaceDir, rev); err != nil {
+		return fmt.Errorf("write last-applied marker: %w", err)
+	}
+	fmt.Printf("applied %d changes from trunk @ %s. review with `git diff --staged`. commit when ready.\n",
+		total, shortRev(rev))
+	return nil
+}
+
+func shortRev(rev string) string {
+	if len(rev) >= 12 {
+		return rev[:12]
+	}
+	return rev
+}
+
+func printApplyDryRun(plan *applyPlan, rev string) {
+	total := len(plan.Added) + len(plan.Modified) + len(plan.Deleted)
+	fmt.Printf("bones apply (dry-run): would apply %d changes from trunk @ %s:\n",
+		total, shortRev(rev))
+	for _, p := range plan.Added {
+		fmt.Printf("  A  %s\n", p)
+	}
+	for _, p := range plan.Modified {
+		fmt.Printf("  M  %s\n", p)
+	}
+	for _, p := range plan.Deleted {
+		fmt.Printf("  D  %s\n", p)
+	}
 }
 
 // applyPreflight is the resolved precondition state, returned by

--- a/cli/apply.go
+++ b/cli/apply.go
@@ -35,86 +35,122 @@ func (c *ApplyCmd) Run(g *libfossilcli.Globals) error {
 	if err != nil {
 		return err
 	}
-
-	tempDir := filepath.Join(pre.WorkspaceDir, ".bones",
-		fmt.Sprintf("apply-%d", time.Now().UnixNano()))
-	if err := os.MkdirAll(tempDir, 0o755); err != nil {
-		return fmt.Errorf("mkdir temp checkout: %w", err)
+	tempDir, cleanup, err := openTempCheckout(pre)
+	if err != nil {
+		return err
 	}
-	defer func() { _ = os.RemoveAll(tempDir) }()
+	defer cleanup()
+	return c.applyFromCheckout(pre, tempDir)
+}
 
-	checkoutCmd := exec.Command(pre.FossilBin, "open", "--force",
-		pre.HubFossil, "--workdir", tempDir)
-	checkoutCmd.Stdout = os.Stderr
-	checkoutCmd.Stderr = os.Stderr
-	if err := checkoutCmd.Run(); err != nil {
-		return fmt.Errorf("fossil open temp checkout: %w", err)
-	}
-	defer func() {
-		closeCmd := exec.Command(pre.FossilBin, "close", "--force")
-		closeCmd.Dir = tempDir
-		_ = closeCmd.Run()
-	}()
-
+// applyFromCheckout executes the apply pipeline once preconditions and
+// the temp checkout are in place. Split out of Run to keep each below
+// the funlen limit while preserving the linear flow.
+func (c *ApplyCmd) applyFromCheckout(pre *applyPreflight, tempDir string) error {
 	manifest, rev, err := trunkManifest(pre.HubFossil, pre.FossilBin)
 	if err != nil {
 		return err
 	}
-
-	dirty, err := dirtyTrackedPaths(pre.WorkspaceDir, manifest)
+	if err := refuseIfDirty(pre.WorkspaceDir, manifest); err != nil {
+		return err
+	}
+	prevManifest, err := loadPrevManifest(pre)
 	if err != nil {
 		return err
 	}
-	if len(dirty) > 0 {
-		preview := dirty
-		if len(preview) > 3 {
-			preview = preview[:3]
-		}
-		return fmt.Errorf(
-			"uncommitted changes in fossil-tracked files: %s — git stash or commit before applying",
-			strings.Join(preview, ", "))
-	}
-
-	prevRev, err := readLastAppliedMarker(pre.WorkspaceDir)
-	if err != nil {
-		return fmt.Errorf("read last-applied marker: %w", err)
-	}
-	var prevManifest []string
-	if prevRev != "" {
-		prevManifest, err = manifestAtRev(pre.HubFossil, pre.FossilBin, prevRev)
-		if err != nil {
-			fmt.Fprintf(os.Stderr,
-				"bones apply: previous rev %s not found in hub fossil; suppressing deletions\n",
-				prevRev)
-			prevManifest = nil
-		}
-	}
-
 	plan, err := classifyDiff(tempDir, pre.WorkspaceDir, manifest, prevManifest)
 	if err != nil {
 		return err
 	}
-
 	total := len(plan.Added) + len(plan.Modified) + len(plan.Deleted)
 	if total == 0 {
 		fmt.Printf("bones apply: already up to date at %s\n", shortRev(rev))
 		return writeLastAppliedMarker(pre.WorkspaceDir, rev)
 	}
-
 	if c.DryRun {
 		printApplyDryRun(plan, rev)
 		return nil
 	}
-
 	if err := applyPlanToTree(tempDir, pre.WorkspaceDir, plan); err != nil {
 		return err
 	}
 	if err := writeLastAppliedMarker(pre.WorkspaceDir, rev); err != nil {
 		return fmt.Errorf("write last-applied marker: %w", err)
 	}
-	fmt.Printf("applied %d changes from trunk @ %s. review with `git diff --staged`. commit when ready.\n",
-		total, shortRev(rev))
+	fmt.Printf(
+		"applied %d changes from trunk @ %s. review with `git diff --staged`. commit when ready.\n",
+		total, shortRev(rev),
+	)
 	return nil
+}
+
+// openTempCheckout opens a fresh fossil checkout of the hub repo at trunk
+// tip in <workspace>/.bones/apply-<unix-nano>/. Returns the temp dir and
+// a cleanup function the caller must defer.
+func openTempCheckout(pre *applyPreflight) (string, func(), error) {
+	tempDir := filepath.Join(pre.WorkspaceDir, ".bones",
+		fmt.Sprintf("apply-%d", time.Now().UnixNano()))
+	if err := os.MkdirAll(tempDir, 0o755); err != nil {
+		return "", nil, fmt.Errorf("mkdir temp checkout: %w", err)
+	}
+	checkoutCmd := exec.Command(pre.FossilBin, "open", "--force",
+		pre.HubFossil, "--workdir", tempDir)
+	checkoutCmd.Stdout = os.Stderr
+	checkoutCmd.Stderr = os.Stderr
+	if err := checkoutCmd.Run(); err != nil {
+		_ = os.RemoveAll(tempDir)
+		return "", nil, fmt.Errorf("fossil open temp checkout: %w", err)
+	}
+	cleanup := func() {
+		closeCmd := exec.Command(pre.FossilBin, "close", "--force")
+		closeCmd.Dir = tempDir
+		_ = closeCmd.Run()
+		_ = os.RemoveAll(tempDir)
+	}
+	return tempDir, cleanup, nil
+}
+
+// refuseIfDirty wraps dirtyTrackedPaths in the user-facing refusal
+// message produced when any fossil-tracked path has uncommitted git
+// changes.
+func refuseIfDirty(workspaceDir string, manifest []string) error {
+	dirty, err := dirtyTrackedPaths(workspaceDir, manifest)
+	if err != nil {
+		return err
+	}
+	if len(dirty) == 0 {
+		return nil
+	}
+	preview := dirty
+	if len(preview) > 3 {
+		preview = preview[:3]
+	}
+	return fmt.Errorf(
+		"uncommitted changes in fossil-tracked files: %s — git stash or commit before applying",
+		strings.Join(preview, ", "),
+	)
+}
+
+// loadPrevManifest reads the last-applied marker and looks up the
+// manifest at that rev. A missing marker returns (nil, nil) — first
+// apply is additive-only. A marker pointing at an unknown rev logs a
+// warning and returns (nil, nil) so deletions are suppressed.
+func loadPrevManifest(pre *applyPreflight) ([]string, error) {
+	prevRev, err := readLastAppliedMarker(pre.WorkspaceDir)
+	if err != nil {
+		return nil, fmt.Errorf("read last-applied marker: %w", err)
+	}
+	if prevRev == "" {
+		return nil, nil
+	}
+	prevManifest, err := manifestAtRev(pre.HubFossil, pre.FossilBin, prevRev)
+	if err != nil {
+		fmt.Fprintf(os.Stderr,
+			"bones apply: previous rev %s not found in hub fossil; "+
+				"suppressing deletions\n", prevRev)
+		return nil, nil
+	}
+	return prevManifest, nil
 }
 
 func shortRev(rev string) string {
@@ -156,7 +192,8 @@ type applyPreflight struct {
 func runApplyPreflight(cwd string) (*applyPreflight, error) {
 	root, err := workspace.FindRoot(cwd)
 	if err != nil {
-		return nil, fmt.Errorf("workspace not found: run `bones init` or `bones up` first (%w)", err)
+		return nil, fmt.Errorf(
+			"workspace not found: run `bones init` or `bones up` first (%w)", err)
 	}
 	hubRepo := filepath.Join(root, ".orchestrator", "hub.fossil")
 	if _, err := os.Stat(hubRepo); err != nil {
@@ -243,7 +280,10 @@ type applyPlan struct {
 // projectRoot (the live working tree). manifest is the trunk-tip path
 // list; prevManifest is the previously-applied path list (nil/empty
 // means "no marker yet, suppress deletions").
-func classifyDiff(tempCheckout, projectRoot string, manifest, prevManifest []string) (*applyPlan, error) {
+func classifyDiff(
+	tempCheckout, projectRoot string,
+	manifest, prevManifest []string,
+) (*applyPlan, error) {
 	plan := &applyPlan{}
 	for _, p := range manifest {
 		src := filepath.Join(tempCheckout, p)
@@ -400,4 +440,3 @@ func trunkRev(hubFossil, fossilBin string) (string, error) {
 	}
 	return "", errors.New("could not parse trunk rev from `fossil info`")
 }
-

--- a/cli/apply_test.go
+++ b/cli/apply_test.go
@@ -284,6 +284,32 @@ func must(t *testing.T, err error) {
 	}
 }
 
+func TestLastAppliedMarker_AbsentReturnsEmpty(t *testing.T) {
+	dir := t.TempDir()
+	rev, err := readLastAppliedMarker(dir)
+	if err != nil {
+		t.Fatalf("absent should not error: %v", err)
+	}
+	if rev != "" {
+		t.Errorf("expected empty rev, got %q", rev)
+	}
+}
+
+func TestLastAppliedMarker_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	want := "abcdef0123456789"
+	if err := writeLastAppliedMarker(dir, want); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	got, err := readLastAppliedMarker(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Errorf("rev = %q, want %q", got, want)
+	}
+}
+
 // setupApplyFixture creates a tmpdir containing a bones workspace
 // marker, an empty hub.fossil placeholder file, and a .git/ directory.
 // Sufficient for preflight checks; tests that exercise actual fossil

--- a/cli/apply_test.go
+++ b/cli/apply_test.go
@@ -10,15 +10,102 @@ import (
 	libfossilcli "github.com/danmestas/libfossil/cli"
 )
 
-func TestApplyCmd_StubReturnsNotImplemented(t *testing.T) {
+func TestApplyRun_AlreadyUpToDate(t *testing.T) {
+	if _, err := exec.LookPath("fossil"); err != nil {
+		t.Skip("fossil not on PATH")
+	}
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+	dir := buildLiveFixture(t)
+	t.Chdir(dir)
+	cmd := &ApplyCmd{}
+	if err := cmd.Run(&libfossilcli.Globals{}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	rev, err := readLastAppliedMarker(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rev == "" {
+		t.Errorf("expected marker to be written on no-op, got empty")
+	}
+}
+
+func TestApplyRun_DryRunDoesNotStage(t *testing.T) {
+	if _, err := exec.LookPath("fossil"); err != nil {
+		t.Skip("fossil not on PATH")
+	}
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+	dir := buildLiveFixture(t)
+	// Add a new fossil commit so there's something to apply.
+	hubFossil := filepath.Join(dir, ".orchestrator", "hub.fossil")
+	wt := filepath.Join(dir, ".bones", "fixture-wt2")
+	mustRun(t, "fossil", "open", "--force", hubFossil, "--workdir", wt)
+	must(t, os.WriteFile(filepath.Join(wt, "newfile.txt"), []byte("added\n"), 0o644))
+	mustRunIn(t, wt, "fossil", "add", "newfile.txt")
+	mustRunIn(t, wt, "fossil", "commit", "--no-warnings", "--user-override", "u", "-m", "add newfile")
+	mustRunIn(t, wt, "fossil", "close", "--force")
+
+	t.Chdir(dir)
+	cmd := &ApplyCmd{DryRun: true}
+	if err := cmd.Run(&libfossilcli.Globals{}); err != nil {
+		t.Fatalf("Run dry-run: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "newfile.txt")); !os.IsNotExist(err) {
+		t.Errorf("dry-run wrote the file: %v", err)
+	}
+	rev, _ := readLastAppliedMarker(dir)
+	if rev != "" {
+		t.Errorf("dry-run should not update marker, got %q", rev)
+	}
+}
+
+func TestApplyRun_DirtyTreeRefuses(t *testing.T) {
+	if _, err := exec.LookPath("fossil"); err != nil {
+		t.Skip("fossil not on PATH")
+	}
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+	dir := buildLiveFixture(t)
+	// Modify the fossil-tracked file to make git dirty on a tracked path.
+	must(t, os.WriteFile(filepath.Join(dir, "a.txt"), []byte("locally edited\n"), 0o644))
+	t.Chdir(dir)
 	cmd := &ApplyCmd{}
 	err := cmd.Run(&libfossilcli.Globals{})
-	if err == nil {
-		t.Fatal("expected an error from stub Run, got nil")
+	if err == nil || !strings.Contains(err.Error(), "uncommitted changes") {
+		t.Fatalf("expected uncommitted-changes refusal, got %v", err)
 	}
-	if !strings.Contains(err.Error(), "not yet implemented") {
-		t.Fatalf("expected 'not yet implemented' in error, got: %v", err)
-	}
+}
+
+// buildLiveFixture creates a tmpdir containing a fossil hub repo with
+// one commit and a git repo whose working tree matches the fossil tip.
+// Used by Run-level tests.
+func buildLiveFixture(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	must(t, os.MkdirAll(filepath.Join(dir, ".bones"), 0o755))
+	must(t, os.MkdirAll(filepath.Join(dir, ".orchestrator"), 0o755))
+
+	hubFossil := filepath.Join(dir, ".orchestrator", "hub.fossil")
+	mustRun(t, "fossil", "new", "--admin-user", "u", hubFossil)
+	wt := filepath.Join(dir, ".bones", "fixture-wt")
+	mustRun(t, "fossil", "open", "--force", hubFossil, "--workdir", wt)
+	must(t, os.WriteFile(filepath.Join(wt, "a.txt"), []byte("alpha\n"), 0o644))
+	mustRunIn(t, wt, "fossil", "add", "a.txt")
+	mustRunIn(t, wt, "fossil", "commit", "--no-warnings", "--user-override", "u", "-m", "init")
+	mustRunIn(t, wt, "fossil", "close", "--force")
+	must(t, os.RemoveAll(wt))
+
+	mustRunIn(t, dir, "git", "init", "-q")
+	must(t, os.WriteFile(filepath.Join(dir, "a.txt"), []byte("alpha\n"), 0o644))
+	mustRunIn(t, dir, "git", "add", "a.txt")
+	mustRunIn(t, dir, "git", "-c", "user.name=t", "-c", "user.email=t@t",
+		"commit", "-q", "-m", "init")
+	return dir
 }
 
 func TestApplyPreflight_NoWorkspace(t *testing.T) {

--- a/cli/apply_test.go
+++ b/cli/apply_test.go
@@ -147,6 +147,80 @@ func equalStringSets(a, b []string) bool {
 	return true
 }
 
+func TestDirtyTracked_ClearTree(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+	dir := t.TempDir()
+	mustRunIn(t, dir, "git", "init", "-q")
+	if err := os.WriteFile(filepath.Join(dir, "a.txt"), []byte("clean\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mustRunIn(t, dir, "git", "add", ".")
+	mustRunIn(t, dir, "git", "-c", "user.name=t", "-c", "user.email=t@t",
+		"commit", "-q", "-m", "init")
+
+	dirty, err := dirtyTrackedPaths(dir, []string{"a.txt"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(dirty) != 0 {
+		t.Errorf("expected clean, got %v", dirty)
+	}
+}
+
+func TestDirtyTracked_ModifiedFossilPath(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+	dir := t.TempDir()
+	mustRunIn(t, dir, "git", "init", "-q")
+	if err := os.WriteFile(filepath.Join(dir, "a.txt"), []byte("v1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mustRunIn(t, dir, "git", "add", ".")
+	mustRunIn(t, dir, "git", "-c", "user.name=t", "-c", "user.email=t@t",
+		"commit", "-q", "-m", "init")
+	if err := os.WriteFile(filepath.Join(dir, "a.txt"), []byte("v2\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	dirty, err := dirtyTrackedPaths(dir, []string{"a.txt"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(dirty) != 1 || dirty[0] != "a.txt" {
+		t.Errorf("expected [a.txt], got %v", dirty)
+	}
+}
+
+func TestDirtyTracked_UntrackedFileIgnored(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+	dir := t.TempDir()
+	mustRunIn(t, dir, "git", "init", "-q")
+	if err := os.WriteFile(filepath.Join(dir, "a.txt"), []byte("v1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mustRunIn(t, dir, "git", "add", "a.txt")
+	mustRunIn(t, dir, "git", "-c", "user.name=t", "-c", "user.email=t@t",
+		"commit", "-q", "-m", "init")
+	// Untracked scratch file outside the manifest. dirtyTrackedPaths
+	// must ignore it; it's not fossil's concern.
+	if err := os.WriteFile(filepath.Join(dir, "scratch.tmp"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	dirty, err := dirtyTrackedPaths(dir, []string{"a.txt"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(dirty) != 0 {
+		t.Errorf("untracked scratch.tmp should not count; got %v", dirty)
+	}
+}
+
 // setupApplyFixture creates a tmpdir containing a bones workspace
 // marker, an empty hub.fossil placeholder file, and a .git/ directory.
 // Sufficient for preflight checks; tests that exercise actual fossil

--- a/cli/apply_test.go
+++ b/cli/apply_test.go
@@ -310,6 +310,57 @@ func TestLastAppliedMarker_RoundTrip(t *testing.T) {
 	}
 }
 
+func TestApplyPlan_WritesAndDeletesAndStages(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+	dir := t.TempDir()
+	root := dir
+	temp := filepath.Join(dir, "tmp-checkout")
+	must(t, os.MkdirAll(temp, 0o755))
+
+	mustRunIn(t, root, "git", "init", "-q")
+	must(t, os.WriteFile(filepath.Join(root, "keep.txt"), []byte("same"), 0o644))
+	must(t, os.WriteFile(filepath.Join(root, "delete.txt"), []byte("gone"), 0o644))
+	mustRunIn(t, root, "git", "add", ".")
+	mustRunIn(t, root, "git", "-c", "user.name=t", "-c", "user.email=t@t",
+		"commit", "-q", "-m", "init")
+
+	must(t, os.WriteFile(filepath.Join(temp, "keep.txt"), []byte("same"), 0o644))
+	must(t, os.WriteFile(filepath.Join(temp, "add.txt"), []byte("new"), 0o644))
+
+	plan := &applyPlan{
+		Added:   []string{"add.txt"},
+		Deleted: []string{"delete.txt"},
+	}
+	if err := applyPlanToTree(temp, root, plan); err != nil {
+		t.Fatalf("applyPlanToTree: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "add.txt")); err != nil {
+		t.Errorf("add.txt should exist: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "delete.txt")); !os.IsNotExist(err) {
+		t.Errorf("delete.txt should be gone, got err=%v", err)
+	}
+	out, err := exec.Command("git", "-C", root, "diff", "--staged", "--name-only").Output()
+	if err != nil {
+		t.Fatal(err)
+	}
+	staged := strings.Fields(string(out))
+	if !contains(staged, "add.txt") || !contains(staged, "delete.txt") {
+		t.Errorf("expected add.txt and delete.txt staged; got %v", staged)
+	}
+}
+
+func contains(haystack []string, needle string) bool {
+	for _, h := range haystack {
+		if h == needle {
+			return true
+		}
+	}
+	return false
+}
+
 // setupApplyFixture creates a tmpdir containing a bones workspace
 // marker, an empty hub.fossil placeholder file, and a .git/ directory.
 // Sufficient for preflight checks; tests that exercise actual fossil

--- a/cli/apply_test.go
+++ b/cli/apply_test.go
@@ -71,6 +71,82 @@ func TestApplyPreflight_HappyPath(t *testing.T) {
 	}
 }
 
+func TestTrunkManifest_RealFossilRepo(t *testing.T) {
+	if _, err := exec.LookPath("fossil"); err != nil {
+		t.Skip("fossil not on PATH")
+	}
+	dir := t.TempDir()
+	hubFossil := filepath.Join(dir, "hub.fossil")
+	wt := filepath.Join(dir, "wt")
+
+	mustRun(t, "fossil", "new", "--admin-user", "u", hubFossil)
+	mustRun(t, "fossil", "open", "--force", hubFossil, "--workdir", wt)
+	defer mustRunIn(t, wt, "fossil", "close", "--force")
+
+	if err := os.WriteFile(filepath.Join(wt, "a.txt"), []byte("alpha\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(wt, "sub"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(wt, "sub", "b.txt"), []byte("beta\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mustRunIn(t, wt, "fossil", "add", "a.txt", "sub/b.txt")
+	mustRunIn(t, wt, "fossil", "commit", "--no-warnings", "--user-override", "u", "-m", "init")
+
+	paths, rev, err := trunkManifest(hubFossil, "fossil")
+	if err != nil {
+		t.Fatalf("trunkManifest: %v", err)
+	}
+	if !equalStringSets(paths, []string{"a.txt", "sub/b.txt"}) {
+		t.Errorf("manifest = %v, want [a.txt sub/b.txt]", paths)
+	}
+	if len(rev) < 12 {
+		t.Errorf("expected hex rev, got %q", rev)
+	}
+}
+
+func mustRun(t *testing.T, name string, args ...string) {
+	t.Helper()
+	cmd := exec.Command(name, args...)
+	cmd.Env = append(os.Environ(), "USER=u")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("%s %v: %v\n%s", name, args, err, out)
+	}
+}
+
+func mustRunIn(t *testing.T, dir, name string, args ...string) {
+	t.Helper()
+	cmd := exec.Command(name, args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "USER=u")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("%s %v in %s: %v\n%s", name, args, dir, err, out)
+	}
+}
+
+func equalStringSets(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	seen := make(map[string]int, len(a))
+	for _, s := range a {
+		seen[s]++
+	}
+	for _, s := range b {
+		seen[s]--
+	}
+	for _, n := range seen {
+		if n != 0 {
+			return false
+		}
+	}
+	return true
+}
+
 // setupApplyFixture creates a tmpdir containing a bones workspace
 // marker, an empty hub.fossil placeholder file, and a .git/ directory.
 // Sufficient for preflight checks; tests that exercise actual fossil

--- a/cli/apply_test.go
+++ b/cli/apply_test.go
@@ -1,0 +1,19 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	libfossilcli "github.com/danmestas/libfossil/cli"
+)
+
+func TestApplyCmd_StubReturnsNotImplemented(t *testing.T) {
+	cmd := &ApplyCmd{}
+	err := cmd.Run(&libfossilcli.Globals{})
+	if err == nil {
+		t.Fatal("expected an error from stub Run, got nil")
+	}
+	if !strings.Contains(err.Error(), "not yet implemented") {
+		t.Fatalf("expected 'not yet implemented' in error, got: %v", err)
+	}
+}

--- a/cli/apply_test.go
+++ b/cli/apply_test.go
@@ -46,7 +46,8 @@ func TestApplyRun_DryRunDoesNotStage(t *testing.T) {
 	mustRun(t, "fossil", "open", "--force", hubFossil, "--workdir", wt)
 	must(t, os.WriteFile(filepath.Join(wt, "newfile.txt"), []byte("added\n"), 0o644))
 	mustRunIn(t, wt, "fossil", "add", "newfile.txt")
-	mustRunIn(t, wt, "fossil", "commit", "--no-warnings", "--user-override", "u", "-m", "add newfile")
+	mustRunIn(t, wt, "fossil", "commit", "--no-warnings",
+		"--user-override", "u", "-m", "add newfile")
 	mustRunIn(t, wt, "fossil", "close", "--force")
 
 	t.Chdir(dir)

--- a/cli/apply_test.go
+++ b/cli/apply_test.go
@@ -1,6 +1,9 @@
 package cli
 
 import (
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -16,4 +19,77 @@ func TestApplyCmd_StubReturnsNotImplemented(t *testing.T) {
 	if !strings.Contains(err.Error(), "not yet implemented") {
 		t.Fatalf("expected 'not yet implemented' in error, got: %v", err)
 	}
+}
+
+func TestApplyPreflight_NoWorkspace(t *testing.T) {
+	dir := t.TempDir()
+	_, err := runApplyPreflight(dir)
+	if err == nil || !strings.Contains(err.Error(), "workspace not found") {
+		t.Fatalf("expected 'workspace not found' error, got %v", err)
+	}
+}
+
+func TestApplyPreflight_NoHubFossil(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".bones"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	_, err := runApplyPreflight(dir)
+	if err == nil || !strings.Contains(err.Error(), "hub repo not found") {
+		t.Fatalf("expected 'hub repo not found' error, got %v", err)
+	}
+}
+
+func TestApplyPreflight_NoGitRepo(t *testing.T) {
+	dir := setupApplyFixture(t)
+	if err := os.RemoveAll(filepath.Join(dir, ".git")); err != nil {
+		t.Fatal(err)
+	}
+	_, err := runApplyPreflight(dir)
+	if err == nil || !strings.Contains(err.Error(), "no git repo") {
+		t.Fatalf("expected 'no git repo' error, got %v", err)
+	}
+}
+
+func TestApplyPreflight_HappyPath(t *testing.T) {
+	if _, err := exec.LookPath("fossil"); err != nil {
+		t.Skip("fossil not on PATH")
+	}
+	dir := setupApplyFixture(t)
+	pre, err := runApplyPreflight(dir)
+	if err != nil {
+		t.Fatalf("runApplyPreflight: %v", err)
+	}
+	if pre.WorkspaceDir != dir {
+		t.Errorf("WorkspaceDir = %q, want %q", pre.WorkspaceDir, dir)
+	}
+	if pre.HubFossil != filepath.Join(dir, ".orchestrator", "hub.fossil") {
+		t.Errorf("HubFossil = %q", pre.HubFossil)
+	}
+	if pre.FossilBin == "" {
+		t.Errorf("FossilBin should be resolved")
+	}
+}
+
+// setupApplyFixture creates a tmpdir containing a bones workspace
+// marker, an empty hub.fossil placeholder file, and a .git/ directory.
+// Sufficient for preflight checks; tests that exercise actual fossil
+// ops should build a real fossil repo on top of this.
+func setupApplyFixture(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".bones"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, ".orchestrator"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".orchestrator", "hub.fossil"),
+		[]byte{}, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return dir
 }

--- a/cli/apply_test.go
+++ b/cli/apply_test.go
@@ -77,7 +77,7 @@ func TestApplyRun_DirtyTreeRefuses(t *testing.T) {
 	t.Chdir(dir)
 	cmd := &ApplyCmd{}
 	err := cmd.Run(&libfossilcli.Globals{})
-	if err == nil || !strings.Contains(err.Error(), "uncommitted changes") {
+	if err == nil || !strings.Contains(err.Error(), "bones apply: uncommitted changes") {
 		t.Fatalf("expected uncommitted-changes refusal, got %v", err)
 	}
 }

--- a/cli/apply_test.go
+++ b/cli/apply_test.go
@@ -221,6 +221,69 @@ func TestDirtyTracked_UntrackedFileIgnored(t *testing.T) {
 	}
 }
 
+func TestClassifyDiff_AddModifyDeleteNoOp(t *testing.T) {
+	dir := t.TempDir()
+	root := filepath.Join(dir, "root")
+	temp := filepath.Join(dir, "temp")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(temp, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	must(t, os.WriteFile(filepath.Join(root, "keep.txt"), []byte("same"), 0o644))
+	must(t, os.WriteFile(filepath.Join(temp, "keep.txt"), []byte("same"), 0o644))
+
+	must(t, os.WriteFile(filepath.Join(root, "modify.txt"), []byte("v1"), 0o644))
+	must(t, os.WriteFile(filepath.Join(temp, "modify.txt"), []byte("v2"), 0o644))
+
+	must(t, os.WriteFile(filepath.Join(temp, "add.txt"), []byte("new"), 0o644))
+
+	must(t, os.WriteFile(filepath.Join(root, "delete.txt"), []byte("gone"), 0o644))
+
+	manifest := []string{"keep.txt", "modify.txt", "add.txt"}
+	prev := []string{"keep.txt", "modify.txt", "delete.txt"}
+
+	plan, err := classifyDiff(temp, root, manifest, prev)
+	if err != nil {
+		t.Fatalf("classifyDiff: %v", err)
+	}
+	if !equalStringSets(plan.Added, []string{"add.txt"}) {
+		t.Errorf("Added = %v, want [add.txt]", plan.Added)
+	}
+	if !equalStringSets(plan.Modified, []string{"modify.txt"}) {
+		t.Errorf("Modified = %v, want [modify.txt]", plan.Modified)
+	}
+	if !equalStringSets(plan.Deleted, []string{"delete.txt"}) {
+		t.Errorf("Deleted = %v, want [delete.txt]", plan.Deleted)
+	}
+}
+
+func TestClassifyDiff_NoPrevManifestSuppressesDeletes(t *testing.T) {
+	dir := t.TempDir()
+	root := filepath.Join(dir, "root")
+	temp := filepath.Join(dir, "temp")
+	must(t, os.MkdirAll(root, 0o755))
+	must(t, os.MkdirAll(temp, 0o755))
+	must(t, os.WriteFile(filepath.Join(root, "stray.txt"), []byte("user-added"), 0o644))
+
+	plan, err := classifyDiff(temp, root, []string{}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plan.Deleted) != 0 {
+		t.Errorf("first apply must not delete; got %v", plan.Deleted)
+	}
+}
+
+func must(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 // setupApplyFixture creates a tmpdir containing a bones workspace
 // marker, an empty hub.fossil placeholder file, and a .git/ directory.
 // Sufficient for preflight checks; tests that exercise actual fossil

--- a/cmd/bones/cli.go
+++ b/cmd/bones/cli.go
@@ -17,7 +17,7 @@ type CLI struct {
 	Down  bonescli.DownCmd  `cmd:"" group:"daily" help:"Reverse up: stop hub + clean scaffold"`
 	Tasks bonescli.TasksCmd `cmd:"" group:"daily" help:"Inspect and mutate runtime agent tasks"`
 	Swarm bonescli.SwarmCmd `cmd:"" group:"daily" help:"Run as a slot-shaped swarm participant"`
-	Apply bonescli.ApplyCmd `cmd:"" group:"daily" help:"Materialize hub fossil trunk into git working tree"`
+	Apply bonescli.ApplyCmd `cmd:"" group:"daily" help:"Materialize hub fossil trunk into git tree"`
 
 	// Repository.
 	Repo libfossilcli.RepoCmd `cmd:"" group:"repo" help:"Fossil repository operations"`

--- a/cmd/bones/cli.go
+++ b/cmd/bones/cli.go
@@ -17,6 +17,7 @@ type CLI struct {
 	Down  bonescli.DownCmd  `cmd:"" group:"daily" help:"Reverse up: stop hub + clean scaffold"`
 	Tasks bonescli.TasksCmd `cmd:"" group:"daily" help:"Inspect and mutate runtime agent tasks"`
 	Swarm bonescli.SwarmCmd `cmd:"" group:"daily" help:"Run as a slot-shaped swarm participant"`
+	Apply bonescli.ApplyCmd `cmd:"" group:"daily" help:"Materialize hub fossil trunk into git working tree"`
 
 	// Repository.
 	Repo libfossilcli.RepoCmd `cmd:"" group:"repo" help:"Fossil repository operations"`

--- a/docs/adr/0037-bones-apply.md
+++ b/docs/adr/0037-bones-apply.md
@@ -1,0 +1,39 @@
+# ADR 0037: bones apply — fossil trunk to git materialization
+
+## Context
+
+The hub-leaf architecture (ADR 0023, ADR 0028) commits agent work into a hub fossil's trunk, separate from the user's git history. ADR 0034 references `bones apply` as the user-gated step that lands trunk content into git, but no such command shipped — the README marketing copy described an intent the CLI did not fulfill. Operators ended up materializing fossil trunk into git by hand, which made the audit-trail story of "bones is the substrate" partially fictional.
+
+bones already has the primitives needed: `swarm fan-in` collapses leaves into a single trunk tip; the system fossil binary can extract a tree at any rev. The only missing seam is the controlled write of that tree into the project root with git-side staging so the user can review and commit on their own terms.
+
+## Decision
+
+`bones apply` is a user-facing verb that materializes the hub fossil's trunk tip into the project-root git working tree and stages the changes via `git add -A`. The command never runs `git commit` — the user owns the commit message and the commit author identity, and uses native git tooling (`git diff --staged`, `git add -p`, `git restore --staged`, `git commit`) to gate what lands.
+
+`bones apply` refuses to run if there are uncommitted changes to fossil-tracked paths. Untracked-by-fossil files (editor swaps, build output, anything outside fossil's view) do not block. The refusal is fail-fast with a one-line message; users decide whether to stash, commit, or discard their local edits before re-running apply.
+
+A `.bones/last-applied` marker records the most recently applied trunk rev. The marker scopes the "delete" branch of the diff: a path missing from the current trunk manifest is removed only if it was present in the previously-applied manifest. On first apply (no marker), bones apply is additive-only — user-added files at paths fossil never tracked are left alone.
+
+## Consequences
+
+- The audit-trail story bones tells operators ("agents commit through bones; you sign off; substrate is the source of truth") becomes structurally true. The fossil → git materialization is no longer a manual step that operators sometimes skip.
+- Authorship of git commits stays with the user. Fossil committer history (slot users, hub-leaf merge attribution) lives in the hub fossil as a parallel timeline, not propagated into git. This is the deliberate consequence of the materialize-only design — bones never speaks on the user's behalf in git history.
+- The fossil binary becomes a hard runtime dependency for the apply path (it was already a soft dependency for `swarm fan-in`). Users without it get the same install-hint exit pattern.
+- Dirty-tree refusal trades convenience for safety: an operator with in-flight git work cannot run apply until they resolve it. The alternative (auto-stash) was rejected because forgotten stashes are real.
+- Sits orthogonal to ADR 0034 and ADR 0036. ADR 0034's pre-commit hook prevents *direct git commits* from bypassing the substrate. ADR 0036's prime injection prevents *planning context* from bypassing the substrate. ADR 0037's apply prevents *trunk content from never reaching git*. Each closes one bypass surface.
+
+## Alternatives considered
+
+**Auto-commit after materialize.** Rejected: the user wants to review what's landing and choose the commit message themselves. Auto-committing makes apply a black box; the design choice that drove this ADR was "lean on git for signoff" rather than reinventing review inside bones.
+
+**Auto-stash on dirty tree.** Rejected: hidden state (a forgotten `git stash` entry) compounds with every dirty apply. Refuse-and-message keeps every action explicit.
+
+**Materialize without staging.** Considered. Pro: lets users use `git diff` (unstaged) to review. Con: loses the convenience of `git diff --staged` as the canonical "what would land" view, and the `--staged` view composes better with `git add -p` for partial acceptance. The decision is to materialize and stage; users can `git restore --staged` if they want the unstaged view.
+
+**Per-slot or per-task subset application.** Rejected for the first iteration: trunk-tip only. A future flag (`--slot`, `--task`) is additive but unscoped here.
+
+**Auto-create a `bones-apply/<rev>` branch.** Rejected. Branch management is core git workflow; users already know what branch they want to be on. Auto-creating contradicts the "lean on git" ethos of the materialize-only design. Bones may warn if the user is on `main` without policy, but does not override their choice.
+
+## Status
+
+Accepted, 2026-04-30.

--- a/docs/superpowers/plans/2026-04-30-bones-apply.md
+++ b/docs/superpowers/plans/2026-04-30-bones-apply.md
@@ -1,0 +1,1262 @@
+# bones apply Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the `bones apply` command per `docs/superpowers/specs/2026-04-30-bones-apply-design.md` — materialize the hub fossil's trunk tip into the project-root git working tree and stage the changes for user-gated commit.
+
+**Architecture:** Single Go file `cli/apply.go` housing `ApplyCmd` and helpers; shells out to the `fossil` binary for checkout/manifest (matching `cli/swarm_fanin.go`'s pattern) and the `git` binary for status/add. Pure-Go diff classifier and marker logic kept private but tested directly.
+
+**Tech Stack:** Go, Kong (CLI parsing), `fossil` CLI, `git` CLI. Tests use `testing` and `t.TempDir`.
+
+---
+
+## Spec Reference
+
+Implementation must satisfy `docs/superpowers/specs/2026-04-30-bones-apply-design.md`. Read it before starting.
+
+## File Structure
+
+**Create:**
+- `cli/apply.go` — `ApplyCmd` struct, `Run`, all helpers
+- `cli/apply_test.go` — unit tests
+- `docs/adr/0037-bones-apply.md` — architecture record
+
+**Modify:**
+- `cmd/bones/cli.go:16-19` — register `Apply bonescli.ApplyCmd` in the `daily` group
+
+## Tasks
+
+### Task 1: ApplyCmd skeleton and CLI registration
+
+**Files:**
+- Create: `cli/apply.go`
+- Modify: `cmd/bones/cli.go`
+- Create: `cli/apply_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+In `cli/apply_test.go`:
+
+```go
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	libfossilcli "github.com/danmestas/libfossil/cli"
+)
+
+func TestApplyCmd_StubReturnsNotImplemented(t *testing.T) {
+	cmd := &ApplyCmd{}
+	err := cmd.Run(&libfossilcli.Globals{})
+	if err == nil {
+		t.Fatal("expected an error from stub Run, got nil")
+	}
+	if !strings.Contains(err.Error(), "not yet implemented") {
+		t.Fatalf("expected 'not yet implemented' in error, got: %v", err)
+	}
+}
+```
+
+- [ ] **Step 2: Run test, expect FAIL**
+
+```
+go test ./cli/ -run TestApplyCmd_StubReturnsNotImplemented -v
+```
+Expected: FAIL — `ApplyCmd` does not exist.
+
+- [ ] **Step 3: Create the skeleton in `cli/apply.go`**
+
+```go
+package cli
+
+import (
+	"errors"
+
+	libfossilcli "github.com/danmestas/libfossil/cli"
+)
+
+// ApplyCmd materializes the hub fossil's trunk tip into the
+// project-root git working tree and stages the changes for the user
+// to review and commit. See
+// docs/superpowers/specs/2026-04-30-bones-apply-design.md.
+//
+// bones apply never runs `git commit`. It writes files and stages with
+// `git add -A` within fossil's tracked-paths set; the user owns the
+// commit message and the commit author identity.
+type ApplyCmd struct {
+	DryRun bool `name:"dry-run" help:"show planned changes without writing or staging"`
+}
+
+func (c *ApplyCmd) Run(g *libfossilcli.Globals) error {
+	return errors.New("bones apply: not yet implemented")
+}
+```
+
+- [ ] **Step 4: Register in `cmd/bones/cli.go`** — add this line after `Swarm` (line 19):
+
+```go
+Apply bonescli.ApplyCmd `cmd:"" group:"daily" help:"Materialize hub fossil trunk into git working tree"`
+```
+
+- [ ] **Step 5: Run test + build, expect PASS + clean build**
+
+```
+go test ./cli/ -run TestApplyCmd_StubReturnsNotImplemented -v
+go build ./cmd/bones
+```
+Expected: test PASS, build OK. Then verify `go run ./cmd/bones apply` prints `bones apply: not yet implemented` and exits non-zero.
+
+- [ ] **Step 6: Commit**
+
+```
+git add cli/apply.go cli/apply_test.go cmd/bones/cli.go
+git commit -m "feat(apply): skeleton ApplyCmd registered in CLI"
+```
+
+### Task 2: Preconditions — workspace, hub fossil, git repo, fossil binary
+
+**Files:**
+- Modify: `cli/apply.go`
+- Modify: `cli/apply_test.go`
+
+- [ ] **Step 1: Write failing tests** in `cli/apply_test.go`. Append:
+
+```go
+import (
+	// ... existing imports
+	"os"
+	"path/filepath"
+)
+
+// applyPreflight is the preflight precondition checker. Returns the
+// resolved paths or a user-facing error.
+type applyPreflight struct {
+	WorkspaceDir string
+	HubFossil    string
+	FossilBin    string
+}
+
+func TestApplyPreflight_NoWorkspace(t *testing.T) {
+	dir := t.TempDir()
+	_, err := runApplyPreflight(dir)
+	if err == nil || !strings.Contains(err.Error(), "workspace not found") {
+		t.Fatalf("expected 'workspace not found' error, got %v", err)
+	}
+}
+
+func TestApplyPreflight_NoHubFossil(t *testing.T) {
+	dir := t.TempDir()
+	// Build the bare workspace marker without a hub fossil.
+	if err := os.MkdirAll(filepath.Join(dir, ".bones"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".bones", "workspace"),
+		[]byte("workspace"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := runApplyPreflight(dir)
+	if err == nil || !strings.Contains(err.Error(), "hub repo not found") {
+		t.Fatalf("expected 'hub repo not found' error, got %v", err)
+	}
+}
+
+func TestApplyPreflight_NoGitRepo(t *testing.T) {
+	dir := setupApplyFixture(t) // see helper below
+	if err := os.RemoveAll(filepath.Join(dir, ".git")); err != nil {
+		t.Fatal(err)
+	}
+	_, err := runApplyPreflight(dir)
+	if err == nil || !strings.Contains(err.Error(), "no git repo") {
+		t.Fatalf("expected 'no git repo' error, got %v", err)
+	}
+}
+
+// setupApplyFixture creates a tmpdir with a bones workspace, a hub
+// fossil, and an initialized git repo. Returns the workspace path.
+func setupApplyFixture(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".bones"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".bones", "workspace"),
+		[]byte("workspace"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, ".orchestrator"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// A real hub.fossil requires fossil binary + init; tests can stub
+	// its presence by writing a placeholder file when only the existence
+	// check is exercised. Tests that exercise actual fossil ops should
+	// build a real fossil repo via exec.Command.
+	if err := os.WriteFile(filepath.Join(dir, ".orchestrator", "hub.fossil"),
+		[]byte{}, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+```
+
+The exact `workspace` marker filename matches what `internal/workspace.Init` writes — verify by reading `internal/workspace/workspace.go` before writing the test, and adjust if the marker path or content differs.
+
+- [ ] **Step 2: Run tests, expect FAIL**
+
+```
+go test ./cli/ -run TestApplyPreflight -v
+```
+Expected: FAIL — `runApplyPreflight` does not exist.
+
+- [ ] **Step 3: Implement `runApplyPreflight` in `cli/apply.go`**
+
+```go
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/danmestas/bones/internal/workspace"
+)
+
+func runApplyPreflight(cwd string) (*applyPreflight, error) {
+	info, err := workspace.Join(context.Background(), cwd)
+	if err != nil {
+		return nil, fmt.Errorf("workspace not found: run `bones init` or `bones up` first (%w)", err)
+	}
+	hubRepo := filepath.Join(info.WorkspaceDir, ".orchestrator", "hub.fossil")
+	if _, err := os.Stat(hubRepo); err != nil {
+		return nil, fmt.Errorf("hub repo not found at %s — run `bones up` first", hubRepo)
+	}
+	if _, err := os.Stat(filepath.Join(info.WorkspaceDir, ".git")); err != nil {
+		return nil, fmt.Errorf("no git repo at %s — bones apply requires git for staging", info.WorkspaceDir)
+	}
+	fossilBin, err := exec.LookPath("fossil")
+	if err != nil {
+		return nil, fmt.Errorf(
+			"bones apply requires the system `fossil` binary; install via " +
+				"`brew install fossil` (or apt) and re-run",
+		)
+	}
+	return &applyPreflight{
+		WorkspaceDir: info.WorkspaceDir,
+		HubFossil:    hubRepo,
+		FossilBin:    fossilBin,
+	}, nil
+}
+
+type applyPreflight struct {
+	WorkspaceDir string
+	HubFossil    string
+	FossilBin    string
+}
+```
+
+- [ ] **Step 4: Run tests, expect PASS**
+
+```
+go test ./cli/ -run TestApplyPreflight -v
+```
+
+- [ ] **Step 5: Commit**
+
+```
+git add cli/apply.go cli/apply_test.go
+git commit -m "feat(apply): preflight checks for workspace, hub fossil, git repo, fossil binary"
+```
+
+### Task 3: Trunk manifest extraction
+
+**Files:**
+- Modify: `cli/apply.go`
+- Modify: `cli/apply_test.go`
+
+- [ ] **Step 1: Write failing test**
+
+```go
+func TestTrunkManifest_RealFossilRepo(t *testing.T) {
+	if _, err := exec.LookPath("fossil"); err != nil {
+		t.Skip("fossil not on PATH")
+	}
+	dir := t.TempDir()
+	hubFossil := filepath.Join(dir, "hub.fossil")
+	wt := filepath.Join(dir, "wt")
+
+	// Build a 2-file fossil repo at trunk.
+	mustRun(t, "fossil", "new", "--admin-user", "u", hubFossil)
+	mustRun(t, "fossil", "open", "--force", hubFossil, "--workdir", wt)
+	defer mustRun(t, "fossil", "-R", hubFossil, "close", "--force")
+
+	if err := os.WriteFile(filepath.Join(wt, "a.txt"), []byte("alpha\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(wt, "sub"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(wt, "sub", "b.txt"), []byte("beta\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mustRunIn(t, wt, "fossil", "add", "a.txt", "sub/b.txt")
+	mustRunIn(t, wt, "fossil", "commit", "--no-warnings", "--user-override", "u", "-m", "init")
+
+	paths, rev, err := trunkManifest(hubFossil, "fossil")
+	if err != nil {
+		t.Fatalf("trunkManifest: %v", err)
+	}
+	want := []string{"a.txt", "sub/b.txt"}
+	if !equalStringSlices(paths, want) {
+		t.Errorf("manifest paths = %v, want %v", paths, want)
+	}
+	if rev == "" {
+		t.Errorf("expected non-empty rev")
+	}
+}
+
+func mustRun(t *testing.T, name string, args ...string) {
+	t.Helper()
+	out, err := exec.Command(name, args...).CombinedOutput()
+	if err != nil {
+		t.Fatalf("%s %v: %v\n%s", name, args, err, out)
+	}
+}
+
+func mustRunIn(t *testing.T, dir, name string, args ...string) {
+	t.Helper()
+	cmd := exec.Command(name, args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "USER=u")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("%s %v in %s: %v\n%s", name, args, dir, err, out)
+	}
+}
+
+func equalStringSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+```
+
+- [ ] **Step 2: Run test, expect FAIL** (`trunkManifest` not defined)
+
+```
+go test ./cli/ -run TestTrunkManifest -v
+```
+
+- [ ] **Step 3: Implement `trunkManifest` in `cli/apply.go`**
+
+```go
+import (
+	"strings"
+)
+
+// trunkManifest returns the sorted list of files tracked at the
+// hub fossil's trunk tip and the tip's rev (hex UUID). Reads via
+// `fossil ls -R <repo>` and `fossil info -R <repo> trunk`.
+func trunkManifest(hubFossil, fossilBin string) ([]string, string, error) {
+	out, err := exec.Command(fossilBin, "ls", "-R", hubFossil, "--age").Output()
+	if err != nil {
+		return nil, "", fmt.Errorf("fossil ls: %w", err)
+	}
+	var paths []string
+	for _, line := range strings.Split(string(out), "\n") {
+		// `fossil ls --age` prints "YYYY-MM-DD HH:MM:SS  path" — split off the timestamp.
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		// Two whitespace columns then path. Split on multiple spaces.
+		fields := strings.SplitN(line, "  ", 2)
+		if len(fields) != 2 {
+			// Defensive: if format isn't as expected, fall back to taking
+			// the last whitespace-separated token.
+			parts := strings.Fields(line)
+			paths = append(paths, parts[len(parts)-1])
+			continue
+		}
+		paths = append(paths, strings.TrimSpace(fields[1]))
+	}
+	rev, err := trunkRev(hubFossil, fossilBin)
+	if err != nil {
+		return paths, "", err
+	}
+	return paths, rev, nil
+}
+
+// trunkRev returns the trunk tip's hex UUID via `fossil info`.
+func trunkRev(hubFossil, fossilBin string) (string, error) {
+	out, err := exec.Command(fossilBin, "info", "-R", hubFossil, "trunk").Output()
+	if err != nil {
+		return "", fmt.Errorf("fossil info trunk: %w", err)
+	}
+	for _, line := range strings.Split(string(out), "\n") {
+		// Output line of interest: "uuid: <40-hex>" or "hash: <40-hex>"
+		// (libfossil version-dependent — accept both).
+		line = strings.TrimSpace(line)
+		for _, prefix := range []string{"uuid:", "hash:"} {
+			if strings.HasPrefix(line, prefix) {
+				return strings.TrimSpace(strings.TrimPrefix(line, prefix)), nil
+			}
+		}
+	}
+	return "", fmt.Errorf("could not parse trunk rev from `fossil info`")
+}
+```
+
+- [ ] **Step 4: Run test, expect PASS**
+
+```
+go test ./cli/ -run TestTrunkManifest -v
+```
+
+- [ ] **Step 5: Commit**
+
+```
+git add cli/apply.go cli/apply_test.go
+git commit -m "feat(apply): trunk manifest + rev extraction via fossil binary"
+```
+
+### Task 4: Dirty git tree refusal (filtered to manifest)
+
+**Files:**
+- Modify: `cli/apply.go`
+- Modify: `cli/apply_test.go`
+
+- [ ] **Step 1: Write failing test**
+
+```go
+func TestDirtyTracked_ClearTree(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+	dir := t.TempDir()
+	mustRunIn(t, dir, "git", "init", "-q")
+	if err := os.WriteFile(filepath.Join(dir, "a.txt"), []byte("clean\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mustRunIn(t, dir, "git", "add", ".")
+	mustRunIn(t, dir, "git", "-c", "user.name=t", "-c", "user.email=t@t",
+		"commit", "-q", "-m", "init")
+
+	dirty, err := dirtyTrackedPaths(dir, []string{"a.txt"})
+	if err != nil {
+		t.Fatalf("dirtyTrackedPaths: %v", err)
+	}
+	if len(dirty) != 0 {
+		t.Errorf("expected clean, got %v", dirty)
+	}
+}
+
+func TestDirtyTracked_ModifiedFossilPath(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+	dir := t.TempDir()
+	mustRunIn(t, dir, "git", "init", "-q")
+	if err := os.WriteFile(filepath.Join(dir, "a.txt"), []byte("v1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mustRunIn(t, dir, "git", "add", ".")
+	mustRunIn(t, dir, "git", "-c", "user.name=t", "-c", "user.email=t@t",
+		"commit", "-q", "-m", "init")
+	if err := os.WriteFile(filepath.Join(dir, "a.txt"), []byte("v2\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	dirty, err := dirtyTrackedPaths(dir, []string{"a.txt"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(dirty) != 1 || dirty[0] != "a.txt" {
+		t.Errorf("expected [a.txt], got %v", dirty)
+	}
+}
+
+func TestDirtyTracked_ModifiedNonFossilPathIgnored(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+	dir := t.TempDir()
+	mustRunIn(t, dir, "git", "init", "-q")
+	if err := os.WriteFile(filepath.Join(dir, "a.txt"), []byte("v1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "scratch.tmp"), []byte("scratch\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mustRunIn(t, dir, "git", "add", "a.txt")
+	mustRunIn(t, dir, "git", "-c", "user.name=t", "-c", "user.email=t@t",
+		"commit", "-q", "-m", "init")
+	// Modify a.txt; scratch.tmp is untracked. Manifest only contains a.txt;
+	// the modification to a.txt is the only thing that should count as dirty.
+	// Then revert a.txt to verify nothing remains dirty after.
+	if err := os.WriteFile(filepath.Join(dir, "a.txt"), []byte("v1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	dirty, err := dirtyTrackedPaths(dir, []string{"a.txt"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(dirty) != 0 {
+		t.Errorf("untracked scratch.tmp should not count; got %v", dirty)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests, expect FAIL**
+
+```
+go test ./cli/ -run TestDirtyTracked -v
+```
+
+- [ ] **Step 3: Implement `dirtyTrackedPaths` in `cli/apply.go`**
+
+```go
+// dirtyTrackedPaths returns the subset of fossil-manifest paths that
+// have staged or unstaged modifications in the workspace's git tree.
+// Untracked-by-fossil files are not consulted regardless of their git
+// state.
+func dirtyTrackedPaths(workspaceDir string, manifest []string) ([]string, error) {
+	if len(manifest) == 0 {
+		return nil, nil
+	}
+	manifestSet := make(map[string]struct{}, len(manifest))
+	for _, p := range manifest {
+		manifestSet[p] = struct{}{}
+	}
+	cmd := exec.Command("git", "status", "--porcelain", "--untracked-files=no")
+	cmd.Dir = workspaceDir
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("git status: %w", err)
+	}
+	var dirty []string
+	for _, line := range strings.Split(string(out), "\n") {
+		if len(line) < 4 {
+			continue
+		}
+		// Porcelain v1: "XY <path>" where X = index status, Y = worktree status.
+		path := strings.TrimSpace(line[3:])
+		// Rename lines have the form "R  old -> new"; take the new name.
+		if idx := strings.LastIndex(path, " -> "); idx >= 0 {
+			path = path[idx+4:]
+		}
+		if _, ok := manifestSet[path]; ok {
+			dirty = append(dirty, path)
+		}
+	}
+	return dirty, nil
+}
+```
+
+- [ ] **Step 4: Run tests, expect PASS**
+
+```
+go test ./cli/ -run TestDirtyTracked -v
+```
+
+- [ ] **Step 5: Commit**
+
+```
+git add cli/apply.go cli/apply_test.go
+git commit -m "feat(apply): refuse if fossil-tracked paths are dirty in git"
+```
+
+### Task 5: Diff classifier (pure)
+
+**Files:**
+- Modify: `cli/apply.go`
+- Modify: `cli/apply_test.go`
+
+- [ ] **Step 1: Write failing test**
+
+```go
+func TestClassifyDiff_AddModifyDeleteNoOp(t *testing.T) {
+	dir := t.TempDir()
+	root := filepath.Join(dir, "root")
+	temp := filepath.Join(dir, "temp")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(temp, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// keep.txt: identical bytes in both → no-op
+	must(t, os.WriteFile(filepath.Join(root, "keep.txt"), []byte("same"), 0o644))
+	must(t, os.WriteFile(filepath.Join(temp, "keep.txt"), []byte("same"), 0o644))
+
+	// modify.txt: different bytes → modify
+	must(t, os.WriteFile(filepath.Join(root, "modify.txt"), []byte("v1"), 0o644))
+	must(t, os.WriteFile(filepath.Join(temp, "modify.txt"), []byte("v2"), 0o644))
+
+	// add.txt: only in temp (manifest) → add
+	must(t, os.WriteFile(filepath.Join(temp, "add.txt"), []byte("new"), 0o644))
+
+	// delete.txt: only in root, in prevManifest, not in current → delete
+	must(t, os.WriteFile(filepath.Join(root, "delete.txt"), []byte("gone"), 0o644))
+
+	manifest := []string{"keep.txt", "modify.txt", "add.txt"}
+	prev := []string{"keep.txt", "modify.txt", "delete.txt"}
+
+	plan, err := classifyDiff(temp, root, manifest, prev)
+	if err != nil {
+		t.Fatalf("classifyDiff: %v", err)
+	}
+	if !equalStringSlices(plan.Added, []string{"add.txt"}) {
+		t.Errorf("Added = %v, want [add.txt]", plan.Added)
+	}
+	if !equalStringSlices(plan.Modified, []string{"modify.txt"}) {
+		t.Errorf("Modified = %v, want [modify.txt]", plan.Modified)
+	}
+	if !equalStringSlices(plan.Deleted, []string{"delete.txt"}) {
+		t.Errorf("Deleted = %v, want [delete.txt]", plan.Deleted)
+	}
+}
+
+func TestClassifyDiff_NoPrevManifestSuppressesDeletes(t *testing.T) {
+	dir := t.TempDir()
+	root := filepath.Join(dir, "root")
+	temp := filepath.Join(dir, "temp")
+	must(t, os.MkdirAll(root, 0o755))
+	must(t, os.MkdirAll(temp, 0o755))
+	must(t, os.WriteFile(filepath.Join(root, "stray.txt"), []byte("user-added"), 0o644))
+
+	plan, err := classifyDiff(temp, root, []string{}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plan.Deleted) != 0 {
+		t.Errorf("first apply must not delete; got %v", plan.Deleted)
+	}
+}
+
+func must(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests, expect FAIL**
+
+```
+go test ./cli/ -run TestClassifyDiff -v
+```
+
+- [ ] **Step 3: Implement `classifyDiff` in `cli/apply.go`**
+
+```go
+// applyPlan describes the file ops bones apply will perform.
+type applyPlan struct {
+	Added    []string // in current manifest, missing or different in root
+	Modified []string // in current manifest, present in root, bytes differ
+	Deleted  []string // in prev manifest, NOT in current manifest, present in root
+}
+
+// classifyDiff computes the apply plan by comparing files in tempCheckout
+// (the source of truth — fossil's checkout at trunk tip) against
+// projectRoot (the live working tree). manifest is the trunk-tip path
+// list; prevManifest is the previously-applied path list (nil/empty
+// means "no marker yet, suppress deletions").
+func classifyDiff(tempCheckout, projectRoot string, manifest, prevManifest []string) (*applyPlan, error) {
+	plan := &applyPlan{}
+	for _, p := range manifest {
+		src := filepath.Join(tempCheckout, p)
+		dst := filepath.Join(projectRoot, p)
+		srcBytes, err := os.ReadFile(src)
+		if err != nil {
+			return nil, fmt.Errorf("read source %s: %w", p, err)
+		}
+		dstBytes, err := os.ReadFile(dst)
+		if os.IsNotExist(err) {
+			plan.Added = append(plan.Added, p)
+			continue
+		}
+		if err != nil {
+			return nil, fmt.Errorf("read dest %s: %w", p, err)
+		}
+		if !bytesEqual(srcBytes, dstBytes) {
+			plan.Modified = append(plan.Modified, p)
+		}
+	}
+	if len(prevManifest) > 0 {
+		current := make(map[string]struct{}, len(manifest))
+		for _, p := range manifest {
+			current[p] = struct{}{}
+		}
+		for _, p := range prevManifest {
+			if _, stillThere := current[p]; stillThere {
+				continue
+			}
+			if _, err := os.Stat(filepath.Join(projectRoot, p)); err == nil {
+				plan.Deleted = append(plan.Deleted, p)
+			}
+		}
+	}
+	return plan, nil
+}
+
+func bytesEqual(a, b []byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+```
+
+- [ ] **Step 4: Run tests, expect PASS**
+
+```
+go test ./cli/ -run TestClassifyDiff -v
+```
+
+- [ ] **Step 5: Commit**
+
+```
+git add cli/apply.go cli/apply_test.go
+git commit -m "feat(apply): pure-Go diff classifier (add/modify/delete/no-op)"
+```
+
+### Task 6: Last-applied marker
+
+**Files:**
+- Modify: `cli/apply.go`
+- Modify: `cli/apply_test.go`
+
+- [ ] **Step 1: Write failing tests**
+
+```go
+func TestLastAppliedMarker_AbsentReturnsEmpty(t *testing.T) {
+	dir := t.TempDir()
+	rev, err := readLastAppliedMarker(dir)
+	if err != nil {
+		t.Fatalf("absent should not error: %v", err)
+	}
+	if rev != "" {
+		t.Errorf("expected empty rev, got %q", rev)
+	}
+}
+
+func TestLastAppliedMarker_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	want := "abcdef0123456789"
+	if err := writeLastAppliedMarker(dir, want); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	got, err := readLastAppliedMarker(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Errorf("rev = %q, want %q", got, want)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests, expect FAIL**
+
+```
+go test ./cli/ -run TestLastAppliedMarker -v
+```
+
+- [ ] **Step 3: Implement marker helpers in `cli/apply.go`**
+
+```go
+const lastAppliedFile = ".bones/last-applied"
+
+// readLastAppliedMarker returns the rev recorded at .bones/last-applied,
+// or "" if the marker is absent. Other I/O errors are returned as-is.
+func readLastAppliedMarker(workspaceDir string) (string, error) {
+	data, err := os.ReadFile(filepath.Join(workspaceDir, lastAppliedFile))
+	if os.IsNotExist(err) {
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(data)), nil
+}
+
+// writeLastAppliedMarker writes the rev to .bones/last-applied,
+// creating .bones/ if needed.
+func writeLastAppliedMarker(workspaceDir, rev string) error {
+	dir := filepath.Join(workspaceDir, ".bones")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(dir, "last-applied"), []byte(rev+"\n"), 0o644)
+}
+```
+
+- [ ] **Step 4: Run tests, expect PASS**
+
+```
+go test ./cli/ -run TestLastAppliedMarker -v
+```
+
+- [ ] **Step 5: Commit**
+
+```
+git add cli/apply.go cli/apply_test.go
+git commit -m "feat(apply): last-applied marker (.bones/last-applied) read/write"
+```
+
+### Task 7: Apply step (write/delete files + git add)
+
+**Files:**
+- Modify: `cli/apply.go`
+- Modify: `cli/apply_test.go`
+
+- [ ] **Step 1: Write failing test**
+
+```go
+func TestApplyPlan_WritesAndDeletesAndStages(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+	dir := t.TempDir()
+	root := dir
+	temp := filepath.Join(dir, "tmp-checkout")
+	must(t, os.MkdirAll(temp, 0o755))
+
+	// Initial git state: keep.txt and delete.txt, both committed.
+	mustRunIn(t, root, "git", "init", "-q")
+	must(t, os.WriteFile(filepath.Join(root, "keep.txt"), []byte("same"), 0o644))
+	must(t, os.WriteFile(filepath.Join(root, "delete.txt"), []byte("gone"), 0o644))
+	mustRunIn(t, root, "git", "add", ".")
+	mustRunIn(t, root, "git", "-c", "user.name=t", "-c", "user.email=t@t",
+		"commit", "-q", "-m", "init")
+
+	// Temp checkout: keep.txt (same), modify.txt (new), add.txt (new). delete.txt absent.
+	must(t, os.WriteFile(filepath.Join(temp, "keep.txt"), []byte("same"), 0o644))
+	must(t, os.WriteFile(filepath.Join(temp, "add.txt"), []byte("new"), 0o644))
+
+	plan := &applyPlan{
+		Added:    []string{"add.txt"},
+		Modified: nil,
+		Deleted:  []string{"delete.txt"},
+	}
+	if err := applyPlanToTree(temp, root, plan); err != nil {
+		t.Fatalf("applyPlanToTree: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "add.txt")); err != nil {
+		t.Errorf("add.txt should exist: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "delete.txt")); !os.IsNotExist(err) {
+		t.Errorf("delete.txt should be gone, got err=%v", err)
+	}
+	out, err := exec.Command("git", "-C", root, "diff", "--staged", "--name-only").Output()
+	if err != nil {
+		t.Fatal(err)
+	}
+	staged := strings.Fields(string(out))
+	if !contains(staged, "add.txt") || !contains(staged, "delete.txt") {
+		t.Errorf("expected add.txt and delete.txt staged; got %v", staged)
+	}
+}
+
+func contains(haystack []string, needle string) bool {
+	for _, h := range haystack {
+		if h == needle {
+			return true
+		}
+	}
+	return false
+}
+```
+
+- [ ] **Step 2: Run test, expect FAIL**
+
+```
+go test ./cli/ -run TestApplyPlan_WritesAndDeletesAndStages -v
+```
+
+- [ ] **Step 3: Implement `applyPlanToTree` in `cli/apply.go`**
+
+```go
+// applyPlanToTree writes adds/modifies from tempCheckout into projectRoot,
+// removes deleted paths, and stages everything that changed via
+// `git add -A -- <paths>`.
+func applyPlanToTree(tempCheckout, projectRoot string, plan *applyPlan) error {
+	staging := append([]string(nil), plan.Added...)
+	staging = append(staging, plan.Modified...)
+	for _, p := range append(plan.Added, plan.Modified...) {
+		src := filepath.Join(tempCheckout, p)
+		dst := filepath.Join(projectRoot, p)
+		data, err := os.ReadFile(src)
+		if err != nil {
+			return fmt.Errorf("read %s: %w", p, err)
+		}
+		info, err := os.Stat(src)
+		if err != nil {
+			return fmt.Errorf("stat %s: %w", p, err)
+		}
+		if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+			return fmt.Errorf("mkdir for %s: %w", p, err)
+		}
+		if err := os.WriteFile(dst, data, info.Mode().Perm()); err != nil {
+			return fmt.Errorf("write %s: %w", p, err)
+		}
+	}
+	for _, p := range plan.Deleted {
+		dst := filepath.Join(projectRoot, p)
+		if err := os.Remove(dst); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("remove %s: %w", p, err)
+		}
+		staging = append(staging, p)
+	}
+	if len(staging) == 0 {
+		return nil
+	}
+	args := append([]string{"add", "-A", "--"}, staging...)
+	cmd := exec.Command("git", args...)
+	cmd.Dir = projectRoot
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("git add: %w\n%s", err, out)
+	}
+	return nil
+}
+```
+
+- [ ] **Step 4: Run test, expect PASS**
+
+```
+go test ./cli/ -run TestApplyPlan_WritesAndDeletesAndStages -v
+```
+
+- [ ] **Step 5: Commit**
+
+```
+git add cli/apply.go cli/apply_test.go
+git commit -m "feat(apply): write/delete files and stage with git add"
+```
+
+### Task 8: Run orchestration + dry-run output
+
+**Files:**
+- Modify: `cli/apply.go`
+
+- [ ] **Step 1: Implement `Run` end-to-end** in `cli/apply.go`. Replace the stub:
+
+```go
+func (c *ApplyCmd) Run(g *libfossilcli.Globals) error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("cwd: %w", err)
+	}
+	pre, err := runApplyPreflight(cwd)
+	if err != nil {
+		return err
+	}
+
+	tempDir := filepath.Join(pre.WorkspaceDir, ".bones",
+		fmt.Sprintf("apply-%d", time.Now().UnixNano()))
+	if err := os.MkdirAll(tempDir, 0o755); err != nil {
+		return fmt.Errorf("mkdir temp checkout: %w", err)
+	}
+	defer func() { _ = os.RemoveAll(tempDir) }()
+
+	checkoutCmd := exec.Command(pre.FossilBin, "open", "--force",
+		pre.HubFossil, "--workdir", tempDir)
+	checkoutCmd.Stdout = os.Stderr
+	checkoutCmd.Stderr = os.Stderr
+	if err := checkoutCmd.Run(); err != nil {
+		return fmt.Errorf("fossil open temp checkout: %w", err)
+	}
+	defer func() {
+		closeCmd := exec.Command(pre.FossilBin, "close", "--force")
+		closeCmd.Dir = tempDir
+		_ = closeCmd.Run()
+	}()
+
+	manifest, rev, err := trunkManifest(pre.HubFossil, pre.FossilBin)
+	if err != nil {
+		return err
+	}
+	if dirty, err := dirtyTrackedPaths(pre.WorkspaceDir, manifest); err != nil {
+		return err
+	} else if len(dirty) > 0 {
+		preview := dirty
+		if len(preview) > 3 {
+			preview = preview[:3]
+		}
+		return fmt.Errorf(
+			"uncommitted changes in fossil-tracked files: %s — git stash or commit before applying",
+			strings.Join(preview, ", "))
+	}
+
+	prevRev, err := readLastAppliedMarker(pre.WorkspaceDir)
+	if err != nil {
+		return fmt.Errorf("read last-applied marker: %w", err)
+	}
+	var prevManifest []string
+	if prevRev != "" {
+		prevManifest, err = manifestAtRev(pre.HubFossil, pre.FossilBin, prevRev)
+		if err != nil {
+			fmt.Fprintf(os.Stderr,
+				"bones apply: previous rev %s not found in hub fossil; suppressing deletions\n", prevRev)
+			prevManifest = nil
+		}
+	}
+
+	plan, err := classifyDiff(tempDir, pre.WorkspaceDir, manifest, prevManifest)
+	if err != nil {
+		return err
+	}
+	if len(plan.Added)+len(plan.Modified)+len(plan.Deleted) == 0 {
+		fmt.Printf("bones apply: already up to date at %s\n", shortRev(rev))
+		return writeLastAppliedMarker(pre.WorkspaceDir, rev)
+	}
+
+	if c.DryRun {
+		printApplyDryRun(plan, rev)
+		return nil
+	}
+
+	if err := applyPlanToTree(tempDir, pre.WorkspaceDir, plan); err != nil {
+		return err
+	}
+	if err := writeLastAppliedMarker(pre.WorkspaceDir, rev); err != nil {
+		return fmt.Errorf("write last-applied marker: %w", err)
+	}
+	total := len(plan.Added) + len(plan.Modified) + len(plan.Deleted)
+	fmt.Printf("applied %d changes from trunk @ %s. review with `git diff --staged`. commit when ready.\n",
+		total, shortRev(rev))
+	return nil
+}
+
+// manifestAtRev is a `trunkManifest`-shaped lookup at a specific rev,
+// used for the previously-applied baseline. Returns an error if the
+// rev is unknown to the hub fossil.
+func manifestAtRev(hubFossil, fossilBin, rev string) ([]string, error) {
+	out, err := exec.Command(fossilBin, "ls", "-R", hubFossil, rev).Output()
+	if err != nil {
+		return nil, fmt.Errorf("fossil ls @ %s: %w", rev, err)
+	}
+	var paths []string
+	for _, line := range strings.Split(string(out), "\n") {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			paths = append(paths, line)
+		}
+	}
+	return paths, nil
+}
+
+func shortRev(rev string) string {
+	if len(rev) >= 12 {
+		return rev[:12]
+	}
+	return rev
+}
+
+func printApplyDryRun(plan *applyPlan, rev string) {
+	fmt.Printf("bones apply (dry-run): would apply %d changes from trunk @ %s:\n",
+		len(plan.Added)+len(plan.Modified)+len(plan.Deleted), shortRev(rev))
+	for _, p := range plan.Added {
+		fmt.Printf("  A  %s\n", p)
+	}
+	for _, p := range plan.Modified {
+		fmt.Printf("  M  %s\n", p)
+	}
+	for _, p := range plan.Deleted {
+		fmt.Printf("  D  %s\n", p)
+	}
+}
+```
+
+Add `"time"` to imports.
+
+- [ ] **Step 2: Replace the stub test** in `cli/apply_test.go`. Delete `TestApplyCmd_StubReturnsNotImplemented` (the stub no longer applies). Add a smoke test:
+
+```go
+func TestApplyRun_AlreadyUpToDate(t *testing.T) {
+	if _, err := exec.LookPath("fossil"); err != nil {
+		t.Skip("fossil not on PATH")
+	}
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+	dir := buildLiveFixture(t) // see helper
+	t.Chdir(dir)
+	cmd := &ApplyCmd{}
+	if err := cmd.Run(&libfossilcli.Globals{}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	rev, err := readLastAppliedMarker(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rev == "" {
+		t.Errorf("expected marker to be written on no-op, got empty")
+	}
+}
+
+// buildLiveFixture creates a tmpdir containing a fossil hub repo
+// (with one commit) and a git repo whose working tree matches the
+// fossil tip. Used by Run-level tests.
+func buildLiveFixture(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	must(t, os.MkdirAll(filepath.Join(dir, ".bones"), 0o755))
+	must(t, os.WriteFile(filepath.Join(dir, ".bones", "workspace"),
+		[]byte("workspace"), 0o644))
+	must(t, os.MkdirAll(filepath.Join(dir, ".orchestrator"), 0o755))
+
+	hubFossil := filepath.Join(dir, ".orchestrator", "hub.fossil")
+	mustRun(t, "fossil", "new", "--admin-user", "u", hubFossil)
+	wt := filepath.Join(dir, ".bones", "fixture-wt")
+	mustRun(t, "fossil", "open", "--force", hubFossil, "--workdir", wt)
+	must(t, os.WriteFile(filepath.Join(wt, "a.txt"), []byte("alpha\n"), 0o644))
+	mustRunIn(t, wt, "fossil", "add", "a.txt")
+	mustRunIn(t, wt, "fossil", "commit", "--no-warnings", "--user-override", "u", "-m", "init")
+	mustRunIn(t, wt, "fossil", "close", "--force")
+	must(t, os.RemoveAll(wt))
+
+	mustRunIn(t, dir, "git", "init", "-q")
+	must(t, os.WriteFile(filepath.Join(dir, "a.txt"), []byte("alpha\n"), 0o644))
+	mustRunIn(t, dir, "git", "add", "a.txt")
+	mustRunIn(t, dir, "git", "-c", "user.name=t", "-c", "user.email=t@t",
+		"commit", "-q", "-m", "init")
+	return dir
+}
+```
+
+`t.Chdir` is Go 1.24+. If the toolchain is older, replace with `os.Chdir(dir)` plus a `t.Cleanup` that restores the original cwd.
+
+- [ ] **Step 3: Run the full apply test suite, expect PASS**
+
+```
+go test ./cli/ -run TestApply -v
+go build ./cmd/bones
+```
+
+- [ ] **Step 4: Commit**
+
+```
+git add cli/apply.go cli/apply_test.go
+git commit -m "feat(apply): wire Run end-to-end with dry-run + already-up-to-date"
+```
+
+### Task 9: ADR 0037 documenting bones apply
+
+**Files:**
+- Create: `docs/adr/0037-bones-apply.md`
+
+- [ ] **Step 1: Write ADR**
+
+```markdown
+# ADR 0037: bones apply — fossil trunk to git materialization
+
+## Context
+
+The hub-leaf architecture (ADR 0023, ADR 0028) commits agent work into a hub fossil's trunk, separate from the user's git history. ADR 0034 references `bones apply` as the user-gated step that lands trunk content into git, but no such command shipped — the README marketing copy described an intent the CLI did not fulfill. Operators ended up materializing fossil trunk into git by hand, which made the audit-trail story of "bones is the substrate" partially fictional.
+
+bones already has the primitives needed: `swarm fan-in` collapses leaves into a single trunk tip; the system `fossil` binary can extract a tree at any rev. The only missing seam is the controlled write of that tree into the project root with git-side staging so the user can review and commit on their own terms.
+
+## Decision
+
+Ship `bones apply` as a user-facing verb that materializes the hub fossil's trunk tip into the project-root git working tree and stages the changes via `git add -A`. The command never runs `git commit` — the user owns the commit message and the commit author identity, and uses native git tooling (`git diff --staged`, `git add -p`, `git restore --staged`, `git commit`) to gate what lands.
+
+`bones apply` refuses to run if there are uncommitted changes to fossil-tracked paths. Untracked-by-fossil files (editor swaps, build output, anything outside fossil's view) do not block. The refusal is fail-fast with a one-line message; users decide whether to stash, commit, or discard their local edits before re-running apply.
+
+A `.bones/last-applied` marker records the most recently applied trunk rev. The marker scopes the "delete" branch of the diff: a path missing from the current trunk manifest is removed only if it was present in the previously-applied manifest. On first apply (no marker), bones apply is additive-only — user-added files at paths fossil never tracked are left alone.
+
+## Consequences
+
+- The audit-trail story bones tells operators ("agents commit through bones; you sign off; substrate is the source of truth") becomes structurally true. The fossil → git materialization is no longer a manual step that operators sometimes skip.
+- Authorship of git commits stays with the user. Fossil committer history (slot users, hub-leaf merge attribution) lives in the hub fossil as a parallel timeline, not propagated into git. This is the deliberate consequence of the materialize-only design — bones never speaks on the user's behalf in git history.
+- The `fossil` binary becomes a hard runtime dependency for the apply path (it was already a soft dependency for `swarm fan-in`). Users without it get the same install-hint exit pattern.
+- Dirty-tree refusal trades convenience for safety: an operator with in-flight git work cannot run apply until they resolve it. The alternative (auto-stash) was rejected because forgotten stashes are real.
+
+## Alternatives considered
+
+**Auto-commit after materialize.** Rejected: the user wants to review what's landing and choose the commit message themselves. Auto-committing makes apply a black box; the design choice that drove this ADR was "lean on git for signoff" rather than reinventing review inside bones.
+
+**Auto-stash on dirty tree.** Rejected: hidden state (a forgotten `git stash` entry) compounds with every dirty apply. Refuse-and-message keeps every action explicit.
+
+**Materialize without staging.** Considered. Pro: lets users use `git diff` (unstaged) to review. Con: loses the convenience of `git diff --staged` as the canonical "what would land" view, and the `--staged` view composes better with `git add -p` for partial acceptance. We materialize and stage; users can `git restore --staged` if they want the unstaged view.
+
+**Per-slot or per-task subset application.** Rejected for v1: trunk-tip only. A future flag (`--slot`, `--task`) is additive but unscoped here.
+
+## Status
+
+Accepted, 2026-04-30.
+```
+
+- [ ] **Step 2: Commit**
+
+```
+git add docs/adr/0037-bones-apply.md
+git commit -m "docs(adr): bones apply — fossil trunk to git materialization"
+```
+
+## Verification
+
+After all tasks land:
+
+1. `go test ./cli/ -v -run TestApply` — every Apply* test passes.
+2. `make check` — fmt-check, vet, lint, race, todo-check all green per `CLAUDE.md`.
+3. `go test -tags=otel -short ./...` — full CI-equivalent run green.
+4. **Manual smoke** in a scratch directory:
+   ```
+   mkdir /tmp/bones-apply-smoke && cd /tmp/bones-apply-smoke
+   git init && git -c user.name=t -c user.email=t@t commit --allow-empty -m init
+   bones init && bones up
+   # use a swarm slot to commit a file via the bones flow:
+   bones swarm join --slot=test --task-id=<id from `bones tasks create`>
+   # (...write a file, run `bones swarm commit -m '...'`, then `bones swarm close`...)
+   bones swarm fan-in
+   bones apply --dry-run   # see planned changes
+   bones apply             # writes + stages
+   git diff --staged       # review
+   git commit -m '...'
+   bones apply             # should print "already up to date"
+   ```
+
+## Out of Scope
+
+Captured but not in this plan:
+
+- **Per-slot / per-task subset (`--slot`, `--task`)** — additive flags landing later; spec §"Out of scope".
+- **Reverse direction (git → fossil)** — `swarm commit` already covers committing through bones; not needed.
+- **Auto-pushing or auto-merging the resulting git commit** — the user owns post-commit branch/PR mechanics.
+- **A doctor check for last-applied marker drift vs trunk tip** — useful future addition; not on this branch.
+
+## Self-Review
+
+**Spec coverage:** Each spec section maps to a task —
+- Goal → Tasks 1–8
+- Command shape → Task 1 (skeleton + flag)
+- Preconditions 1–3 → Task 2; Precondition 4 → Task 4; Precondition 5 → Task 2
+- Flow steps 1–10 → Tasks 3, 5, 6, 7, 8
+- Last-applied marker → Task 6 + Task 8 (used in Run)
+- Edge cases → Task 8 (already-up-to-date, dry-run); other edges (binary missing, collisions) covered by precondition flow
+- Authorship → covered by the design (no git commit step exists in implementation)
+- Implementation seam → file layout matches Task file lists
+- Test plan outline → Tasks 2, 4, 5, 6, 7, 8
+
+**Placeholder scan:** No "TBD"/"TODO" patterns. Code blocks are complete. The `t.Chdir` note in Task 8 is a real toolchain caveat, not a placeholder.
+
+**Type consistency:** `applyPlan` (Added/Modified/Deleted) used identically in Tasks 5 and 7. `applyPreflight` (WorkspaceDir/HubFossil/FossilBin) defined in Task 2 and consumed in Task 8. Function names match: `runApplyPreflight`, `trunkManifest`, `dirtyTrackedPaths`, `classifyDiff`, `readLastAppliedMarker`, `writeLastAppliedMarker`, `applyPlanToTree`, `manifestAtRev`, `shortRev`, `printApplyDryRun`. No drift.

--- a/docs/superpowers/specs/2026-04-30-bones-apply-design.md
+++ b/docs/superpowers/specs/2026-04-30-bones-apply-design.md
@@ -1,0 +1,118 @@
+# `bones apply` — design spec
+
+## Goal
+
+Materialize the hub fossil's trunk tip into the project-root git working tree and stage the changes, so the user can review with native git tooling (`git diff --staged`, `git add -p`, `git restore --staged`) and commit on their own. Closes the gap between ADR 0034's "agents commit through fossil" architecture and the user's actual git history.
+
+## Command shape
+
+```
+bones apply [--dry-run]
+```
+
+- No required flags. Targets the current git branch in the current workspace.
+- `--dry-run`: print the list of would-be changes (added / modified / deleted, with byte-delta summary) and exit. No writes, no staging.
+
+The command lives at `cli/apply.go` as `ApplyCmd`, registered in `cli/cli.go` next to `SwarmFanInCmd`. It is a thin verb-style command (KongCLI struct → `Run(g *libfossilcli.Globals) error`) following the same shape as the existing `swarm fan-in`.
+
+## Preconditions (fail fast, exit non-zero with a clear message)
+
+1. **Workspace exists.** `workspace.Join(ctx, cwd)` succeeds. Failure message: `"workspace not found: run \`bones init\` or \`bones up\` first"`.
+2. **Hub fossil exists.** `<workspace>/.orchestrator/hub.fossil` is a regular file. Failure message: `"hub repo not found at <path> — run \`bones up\` first"`.
+3. **Git repo at workspace root.** `<workspace>/.git` exists. Failure message: `"no git repo at <workspace> — bones apply requires git for staging"`.
+4. **Git working tree is clean within fossil's view.** `git status --porcelain` filtered to paths in the trunk-tip manifest is empty. Failure message: `"uncommitted changes in fossil-tracked files: <up-to-3 paths>... — git stash or commit before applying"`. Untracked files outside fossil's view (editor swaps, build output, anything in fossil's ignore-globs) do not block.
+5. **`fossil` binary on PATH.** Same look-up as `cli/swarm_fanin.go:81-87`; same install hint on miss.
+
+## Flow
+
+1. Resolve preconditions (above). On failure, print the specific message and exit non-zero.
+2. Open a temp checkout of the hub fossil at trunk tip:
+   - Path: `<workspace>/.bones/apply-<unix-nano>/`
+   - `fossil open --force <hub.fossil> --workdir <temp>`
+   - Defer `fossil close --force` and `os.RemoveAll(temp)` on every exit path.
+3. Compute the trunk-tip manifest:
+   - Run `fossil ls -R <hub.fossil>` (or in the temp checkout). Each line is one tracked path.
+   - The result is the **scope** for steps 4–6: anything outside the manifest is left alone.
+4. Diff manifest content vs. project-root content:
+   - For each manifest path, read both bytes (temp checkout vs. project root).
+   - **Add:** path in manifest, missing in project root → write.
+   - **Modify:** path in both, bytes differ → overwrite.
+   - **Delete:** path in project root, NOT in current manifest, AND the path WAS in the manifest at the previously-applied rev (looked up via `fossil ls -R <hub.fossil> --rev <prev-rev>` where `<prev-rev>` comes from the last-applied marker) → remove. If no marker exists, suppress all deletions on this run (additive-only first apply).
+   - **No-op:** path in both, bytes identical → skip.
+5. If `--dry-run`: emit a JSON-or-text summary of `{added, modified, deleted}` with paths and byte deltas; exit 0 before any writes.
+6. Write the changes:
+   - Adds + modifies: `os.WriteFile` with the temp-checkout path's mode preserved.
+   - Deletes: `os.Remove`.
+   - Operations are NOT atomic across the working tree — partial failure leaves a partially-applied state. Recovery is `git restore .` (because step 7 stages, so partial writes are visible in the index too); document this in the user-facing message on error.
+7. `git add -A -- <fossil-tracked-paths>` to stage all changed paths within fossil's view. Untracked-and-fossil-ignored files are not touched.
+8. Tear down temp checkout (deferred).
+9. Update the last-applied marker at `<workspace>/.bones/last-applied` with the trunk-tip rev (single line, hex UUID). This is what step 4's "delete" branch consults next time.
+10. Print a single-line summary:
+    ```
+    applied N changes from trunk @ <short-rev>. review with `git diff --staged`. commit when ready.
+    ```
+
+## Last-applied marker
+
+A plain-text file at `<workspace>/.bones/last-applied` storing the hex fossil UUID of the most recently applied trunk tip. Used to scope step 4's "delete" branch — without it, a user-added file at a path that was never in fossil would get incorrectly deleted on first apply.
+
+If the marker is absent (fresh workspace, or first apply ever), the delete branch is suppressed entirely: bones apply behaves as additive-only on first run. The user can clean up stragglers manually if needed.
+
+The marker is written only on successful apply (after step 7). Dry-run does not update it.
+
+## Edge cases
+
+| Case | Behavior |
+|---|---|
+| Trunk tip == working tree (no diffs) | Print `"already up to date at <short-rev>"`, exit 0. Write/update the marker so subsequent runs have a delete-baseline; no staging. |
+| Fossil binary missing | Same install-hint exit as `swarm fan-in` (`cli/swarm_fanin.go:82-87`). |
+| Manifest path collides with an untracked file at same path | Refuse, print the colliding path, exit non-zero. The user must decide: delete the stray file, or move it. |
+| File mode mismatch (e.g., executable bit) | Re-apply mode from the temp checkout. Fossil tracks mode; honor it. |
+| Symlinks | Fossil-style symlinks are honored if `fossil settings allow-symlinks` was set when committed. Non-symlink fossil treatment (default) writes a regular file containing the target path; preserve that as-is. |
+| Permission error writing a file | Bubble the offending path; partial-state recovery is `git restore .`. |
+| `.bones/last-applied` exists but points to an unknown rev (e.g., user pruned the fossil) | Treat as absent (suppress delete branch); log a warning. |
+
+## Authorship
+
+`bones apply` does not run `git commit`. Authorship of the resulting commit is the user's git config — their choice of message, their `user.name`. The fossil commit history (slot users like `slot/foo`, hub-leaf merge attribution from `swarm fan-in`) stays in the hub fossil as the audit trail; it is not propagated to the git commit.
+
+This is a deliberate consequence of design choice C from brainstorming: bones materializes, the user gates. Bones never speaks on the user's behalf in git history.
+
+## Out of scope
+
+- **Reverse direction (git → fossil).** Not what apply does; `swarm commit` is the path for committing through bones.
+- **Per-slot or per-task subset application.** Default and only mode is whole trunk tip. A future `--slot=<name>` or `--task=<id>` flag is additive but unscoped here.
+- **Non-current branch targeting.** No `--branch` flag. User is expected to `git checkout <target>` before running apply.
+- **Auto-pushing or auto-merging.** Out. User commits, then chooses what to do with the commit.
+- **Conflict resolution.** Refusal-on-dirty (precondition 4) means we never reach a conflict scenario. If we did, we'd surface and exit; we would not 3-way merge.
+- **Tracking which fossil commits map to which git commits.** Not maintained. The hub fossil and git history are parallel timelines; the marker is the only correlation point.
+
+## Implementation seam
+
+| File | Purpose |
+|---|---|
+| `cli/apply.go` (new) | `ApplyCmd` struct, `Run` method, and the CLI orchestration. |
+| `cli/cli.go` | Register `ApplyCmd` next to `SwarmFanInCmd` in the Kong command list. |
+| `cli/apply_test.go` (new) | Table-driven unit tests for precondition failures, dry-run output, the diff classifier (add/modify/delete/no-op), and last-applied marker handling. |
+| `internal/apply/` (optional, only if logic exceeds ~200 LOC in `cli/apply.go`) | Pure-Go helpers for manifest walking and diff classification, kept testable without `fossil` binary in the test loop. |
+
+The implementation reuses `cli/swarm_fanin.go`'s `runFossil` / `runFossilIn` / `fossilEnv` helpers — extract them into a small shared file (`cli/fossil_exec.go` or similar) if convenient, or duplicate if extraction adds churn.
+
+## Test plan outline
+
+- Precondition failures: missing workspace, missing hub fossil, no git repo, dirty working tree (within fossil view), missing fossil binary. Each produces the documented message and exit code.
+- Dry-run output stable across runs (no temp paths leaking into the diff list).
+- Add / modify / delete / no-op classification: build a fixture hub fossil + project-root tree pair where one of each case is exercised; assert the classifier output.
+- Last-applied marker: absent → suppress delete; present-and-valid → enable delete; present-but-stale → suppress delete with warning.
+- "Already up to date" no-op path: assert exit 0 and no staging side effects.
+- Untracked-file collision: assert refusal with the colliding path.
+
+End-to-end smoke (manual or scripted): `bones init && bones up`, hand-author a fossil commit on trunk via `swarm commit` from a slot, run `bones apply` on a clean main, observe the staged diff, run `git commit -m '...'`, run `bones apply` again, observe "already up to date".
+
+## References
+
+- ADR 0023 — Hub-leaf orchestrator (where the fossil-checkout-at-project-root design is decided).
+- ADR 0028 — `bones swarm` verbs (commit / fan-in / close lineage).
+- ADR 0034 — Prevent silent bypass of the bones substrate (the architectural assumption that user-gated apply exists).
+- ADR 0036 — Prime on session boundaries (orthogonal but adjacent: prime is the planning-context surface, apply is the code-materialization surface).
+- `cli/swarm_fanin.go` — implementation pattern for fossil-binary-shelling commands.

--- a/internal/workspace/walk.go
+++ b/internal/workspace/walk.go
@@ -13,6 +13,18 @@ const markerDirName = ".bones"
 // a runtime or filesystem anomaly.
 const maxWalkUpDepth = 64
 
+// FindRoot is the unauthenticated workspace lookup: walks up from start
+// until it finds a directory containing the .bones marker dir, returns
+// that directory, or ErrNoWorkspace if the filesystem root is reached.
+//
+// Unlike Join, FindRoot does not load config.json or contact the leaf
+// daemon — useful for commands that only need the workspace path
+// (e.g. bones apply, which materializes from the hub fossil and never
+// talks to the leaf).
+func FindRoot(start string) (string, error) {
+	return walkUp(start)
+}
+
 // walkUp searches from start upward for a directory containing markerDirName.
 // Returns the path of the directory containing it, or ErrNoWorkspace if the
 // filesystem root is reached without finding one.


### PR DESCRIPTION
## Summary

- New `bones apply` command materializes the hub fossil's trunk tip into the project-root git working tree and stages the changes for the user to review and commit.
- Refuses if any fossil-tracked path has uncommitted git changes — the user is the gate; uncommitted work is intent we don't clobber.
- `--dry-run` prints the planned change set (A/M/D paths) without writing or staging.
- `.bones/last-applied` marker scopes the "delete" branch so first apply is additive-only.
- ADR 0037 documents the architecture; orthogonal to ADR 0034 (commit-bypass) and ADR 0036 (planning-context-bypass).

## Why

ADR 0034 referenced `bones apply` as the user-gated step that lands trunk into git, but no such command shipped — README marketing copy described an intent the CLI did not fulfill, and operators ended up materializing trunk → git by hand. This PR closes that gap so the audit-trail story bones tells is structurally true.

## Design choice: lean on git for signoff

`bones apply` never runs `git commit`. The user gates with native git tooling (`git diff --staged`, `git add -p`, `git restore --staged`, `git commit`). Bones materializes; user reviews; user commits. Authorship of git history stays with the user.

## Test plan

- [x] `go test ./cli/ -v -run TestApply` — all preflight, dirty-tree, manifest, classifier, marker, apply, and Run tests pass (E2E flows exercised via real fossil + git fixtures)
- [x] `make check` — fmt-check, vet, lint, race, todo-check all green
- [x] `go test -tags=otel -short ./...` — full CI-equivalent run green
- [x] Spec at `docs/superpowers/specs/2026-04-30-bones-apply-design.md`
- [x] Plan at `docs/superpowers/plans/2026-04-30-bones-apply.md`