### PR TITLE
feat(swarm): protocol hardening — close precondition, reap, JSON validate-plan, events log

### DIFF
--- a/cli/swarm.go
+++ b/cli/swarm.go
@@ -28,6 +28,7 @@ type SwarmCmd struct {
 	Cwd    SwarmCwdCmd    `cmd:"" help:"Print the slot's worktree path"`
 	Tasks  SwarmTasksCmd  `cmd:"" help:"List ready tasks matching slot"`
 	FanIn  SwarmFanInCmd  `cmd:"" name:"fan-in" help:"Merge open hub leaves into trunk"`
+	Reap   SwarmReapCmd   `cmd:"" help:"Force-close stale same-host sessions as result=fail"`
 }
 
 // openSwarmSessions dials NATS for the workspace and opens a swarm

--- a/cli/swarm_close.go
+++ b/cli/swarm_close.go
@@ -23,12 +23,13 @@ import (
 // record (already closed) is not an error so re-running close
 // after a crash converges.
 type SwarmCloseCmd struct {
-	Slot    string `name:"slot" help:"slot name (defaults to single active slot on this host)"`
-	Result  string `name:"result" default:"success" help:"success|fail|fork"`
-	Summary string `name:"summary" default:"swarm close" help:"final summary posted to task thread"`
-	Branch  string `name:"branch" help:"only with --result=fork: branch name"`
-	Rev     string `name:"rev" help:"only with --result=fork: rev"`
-	HubURL  string `name:"hub-url" help:"override hub fossil HTTP URL"`
+	Slot       string `name:"slot" help:"slot (defaults to single active slot on host)"`
+	Result     string `name:"result" default:"success" help:"success|fail|fork"`
+	Summary    string `name:"summary" default:"swarm close" help:"final summary"`
+	Branch     string `name:"branch" help:"only with --result=fork: branch name"`
+	Rev        string `name:"rev" help:"only with --result=fork: rev"`
+	HubURL     string `name:"hub-url" help:"override hub fossil HTTP URL"`
+	NoArtifact string `name:"no-artifact" help:"reason for closing success without a commit"`
 }
 
 func (c *SwarmCloseCmd) Run(g *libfossilcli.Globals) error {
@@ -62,6 +63,7 @@ func (c *SwarmCloseCmd) Run(g *libfossilcli.Globals) error {
 
 	closeOpts := swarm.CloseOpts{
 		CloseTaskOnSuccess: c.Result == string(dispatch.ResultSuccess),
+		NoArtifact:         c.NoArtifact,
 	}
 	if err := lease.Close(ctx, closeOpts); err != nil {
 		return fmt.Errorf("swarm close: %w", err)

--- a/cli/swarm_reap.go
+++ b/cli/swarm_reap.go
@@ -1,0 +1,196 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"time"
+
+	libfossilcli "github.com/danmestas/libfossil/cli"
+
+	"github.com/danmestas/bones/internal/coord"
+	"github.com/danmestas/bones/internal/dispatch"
+	"github.com/danmestas/bones/internal/swarm"
+	"github.com/danmestas/bones/internal/workspace"
+)
+
+// SwarmReapCmd force-closes stale swarm sessions on this host. A
+// session is "stale" when LastRenewed is older than the staleness
+// threshold (DefaultThresholdSec, mirroring `bones swarm status`'s
+// classification). Reap closes each stale same-host session as
+// result=fail with summary "auto-reaped: stale" and releases the
+// claim so the task is re-dispatchable.
+//
+// Cross-host stale sessions are reported but never reaped — the
+// owning host's PID may still be making local progress, and a
+// remote reap would clobber that. Operators with cross-host stale
+// sessions must run `bones swarm reap` from the owning host.
+//
+// The verb exists because the harness layer can drop a leaf
+// without running close (orchestrator rate-limit, kill -9, machine
+// sleep) and the substrate's TTL eviction is too coarse a signal
+// for operators who want to recover within seconds. Before this
+// verb, the manual recovery path was a per-slot
+// `bones swarm close --slot=X --result=fail` loop.
+type SwarmReapCmd struct {
+	Threshold time.Duration `name:"threshold" default:"90s" help:"staleness threshold"`
+	DryRun    bool          `name:"dry-run" help:"report stale slots without closing"`
+	HubURL    string        `name:"hub-url" help:"override hub fossil HTTP URL"`
+}
+
+// Run executes the reap. Workspace + sessions are opened once; per-
+// stale-session closes run sequentially (small N expected; concurrent
+// closes would race the same hub fossil).
+func (c *SwarmReapCmd) Run(g *libfossilcli.Globals) error {
+	ctx, stop, info, err := joinWorkspace()
+	if err != nil {
+		return err
+	}
+	defer stop()
+
+	stale, err := c.findStale(ctx, info)
+	if err != nil {
+		return err
+	}
+	if len(stale) == 0 {
+		fmt.Fprintln(os.Stderr, "swarm reap: no stale sessions on this host")
+		return nil
+	}
+	if c.DryRun {
+		c.reportDryRun(stale)
+		return nil
+	}
+	return c.reapAll(ctx, info, stale)
+}
+
+// findStale lists sessions and returns the same-host entries whose
+// last-renewed age exceeds Threshold. Cross-host stale sessions are
+// printed to stderr as a hint for the operator but not returned.
+func (c *SwarmReapCmd) findStale(
+	ctx context.Context, info workspace.Info,
+) ([]swarm.Session, error) {
+	sess, closeSess, err := openSwarmSessions(ctx, info)
+	if err != nil {
+		return nil, err
+	}
+	defer closeSess()
+	all, err := sess.List(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("swarm reap: list sessions: %w", err)
+	}
+	host, _ := os.Hostname()
+	now := timeNow()
+	var stale []swarm.Session
+	for _, s := range all {
+		age := now.Sub(s.LastRenewed)
+		if age <= c.Threshold {
+			continue
+		}
+		if s.Host != host {
+			fmt.Fprintf(os.Stderr,
+				"swarm reap: skip cross-host slot %q (owner=%s, age=%s) — reap on owning host\n",
+				s.Slot, s.Host, age.Round(time.Second),
+			)
+			continue
+		}
+		stale = append(stale, s)
+	}
+	return stale, nil
+}
+
+// reportDryRun prints the slots that would be reaped without
+// touching them. Useful for operators who want to confirm the
+// staleness classification before letting the verb act.
+func (c *SwarmReapCmd) reportDryRun(stale []swarm.Session) {
+	now := timeNow()
+	for _, s := range stale {
+		age := now.Sub(s.LastRenewed).Round(time.Second)
+		fmt.Fprintf(os.Stderr,
+			"swarm reap (dry-run): would reap slot=%s task=%s age=%s\n",
+			s.Slot, s.TaskID, age,
+		)
+	}
+}
+
+// reapAll closes each stale session as result=fail. Per-slot
+// failures are printed but don't abort the loop — the operator
+// wants partial cleanup over no cleanup. Returns the first error
+// at end so the verb's exit code reflects mixed-state outcomes.
+func (c *SwarmReapCmd) reapAll(
+	ctx context.Context, info workspace.Info, stale []swarm.Session,
+) error {
+	var firstErr error
+	for _, s := range stale {
+		if err := c.reapOne(ctx, info, s); err != nil {
+			fmt.Fprintf(os.Stderr,
+				"swarm reap: slot=%s: %v\n", s.Slot, err,
+			)
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		fmt.Fprintf(os.Stderr,
+			"swarm reap: slot=%s task=%s closed (result=fail, auto-reaped: stale)\n",
+			s.Slot, s.TaskID,
+		)
+	}
+	return firstErr
+}
+
+// reapOne resumes the slot's lease and closes it as result=fail.
+// Mirrors swarm close's flow (post result then close lease) so
+// downstream consumers see the same dispatch ResultMessage shape
+// they'd see from a manual close.
+func (c *SwarmReapCmd) reapOne(
+	ctx context.Context, info workspace.Info, s swarm.Session,
+) error {
+	lease, err := swarm.Resume(ctx, info, s.Slot, swarm.AcquireOpts{
+		HubURL: resolveHubURL(c.HubURL),
+	})
+	if err != nil {
+		if errors.Is(err, swarm.ErrSessionNotFound) {
+			// Already reaped concurrently — converge silently.
+			return nil
+		}
+		return fmt.Errorf("resume: %w", err)
+	}
+	defer func() { _ = lease.Release(ctx) }()
+
+	if err := postReapResult(ctx, info, lease.FossilUser(), lease.TaskID()); err != nil {
+		fmt.Fprintf(os.Stderr,
+			"swarm reap: slot=%s: warning: post result failed: %v\n",
+			s.Slot, err,
+		)
+	}
+	return lease.Close(ctx, swarm.CloseOpts{
+		CloseTaskOnSuccess: false,
+		Reaped:             true,
+	})
+}
+
+// postReapResult emits the dispatch ResultMessage on the task
+// thread before close. Same shape as cli/swarm_close.go::postResult,
+// inlined here to avoid coupling the two verbs through a shared
+// helper that'd grow whenever either verb's posting needs change.
+func postReapResult(
+	ctx context.Context, info workspace.Info, agentID, taskID string,
+) error {
+	cfg := newCoordConfig(info)
+	cfg.AgentID = agentID
+	cfg.ProjectPrefix = coord.DeriveProjectPrefix(info.AgentID)
+	co, err := coord.Open(ctx, cfg)
+	if err != nil {
+		return fmt.Errorf("open coord: %w", err)
+	}
+	defer func() { _ = co.Close() }()
+	msg := dispatch.ResultMessage{
+		Kind:    dispatch.ResultFail,
+		Summary: "auto-reaped: stale",
+	}
+	if err := co.Post(ctx, taskID, []byte(dispatch.FormatResult(msg))); err != nil {
+		return fmt.Errorf("post: %w", err)
+	}
+	return nil
+}

--- a/cli/validate_plan.go
+++ b/cli/validate_plan.go
@@ -23,28 +23,94 @@ import (
 //  2. Slots are directory-disjoint (no two slots share a directory prefix).
 //  3. Each task's Files: paths begin with the slot's owned directory.
 //
-// Exits 0 if valid, 1 if violations are reported. With --list-slots,
-// also emits a JSON slot→task mapping to stdout on success.
+// Output contract (deliberately strict so orchestrator scripts can
+// pipe stdout through `jq` / `python -c json.load` without
+// stripping prose first):
+//
+//	stdout : always a single JSON object {errors, slots} — empty
+//	         arrays on a clean validation, non-empty Errors on a
+//	         violation. Even parse failures emit a JSON object so
+//	         consumers don't have to special-case stdout shape.
+//	stderr : human-readable prose, one violation per line, on
+//	         failures. Empty on a clean run.
+//	exit   : 0 = valid, 1 = plan-level violations, 2 = parse / IO error.
+//
+// --list-slots is retained as a no-op flag for backwards compatibility
+// with orchestrator scripts authored against the older "JSON only on
+// success when --list-slots set" shape. It emits a one-line stderr
+// hint the first time it's used so callers know the flag is
+// deprecated; behavior is identical with or without it.
 type ValidatePlanCmd struct {
 	Path      string `arg:"" type:"existingfile" help:"Markdown plan path"`
-	ListSlots bool   `name:"list-slots" help:"emit JSON slot→task list (still runs validation)"`
+	ListSlots bool   `name:"list-slots" help:"deprecated no-op (JSON is always emitted on stdout)"`
+}
+
+// ValidateResult is the on-stdout JSON shape emitted by every
+// invocation of ValidatePlanCmd. Fields are always present; Errors
+// is non-empty iff exit is non-zero. Slots is best-effort: even on
+// validation failure we still emit whatever slot annotations the
+// parser saw, so an orchestrator that wants to dispatch the valid
+// slots alongside reporting the failures has the data without
+// re-parsing.
+type ValidateResult struct {
+	Errors []string    `json:"errors"`
+	Slots  []slotEntry `json:"slots"`
 }
 
 func (c *ValidatePlanCmd) Run(g *libfossilcli.Globals) error {
-	tasks, violations, err := validatePlan(c.Path)
-	if err != nil {
+	if c.ListSlots {
+		fmt.Fprintln(os.Stderr,
+			"validate-plan: --list-slots is a no-op; JSON is now always emitted on stdout")
+	}
+	res, exitCode := runValidatePlan(c.Path)
+	if err := emitValidateResult(os.Stdout, res); err != nil {
 		return err
 	}
-	if len(violations) > 0 {
-		for _, v := range violations {
-			fmt.Fprintln(os.Stderr, v)
-		}
-		os.Exit(1)
+	for _, e := range res.Errors {
+		fmt.Fprintln(os.Stderr, e)
 	}
-	if c.ListSlots {
-		enc := json.NewEncoder(os.Stdout)
-		enc.SetIndent("", "  ")
-		return enc.Encode(buildSlotList(tasks))
+	if exitCode != 0 {
+		os.Exit(exitCode)
+	}
+	return nil
+}
+
+// runValidatePlan opens the plan, runs the structural checks, and
+// returns the ValidateResult plus an exit code. Pulled out of Run
+// so tests can drive the validation surface without forking
+// processes; the os.Exit is the only side effect Run adds.
+func runValidatePlan(path string) (ValidateResult, int) {
+	tasks, violations, err := validatePlan(path)
+	if err != nil {
+		return ValidateResult{
+			Errors: []string{err.Error()},
+			Slots:  []slotEntry{},
+		}, 2
+	}
+	list := buildSlotList(tasks)
+	if list.Slots == nil {
+		list.Slots = []slotEntry{}
+	}
+	res := ValidateResult{
+		Errors: violations,
+		Slots:  list.Slots,
+	}
+	if res.Errors == nil {
+		res.Errors = []string{}
+	}
+	if len(violations) > 0 {
+		return res, 1
+	}
+	return res, 0
+}
+
+// emitValidateResult writes the canonical indented-JSON form of res.
+// Pulled out so tests can assert on the on-the-wire bytes.
+func emitValidateResult(w *os.File, res ValidateResult) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(res); err != nil {
+		return fmt.Errorf("validate-plan: encode result: %w", err)
 	}
 	return nil
 }

--- a/cli/validate_plan_test.go
+++ b/cli/validate_plan_test.go
@@ -102,3 +102,63 @@ func TestValidatePlan_InvalidPlanSuppressedJSON(t *testing.T) {
 		t.Fatal("expected violations for invalid plan")
 	}
 }
+
+// TestRunValidatePlan_CleanReturnsZero verifies the
+// runValidatePlan contract: clean plans return exit=0 with empty
+// errors and a populated slot list. The result shape is the JSON
+// orchestrator scripts pipe through jq/json.load.
+func TestRunValidatePlan_CleanReturnsZero(t *testing.T) {
+	res, exit := runValidatePlan(filepath.Join("testdata", "valid_plan.md"))
+	if exit != 0 {
+		t.Fatalf("exit: got %d, want 0; errors=%v", exit, res.Errors)
+	}
+	if len(res.Errors) != 0 {
+		t.Fatalf("errors: %v", res.Errors)
+	}
+	if len(res.Slots) != 2 {
+		t.Fatalf("slots: got %d, want 2", len(res.Slots))
+	}
+	// Always-present fields: even with zero errors, Errors must
+	// marshal as `[]` not `null` so consumers don't have to
+	// special-case the missing-key shape.
+	b, err := json.Marshal(res)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(b), `"errors":[]`) {
+		t.Errorf("errors field not empty array: %s", b)
+	}
+}
+
+// TestRunValidatePlan_ViolationsReturnsOne pins the failure-mode
+// output: violations land in res.Errors as an array of strings, exit
+// is 1, and the slots that DID parse cleanly are still surfaced so
+// orchestrators that want to act on partial data can.
+func TestRunValidatePlan_ViolationsReturnsOne(t *testing.T) {
+	res, exit := runValidatePlan(filepath.Join("testdata", "invalid_files_outside_slot.md"))
+	if exit != 1 {
+		t.Fatalf("exit: got %d, want 1", exit)
+	}
+	if len(res.Errors) == 0 {
+		t.Fatal("expected at least one error in res.Errors")
+	}
+	joined := strings.Join(res.Errors, "\n")
+	if !strings.Contains(joined, "outside slot directory") {
+		t.Errorf("expected 'outside slot directory' in errors, got: %s", joined)
+	}
+}
+
+// TestRunValidatePlan_ParseErrorReturnsTwo pins the parse-error
+// shape: missing-file or IO failure produces a JSON-emittable
+// result with the error text in res.Errors and exit=2 (distinct
+// from exit=1 so callers can tell "your plan is wrong" apart from
+// "your path is wrong").
+func TestRunValidatePlan_ParseErrorReturnsTwo(t *testing.T) {
+	res, exit := runValidatePlan(filepath.Join("testdata", "this_file_does_not_exist.md"))
+	if exit != 2 {
+		t.Fatalf("exit: got %d, want 2", exit)
+	}
+	if len(res.Errors) == 0 {
+		t.Fatal("expected error in res.Errors")
+	}
+}

--- a/cmd/bones/integration/swarm_test.go
+++ b/cmd/bones/integration/swarm_test.go
@@ -181,6 +181,81 @@ func TestCLI_Swarm(t *testing.T) {
 	})
 }
 
+// TestCLI_SwarmReap exercises the end-to-end reap flow: join a
+// slot, never commit, then run `bones swarm reap --threshold=1ms`
+// to force the session into stale classification and verify it
+// gets closed as result=fail with the auto-reaped summary.
+//
+// The verb fixes a recurring operator pain point — when an
+// orchestrator hits a rate limit or a host crashes mid-task, the
+// session record persists past the agent's death and `bones swarm
+// status` shows "stale 113s ago" rows the operator must clean up
+// one by one with `bones swarm close --slot=X --result=fail`.
+// reap automates the loop.
+func TestCLI_SwarmReap(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip in -short: integration test")
+	}
+	requireBinaries(t)
+	dir := setupSwarmWorkspace(t)
+	if resolved, err := filepath.EvalSymlinks(dir); err == nil {
+		dir = resolved
+	}
+	httpPort, natsPort := pickPortPair(t)
+	startSwarmHub(t, dir, httpPort, natsPort)
+	hubURL := fmt.Sprintf("http://127.0.0.1:%d", httpPort)
+
+	relFile := "rendering/orphan.txt"
+	absFile := filepath.Join(dir, relFile)
+	taskID := createSwarmTask(t, dir, absFile, "[slot: rendering] reap me")
+	slot := "rendering"
+
+	if _, stderr, code := runCmd(t, bonesBin, dir,
+		"swarm", "join",
+		"--slot="+slot, "--task-id="+taskID,
+		"--hub-url="+hubURL,
+	); code != 0 {
+		t.Fatalf("swarm join exit=%d stderr=%s", code, stderr)
+	}
+
+	// Wait long enough that LastRenewed is older than threshold=1ms.
+	// 50ms is slow enough to be reliable on busy CI yet fast enough
+	// not to dominate test wall time.
+	time.Sleep(50 * time.Millisecond)
+
+	// Dry-run first: must report the slot but not act on it.
+	dryStdout, dryStderr, dryCode := runCmd(t, bonesBin, dir,
+		"swarm", "reap", "--threshold=1ms", "--dry-run",
+	)
+	if dryCode != 0 {
+		t.Fatalf("reap dry-run exit=%d stderr=%s", dryCode, dryStderr)
+	}
+	if !strings.Contains(dryStderr, "would reap slot=rendering") {
+		t.Fatalf("dry-run stderr missing slot mention: %s", dryStderr)
+	}
+	_ = dryStdout
+
+	// Session must still be present after dry-run.
+	statusOut, _, _ := runCmd(t, bonesBin, dir, "swarm", "status", "--json")
+	if !strings.Contains(statusOut, slot) {
+		t.Fatalf("dry-run removed session: %s", statusOut)
+	}
+
+	// Real run: reap closes the stale session.
+	if _, stderr, code := runCmd(t, bonesBin, dir,
+		"swarm", "reap", "--threshold=1ms", "--hub-url="+hubURL,
+	); code != 0 {
+		t.Fatalf("reap exit=%d stderr=%s", code, stderr)
+	}
+
+	// Session should be gone now.
+	postStatus, _, _ := runCmd(t, bonesBin, dir, "swarm", "status", "--json")
+	trimmed := strings.TrimSpace(postStatus)
+	if trimmed != "null" && trimmed != "[]" {
+		t.Errorf("post-reap status: want empty, got %q", postStatus)
+	}
+}
+
 // TestCLI_SwarmJoin_RefusesBootstrapFromLeafContext pins the
 // role-separation guard: when a workspace has no hub.fossil yet,
 // `swarm join` must refuse with a leaf-appropriate message instead

--- a/internal/swarm/events.go
+++ b/internal/swarm/events.go
@@ -1,0 +1,126 @@
+package swarm
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// EventsFile is the workspace-relative path of the structured
+// swarm-lifecycle event log. Living next to the workspace leaf log
+// keeps the audit-shaped data in one place; the dedicated filename
+// makes the purpose obvious to operators tailing it.
+//
+// Path is `<workspace>/.bones/swarm-events.jsonl`. JSONL (one JSON
+// object per line) is the right shape for `tail -f`, `grep`, and
+// streaming-friendly tooling. Each line is small (~150 bytes) so
+// POSIX-atomic appends from concurrent slot processes don't tear.
+const EventsFile = ".bones/swarm-events.jsonl"
+
+// EventKind enumerates the slot-lifecycle event types written to
+// the JSONL log. Each kind corresponds to a distinct verb at the
+// CLI surface; consumers (operator dashboards, replays) can filter
+// by kind without parsing the rest of the line.
+type EventKind string
+
+const (
+	// EventSlotJoin is emitted when Acquire successfully writes a
+	// session record. The slot is bound to a task and a leaf is open.
+	EventSlotJoin EventKind = "slot_join"
+
+	// EventSlotCommit is emitted when ResumedLease.Commit returns
+	// without a leaf-side error. PushErr / RenewErr surface in the
+	// returned CommitResult but the structured event records the
+	// successful local commit (audit-trail-relevant).
+	EventSlotCommit EventKind = "slot_commit"
+
+	// EventSlotClose is emitted when ResumedLease.Close completes
+	// the cleanup path. Always carries Result so post-mortem
+	// analysis sees success/fail/fork distinction.
+	EventSlotClose EventKind = "slot_close"
+
+	// EventSlotReap is emitted by the swarm reap verb instead of
+	// EventSlotClose so operators can distinguish operator-driven
+	// cleanup ("we shut this slot down") from substrate-driven
+	// reaping ("the agent went silent and we cleaned up after it").
+	EventSlotReap EventKind = "slot_reap"
+)
+
+// Event is the on-disk shape written to swarm-events.jsonl. Fields
+// are minimal-but-sufficient for an operator to reconstruct who
+// did what when. Optional fields use omitempty so close events
+// don't carry stale CommitUUIDs and join events don't carry
+// spurious Result strings.
+type Event struct {
+	TS         time.Time `json:"ts"`
+	Kind       EventKind `json:"event"`
+	Slot       string    `json:"slot"`
+	TaskID     string    `json:"task_id,omitempty"`
+	AgentID    string    `json:"agent_id,omitempty"`
+	Host       string    `json:"host,omitempty"`
+	Result     string    `json:"result,omitempty"`
+	NoArtifact string    `json:"no_artifact,omitempty"`
+	CommitUUID string    `json:"commit_uuid,omitempty"`
+}
+
+// appendEvent appends one Event to the workspace-local JSONL log.
+// Best-effort: a failed write is logged to stderr but never
+// propagated as an error — losing an audit line is recoverable;
+// failing the user-facing verb because the log is read-only is
+// not. Append uses O_APPEND so concurrent writers don't clobber
+// each other (POSIX guarantees atomic writes ≤PIPE_BUF for the
+// small payloads we emit).
+//
+// workspaceDir is the workspace root (not .bones/). The file is
+// created with 0o644 if missing; the .bones directory is assumed
+// to exist (Acquire, the only caller path that can predate it,
+// already ensures `<workspace>/.bones/swarm/<slot>` via its leaf
+// open).
+func appendEvent(workspaceDir string, e Event) {
+	if workspaceDir == "" {
+		return
+	}
+	if e.TS.IsZero() {
+		e.TS = time.Now().UTC()
+	}
+	path := filepath.Join(workspaceDir, EventsFile)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		fmt.Fprintf(os.Stderr,
+			"swarm: append event: mkdir %s: %v\n", filepath.Dir(path), err)
+		return
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		fmt.Fprintf(os.Stderr,
+			"swarm: append event: open %s: %v\n", path, err)
+		return
+	}
+	defer func() { _ = f.Close() }()
+	b, err := json.Marshal(e)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "swarm: append event: marshal: %v\n", err)
+		return
+	}
+	b = append(b, '\n')
+	if _, err := f.Write(b); err != nil {
+		fmt.Fprintf(os.Stderr,
+			"swarm: append event: write %s: %v\n", path, err)
+	}
+}
+
+// emitJoinEvent is the call-site helper Acquire uses to keep its
+// own body under the funlen cap. Pulls the os.Hostname() lookup
+// and the appendEvent boilerplate out of the hot path.
+func emitJoinEvent(workspaceDir, slot, taskID, fossilUser string, ts time.Time) {
+	host, _ := os.Hostname()
+	appendEvent(workspaceDir, Event{
+		TS:      ts,
+		Kind:    EventSlotJoin,
+		Slot:    slot,
+		TaskID:  taskID,
+		AgentID: fossilUser,
+		Host:    host,
+	})
+}

--- a/internal/swarm/events_test.go
+++ b/internal/swarm/events_test.go
@@ -1,0 +1,146 @@
+package swarm
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/danmestas/bones/internal/coord"
+	"github.com/danmestas/bones/internal/wspath"
+)
+
+// TestEvents_FullLifecycle pins the structured-events log: a slot
+// that joins, commits, and closes must leave three lines in
+// `<workspace>/.bones/swarm-events.jsonl` — one per state
+// transition — each parseable as a swarm.Event with the right Kind
+// and Slot. Operators tail this file to watch the swarm; if
+// anything stops emitting, dashboards go dark silently. Pin it.
+func TestEvents_FullLifecycle(t *testing.T) {
+	f := newLeaseFixture(t)
+	holdPath := filepath.Join(f.dir, "evtslot", "hello.txt")
+	taskID := string(f.createTask(t, "evt-task-1", holdPath))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	first, err := Acquire(ctx, f.info, "evtslot", taskID, AcquireOpts{Hub: f.hub})
+	if err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	if err := first.Release(ctx); err != nil {
+		t.Fatalf("Release: %v", err)
+	}
+
+	// Commit so the close path doesn't hit the artifact precondition.
+	resumed, err := Resume(ctx, f.info, "evtslot", AcquireOpts{Hub: f.hub})
+	if err != nil {
+		t.Fatalf("Resume: %v", err)
+	}
+	wt := resumed.WT()
+	if err := os.WriteFile(filepath.Join(wt, "hello.txt"), []byte("hi"), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	files := []coord.File{{
+		Path:    wspath.Must(holdPath),
+		Name:    "hello.txt",
+		Content: []byte("hi"),
+	}}
+	if _, err := resumed.Commit(ctx, "evt commit", files); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+
+	resumed2, err := Resume(ctx, f.info, "evtslot", AcquireOpts{Hub: f.hub})
+	if err != nil {
+		t.Fatalf("Resume2: %v", err)
+	}
+	if err := resumed2.Close(ctx, CloseOpts{CloseTaskOnSuccess: true}); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	events := readEvents(t, f.dir)
+	wantKinds := []EventKind{EventSlotJoin, EventSlotCommit, EventSlotClose}
+	if len(events) != len(wantKinds) {
+		t.Fatalf("event count: got %d, want %d; events=%+v", len(events), len(wantKinds), events)
+	}
+	for i, want := range wantKinds {
+		if events[i].Kind != want {
+			t.Errorf("event[%d] kind: got %s, want %s", i, events[i].Kind, want)
+		}
+		if events[i].Slot != "evtslot" {
+			t.Errorf("event[%d] slot: got %q, want evtslot", i, events[i].Slot)
+		}
+	}
+	if events[1].CommitUUID == "" {
+		t.Errorf("commit event missing CommitUUID: %+v", events[1])
+	}
+	if events[2].Result != "success" {
+		t.Errorf("close event result: got %q, want success", events[2].Result)
+	}
+}
+
+// TestEvents_ReapedKindOverridesClose verifies that a Close called
+// with Reaped:true emits EventSlotReap rather than EventSlotClose
+// — the audit-log distinction between substrate-driven cleanup and
+// operator-driven close that the swarm reap verb relies on.
+func TestEvents_ReapedKindOverridesClose(t *testing.T) {
+	f := newLeaseFixture(t)
+	holdPath := filepath.Join(f.dir, "reapevt", "hello.txt")
+	taskID := string(f.createTask(t, "reap-task-1", holdPath))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	first, err := Acquire(ctx, f.info, "reapevt", taskID, AcquireOpts{Hub: f.hub})
+	if err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	if err := first.Release(ctx); err != nil {
+		t.Fatalf("Release: %v", err)
+	}
+
+	resumed, err := Resume(ctx, f.info, "reapevt", AcquireOpts{Hub: f.hub})
+	if err != nil {
+		t.Fatalf("Resume: %v", err)
+	}
+	if err := resumed.Close(ctx, CloseOpts{
+		CloseTaskOnSuccess: false,
+		Reaped:             true,
+	}); err != nil {
+		t.Fatalf("Close (reaped): %v", err)
+	}
+
+	events := readEvents(t, f.dir)
+	// Last event must be the reap, not a generic close.
+	last := events[len(events)-1]
+	if last.Kind != EventSlotReap {
+		t.Errorf("last event kind: got %s, want %s", last.Kind, EventSlotReap)
+	}
+}
+
+// readEvents loads the JSONL events file and returns parsed Events
+// in file order. Nil-safe on missing file (returns empty slice +
+// fatals the test if the read itself errored).
+func readEvents(t *testing.T, workspaceDir string) []Event {
+	t.Helper()
+	path := filepath.Join(workspaceDir, EventsFile)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read events file %s: %v", path, err)
+	}
+	var out []Event
+	for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+		if line == "" {
+			continue
+		}
+		var e Event
+		if err := json.Unmarshal([]byte(line), &e); err != nil {
+			t.Fatalf("decode event %q: %v", line, err)
+		}
+		out = append(out, e)
+	}
+	return out
+}

--- a/internal/swarm/lease.go
+++ b/internal/swarm/lease.go
@@ -88,6 +88,21 @@ var ErrCrossHostOperation = errors.New(
 	"swarm: cross-host operation refused — run the verb on the slot's owning host",
 )
 
+// ErrCloseRequiresArtifact is returned by ResumedLease.Close when the
+// caller asked for CloseTaskOnSuccess but no commit has landed on the
+// slot since join (LastRenewed == StartedAt on the session record).
+// The substrate refuses the silent-bypass shape — closing success
+// without producing an artifact severs the audit trail bones is
+// supposed to preserve. Callers that have a legitimate reason to
+// close success without a commit (e.g. a research subagent that
+// returned findings inline) must pass CloseOpts.NoArtifact with an
+// explicit reason; the reason is recorded so the post-mortem question
+// "why did this slot leave no commit?" has a documented answer.
+var ErrCloseRequiresArtifact = errors.New(
+	"swarm: close --result=success refused — no commit landed since join; " +
+		"either commit the slot's artifact first or pass --no-artifact=<reason>",
+)
+
 // AcquireOpts tunes Acquire and Resume. Zero-value defaults are
 // production-correct: HubURL → DefaultHubFossilURL, Caps →
 // DefaultCaps, NATSConn dialed from info.NATSURL, Now →
@@ -164,6 +179,23 @@ type CloseOpts struct {
 	// dispatch. swarm close --result=success sets this true; fail
 	// and fork leave it false.
 	CloseTaskOnSuccess bool
+
+	// NoArtifact, when non-empty, bypasses the
+	// "success requires a commit since join" precondition. The
+	// string is the operator's reason (e.g. "inline-only research
+	// findings") and is recorded in the lifecycle event log so the
+	// audit trail has a documented explanation for the missing
+	// artifact. Ignored when CloseTaskOnSuccess is false (fail and
+	// fork results have no artifact requirement).
+	NoArtifact string
+
+	// Reaped, when true, tags the emitted lifecycle event as
+	// EventSlotReap rather than EventSlotClose. Set by the
+	// `bones swarm reap` verb so post-mortem analysis can tell
+	// substrate-driven cleanup ("agent went silent") apart from
+	// operator-driven close ("subagent reported done"). No effect
+	// on the cleanup mechanics.
+	Reaped bool
 }
 
 // leaseBase holds the fields shared by FreshLease and ResumedLease.
@@ -330,6 +362,8 @@ func Acquire(
 		cleanupConn()
 		return nil, err
 	}
+
+	emitJoinEvent(info.WorkspaceDir, slot, taskID, fossilUser, now())
 
 	return &FreshLease{
 		leaseBase: leaseBase{
@@ -523,6 +557,15 @@ func (l *ResumedLease) Commit(
 	pushRes, pushErr := pushLeafFossil(ctx, l.info.WorkspaceDir, l.slot, l.fossilUser, l.hubURL)
 	renewErr := l.bumpLastRenewed(ctx)
 
+	appendEvent(l.info.WorkspaceDir, Event{
+		TS:         l.now(),
+		Kind:       EventSlotCommit,
+		Slot:       l.slot,
+		TaskID:     l.taskID,
+		AgentID:    l.fossilUser,
+		CommitUUID: uuid,
+	})
+
 	return CommitResult{
 		UUID:       uuid,
 		PushResult: pushRes,
@@ -593,6 +636,14 @@ func (l *ResumedLease) Close(ctx context.Context, opts CloseOpts) error {
 	if !l.released.CompareAndSwap(false, true) {
 		return nil
 	}
+	if err := l.checkArtifactPrecondition(ctx, opts); err != nil {
+		// Precondition failed BEFORE any state mutation. Reset the
+		// released flag so the caller can retry (e.g. after running
+		// `swarm commit`). teardown stays unrun — the lease is still
+		// usable.
+		l.released.Store(false)
+		return err
+	}
 	if err := l.closeTaskAndReleaseClaim(ctx, opts.CloseTaskOnSuccess); err != nil {
 		l.teardown()
 		return err
@@ -611,7 +662,52 @@ func (l *ResumedLease) Close(ctx context.Context, opts CloseOpts) error {
 		return err
 	}
 	l.teardown()
+	result := "fail"
+	if opts.CloseTaskOnSuccess {
+		result = "success"
+	}
+	kind := EventSlotClose
+	if opts.Reaped {
+		kind = EventSlotReap
+	}
+	appendEvent(l.info.WorkspaceDir, Event{
+		TS:         l.now(),
+		Kind:       kind,
+		Slot:       l.slot,
+		TaskID:     l.taskID,
+		AgentID:    l.fossilUser,
+		Result:     result,
+		NoArtifact: opts.NoArtifact,
+	})
 	return nil
+}
+
+// checkArtifactPrecondition refuses CloseTaskOnSuccess when no commit
+// has bumped LastRenewed since join (i.e. LastRenewed equals
+// StartedAt on the session record). NoArtifact bypasses the check;
+// CloseTaskOnSuccess=false skips it entirely (fail and fork close
+// shapes carry no artifact contract). Returns nil on bypass, on
+// successful precondition, or when the session record is gone (close
+// converges idempotently — the missing record itself implies the
+// caller already closed and we have nothing to refuse).
+func (l *ResumedLease) checkArtifactPrecondition(ctx context.Context, opts CloseOpts) error {
+	if !opts.CloseTaskOnSuccess || opts.NoArtifact != "" {
+		return nil
+	}
+	if l.sessions == nil {
+		return nil
+	}
+	sess, _, err := l.sessions.Get(ctx, l.slot)
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			return nil
+		}
+		return fmt.Errorf("swarm.ResumedLease.Close: read session: %w", err)
+	}
+	if sess.LastRenewed.After(sess.StartedAt) {
+		return nil
+	}
+	return ErrCloseRequiresArtifact
 }
 
 // deleteSessionRecord CAS-deletes the session record, retrying on

--- a/internal/swarm/lease_test.go
+++ b/internal/swarm/lease_test.go
@@ -298,7 +298,14 @@ func TestClose_DeletesRecordAndPidFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Resume: %v", err)
 	}
-	if err := resumed.Close(ctx, CloseOpts{CloseTaskOnSuccess: true}); err != nil {
+	// This test pins the cleanup contract (record + pid file removed,
+	// slot reusable), not the artifact contract — bypass the
+	// "no commit since join" precondition with NoArtifact so the
+	// cleanup path is what's exercised.
+	if err := resumed.Close(ctx, CloseOpts{
+		CloseTaskOnSuccess: true,
+		NoArtifact:         "test: covers cleanup path",
+	}); err != nil {
 		t.Fatalf("Close: %v", err)
 	}
 	if _, err := os.Stat(pidPath); !os.IsNotExist(err) {
@@ -388,6 +395,75 @@ func TestCommit_SuccessUpdatesTrunkAndRenewsSession(t *testing.T) {
 
 	if err := resumed.Release(ctx); err != nil {
 		t.Errorf("Release: %v", err)
+	}
+}
+
+// TestClose_RefusesSuccessWithoutCommit pins the artifact-contract
+// precondition: a slot that was joined but never committed must not
+// be allowed to close --result=success silently. The substrate
+// refuses the silent-bypass shape so the audit trail bones promises
+// (every successful slot leaves a commit) holds structurally rather
+// than by agent politeness.
+func TestClose_RefusesSuccessWithoutCommit(t *testing.T) {
+	f := newLeaseFixture(t)
+	holdPath := filepath.Join(f.dir, "noartifact", "hello.txt")
+	taskID := string(f.createTask(t, "noartifact-task-1", holdPath))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	first, err := Acquire(ctx, f.info, "noartifact", taskID, AcquireOpts{Hub: f.hub})
+	if err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	if err := first.Release(ctx); err != nil {
+		t.Fatalf("Release: %v", err)
+	}
+
+	resumed, err := Resume(ctx, f.info, "noartifact", AcquireOpts{Hub: f.hub})
+	if err != nil {
+		t.Fatalf("Resume: %v", err)
+	}
+	closeErr := resumed.Close(ctx, CloseOpts{CloseTaskOnSuccess: true})
+	if !errors.Is(closeErr, ErrCloseRequiresArtifact) {
+		t.Fatalf("Close: want ErrCloseRequiresArtifact, got %v", closeErr)
+	}
+
+	// The lease should still be usable after a refused close — the
+	// caller's recovery path is to commit, then retry close.
+	if err := resumed.Close(ctx, CloseOpts{
+		CloseTaskOnSuccess: true,
+		NoArtifact:         "test-bypass",
+	}); err != nil {
+		t.Fatalf("Close with NoArtifact bypass: %v", err)
+	}
+}
+
+// TestClose_AllowsFailWithoutCommit covers the asymmetry: the
+// precondition gates only --result=success. A failed or forked
+// close has no artifact contract — the slot didn't claim to have
+// produced something — so the precondition must not engage.
+func TestClose_AllowsFailWithoutCommit(t *testing.T) {
+	f := newLeaseFixture(t)
+	holdPath := filepath.Join(f.dir, "failclose", "hello.txt")
+	taskID := string(f.createTask(t, "failclose-task-1", holdPath))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	first, err := Acquire(ctx, f.info, "failclose", taskID, AcquireOpts{Hub: f.hub})
+	if err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	if err := first.Release(ctx); err != nil {
+		t.Fatalf("Release: %v", err)
+	}
+	resumed, err := Resume(ctx, f.info, "failclose", AcquireOpts{Hub: f.hub})
+	if err != nil {
+		t.Fatalf("Resume: %v", err)
+	}
+	if err := resumed.Close(ctx, CloseOpts{CloseTaskOnSuccess: false}); err != nil {
+		t.Fatalf("Close fail: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Tightens four contract surfaces in the swarm protocol where the Apr 30 serverdom session log showed silent-bypass paths. Evidence: 27% of dispatches that session (6 of 22) closed `result=success` without any commit landing on the hub. Bones had no detector; orchestrator believed everything succeeded.

Five changes, evidence-backed, focused on enforcement and observability:

1. **`bones swarm close` precondition** — refuses `--result=success` when `LastRenewed == StartedAt` on the session record (no commit since join). Bypass via `--no-artifact=<reason>` records the reason in the events log. Cleanup paths (`fail`, `fork`) unchanged.

2. **`bones swarm reap`** — new verb that finds stale same-host sessions (LastRenewed older than `--threshold`, default 90s) and closes them as `result=fail` with `auto-reaped: stale`. Replaces the manual `bones swarm close --slot=X --result=fail` loop the orchestrator was running after every rate-limit kill. `--dry-run` available.

3. **`validate-plan` JSON-only stdout** — always emits `{errors,slots}` to stdout regardless of outcome; prose to stderr only; exit codes split (0 clean, 1 violations, 2 parse/IO). Removes the prose-mixed-with-JSON output that broke `bones validate-plan ... | python3 -c 'json.load(sys.stdin)'`. `--list-slots` retained as deprecated no-op.

4. **`.bones/swarm-events.jsonl`** — new structured audit log written from `internal/swarm` on `slot_join`, `slot_commit`, `slot_close`, `slot_reap`. Fills the gap where `leaf.log` was signal-empty for swarm activity (it's a telemetry/NATS bridge log, not an audit log). Best-effort appends; never blocks the verb.

5. **Auto-create slot user on `swarm join`** — *no code change needed*. `swarm.Acquire` already idempotently calls `ensureSlotUser` (`internal/swarm/lease.go:838`). The orchestrator skill in serverdom has a redundant `bones hub user add slot-X` loop that should be deleted; that's a skill-side change in a separate repo.

## Test plan

- [x] `make check` (fmt-check, vet, lint, race, todo-check) — green
- [x] `go test -tags=otel -short ./...` (CI-equivalent) — green
- [x] New unit tests:
  - `TestClose_RefusesSuccessWithoutCommit` — precondition fires
  - `TestClose_AllowsFailWithoutCommit` — fail/fork bypass the precondition
  - `TestEvents_FullLifecycle` — join/commit/close emit JSONL events
  - `TestEvents_ReapedKindOverridesClose` — reap emits `slot_reap` not `slot_close`
  - `TestRunValidatePlan_CleanReturnsZero` / `_ViolationsReturnsOne` / `_ParseErrorReturnsTwo` — exit-code separation
- [x] New integration test: `TestCLI_SwarmReap` — full reap flow against real hub
- [x] Existing test `TestClose_DeletesRecordAndPidFile` updated to pass `NoArtifact` (it pins the cleanup contract, not the artifact contract)

## Risks

- **Existing scripts using `bones swarm close --result=success`**: any caller that closes success without committing will now error. The failure mode is loud (clear error message) and recoverable (`--no-artifact=<reason>` or run a commit first). Orchestrator skill in serverdom needs to be updated to either commit-then-close or pass `--no-artifact` for inline-only subagents.
- **`validate-plan` output format change**: stdout shape is now strict JSON. Scripts that grepped stdout for plain-text violations need to migrate to `jq '.errors'` or stderr. The prose-on-stderr is unchanged for human readers.

## Out of scope (deferred)

- Orchestrator-skill fixes (in `serverdom/.claude/skills/orchestrator`): query hub for truth instead of agent self-reports; enforce phase-ordering with `swarm fan-in` between dispatch batches; handle rate-limit resume.
- Subagent skill: lift Write-blocking for swarm contexts so research subagents can commit reports.
- leaf.log signoz/nats sync error coalescing (6,680 useless lines / 76min observed).
- `bones tail` verb to stream `swarm-events.jsonl` with friendly output.

These are separate concerns sized for a separate PR each.