### PR TITLE
fix(release): skip Homebrew formula update on prereleases

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -103,6 +103,7 @@ release:
 
 brews:
   - name: bones
+    skip_upload: auto
     repository:
       owner: danmestas
       name: homebrew-tap


### PR DESCRIPTION
## Summary
Adds `skip_upload: auto` to the `brews:` block in `.goreleaser.yml`.

## Context
With `release.prerelease: auto`, GoReleaser correctly marks rc/beta/alpha tags as GitHub prereleases. But without `skip_upload: auto` on the brews block, the Homebrew formula was still being updated for those prereleases. Effect: `brew upgrade bones` would pull rc binaries as stable updates.

`skip_upload: auto` skips formula updates whenever the release is marked as prerelease. Stable releases still update the formula as before.

This came up while validating the cross-repo release cascade — flagged in EdgeSync first; same fix applies symmetrically here. Same fix shipped in parallel to EdgeSync.

## Test plan
- [x] `goreleaser check` accepts the config
- [x] Pre-commit + pre-push hooks (make ci-fast) green