### PR TITLE
chore: add local dev hygiene targets and pre-push hook

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Pre-push hook — runs `make ci-fast` (~60s) to catch obvious breakage
+# before pushing. Mirrors a fast subset of GitHub CI.
+#
+# Skip with: git push --no-verify
+
+set -e
+echo "[pre-push] running make ci-fast..."
+cd "$(git rev-parse --show-toplevel)"
+make ci-fast

--- a/.github/RELEASE_TEMPLATE.md
+++ b/.github/RELEASE_TEMPLATE.md
@@ -1,0 +1,13 @@
+<!-- Edit before tagging. The `make release` target appends `git log --oneline` since the previous tag below this template, then opens $EDITOR. Save and quit to create the annotated tag. -->
+
+## Highlights
+
+-
+
+## Breaking changes
+
+None.
+
+## Upgrade notes
+
+-

--- a/Makefile
+++ b/Makefile
@@ -95,3 +95,17 @@ bin:
 
 bones: bin
 	go build -o bin/bones ./cmd/bones
+
+# CI mirror — runs make check + otel lanes from .github/workflows/ci.yml.
+# Cross-repo leaf-binary integration is CI-only.
+.PHONY: ci ci-fast
+ci:
+	$(MAKE) check
+	go build -tags=otel ./...
+	go test -tags=otel -short ./... -count=1
+
+# Fast subset for pre-push hook (~30-60s; no -tags=otel, no -race).
+ci-fast:
+	go vet ./...
+	go build ./...
+	go test -short -count=1 -timeout=30s ./...

--- a/Makefile
+++ b/Makefile
@@ -109,3 +109,25 @@ ci-fast:
 	go vet ./...
 	go build ./...
 	go test -short -count=1 -timeout=30s ./...
+
+.PHONY: release
+release:
+	@test -n "$(VERSION)" || { echo "VERSION=vX.Y.Z required"; exit 1; }
+	@echo "$(VERSION)" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+(-.+)?$$' || { echo "bad version format: $(VERSION)"; exit 1; }
+	@git diff --quiet || { echo "tree dirty; commit or stash first"; exit 1; }
+	@git fetch origin --tags
+	@if git rev-parse "$(VERSION)" >/dev/null 2>&1; then echo "tag $(VERSION) already exists"; exit 1; fi
+	@$(MAKE) ci
+	@PREV=$$(git describe --tags --abbrev=0 2>/dev/null || echo ""); \
+	  TMPL=.github/RELEASE_TEMPLATE.md; \
+	  TMP=$$(mktemp); \
+	  { echo "Release $(VERSION)"; echo; \
+	    [ -f $$TMPL ] && { cat $$TMPL; echo; }; \
+	    echo "## Changes"; \
+	    if [ -n "$$PREV" ]; then git log --oneline $$PREV..HEAD; else git log --oneline; fi; } > $$TMP; \
+	  $${EDITOR:-vi} $$TMP; \
+	  git tag -a "$(VERSION)" -F $$TMP; \
+	  rm $$TMP
+	@echo ""
+	@echo "Tag $(VERSION) created locally. To publish:"
+	@echo "  git push origin $(VERSION)"

--- a/Makefile
+++ b/Makefile
@@ -131,3 +131,9 @@ release:
 	@echo ""
 	@echo "Tag $(VERSION) created locally. To publish:"
 	@echo "  git push origin $(VERSION)"
+
+.PHONY: setup-hooks
+setup-hooks:
+	git config core.hooksPath .githooks
+	@echo "Git hooks configured to use .githooks/ directory."
+	@echo "Pre-push runs make ci-fast (~60s). Skip with: git push --no-verify"


### PR DESCRIPTION
## Summary
- Add `make ci` (verbatim mirror of `.github/workflows/ci.yml`)
- Add `make ci-fast` (vet+build+short tests, ~60s for pre-push)
- Add `make release VERSION=...` helper with annotated tag template
- Add `make setup-hooks` (matches libfossil/edgesync pattern)
- Add `.githooks/pre-push` running `make ci-fast`
- Add `.github/RELEASE_TEMPLATE.md` boilerplate

No remote behavior change. Lays groundwork for the upstream-bump
workflow in PR #4 and for consistent release ergonomics.

## Test plan
- [x] `make ci` exits 0 on a clean main
- [x] `make ci-fast` runs in <60s
- [x] `make release VERSION=v9.9.9-test EDITOR=true` validates and creates a local tag, then deleted
- [x] `make setup-hooks` configures \`core.hooksPath\` to \`.githooks/\`
- [x] `git push --dry-run` triggers the pre-push hook
- [x] `make release` rejects bad version formats and missing VERSION

Spec: see libfossil docs/superpowers/specs/2026-04-30-cross-repo-release-automation-design.md