### PR TITLE
feat(telemetry): instrument hub/up/apply/doctor spans (PR 2/4)

### DIFF
--- a/cli/apply.go
+++ b/cli/apply.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -12,6 +13,7 @@ import (
 
 	libfossilcli "github.com/danmestas/libfossil/cli"
 
+	"github.com/danmestas/bones/internal/telemetry"
 	"github.com/danmestas/bones/internal/workspace"
 )
 
@@ -27,7 +29,13 @@ type ApplyCmd struct {
 	DryRun bool `name:"dry-run" help:"show planned changes without writing or staging"`
 }
 
-func (c *ApplyCmd) Run(g *libfossilcli.Globals) error {
+func (c *ApplyCmd) Run(g *libfossilcli.Globals) (err error) {
+	outcome := &applyOutcome{DryRun: c.DryRun}
+	_, end := telemetry.RecordCommand(context.Background(), "apply",
+		telemetry.Bool("dry_run", c.DryRun),
+	)
+	defer func() { end(err, outcome.attrs()...) }()
+
 	cwd, err := os.Getwd()
 	if err != nil {
 		return fmt.Errorf("cwd: %w", err)
@@ -41,18 +49,46 @@ func (c *ApplyCmd) Run(g *libfossilcli.Globals) error {
 		return err
 	}
 	defer cleanup()
-	return c.applyFromCheckout(pre, tempDir)
+	return c.applyFromCheckout(pre, tempDir, outcome)
+}
+
+// applyOutcome carries the post-hoc attributes the telemetry span needs,
+// populated as applyFromCheckout walks its pipeline. The span is opened
+// in Run before the outcome is known (so duration covers preconditions
+// + work) and the attrs are attached at end.
+type applyOutcome struct {
+	DryRun          bool
+	AlreadyUpToDate bool
+	DirtyRefused    bool
+	Added           int
+	Modified        int
+	Deleted         int
+}
+
+func (o *applyOutcome) attrs() []telemetry.Attr {
+	return []telemetry.Attr{
+		telemetry.Bool("dry_run", o.DryRun),
+		telemetry.Bool("already_up_to_date", o.AlreadyUpToDate),
+		telemetry.Bool("dirty_refused", o.DirtyRefused),
+		telemetry.Int("added", int64(o.Added)),
+		telemetry.Int("modified", int64(o.Modified)),
+		telemetry.Int("deleted", int64(o.Deleted)),
+	}
 }
 
 // applyFromCheckout executes the apply pipeline once preconditions and
 // the temp checkout are in place. Split out of Run to keep each below
-// the funlen limit while preserving the linear flow.
-func (c *ApplyCmd) applyFromCheckout(pre *applyPreflight, tempDir string) error {
+// the funlen limit while preserving the linear flow. outcome is
+// populated as we go so Run's deferred span end has the post-hoc attrs.
+func (c *ApplyCmd) applyFromCheckout(
+	pre *applyPreflight, tempDir string, outcome *applyOutcome,
+) error {
 	manifest, rev, err := trunkManifest(pre.HubFossil, pre.FossilBin)
 	if err != nil {
 		return err
 	}
 	if err := refuseIfDirty(pre.WorkspaceDir, manifest); err != nil {
+		outcome.DirtyRefused = true
 		return err
 	}
 	prevManifest, err := loadPrevManifest(pre)
@@ -63,8 +99,12 @@ func (c *ApplyCmd) applyFromCheckout(pre *applyPreflight, tempDir string) error 
 	if err != nil {
 		return err
 	}
+	outcome.Added = len(plan.Added)
+	outcome.Modified = len(plan.Modified)
+	outcome.Deleted = len(plan.Deleted)
 	total := len(plan.Added) + len(plan.Modified) + len(plan.Deleted)
 	if total == 0 {
+		outcome.AlreadyUpToDate = true
 		fmt.Printf("bones apply: already up to date at %s\n", shortRev(rev))
 		return writeLastAppliedMarker(pre.WorkspaceDir, rev)
 	}

--- a/cli/doctor.go
+++ b/cli/doctor.go
@@ -15,6 +15,7 @@ import (
 	"github.com/danmestas/bones/internal/githook"
 	"github.com/danmestas/bones/internal/scaffoldver"
 	"github.com/danmestas/bones/internal/swarm"
+	"github.com/danmestas/bones/internal/telemetry"
 	"github.com/danmestas/bones/internal/version"
 	"github.com/danmestas/bones/internal/workspace"
 )
@@ -34,12 +35,26 @@ type DoctorCmd struct {
 // Run invokes the EdgeSync doctor first; on completion (regardless
 // of pass/warn/fail) it appends a "swarm sessions" section that
 // iterates bones-swarm-sessions and reports each entry's state.
-func (c *DoctorCmd) Run(g *libfossilcli.Globals) error {
+func (c *DoctorCmd) Run(g *libfossilcli.Globals) (err error) {
+	_, end := telemetry.RecordCommand(context.Background(), "doctor")
+	var (
+		baseFailed  bool
+		swarmFailed bool
+	)
+	defer func() {
+		end(err,
+			telemetry.Bool("base_failed", baseFailed),
+			telemetry.Bool("swarm_failed", swarmFailed),
+		)
+	}()
+
 	// The EdgeSync side returns an error on failed checks; surface
 	// that error AFTER our additional report so operators see the
 	// swarm picture even when an upstream check failed.
 	baseErr := c.DoctorCmd.Run(g)
+	baseFailed = baseErr != nil
 	swarmErr := c.runSwarmReport()
+	swarmFailed = swarmErr != nil
 	c.runBypassReport()
 	if baseErr != nil {
 		return baseErr

--- a/cli/up.go
+++ b/cli/up.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/danmestas/bones/internal/githook"
 	"github.com/danmestas/bones/internal/hub"
+	"github.com/danmestas/bones/internal/telemetry"
 	"github.com/danmestas/bones/internal/workspace"
 )
 
@@ -20,8 +21,13 @@ import (
 //  2. orchestrator scaffold (scripts, skills, hooks)
 //  3. build bin/leaf if missing
 //  4. run hub-bootstrap.sh and verify the hub is up
-func runUp(cwd string) error {
-	info, err := initOrJoinWorkspace(context.Background(), cwd)
+func runUp(cwd string) (err error) {
+	ctx, end := telemetry.RecordCommand(context.Background(), "bones.up",
+		telemetry.String("workspace_hash", telemetry.WorkspaceHash(cwd)),
+	)
+	defer func() { end(err) }()
+
+	info, err := initOrJoinWorkspace(ctx, cwd)
 	if err != nil {
 		return fmt.Errorf("workspace: %w", err)
 	}

--- a/internal/hub/hub.go
+++ b/internal/hub/hub.go
@@ -16,6 +16,8 @@ import (
 	"github.com/danmestas/libfossil"
 	_ "github.com/danmestas/libfossil/db/driver/modernc"
 	natsserver "github.com/nats-io/nats-server/v2/server"
+
+	"github.com/danmestas/bones/internal/telemetry"
 )
 
 // detachEnv, when set, signals to a fork-exec'd child process that it
@@ -59,7 +61,7 @@ const natsBootstrapBackoff = 1 * time.Second
 // Without detach, Start blocks on ctx.Done(): the calling process is
 // the hub. Pid files reference the calling process. On cancellation,
 // both servers shut down cleanly and pid files are removed.
-func Start(ctx context.Context, root string, options ...Option) error {
+func Start(ctx context.Context, root string, options ...Option) (err error) {
 	o := defaults()
 	for _, fn := range options {
 		fn(&o)
@@ -67,7 +69,8 @@ func Start(ctx context.Context, root string, options ...Option) error {
 	// Re-entry from the fork-exec'd child: even if the user passed
 	// WithDetach(true), the BONES_HUB_FOREGROUND env var (set by our
 	// fork) forces foreground so we don't recurse.
-	if os.Getenv(detachEnv) == "1" {
+	isDetachChild := os.Getenv(detachEnv) == "1"
+	if isDetachChild {
 		o.detach = false
 	}
 
@@ -75,6 +78,20 @@ func Start(ctx context.Context, root string, options ...Option) error {
 	if err != nil {
 		return err
 	}
+
+	// Telemetry: record only the parent's Start. The detached child
+	// re-enters Start with BONES_HUB_FOREGROUND=1 and would otherwise
+	// emit a daemon-lifetime span the parent already covered.
+	if !isDetachChild {
+		urlRecorded := readURLFile(p.fossilURL) != ""
+		var end telemetry.EndFunc
+		ctx, end = telemetry.RecordCommand(ctx, "hub.start",
+			telemetry.Bool("detach", o.detach),
+			telemetry.Bool("url_recorded", urlRecorded),
+		)
+		defer func() { end(err) }()
+	}
+
 	if err := os.MkdirAll(p.pidDir, 0o755); err != nil {
 		return fmt.Errorf("hub: pids dir: %w", err)
 	}
@@ -212,11 +229,14 @@ func spawnDetachedChild(p paths, o opts) error {
 // pid is the same as os.Getpid(), Stop only removes the pid file. The
 // foreground Start has its own ctx-cancellation path; signaling self
 // would terminate the caller before it could clean up.
-func Stop(root string) error {
+func Stop(root string) (err error) {
 	p, err := newPaths(root)
 	if err != nil {
 		return err
 	}
+
+	_, end := telemetry.RecordCommand(context.Background(), "hub.stop")
+	defer func() { end(err) }()
 
 	self := os.Getpid()
 	// Both servers share a single child process in the detached model,

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -30,7 +30,9 @@ func Int(key string, value int64) Attr { return Attr{key: key, value: value} }
 func Bool(key string, value bool) Attr { return Attr{key: key, value: value} }
 
 // EndFunc finalizes a span started by RecordCommand. Pass the operation's
-// terminal error (or nil on success); the OTel branch records the error and
-// closes the span. Always call exactly once — typically via `defer end(err)`
-// against a named-return `err`.
-type EndFunc func(err error)
+// terminal error (or nil on success) and any outcome attributes computed
+// during the call (counts, refusal flags, etc.) — the OTel branch attaches
+// the attrs and records the error before closing the span. Always call
+// exactly once — typically via `defer func(){ end(err) }()` against a
+// named-return `err`.
+type EndFunc func(err error, attrs ...Attr)

--- a/internal/telemetry/telemetry_default.go
+++ b/internal/telemetry/telemetry_default.go
@@ -11,5 +11,5 @@ import "context"
 func RecordCommand(
 	ctx context.Context, _ string, _ ...Attr,
 ) (context.Context, EndFunc) {
-	return ctx, func(error) {}
+	return ctx, func(error, ...Attr) {}
 }

--- a/internal/telemetry/telemetry_otel.go
+++ b/internal/telemetry/telemetry_otel.go
@@ -34,7 +34,21 @@ func RecordCommand(
 		}
 	}
 	ctx, span := tracer.Start(ctx, name, trace.WithAttributes(kv...))
-	return ctx, func(err error) {
+	return ctx, func(err error, outcome ...Attr) {
+		if len(outcome) > 0 {
+			out := make([]attribute.KeyValue, 0, len(outcome))
+			for _, a := range outcome {
+				switch v := a.value.(type) {
+				case string:
+					out = append(out, attribute.String(a.key, v))
+				case int64:
+					out = append(out, attribute.Int64(a.key, v))
+				case bool:
+					out = append(out, attribute.Bool(a.key, v))
+				}
+			}
+			span.SetAttributes(out...)
+		}
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())


### PR DESCRIPTION
## Summary

Second of four PRs preparing bones for opt-in telemetry to a SigNoz backend (PR #93 was the path-scrub helper). Still local-only — no exporter wired, default build is no-op, nothing leaves the user's machine. This PR fills in the instrumentation so once an opt-in OTLP exporter lands (PR 3), the data is there to ship.

## What changed

- **\`internal/telemetry/telemetry.go\`** — \`EndFunc\` is now \`func(error, ...Attr)\` so callers can attach outcome attributes computed during the call (counts, refusal flags). Existing callers \`end(err)\` keep compiling unchanged.
- **\`internal/telemetry/telemetry_otel.go\`** — applies outcome attrs via \`span.SetAttributes\` before \`span.End\`.
- **\`internal/hub/hub.go\`** — \`hub.start\` span (detach, url_recorded), \`hub.stop\` span. The detached child suppresses its own span so the parent's covers the lifecycle (a child's would be a daemon-lifetime span).
- **\`cli/up.go\`** — \`bones.up\` span with \`workspace_hash\`. Threads ctx into \`initOrJoinWorkspace\` so the existing \`agent_init.*\` span nests under \`bones.up\`.
- **\`cli/apply.go\`** — \`apply\` span with \`dry_run\`, \`already_up_to_date\`, \`dirty_refused\`, \`added\`, \`modified\`, \`deleted\`. New \`applyOutcome\` struct populated as \`applyFromCheckout\` walks the pipeline; \`Run\` attaches the populated outcome on defer.
- **\`cli/doctor.go\`** — \`doctor\` span with \`base_failed\`, \`swarm_failed\`.

## Why these spans, no PII risk

Every attribute is either:
- a bool (refusal flags, success indicators),
- an int64 (counts), or
- a deterministic 12-char workspace_hash (per PR #93's helper — never the literal path).

No file paths, no command output strings, no error message strings, no slot/task names, no hostname, no commit content. The schema fits the no-PII policy you asked for.

## Schema (what would land in SigNoz once an exporter ships)

| Span | Attributes |
|---|---|
| \`hub.start\` | detach (bool), url_recorded (bool) |
| \`hub.stop\` | (timing only) |
| \`bones.up\` | workspace_hash (string) — child spans: \`agent_init.init\`, \`agent_init.join\` |
| \`apply\` | dry_run, already_up_to_date, dirty_refused (bool), added, modified, deleted (int64) |
| \`doctor\` | base_failed, swarm_failed (bool) |

## Test plan

- [x] \`go test ./internal/hub/\` — pass
- [x] \`go test ./internal/telemetry/\` — pass (existing tests cover the variadic-attrs default path)
- [x] \`go test ./cli/ -run TestApply\` — pass (apply outcome population doesn't change behavior)
- [x] \`go build ./...\` — pass
- [x] \`go build -tags=otel ./...\` — pass (OTel branch compiles with new signature)
- [x] \`make check\` — fmt-check, vet, lint, race, todo-check all green
- [x] \`go test -tags=otel -short ./...\` — full CI-equivalent green

## Next

PR 3 will add the opt-in OTLP exporter (gated by \`BONES_TELEMETRY=1\` + \`BONES_OTEL_ENDPOINT=...\`). I'll bring you a privacy ADR + opt-in UX proposal before shipping that one — that's the part that actually leaves the user's machine.