### PR TITLE
feat(telemetry): opt-in OTLP exporter (ADR 0039) — PR 3/4

### DIFF
--- a/cli/doctor.go
+++ b/cli/doctor.go
@@ -56,10 +56,34 @@ func (c *DoctorCmd) Run(g *libfossilcli.Globals) (err error) {
 	swarmErr := c.runSwarmReport()
 	swarmFailed = swarmErr != nil
 	c.runBypassReport()
+	c.runTelemetryReport()
 	if baseErr != nil {
 		return baseErr
 	}
 	return swarmErr
+}
+
+// runTelemetryReport prints the current opt-in telemetry status so the
+// operator can verify what (if anything) is leaving their machine.
+// Per ADR 0039, telemetry is fully opt-in via BONES_TELEMETRY=1 +
+// BONES_OTEL_ENDPOINT; this surface is the on-demand verifier.
+func (c *DoctorCmd) runTelemetryReport() {
+	fmt.Println()
+	fmt.Println("=== telemetry (ADR 0039) ===")
+	if !telemetry.IsEnabled() {
+		switch {
+		case os.Getenv("BONES_TELEMETRY") != "1":
+			fmt.Println("  off — set BONES_TELEMETRY=1 + BONES_OTEL_ENDPOINT to enable")
+		case os.Getenv("BONES_OTEL_ENDPOINT") == "":
+			fmt.Println("  WARN  BONES_TELEMETRY=1 but BONES_OTEL_ENDPOINT empty — no export")
+		default:
+			// Default build: env vars set but no exporter compiled.
+			fmt.Println("  off — built without -tags=otel (no exporter compiled in)")
+		}
+		return
+	}
+	fmt.Printf("  on  endpoint=%s install_id=%s\n",
+		os.Getenv("BONES_OTEL_ENDPOINT"), telemetry.InstallID())
 }
 
 // runBypassReport prints the ADR-0034 bypass-prevention checks: is

--- a/cmd/bones/main.go
+++ b/cmd/bones/main.go
@@ -9,6 +9,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"os"
@@ -16,6 +17,7 @@ import (
 	"github.com/alecthomas/kong"
 	_ "github.com/danmestas/libfossil/db/driver/modernc"
 
+	"github.com/danmestas/bones/internal/telemetry"
 	"github.com/danmestas/bones/internal/updatecheck"
 	bversion "github.com/danmestas/bones/internal/version"
 )
@@ -38,6 +40,12 @@ func main() {
 	// cached state. Suppressed by BONES_UPDATE_CHECK=0 and skipped on
 	// "dev" builds (i.e. anything not built by GoReleaser).
 	updatecheck.Check(version)
+
+	// Opt-in telemetry: reads BONES_TELEMETRY + BONES_OTEL_ENDPOINT
+	// per ADR 0039. No-op in default builds (no exporter compiled in)
+	// and no-op when env vars are absent (zero network egress).
+	shutdown := telemetry.Init(context.Background(), version, commit)
+	defer shutdown(context.Background())
 
 	// Handle --version / -V at the top level. Done before Kong.Parse so
 	// it doesn't collide with sub-flags like `bones repo extract --version`.

--- a/docs/adr/0039-opt-in-telemetry.md
+++ b/docs/adr/0039-opt-in-telemetry.md
@@ -1,0 +1,93 @@
+# ADR 0039: Opt-in OTLP telemetry for fixing bones
+
+## Context
+
+Errors that happen on operators' machines are invisible to the bones author. Hub-bind collisions, scaffold drift, swarm-commit failures, dirty-tree refusals, doctor warnings — all leave no trace beyond the operator's stderr unless they think to file an issue. The multi-workspace bug fixed in v0.4.1 (per ADR 0038) is a concrete example: it bit any user who tried to run bones against more than one repo concurrently, and the only way to learn about it was if the operator filed an issue. Telemetry that surfaces those failures upstream — without leaking PII — would close the feedback loop.
+
+The substrate for this is already partly built. PR #93 introduced `WorkspaceHash`, replacing literal `cwd` paths in spans with a deterministic 12-char sha256 prefix. PR #95 instrumented the verbs that matter — `hub.start`/`hub.stop`, `bones.up`, `apply`, `doctor` — with attributes that are exclusively booleans, integers, or workspace hashes (no paths, no error message strings, no slot/task names). No exporter was wired in either, so the spans went nowhere.
+
+This ADR closes the loop with an OTLP exporter, with privacy as a structural property of the design, not a configuration knob.
+
+## Decision
+
+bones ships an opt-in OTLP HTTP exporter that ships spans only when the operator explicitly enables it via two environment variables. Default off. Default build doesn't even compile in the exporter dependency.
+
+### Activation
+
+```
+BONES_TELEMETRY=1
+BONES_OTEL_ENDPOINT=https://signoz.example.com/v1/traces
+BONES_OTEL_HEADERS="signoz-ingestion-key=<token>"   # optional
+```
+
+Both `BONES_TELEMETRY=1` and a non-empty `BONES_OTEL_ENDPOINT` must be set. Either missing → no exporter is initialized → zero network egress. The `BONES_OTEL_HEADERS` value is a comma-separated `key=value` list, supporting token auth schemes like SigNoz Cloud's ingestion key.
+
+The exporter only exists in `-tags=otel` builds. Default builds (the binary you get from `brew install` or `go install`) compile a no-op `Init` regardless of env-var state. This is the structural guarantee that an unconfigured user cannot accidentally export anything.
+
+### First-run notice
+
+The first time bones starts with telemetry enabled (no `~/.bones/telemetry-acknowledged` marker), it prints one stderr line:
+
+```
+bones: telemetry enabled — exporting to https://signoz.example.com/v1/traces. Disable with BONES_TELEMETRY=0.
+```
+
+Then it writes the marker. Subsequent runs are silent until the marker is removed (or `$HOME` changes). The notice is intentionally loud and intentionally not silenceable — the user paying for telemetry to be on deserves to be told, every time the marker disappears.
+
+### Resource attributes (per process)
+
+| Attribute | Source | Purpose |
+|---|---|---|
+| `service.name` | hardcoded `"bones"` | OTLP convention |
+| `service.version` | linker-injected version | "8% of v0.4.1 installs hit X" |
+| `bones.commit` | linker-injected short commit | finer-grained attribution |
+| `goos`, `goarch` | runtime | OS-specific bug surfacing |
+| `install_id` | UUIDv4 at `~/.bones/install-id` | per-install aggregation without identifying the user |
+
+Explicitly **not** included: hostname, username, IP, working directory, repo name, environment variables.
+
+### Span attribute policy
+
+Per the schema set in PR #95, span attributes are exclusively:
+
+- **bool** — flags like `dry_run`, `dirty_refused`, `url_recorded`, `base_failed`
+- **int64** — counts like `added`, `modified`, `deleted`
+- **string** — only the 12-char `workspace_hash` (deterministic, irreversible)
+
+No file paths, no error message strings (errors are recorded via OTel's `RecordError` which only sees the type unless we feed it the string — and we don't), no slot names, no task titles, no commit content.
+
+### Failure mode
+
+Export failures are logged to `.orchestrator/hub.log` and dropped. No retries. Telemetry must never block a bones operation, and a misconfigured endpoint must not cause `bones up` or `bones apply` to fail. Shutdown flushes spans within a 5-second budget; anything still pending at exit is dropped.
+
+### `bones doctor` surface
+
+`bones doctor` adds a `=== telemetry ===` section showing:
+- `off — set BONES_TELEMETRY=1 + BONES_OTEL_ENDPOINT to enable` (default)
+- `off — built without -tags=otel (no exporter compiled in)`
+- `WARN  BONES_TELEMETRY=1 but BONES_OTEL_ENDPOINT empty — no export`
+- `on  endpoint=<url> install_id=<uuid>` (active)
+
+This is the operator's on-demand verifier for what (if anything) is leaving their machine.
+
+## Consequences
+
+- The bones author gets visibility into failure modes that would otherwise require user-initiated bug reports. Aggregate signal (% of installs hit hub-bind error, dirty-tree refusal frequency, hub-shutdown errors) becomes accessible without surveys or guessing.
+- Operators have to actively opt in. The default install ships zero-egress; the otel-tag build still ships zero-egress without the env vars. There is no way to enable telemetry by accident.
+- The `install_id` is the operator's choice: deleting `~/.bones/install-id` rotates it, severing any cross-session correlation. Documented in the doctor surface.
+- Adding new attributes to existing spans must follow the bool/int64/workspace_hash policy. Adding a string attribute requires a follow-up ADR explaining why it can't be reduced to a hash or a flag.
+- The `-tags=otel` GoReleaser build becomes the meaningful artifact. The default build remains the privacy-conservative path; users who want to send telemetry can build from source with `go install -tags=otel github.com/danmestas/bones/cmd/bones@latest` or wait for an opt-in release artifact.
+
+## Alternatives considered
+
+**Default-on with redaction layer.** Rejected. Telemetry that's on without explicit consent burns trust faster than the bugs it would catch. No redaction layer is bulletproof; structural opt-in via env-var-and-build-tag is.
+
+**Single binary that always includes the exporter.** Rejected. A user who never sets the env vars still ships a binary that knows how to talk to OTLP endpoints. The build-tag gate keeps the dependency surface (and the attack surface) zero for the common case.
+
+**Scrub error message strings and ship them.** Rejected for the first iteration. Error strings frequently include file paths, command output, and environmental details that are hard to redact safely. Bool flags + numeric outcomes already answer "how often does X happen" at the resolution that matters for fixing bones; full error messages can come later if a stronger redaction story exists.
+
+**Persisted opt-in (config file, not env var).** Considered. Env vars are scriptable, ephemeral by default, and visible to the operator at every invocation. A config-file opt-in is friendlier but invisible — turning telemetry on once and forgetting is exactly the failure mode opt-in is meant to prevent.
+
+## Status
+
+Accepted, 2026-04-30.

--- a/internal/telemetry/init.go
+++ b/internal/telemetry/init.go
@@ -1,0 +1,26 @@
+package telemetry
+
+import "context"
+
+// Init configures the telemetry exporter and returns a shutdown function
+// the caller (typically cmd/bones/main.go) should defer to flush
+// in-flight spans before exit.
+//
+// In default builds Init is a no-op and returns a no-op shutdown.
+// In `-tags=otel` builds Init reads BONES_TELEMETRY and
+// BONES_OTEL_ENDPOINT env vars; if both are set, an OTLP HTTP exporter
+// is wired and the global tracer provider is replaced.
+//
+// Init never returns a fatal error — telemetry is opt-in and must not
+// block or fail bones operations. Configuration errors are logged to
+// stderr and the no-op shutdown is returned in their place.
+func Init(ctx context.Context, version, commit string) func(context.Context) {
+	return initImpl(ctx, version, commit)
+}
+
+// IsEnabled reports whether telemetry is currently configured to export.
+// Reads the same env-var contract Init uses. Useful for `bones doctor`
+// to print "telemetry: on" without re-initializing the exporter.
+func IsEnabled() bool {
+	return isEnabledImpl()
+}

--- a/internal/telemetry/init_default.go
+++ b/internal/telemetry/init_default.go
@@ -1,0 +1,17 @@
+//go:build !otel
+
+package telemetry
+
+import "context"
+
+// initImpl is the no-op default. Without -tags=otel, bones has no
+// exporter wired regardless of env-var state — telemetry is dead code.
+func initImpl(_ context.Context, _, _ string) func(context.Context) {
+	return func(context.Context) {}
+}
+
+// isEnabledImpl always reports false in the default build: even if the
+// env vars are set, no exporter exists to honor them.
+func isEnabledImpl() bool {
+	return false
+}

--- a/internal/telemetry/init_default_test.go
+++ b/internal/telemetry/init_default_test.go
@@ -1,0 +1,25 @@
+//go:build !otel
+
+package telemetry
+
+import (
+	"context"
+	"testing"
+)
+
+func TestInit_DefaultIsNoOp(t *testing.T) {
+	shutdown := Init(context.Background(), "test", "abc")
+	if shutdown == nil {
+		t.Fatal("Init returned nil shutdown")
+	}
+	// Calling shutdown must not panic.
+	shutdown(context.Background())
+}
+
+func TestIsEnabled_DefaultIsFalse(t *testing.T) {
+	t.Setenv("BONES_TELEMETRY", "1")
+	t.Setenv("BONES_OTEL_ENDPOINT", "https://anywhere")
+	if IsEnabled() {
+		t.Error("default build IsEnabled() should be false even with env vars set")
+	}
+}

--- a/internal/telemetry/init_otel.go
+++ b/internal/telemetry/init_otel.go
@@ -1,0 +1,113 @@
+//go:build otel
+
+package telemetry
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"runtime"
+	"strings"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
+	"go.opentelemetry.io/otel/sdk/resource"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+)
+
+const (
+	envEnabled  = "BONES_TELEMETRY"
+	envEndpoint = "BONES_OTEL_ENDPOINT"
+	envHeaders  = "BONES_OTEL_HEADERS"
+)
+
+func isEnabledImpl() bool {
+	return os.Getenv(envEnabled) == "1" && os.Getenv(envEndpoint) != ""
+}
+
+// initImpl wires an OTLP HTTP exporter when both BONES_TELEMETRY=1 and
+// BONES_OTEL_ENDPOINT are set. The shutdown function flushes pending
+// spans within a 5-second budget so a kill at process end can't strand
+// in-flight exports forever.
+//
+// Any configuration error is logged to stderr and the no-op shutdown
+// is returned: telemetry must never block bones operations.
+func initImpl(ctx context.Context, version, commit string) func(context.Context) {
+	noop := func(context.Context) {}
+
+	if !isEnabledImpl() {
+		return noop
+	}
+	endpoint := os.Getenv(envEndpoint)
+
+	exporter, err := buildExporter(ctx, endpoint)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "bones: telemetry init failed: %v\n", err)
+		return noop
+	}
+
+	res, err := buildResource(ctx, version, commit)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "bones: telemetry resource init failed: %v\n", err)
+		return noop
+	}
+
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithBatcher(exporter),
+		sdktrace.WithResource(res),
+	)
+	otel.SetTracerProvider(tp)
+
+	FirstRunNotice(os.Stderr, endpoint)
+
+	return func(ctx context.Context) {
+		shutdownCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+		_ = tp.Shutdown(shutdownCtx)
+	}
+}
+
+func buildExporter(ctx context.Context, endpoint string) (sdktrace.SpanExporter, error) {
+	opts := []otlptracehttp.Option{otlptracehttp.WithEndpointURL(endpoint)}
+	if hdrs := parseHeaders(os.Getenv(envHeaders)); len(hdrs) > 0 {
+		opts = append(opts, otlptracehttp.WithHeaders(hdrs))
+	}
+	return otlptracehttp.New(ctx, opts...)
+}
+
+func buildResource(ctx context.Context, version, commit string) (*resource.Resource, error) {
+	return resource.New(ctx,
+		resource.WithAttributes(
+			semconv.ServiceName("bones"),
+			semconv.ServiceVersion(version),
+			attribute.String("bones.commit", commit),
+			attribute.String("install_id", InstallID()),
+			attribute.String("goos", runtime.GOOS),
+			attribute.String("goarch", runtime.GOARCH),
+		),
+	)
+}
+
+// parseHeaders parses a comma-separated key=value list (e.g.
+// "signoz-ingestion-key=abc,extra=foo") into a map suitable for
+// otlptracehttp.WithHeaders. Empty input returns nil. Malformed entries
+// (no '=') are silently dropped — better to lose a header than crash
+// at startup.
+func parseHeaders(s string) map[string]string {
+	if s == "" {
+		return nil
+	}
+	out := map[string]string{}
+	for _, kv := range strings.Split(s, ",") {
+		kv = strings.TrimSpace(kv)
+		idx := strings.Index(kv, "=")
+		if idx <= 0 {
+			continue
+		}
+		out[strings.TrimSpace(kv[:idx])] = strings.TrimSpace(kv[idx+1:])
+	}
+	return out
+}

--- a/internal/telemetry/installid.go
+++ b/internal/telemetry/installid.go
@@ -1,0 +1,43 @@
+package telemetry
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+// installIDFile is the path (relative to the user's home directory)
+// where the opaque per-install UUID is persisted. Same install across
+// many workspaces produces the same ID; uninstalling and reinstalling
+// produces a new one (manual deletion of ~/.bones/install-id resets it).
+const installIDFile = ".bones/install-id"
+
+// InstallID returns the opaque per-install identifier from
+// ~/.bones/install-id, generating and persisting a fresh UUIDv4 if the
+// file does not yet exist. Returns "" on I/O error — telemetry must
+// never block or fail a bones operation.
+//
+// The ID is meaningful only to the operator's own SigNoz backend: it
+// lets aggregations like "8% of installs hit hub-bind error in v0.4.1"
+// be answered without identifying any individual user. Hostname,
+// username, and path are deliberately not included anywhere.
+func InstallID() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	path := filepath.Join(home, installIDFile)
+	if data, err := os.ReadFile(path); err == nil {
+		if id := strings.TrimSpace(string(data)); id != "" {
+			return id
+		}
+	}
+	id := uuid.NewString()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return id
+	}
+	_ = os.WriteFile(path, []byte(id+"\n"), 0o644)
+	return id
+}

--- a/internal/telemetry/installid_test.go
+++ b/internal/telemetry/installid_test.go
@@ -1,0 +1,48 @@
+package telemetry
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestInstallID_GeneratesAndPersists(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	first := InstallID()
+	if first == "" {
+		t.Fatal("InstallID returned empty")
+	}
+	if len(first) < 32 {
+		t.Errorf("expected UUID-shaped string, got %q", first)
+	}
+
+	// Persisted: second call returns the same value.
+	second := InstallID()
+	if first != second {
+		t.Errorf("InstallID is non-deterministic: %q vs %q", first, second)
+	}
+
+	// Stored on disk.
+	data, err := os.ReadFile(filepath.Join(os.Getenv("HOME"), installIDFile))
+	if err != nil {
+		t.Fatalf("install-id not persisted: %v", err)
+	}
+	if string(data) == "" {
+		t.Error("install-id file is empty")
+	}
+}
+
+func TestInstallID_DifferentHomesDifferentIDs(t *testing.T) {
+	homeA := t.TempDir()
+	homeB := t.TempDir()
+
+	t.Setenv("HOME", homeA)
+	idA := InstallID()
+	t.Setenv("HOME", homeB)
+	idB := InstallID()
+
+	if idA == idB {
+		t.Errorf("expected distinct IDs across homes, got %q both", idA)
+	}
+}

--- a/internal/telemetry/notice.go
+++ b/internal/telemetry/notice.go
@@ -1,0 +1,45 @@
+package telemetry
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+// telemetryAckFile records that the operator has been shown the
+// first-run notice. Idempotency marker only: deletion of the file
+// re-arms the notice.
+const telemetryAckFile = ".bones/telemetry-acknowledged"
+
+// FirstRunNotice prints a one-line notice to w if the operator has not
+// yet acknowledged that telemetry is on. The acknowledgment is recorded
+// at ~/.bones/telemetry-acknowledged so subsequent invocations stay
+// quiet. Removing that file (or pointing $HOME elsewhere) re-arms the
+// notice.
+//
+// Always loud, never silent: the notice is the operator's signal that
+// data will leave their machine. If the ack file can't be written, the
+// notice still prints — better to nag than to silently export.
+func FirstRunNotice(w io.Writer, endpoint string) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		writeNotice(w, endpoint)
+		return
+	}
+	path := filepath.Join(home, telemetryAckFile)
+	if _, err := os.Stat(path); err == nil {
+		return
+	}
+	writeNotice(w, endpoint)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return
+	}
+	_ = os.WriteFile(path, []byte("acknowledged\n"), 0o644)
+}
+
+func writeNotice(w io.Writer, endpoint string) {
+	_, _ = fmt.Fprintf(w,
+		"bones: telemetry enabled — exporting to %s. Disable with BONES_TELEMETRY=0.\n",
+		endpoint)
+}

--- a/internal/telemetry/notice_test.go
+++ b/internal/telemetry/notice_test.go
@@ -1,0 +1,56 @@
+package telemetry
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestFirstRunNotice_PrintsOnceThenSilent(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	var buf bytes.Buffer
+	FirstRunNotice(&buf, "https://signoz.example.com/v1/traces")
+	first := buf.String()
+	if !strings.Contains(first, "telemetry enabled") {
+		t.Fatalf("first call did not print notice: %q", first)
+	}
+	if !strings.Contains(first, "https://signoz.example.com/v1/traces") {
+		t.Errorf("notice missing endpoint: %q", first)
+	}
+
+	// Second call: ack file exists, notice is silent.
+	buf.Reset()
+	FirstRunNotice(&buf, "https://signoz.example.com/v1/traces")
+	if buf.Len() != 0 {
+		t.Errorf("second call printed: %q", buf.String())
+	}
+
+	// Ack file exists.
+	ack := filepath.Join(os.Getenv("HOME"), telemetryAckFile)
+	if _, err := os.Stat(ack); err != nil {
+		t.Errorf("ack file missing: %v", err)
+	}
+}
+
+func TestFirstRunNotice_RearmedAfterAckRemoval(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	var buf bytes.Buffer
+	FirstRunNotice(&buf, "https://x")
+	if buf.Len() == 0 {
+		t.Fatal("first call should print")
+	}
+
+	// Remove ack — notice should re-arm.
+	if err := os.Remove(filepath.Join(os.Getenv("HOME"), telemetryAckFile)); err != nil {
+		t.Fatal(err)
+	}
+	buf.Reset()
+	FirstRunNotice(&buf, "https://x")
+	if buf.Len() == 0 {
+		t.Error("expected notice after ack removal, got nothing")
+	}
+}


### PR DESCRIPTION
## Summary

Third of four PRs for opt-in telemetry to a SigNoz backend (#93 path scrub, #95 instrumentation, this one wires the exporter, future PR for SigNoz dashboard).

This is the PR that actually ships data — gated by structural opt-in. Default builds compile no exporter dependency at all. \`-tags=otel\` builds compile the exporter in, but it stays a no-op unless both \`BONES_TELEMETRY=1\` and \`BONES_OTEL_ENDPOINT=...\` are set in env.

ADR 0039 is the privacy contract: bool / int64 / 12-char workspace_hash attrs only — no paths, no error message strings, no slot/task names.

## What changed

- **\`internal/telemetry/installid.go\`** — \`InstallID()\` returns an opaque UUIDv4 persisted at \`~/.bones/install-id\`. Lets aggregations like "8% of installs hit X" work without identifying anyone.
- **\`internal/telemetry/notice.go\`** — \`FirstRunNotice()\` prints a one-line stderr warning when telemetry is enabled and no \`~/.bones/telemetry-acknowledged\` marker exists, then writes the marker. Re-arms if the marker is removed.
- **\`internal/telemetry/init.go\`** — public \`Init(ctx, version, commit) → shutdownFunc\` and \`IsEnabled()\`.
- **\`internal/telemetry/init_default.go\`** (\`!otel\`) — both are no-ops; default-build binaries cannot ship telemetry regardless of env-var state.
- **\`internal/telemetry/init_otel.go\`** (\`otel\`) — reads env vars, builds OTLP HTTP exporter (with optional comma-separated \`BONES_OTEL_HEADERS\` for token auth), wires the SDK tracer provider, fires \`FirstRunNotice\`. Resource attrs: service.name, service.version, bones.commit, goos, goarch, install_id.
- **\`cmd/bones/main.go\`** — calls \`telemetry.Init\` at startup and defers shutdown to flush in-flight spans.
- **\`cli/doctor.go\`** — adds \`=== telemetry (ADR 0039) ===\` section that distinguishes off/misconfigured/no-otel-tag/on states. Prints endpoint + install_id when on.
- **\`docs/adr/0039-opt-in-telemetry.md\`** — full privacy contract and rationale.

## Activation surface

\`\`\`
BONES_TELEMETRY=1
BONES_OTEL_ENDPOINT=https://signoz.example.com/v1/traces
BONES_OTEL_HEADERS="signoz-ingestion-key=<token>"   # optional
\`\`\`

Either env var unset → no exporter initialized → zero network egress.

The default \`brew install\` / \`go install\` binary doesn't compile the exporter in. To enable telemetry, the operator builds with \`-tags=otel\`:
\`\`\`
go install -tags=otel github.com/danmestas/bones/cmd/bones@latest
\`\`\`

Or builds locally for use on their own machine. A future release artifact may ship an opt-in \`-otel\` build alongside the default one.

## Failure mode

Configuration errors log to stderr, return a no-op shutdown, and bones continues normally. Export failures are dropped at the OTel SDK layer (no retries, no blocking). Shutdown flushes within a 5-second budget; anything still pending at exit is dropped.

## Test plan

- [x] \`go test ./internal/telemetry/\` — 14 tests pass (existing 7 + new InstallID, FirstRunNotice, default Init no-op verification)
- [x] \`go build ./...\` — pass (default build, no exporter deps)
- [x] \`go build -tags=otel ./...\` — pass (otel build, exporter linked)
- [x] \`make check\` — fmt-check, vet, lint, race, todo-check all green
- [x] \`go test -tags=otel -short ./...\` — full CI-equivalent green