### PR TITLE
fix: per-workspace hub ports + workspace-scoped lifecycle (ADR 0038)

### DIFF
--- a/cli/hub.go
+++ b/cli/hub.go
@@ -40,9 +40,13 @@ type HubCmd struct {
 // servers down on SIGINT/SIGTERM. Foreground mode is the easiest way to
 // see hub logs interactively.
 type HubStartCmd struct {
-	Detach     bool `name:"detach" help:"return immediately after the hub is reachable"`
-	FossilPort int  `name:"fossil-port" help:"Fossil HTTP port" default:"8765"`
-	NATSPort   int  `name:"nats-port" help:"NATS client port" default:"4222"`
+	Detach bool `name:"detach" help:"return immediately after the hub is reachable"`
+	// 0 = let the hub allocate per-workspace (default). The hub records
+	// the resolved URL at .orchestrator/hub-{fossil,nats}-url so a
+	// second workspace can run concurrently on its own free ports.
+	// Pass an explicit non-zero port to pin.
+	FossilPort int `name:"fossil-port" help:"Fossil HTTP port (0 = per-workspace allocation)" default:"0"`
+	NATSPort   int `name:"nats-port" help:"NATS client port (0 = per-workspace allocation)" default:"0"`
 }
 
 func (c *HubStartCmd) Run(g *libfossilcli.Globals) error {

--- a/cli/hub.go
+++ b/cli/hub.go
@@ -45,8 +45,8 @@ type HubStartCmd struct {
 	// the resolved URL at .orchestrator/hub-{fossil,nats}-url so a
 	// second workspace can run concurrently on its own free ports.
 	// Pass an explicit non-zero port to pin.
-	FossilPort int `name:"fossil-port" help:"Fossil HTTP port (0 = per-workspace allocation)" default:"0"`
-	NATSPort   int `name:"nats-port" help:"NATS client port (0 = per-workspace allocation)" default:"0"`
+	FossilPort int `name:"fossil-port" default:"0" help:"Fossil HTTP port (0 = per-ws)"`
+	NATSPort   int `name:"nats-port" default:"0" help:"NATS client port (0 = per-ws)"`
 }
 
 func (c *HubStartCmd) Run(g *libfossilcli.Globals) error {

--- a/cli/orchestrator.go
+++ b/cli/orchestrator.go
@@ -111,8 +111,15 @@ func mergeSettings(path string) error {
 	addHook(hooks, "SessionStart", "bones tasks prime --json")
 	addHook(hooks, "SessionStart", "bash .orchestrator/scripts/hub-bootstrap.sh")
 	addHook(hooks, "PreCompact", "bones tasks prime --json")
+
+	// The hub is a workspace-scoped daemon (per-workspace pid files +
+	// per-workspace ports). Tying its teardown to SessionEnd was a bug:
+	// closing one Claude session would kill a hub another workspace, or
+	// even another concurrent session in the same workspace, may still
+	// be using. `bones down` is the explicit teardown; SessionEnd no
+	// longer carries hub-shutdown.
 	migrateStopToSessionEnd(hooks)
-	addHook(hooks, "SessionEnd", "bash .orchestrator/scripts/hub-shutdown.sh")
+	migrateSessionEndShutdown(hooks)
 
 	root["hooks"] = hooks
 
@@ -127,11 +134,29 @@ func mergeSettings(path string) error {
 }
 
 // migrateStopToSessionEnd removes any hub-shutdown entry under the
-// legacy "Stop" event so it can be re-added under "SessionEnd". The
-// scan is shim-specific (matches the hub-shutdown.sh command) so
-// unrelated Stop hooks the user has installed are preserved.
+// legacy "Stop" event. Originally this freed the entry to be re-added
+// under SessionEnd, but per ADR 0038 we no longer add it there either —
+// the migration now just prunes the legacy entry. The scan is
+// shim-specific (matches the hub-shutdown.sh command) so unrelated Stop
+// hooks the user has installed are preserved.
 func migrateStopToSessionEnd(hooks map[string]any) {
-	groups, _ := hooks["Stop"].([]any)
+	pruneHubShutdown(hooks, "Stop")
+}
+
+// migrateSessionEndShutdown drops the bones-managed hub-shutdown entry
+// from the SessionEnd event for workspaces scaffolded before ADR 0038.
+// The hub is workspace-scoped now and only torn down by `bones down`;
+// SessionEnd should not stop it.
+func migrateSessionEndShutdown(hooks map[string]any) {
+	pruneHubShutdown(hooks, "SessionEnd")
+}
+
+// pruneHubShutdown is the shared body of the two hub-shutdown migrations.
+// It walks hooks[event] and drops any entry whose command contains
+// "hub-shutdown.sh", removing empty groups and the event key itself if
+// nothing else lives under it. Unrelated entries are preserved verbatim.
+func pruneHubShutdown(hooks map[string]any, event string) {
+	groups, _ := hooks[event].([]any)
 	if groups == nil {
 		return
 	}
@@ -163,10 +188,10 @@ func migrateStopToSessionEnd(hooks map[string]any) {
 		keep = append(keep, gm)
 	}
 	if len(keep) == 0 {
-		delete(hooks, "Stop")
+		delete(hooks, event)
 		return
 	}
-	hooks["Stop"] = keep
+	hooks[event] = keep
 }
 
 func addHook(hooks map[string]any, event, cmd string) {

--- a/cli/orchestrator_test.go
+++ b/cli/orchestrator_test.go
@@ -94,9 +94,6 @@ func TestScaffoldOrchestrator_PreservesExistingHooks(t *testing.T) {
 	if !strings.Contains(out, "hub-bootstrap.sh") {
 		t.Errorf("hub-bootstrap not added:\n%s", out)
 	}
-	if !strings.Contains(out, "hub-shutdown.sh") {
-		t.Errorf("hub-shutdown not added:\n%s", out)
-	}
 	if !strings.Contains(out, "keepme") {
 		t.Errorf("unrelated top-level key lost:\n%s", out)
 	}
@@ -104,9 +101,10 @@ func TestScaffoldOrchestrator_PreservesExistingHooks(t *testing.T) {
 
 // TestScaffoldOrchestrator_MigrateLegacyStopHook verifies that running
 // scaffoldOrchestrator on a workspace whose settings.json has the
-// hub-shutdown shim under the legacy Stop event migrates it to
-// SessionEnd. Older bones (≤ v0.3.0) installed under Stop, which
-// fired after every assistant turn instead of on session end.
+// hub-shutdown shim under the legacy Stop event drops it. Older bones
+// (≤ v0.3.0) installed under Stop, which fired after every assistant
+// turn. ADR 0035 moved it to SessionEnd; ADR 0038 dropped it entirely
+// (hub is workspace-scoped, only `bones down` stops it).
 func TestScaffoldOrchestrator_MigrateLegacyStopHook(t *testing.T) {
 	dir := t.TempDir()
 	settingsPath := filepath.Join(dir, ".claude", "settings.json")
@@ -150,8 +148,8 @@ func TestScaffoldOrchestrator_MigrateLegacyStopHook(t *testing.T) {
 	if _, ok := hooks["Stop"]; ok {
 		t.Errorf("legacy Stop hook not migrated:\n%s", got)
 	}
-	if _, ok := hooks["SessionEnd"]; !ok {
-		t.Errorf("hub-shutdown not added under SessionEnd:\n%s", got)
+	if strings.Contains(string(got), "hub-shutdown.sh") {
+		t.Errorf("hub-shutdown should not be re-added anywhere (ADR 0038):\n%s", got)
 	}
 }
 
@@ -312,15 +310,98 @@ func verifyHooks(t *testing.T, path string) {
 	if !strings.Contains(out, "hub-bootstrap.sh") {
 		t.Errorf("SessionStart hub-bootstrap missing:\n%s", out)
 	}
-	if !strings.Contains(out, "hub-shutdown.sh") {
-		t.Errorf("SessionEnd hub-shutdown missing:\n%s", out)
+	// Per ADR 0038: hub is workspace-scoped, so the scaffold no longer
+	// installs a SessionEnd hub-shutdown hook. `bones down` is the
+	// explicit teardown.
+	if strings.Contains(out, "hub-shutdown.sh") {
+		t.Errorf("SessionEnd hub-shutdown should not be scaffolded:\n%s", out)
 	}
 	hooks := parsed["hooks"].(map[string]any)
-	if _, ok := hooks["SessionEnd"]; !ok {
-		t.Errorf("hub-shutdown not under SessionEnd:\n%s", out)
-	}
 	if _, ok := hooks["Stop"]; ok {
 		t.Errorf("hub-shutdown leaked into Stop:\n%s", out)
+	}
+}
+
+// TestScaffoldOrchestrator_MigrateLegacySessionEndShutdown verifies that
+// running scaffoldOrchestrator on a workspace whose settings.json has
+// the bones-managed hub-shutdown shim under SessionEnd (the pre-ADR-0038
+// shape) drops it on re-scaffold.
+func TestScaffoldOrchestrator_MigrateLegacySessionEndShutdown(t *testing.T) {
+	dir := t.TempDir()
+	settingsPath := filepath.Join(dir, ".claude", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	legacy := map[string]any{
+		"hooks": map[string]any{
+			"SessionEnd": []any{
+				map[string]any{
+					"matcher": "",
+					"hooks": []any{
+						map[string]any{
+							"command": "bash .orchestrator/scripts/hub-shutdown.sh",
+							"type":    "command",
+							"timeout": float64(10),
+						},
+					},
+				},
+			},
+		},
+	}
+	data, _ := json.MarshalIndent(legacy, "", "  ")
+	if err := os.WriteFile(settingsPath, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := scaffoldOrchestrator(dir); err != nil {
+		t.Fatalf("scaffoldOrchestrator: %v", err)
+	}
+
+	got, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(got), "hub-shutdown.sh") {
+		t.Errorf("legacy SessionEnd hub-shutdown not migrated away:\n%s", got)
+	}
+}
+
+// TestScaffoldOrchestrator_PreservesUnrelatedSessionEndHook ensures the
+// migration only drops the bones shim, not other SessionEnd hooks the
+// user installed.
+func TestScaffoldOrchestrator_PreservesUnrelatedSessionEndHook(t *testing.T) {
+	dir := t.TempDir()
+	settingsPath := filepath.Join(dir, ".claude", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	other := map[string]any{
+		"hooks": map[string]any{
+			"SessionEnd": []any{
+				map[string]any{
+					"matcher": "",
+					"hooks": []any{
+						map[string]any{
+							"command": "echo session ended",
+							"type":    "command",
+						},
+					},
+				},
+			},
+		},
+	}
+	data, _ := json.MarshalIndent(other, "", "  ")
+	if err := os.WriteFile(settingsPath, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := scaffoldOrchestrator(dir); err != nil {
+		t.Fatalf("scaffoldOrchestrator: %v", err)
+	}
+
+	got, _ := os.ReadFile(settingsPath)
+	if !strings.Contains(string(got), "echo session ended") {
+		t.Errorf("unrelated SessionEnd hook lost:\n%s", got)
 	}
 }
 

--- a/cli/swarm.go
+++ b/cli/swarm.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/nats-io/nats.go"
 
+	"github.com/danmestas/bones/internal/hub"
 	"github.com/danmestas/bones/internal/swarm"
 	"github.com/danmestas/bones/internal/workspace"
 )
@@ -89,10 +90,7 @@ func bootstrapResume(
 		return nil, workspace.Info{}, nil, nil, err
 	}
 
-	if hubURL == "" {
-		hubURL = swarm.DefaultHubFossilURL
-	}
-	opts.HubURL = hubURL
+	opts.HubURL = resolveHubURL(hubURL)
 	lease, err := swarm.Resume(ctx, info, slot, opts)
 	if err != nil {
 		stop()
@@ -102,6 +100,34 @@ func bootstrapResume(
 		return nil, workspace.Info{}, nil, nil, fmt.Errorf("%s: %w", verbName, err)
 	}
 	return ctx, info, lease, stop, nil
+}
+
+// resolveHubURL returns the hub fossil HTTP URL for swarm operations,
+// in priority order:
+//  1. override (an explicit `--hub-url=...` flag) wins
+//  2. the workspace's recorded URL at .orchestrator/hub-fossil-url
+//  3. swarm.DefaultHubFossilURL as a legacy fallback for workspaces
+//     scaffolded before per-workspace ports landed
+//
+// The legacy fallback exists so a never-rescaffolded workspace still
+// works; new workspaces always have a recorded URL because the hub
+// writes one on every Start.
+func resolveHubURL(override string) string {
+	if override != "" {
+		return override
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		return swarm.DefaultHubFossilURL
+	}
+	root, err := workspace.FindRoot(cwd)
+	if err != nil {
+		return swarm.DefaultHubFossilURL
+	}
+	if url := hub.FossilURL(root); url != "" {
+		return url
+	}
+	return swarm.DefaultHubFossilURL
 }
 
 // resolveSlot picks the slot to operate on for verbs that allow

--- a/cli/swarm_commit.go
+++ b/cli/swarm_commit.go
@@ -51,11 +51,7 @@ func (c *SwarmCommitCmd) Run(g *libfossilcli.Globals) error {
 	if err != nil {
 		return fmt.Errorf("swarm commit: %w", err)
 	}
-	hubURL := c.HubURL
-	if hubURL == "" {
-		hubURL = swarm.DefaultHubFossilURL
-	}
-	c.emitCommitReport(lease.Slot(), lease.TaskID(), files, res, hubURL)
+	c.emitCommitReport(lease.Slot(), lease.TaskID(), files, res, resolveHubURL(c.HubURL))
 	return nil
 }
 

--- a/cli/swarm_join.go
+++ b/cli/swarm_join.go
@@ -49,12 +49,8 @@ func (c *SwarmJoinCmd) Run(g *libfossilcli.Globals) error {
 }
 
 func (c *SwarmJoinCmd) run(ctx context.Context, info workspace.Info) error {
-	hubURL := c.HubURL
-	if hubURL == "" {
-		hubURL = swarm.DefaultHubFossilURL
-	}
 	lease, err := swarm.Acquire(ctx, info, c.Slot, c.TaskID, swarm.AcquireOpts{
-		HubURL:        hubURL,
+		HubURL:        resolveHubURL(c.HubURL),
 		Caps:          c.Caps,
 		ForceTakeover: c.ForceTakeover,
 		NoAutosync:    c.NoAutosync,

--- a/cli/up.go
+++ b/cli/up.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/danmestas/bones/internal/githook"
+	"github.com/danmestas/bones/internal/hub"
 	"github.com/danmestas/bones/internal/workspace"
 )
 
@@ -52,10 +53,16 @@ func runUp(cwd string) error {
 		return fmt.Errorf("hub-bootstrap: %w", err)
 	}
 
-	if err := waitHubReady("http://127.0.0.1:8765/xfer", 5*time.Second); err != nil {
+	fossilURL := hub.FossilURL(wsDir)
+	natsURL := hub.NATSURL(wsDir)
+	if fossilURL == "" {
+		return fmt.Errorf("hub started but no .orchestrator/hub-fossil-url recorded — " +
+			"check .orchestrator/hub.log")
+	}
+	if err := waitHubReady(fossilURL+"/xfer", 5*time.Second); err != nil {
 		return fmt.Errorf("hub health check: %w", err)
 	}
-	fmt.Println("up: hub is up at http://127.0.0.1:8765 — NATS at nats://127.0.0.1:4222")
+	fmt.Printf("up: hub is up at %s — NATS at %s\n", fossilURL, natsURL)
 	return nil
 }
 

--- a/docs/adr/0038-per-workspace-hub-ports.md
+++ b/docs/adr/0038-per-workspace-hub-ports.md
@@ -1,0 +1,54 @@
+# ADR 0038: Per-workspace hub ports + workspace-scoped lifecycle
+
+## Context
+
+The hub started life as a singleton. ADR 0023 set up the hub-leaf split with a per-workspace fossil checkout, but the hub's HTTP and NATS ports were hardcoded — Fossil on 8765, NATS on 4222 — in `internal/hub/options.go`. Two consequences flowed from that:
+
+1. **Multi-workspace concurrent use was broken.** Bones in workspace B could never bind 8765 or 4222 if workspace A's hub was already running. The second `bones up` (or SessionStart in the second workspace) failed at port-bind time. Pid-file idempotence is per-workspace, so workspace B's hub didn't see A's pid file and wasn't short-circuited; it tried fresh and failed.
+
+2. **Hub lifecycle had two owners.** `bones up` started the hub; the SessionStart hook also started it (idempotent, no-op); but the SessionEnd hook *stopped* it. The workspace-scoped daemon was being torn down by a session-scoped event. A user opening Claude once and closing it left the workspace with no hub — and `bones up`'s help text still claimed the hub was "up." With multi-workspace concurrent use now in scope, the dual-ownership story was actively harmful: closing one Claude session could kill a hub another workspace was relying on.
+
+## Decision
+
+The hub is a workspace-scoped daemon with per-workspace dynamic ports.
+
+### 1. Per-workspace ports
+
+`hub.Start` defaults to ports `0` (was 8765 / 4222). Resolution order when a port arrives as zero:
+
+1. Read the workspace's recorded URL at `<workspace>/.orchestrator/hub-fossil-url` (or `hub-nats-url`) and reuse the recorded port. Steady-state restarts keep stable URLs.
+2. Allocate a free TCP port via `net.Listen("tcp", "127.0.0.1:0")`.
+
+After resolution, `hub.Start` writes both URL files so consumers can discover the live hub without knowing the allocation policy. `hub.Stop` removes them.
+
+Two new public helpers — `hub.FossilURL(root)` and `hub.NATSURL(root)` — return the recorded URLs (or `""` when no hub is running). Consumers (`cli/up.go`, `cli/swarm.go`'s `resolveHubURL`, future `bones doctor`, future `bones tasks status`) read from these helpers.
+
+The `--fossil-port=N` and `--nats-port=N` flags still pin to N when supplied, for diagnostics or fixed-port deployments.
+
+### 2. Workspace-scoped lifecycle
+
+The scaffold no longer installs a SessionEnd `hub-shutdown.sh` hook. Hub teardown lives only in `bones down`, the explicit workspace teardown. SessionStart still runs `hub-bootstrap.sh` — it's idempotent, so it acts as a best-effort recovery if the hub crashed or was manually stopped.
+
+A new migration in `mergeSettings` (`migrateSessionEndShutdown`, layered on the existing `pruneHubShutdown` helper) drops the legacy SessionEnd hub-shutdown entry on re-scaffold. The next `bones up` on an existing workspace silently cleans up the stale hook.
+
+## Consequences
+
+- **Multi-workspace concurrent use works.** Each workspace gets its own ports, recorded in its own `.orchestrator/`. Two `bones up` invocations no longer collide; two Claude sessions in two workspaces no longer fight over port 8765.
+- **Hub lifecycle is single-owner.** `bones up` starts the hub; `bones down` stops it. SessionStart is recovery-only; SessionEnd no longer kills shared state.
+- **URLs are stable across hub restarts.** A `bones hub stop && bones hub start` reuses the recorded port, so consumer URLs don't drift unless the workspace is fully `bones down`'d.
+- **Existing workspaces migrate transparently.** `bones up` rerun on a pre-ADR-0038 workspace prunes the SessionEnd entry and writes URL files on the next hub start.
+- **Consumers must read recorded URLs, not hardcode.** Any future code that talks to the hub looks up `hub.FossilURL(root)` (or `hub.NATSURL(root)`), with `swarm.DefaultHubFossilURL` retained only as a legacy fallback for unrescaffolded workspaces.
+
+## Alternatives considered
+
+**Single global hub multiplexing all workspaces.** Rejected. Cross-workspace NATS subject routing would invade every consumer; the workspace-as-isolation-unit story matches the existing design (per-workspace fossil, per-workspace pid files, per-workspace .bones/).
+
+**Mutex semantics — refuse to start a second workspace while one is up.** Cheaper than dynamic ports, but breaks the user's mental model ("each repo is its own bones") and forces cross-workspace coordination on the user.
+
+**Allocate ports at `bones up` time, store in `.bones/config.json`.** Considered. Rejected because hub state already has its own home (`.orchestrator/`), and tying hub ports to workspace config means re-running `bones up` to recover from a port stuck-in-TIME_WAIT. The recorded-URL-files approach gives the same persistence with cleaner ownership.
+
+**Keep SessionStart as the sole owner (drop hub start from `bones up`).** Considered. Rejected because users expect post-`bones up` to be in a runnable state — `bones doctor`, `bones tasks` (when those move to talk to the hub), and any non-Claude shell access need a hub before SessionStart fires. SessionStart is recovery, not bootstrap.
+
+## Status
+
+Accepted, 2026-04-30.

--- a/internal/hub/hub.go
+++ b/internal/hub/hub.go
@@ -87,6 +87,14 @@ func Start(ctx context.Context, root string, options ...Option) error {
 		return nil
 	}
 
+	// Resolve any zero-valued port to the workspace's recorded port
+	// (recovery / restart) or a fresh free one (first run, or after
+	// `bones down`). Writes the URL files so consumers can discover the
+	// live hub.
+	if err := resolvePorts(p, &o); err != nil {
+		return err
+	}
+
 	if o.detach {
 		return spawnDetachedChild(p, o)
 	}
@@ -227,6 +235,10 @@ func Stop(root string) error {
 		}
 		_ = os.Remove(pidFile)
 	}
+	// Clear the recorded URL files so subsequent FossilURL/NATSURL
+	// callers see the hub as down.
+	_ = os.Remove(p.fossilURL)
+	_ = os.Remove(p.natsURL)
 	return nil
 }
 
@@ -241,6 +253,8 @@ type paths struct {
 	hubRepo     string
 	fossilPid   string
 	natsPid     string
+	fossilURL   string
+	natsURL     string
 	fossilLog   string
 	natsLog     string
 	natsStore   string
@@ -269,6 +283,8 @@ func newPaths(root string) (paths, error) {
 		hubRepo:     filepath.Join(orch, "hub.fossil"),
 		fossilPid:   filepath.Join(orch, "pids", "fossil.pid"),
 		natsPid:     filepath.Join(orch, "pids", "nats.pid"),
+		fossilURL:   filepath.Join(orch, "hub-fossil-url"),
+		natsURL:     filepath.Join(orch, "hub-nats-url"),
 		fossilLog:   filepath.Join(orch, "fossil.log"),
 		natsLog:     filepath.Join(orch, "nats.log"),
 		natsStore:   filepath.Join(orch, "nats-store"),

--- a/internal/hub/options.go
+++ b/internal/hub/options.go
@@ -27,16 +27,21 @@ type opts struct {
 	detach     bool
 }
 
-// defaults returns the production defaults: fossil on 8765, NATS on 4222,
-// foreground (Start blocks on ctx.Done()).
+// defaults returns the production defaults: ports left zero so
+// resolvePorts allocates per-workspace, foreground (Start blocks on
+// ctx.Done()). A zero port means "look up the workspace's recorded URL
+// or pick a free port"; passing WithFossilPort(N) or WithNATSPort(N)
+// pins to N.
 func defaults() opts {
-	return opts{fossilPort: 8765, natsPort: 4222}
+	return opts{fossilPort: 0, natsPort: 0}
 }
 
-// WithFossilPort overrides the Fossil HTTP port. The default is 8765.
+// WithFossilPort pins the Fossil HTTP port. Zero means "let the hub
+// allocate per-workspace" (default behavior).
 func WithFossilPort(p int) Option { return func(o *opts) { o.fossilPort = p } }
 
-// WithNATSPort overrides the NATS client port. The default is 4222.
+// WithNATSPort pins the NATS client port. Zero means "let the hub
+// allocate per-workspace" (default behavior).
 func WithNATSPort(p int) Option { return func(o *opts) { o.natsPort = p } }
 
 // WithDetach controls Start's blocking behavior. When true, Start returns

--- a/internal/hub/url.go
+++ b/internal/hub/url.go
@@ -1,0 +1,115 @@
+package hub
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"strings"
+)
+
+// FossilURL returns the hub Fossil HTTP URL recorded for the workspace
+// at root, or "" if no hub is currently running there.
+//
+// Consumers (`bones up`, `swarm join/commit/close`, `tasks status`,
+// etc.) read this rather than hardcoding 127.0.0.1:8765 so two bones
+// workspaces can run concurrently with port allocations of their own.
+func FossilURL(root string) string {
+	p, err := newPaths(root)
+	if err != nil {
+		return ""
+	}
+	return readURLFile(p.fossilURL)
+}
+
+// NATSURL returns the hub NATS URL recorded for the workspace at root,
+// or "" if no hub is running.
+func NATSURL(root string) string {
+	p, err := newPaths(root)
+	if err != nil {
+		return ""
+	}
+	return readURLFile(p.natsURL)
+}
+
+func readURLFile(path string) string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(data))
+}
+
+// resolvePorts fills any zero-valued port in opts. Resolution order:
+//  1. Recorded URL file (so a steady-state restart picks the same port
+//     it had before, which keeps consumer URLs stable across hub
+//     restarts).
+//  2. Free port from the OS via pickFreePort.
+//
+// After resolution, the URL files are (re)written so consumers always
+// see the live hub's URLs — even when the caller passed explicit ports.
+func resolvePorts(p paths, o *opts) error {
+	if o.fossilPort == 0 {
+		if recorded := portFromURL(readURLFile(p.fossilURL)); recorded != 0 {
+			o.fossilPort = recorded
+		} else {
+			port, err := pickFreePort()
+			if err != nil {
+				return fmt.Errorf("hub: pick fossil port: %w", err)
+			}
+			o.fossilPort = port
+		}
+	}
+	if o.natsPort == 0 {
+		if recorded := portFromURL(readURLFile(p.natsURL)); recorded != 0 {
+			o.natsPort = recorded
+		} else {
+			port, err := pickFreePort()
+			if err != nil {
+				return fmt.Errorf("hub: pick nats port: %w", err)
+			}
+			o.natsPort = port
+		}
+	}
+	return writeURLFiles(p, *o)
+}
+
+// writeURLFiles records the hub's fully-resolved URLs so consumers can
+// discover them without knowing the port allocation policy.
+func writeURLFiles(p paths, o opts) error {
+	fossilURL := fmt.Sprintf("http://127.0.0.1:%d", o.fossilPort)
+	natsURL := fmt.Sprintf("nats://127.0.0.1:%d", o.natsPort)
+	if err := os.WriteFile(p.fossilURL, []byte(fossilURL+"\n"), 0o644); err != nil {
+		return fmt.Errorf("hub: write fossil-url: %w", err)
+	}
+	if err := os.WriteFile(p.natsURL, []byte(natsURL+"\n"), 0o644); err != nil {
+		return fmt.Errorf("hub: write nats-url: %w", err)
+	}
+	return nil
+}
+
+// portFromURL extracts the trailing :port from a URL like
+// "http://127.0.0.1:8765" or "nats://127.0.0.1:4222". Returns 0 on any
+// parse error.
+func portFromURL(url string) int {
+	idx := strings.LastIndex(url, ":")
+	if idx < 0 || idx == len(url)-1 {
+		return 0
+	}
+	var port int
+	if _, err := fmt.Sscanf(url[idx+1:], "%d", &port); err != nil {
+		return 0
+	}
+	return port
+}
+
+// pickFreePort asks the OS for a free TCP port. Mirrors the helper in
+// internal/workspace; duplicated here to avoid an import cycle.
+func pickFreePort() (int, error) {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return 0, err
+	}
+	port := l.Addr().(*net.TCPAddr).Port
+	_ = l.Close()
+	return port, nil
+}

--- a/internal/hub/url_test.go
+++ b/internal/hub/url_test.go
@@ -1,0 +1,181 @@
+package hub
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestPortFromURL(t *testing.T) {
+	cases := []struct {
+		url  string
+		want int
+	}{
+		{"http://127.0.0.1:8765", 8765},
+		{"nats://127.0.0.1:4222", 4222},
+		{"http://127.0.0.1:0", 0},
+		{"", 0},
+		{"http://127.0.0.1", 0},
+		{"http://127.0.0.1:notaport", 0},
+	}
+	for _, c := range cases {
+		if got := portFromURL(c.url); got != c.want {
+			t.Errorf("portFromURL(%q) = %d, want %d", c.url, got, c.want)
+		}
+	}
+}
+
+func TestPickFreePort(t *testing.T) {
+	port, err := pickFreePort()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if port <= 0 || port > 65535 {
+		t.Errorf("port %d out of range", port)
+	}
+}
+
+func TestResolvePorts_AllocatesFreeWhenZero(t *testing.T) {
+	dir := t.TempDir()
+	p, err := newPaths(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(p.orchDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	o := opts{fossilPort: 0, natsPort: 0}
+	if err := resolvePorts(p, &o); err != nil {
+		t.Fatal(err)
+	}
+	if o.fossilPort == 0 || o.natsPort == 0 {
+		t.Errorf("ports not assigned: %+v", o)
+	}
+	if o.fossilPort == o.natsPort {
+		t.Errorf("collision: both ports = %d", o.fossilPort)
+	}
+	if FossilURL(dir) == "" {
+		t.Errorf("fossil URL file not written")
+	}
+	if NATSURL(dir) == "" {
+		t.Errorf("nats URL file not written")
+	}
+}
+
+func TestResolvePorts_ReadsRecordedURL(t *testing.T) {
+	dir := t.TempDir()
+	p, err := newPaths(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(p.orchDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Pre-record URLs as if a previous hub had run.
+	if err := os.WriteFile(p.fossilURL,
+		[]byte("http://127.0.0.1:9001\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p.natsURL,
+		[]byte("nats://127.0.0.1:9002\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	o := opts{fossilPort: 0, natsPort: 0}
+	if err := resolvePorts(p, &o); err != nil {
+		t.Fatal(err)
+	}
+	if o.fossilPort != 9001 {
+		t.Errorf("fossilPort = %d, want 9001 (recorded)", o.fossilPort)
+	}
+	if o.natsPort != 9002 {
+		t.Errorf("natsPort = %d, want 9002 (recorded)", o.natsPort)
+	}
+}
+
+func TestResolvePorts_PreservesExplicitPort(t *testing.T) {
+	dir := t.TempDir()
+	p, err := newPaths(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(p.orchDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	o := opts{fossilPort: 7777, natsPort: 7778}
+	if err := resolvePorts(p, &o); err != nil {
+		t.Fatal(err)
+	}
+	if o.fossilPort != 7777 || o.natsPort != 7778 {
+		t.Errorf("explicit ports clobbered: %+v", o)
+	}
+	// URL files should still reflect the explicit port.
+	if got := FossilURL(dir); got != "http://127.0.0.1:7777" {
+		t.Errorf("FossilURL = %q, want http://127.0.0.1:7777", got)
+	}
+}
+
+func TestFossilURL_ReturnsEmptyWhenAbsent(t *testing.T) {
+	dir := t.TempDir()
+	if got := FossilURL(dir); got != "" {
+		t.Errorf("FossilURL = %q, want empty", got)
+	}
+	if got := NATSURL(dir); got != "" {
+		t.Errorf("NATSURL = %q, want empty", got)
+	}
+}
+
+func TestFossilURL_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	p, err := newPaths(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(p.orchDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	want := "http://127.0.0.1:8765"
+	if err := os.WriteFile(p.fossilURL, []byte(want+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := FossilURL(dir); got != want {
+		t.Errorf("FossilURL = %q, want %q", got, want)
+	}
+}
+
+// TestStartStopWritesAndRemovesURLFiles is a thin assert layered on the
+// existing round-trip: after Start binds, the URL files exist; after
+// Stop, they're gone.
+func TestStartStopWritesAndRemovesURLFiles(t *testing.T) {
+	root := t.TempDir()
+	p, err := newPaths(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(p.orchDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	o := opts{fossilPort: 0, natsPort: 0}
+	if err := resolvePorts(p, &o); err != nil {
+		t.Fatal(err)
+	}
+	for _, path := range []string{p.fossilURL, p.natsURL} {
+		if _, err := os.Stat(path); err != nil {
+			t.Errorf("URL file %s missing after resolvePorts: %v",
+				filepath.Base(path), err)
+		}
+	}
+	want := fmt.Sprintf("http://127.0.0.1:%d", o.fossilPort)
+	if got := FossilURL(root); got != want {
+		t.Errorf("FossilURL = %q, want %q", got, want)
+	}
+	// Stop removes URL files.
+	if err := Stop(root); err != nil {
+		t.Fatal(err)
+	}
+	for _, path := range []string{p.fossilURL, p.natsURL} {
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Errorf("URL file %s still present after Stop", filepath.Base(path))
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Closes a structural bug where running bones in 3-4 different repos concurrently was impossible: the hub had hardcoded port 8765 (Fossil) and 4222 (NATS), so the second \`bones up\` always failed at port-bind. Pid-file idempotence is per-workspace, so workspace B never short-circuited on workspace A's pid file.

This PR makes the hub allocate per-workspace dynamic ports, persist them so consumers can discover them, and treats the hub as a workspace-scoped daemon (not session-scoped).

### What changed

- **\`internal/hub/options.go\`**: defaults change from {8765, 4222} to {0, 0}. Zero means "let the hub allocate".
- **\`internal/hub/url.go\`** (new): \`resolvePorts\` reads recorded URLs or picks a free port via \`net.Listen("tcp", "127.0.0.1:0")\`. \`writeURLFiles\` persists \`.orchestrator/hub-fossil-url\` and \`.orchestrator/hub-nats-url\`. Public helpers \`hub.FossilURL(root)\` / \`hub.NATSURL(root)\` for consumers.
- **\`cli/hub.go\`**: Kong defaults change to "0".
- **\`cli/up.go\`**: reads hub URL from workspace recording instead of hardcoded :8765.
- **\`cli/swarm.go\`**: new \`resolveHubURL\` helper consulted by all swarm verbs; \`swarm.DefaultHubFossilURL\` retained as legacy fallback.
- **\`cli/orchestrator.go\`**: scaffold no longer adds SessionEnd hub-shutdown. New \`migrateSessionEndShutdown\` prunes the legacy entry on re-scaffold, sharing \`pruneHubShutdown\` with the existing Stop migration.
- **ADR 0038**: documents the architecture.

### Test plan

- [x] \`go test ./internal/hub/ -v\` — 11 tests pass including new port-resolution and URL-file round-trip
- [x] \`go test ./cli/ -run TestScaffoldOrchestrator -v\` — 12 tests pass including new SessionEnd-shutdown migration
- [x] \`make check\` — fmt-check, vet, lint, race, todo-check all green
- [x] \`go test -tags=otel -short ./...\` — full CI-equivalent run green
- [x] **Multi-workspace smoke**: \`bones up\` in /tmp/ws-A and /tmp/ws-B back-to-back; both hubs live concurrently on different ports (verified with \`lsof -iTCP\`); both workspaces tear down cleanly with \`bones down\`.

### Migration

Existing workspaces silently migrate on the next \`bones up\`:
- The legacy SessionEnd hub-shutdown hook is dropped from \`.claude/settings.json\`.
- The next \`bones hub start\` writes URL files (recovers the recorded port if any, else allocates fresh).
- No user action required beyond re-running \`bones up\`.