### PR TITLE
feat(telemetry): scrub workspace path with WorkspaceHash (PR 1/4 of telemetry plan)

### DIFF
--- a/internal/telemetry/scrub.go
+++ b/internal/telemetry/scrub.go
@@ -1,0 +1,28 @@
+package telemetry
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"path/filepath"
+)
+
+// WorkspaceHash returns a 12-char hex prefix of sha256(cleaned-absolute-path).
+// Same workspace path always produces the same hash, but the path itself
+// never reaches a telemetry exporter — so spans can correlate across
+// invocations of the same workspace without leaking the username,
+// project name, or directory layout.
+//
+// Empty input returns "" (callers can drop the attr rather than emit a
+// hash of nothing).
+func WorkspaceHash(path string) string {
+	if path == "" {
+		return ""
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		abs = path
+	}
+	abs = filepath.Clean(abs)
+	sum := sha256.Sum256([]byte(abs))
+	return hex.EncodeToString(sum[:])[:12]
+}

--- a/internal/telemetry/scrub_test.go
+++ b/internal/telemetry/scrub_test.go
@@ -1,0 +1,58 @@
+package telemetry
+
+import "testing"
+
+func TestWorkspaceHash_Stable(t *testing.T) {
+	a := WorkspaceHash("/Users/alice/projects/foo")
+	b := WorkspaceHash("/Users/alice/projects/foo")
+	if a != b {
+		t.Fatalf("same path produced different hashes: %q vs %q", a, b)
+	}
+	if len(a) != 12 {
+		t.Errorf("expected 12-char hash, got %d chars: %q", len(a), a)
+	}
+}
+
+func TestWorkspaceHash_DifferentPathsDifferentHashes(t *testing.T) {
+	a := WorkspaceHash("/Users/alice/projects/foo")
+	b := WorkspaceHash("/Users/alice/projects/bar")
+	if a == b {
+		t.Fatalf("different paths produced same hash: %q", a)
+	}
+}
+
+func TestWorkspaceHash_NormalizesPath(t *testing.T) {
+	a := WorkspaceHash("/Users/alice/projects/foo")
+	b := WorkspaceHash("/Users/alice/projects/foo/")
+	c := WorkspaceHash("/Users/alice/projects/foo/../foo")
+	if a != b || a != c {
+		t.Errorf("normalization broken: %q %q %q", a, b, c)
+	}
+}
+
+func TestWorkspaceHash_EmptyReturnsEmpty(t *testing.T) {
+	if got := WorkspaceHash(""); got != "" {
+		t.Errorf("empty input → %q, want \"\"", got)
+	}
+}
+
+func TestWorkspaceHash_NoPathLeakage(t *testing.T) {
+	// A 12-hex-char hash can't contain "/Users/" or "alice" — sanity check
+	// that we never accidentally return the input.
+	in := "/Users/alice/projects/foo"
+	out := WorkspaceHash(in)
+	for _, leaked := range []string{"/", "alice", "Users", "projects", "foo"} {
+		if contains(out, leaked) {
+			t.Errorf("hash %q leaks substring %q from input %q", out, leaked, in)
+		}
+	}
+}
+
+func contains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -88,9 +88,12 @@ func instrumented(
 	op, cwd string,
 	fn func(context.Context) (Info, error),
 ) (Info, error) {
+	// workspace_hash is a sha256 prefix of the resolved cwd. Same
+	// workspace produces the same hash; the literal path never reaches
+	// a telemetry exporter.
 	ctx, end := telemetry.RecordCommand(ctx, "agent_init."+op,
 		telemetry.String("op", op),
-		telemetry.String("cwd", cwd),
+		telemetry.String("workspace_hash", telemetry.WorkspaceHash(cwd)),
 	)
 	start := time.Now()
 	slog.DebugContext(ctx, op+" start", "cwd", cwd)


### PR DESCRIPTION
## Summary

First of four small PRs preparing bones for opt-in telemetry to a SigNoz backend. This PR is local-only — no exporter wired, nothing leaves the user's machine, default-build is still no-op. It just removes the one path-shaped attribute that was already being emitted into the telemetry seam.

## What changed

- **\`internal/telemetry/scrub.go\`** (new): \`WorkspaceHash(path)\` returns a deterministic 12-char sha256 hex prefix of the resolved absolute path. Same workspace produces the same hash; the path itself never reaches an exporter.
- **\`internal/workspace/workspace.go\`**: \`agent_init.*\` spans now emit \`workspace_hash\` instead of literal \`cwd\`.
- **\`internal/telemetry/scrub_test.go\`** (new): five tests — stable hashing, different paths produce different hashes, normalization, empty input, and a leakage check confirming the hash never contains substrings of its input.

## Why now

Subsequent PRs in this series will instrument the hub, swarm verbs, apply, and doctor, then add an opt-in OTLP exporter. Scrubbing the existing site first means each subsequent PR has a single helper to reach for instead of bolting it on later when an exporter is already shipping data.

## Test plan

- [x] \`go test ./internal/telemetry/\` — all helper tests pass
- [x] \`go test ./internal/workspace/\` — workspace tests pass against the new attr
- [x] \`make check\` — fmt-check, vet, lint, race, todo-check all green