### PR TITLE
feat(telemetry): default-on Axiom export with one-command opt-out (ADR 0040)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,3 +31,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_PAT_TOKEN: ${{ secrets.HOMEBREW_PAT_TOKEN }}
+          # AXIOM_INGEST_TOKEN feeds the goreleaser ldflag that bakes
+          # the Axiom write token into release binaries (ADR 0040).
+          # Empty value still produces a valid binary — the runtime
+          # resolver lands at "off — release misconfigured" so the
+          # failure mode is loud, not silent. Sourced from Doppler
+          # via the GitHub secret of the same name.
+          AXIOM_INGEST_TOKEN: ${{ secrets.AXIOM_INGEST_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -17,14 +17,29 @@ builds:
     binary: bones
     env:
       - CGO_ENABLED=0
+    # -tags=otel compiles in the OTLP exporter so release binaries
+    # can phone home per ADR 0040. Source builds (`go install`)
+    # without this tag remain zero-egress; the build-tag gate is
+    # the structural guarantee that source-built binaries don't
+    # surprise their builders.
+    tags:
+      - otel
     flags:
       - -trimpath
       - -buildvcs=false
+    # AXIOM_INGEST_TOKEN is read from the build environment at
+    # release time. Locally: `doppler run -- goreleaser release`.
+    # CI: GitHub Actions secret (synced from Doppler or pasted).
+    # An empty token compiles successfully but the runtime resolver
+    # lands at "off — release misconfigured" — surfaces the missing
+    # secret in `bones doctor` instead of silently shipping a dead
+    # exporter (ADR 0040 §"Build-time gating").
     ldflags:
       - -s -w
       - -X main.version={{.Version}}
       - -X main.commit={{.ShortCommit}}
       - -X main.date={{.CommitDate}}
+      - -X github.com/danmestas/bones/internal/telemetry.axiomToken={{ .Env.AXIOM_INGEST_TOKEN }}
     goos:
       - linux
       - darwin

--- a/cli/doctor.go
+++ b/cli/doctor.go
@@ -63,27 +63,31 @@ func (c *DoctorCmd) Run(g *libfossilcli.Globals) (err error) {
 	return swarmErr
 }
 
-// runTelemetryReport prints the current opt-in telemetry status so the
+// runTelemetryReport prints the current telemetry status so the
 // operator can verify what (if anything) is leaving their machine.
-// Per ADR 0039, telemetry is fully opt-in via BONES_TELEMETRY=1 +
-// BONES_OTEL_ENDPOINT; this surface is the on-demand verifier.
+// Per ADR 0040, telemetry is default-on for release binaries with
+// a one-command opt-out; this surface is the on-demand verifier.
+//
+// Output mirrors `bones telemetry status` so a doctor run answers
+// the same operator question without a second invocation.
 func (c *DoctorCmd) runTelemetryReport() {
 	fmt.Println()
-	fmt.Println("=== telemetry (ADR 0039) ===")
-	if !telemetry.IsEnabled() {
-		switch {
-		case os.Getenv("BONES_TELEMETRY") != "1":
-			fmt.Println("  off — set BONES_TELEMETRY=1 + BONES_OTEL_ENDPOINT to enable")
-		case os.Getenv("BONES_OTEL_ENDPOINT") == "":
-			fmt.Println("  WARN  BONES_TELEMETRY=1 but BONES_OTEL_ENDPOINT empty — no export")
-		default:
-			// Default build: env vars set but no exporter compiled.
-			fmt.Println("  off — built without -tags=otel (no exporter compiled in)")
-		}
-		return
+	fmt.Println("=== telemetry (ADR 0040) ===")
+	state := "off"
+	if telemetry.IsEnabled() {
+		state = "on"
 	}
-	fmt.Printf("  on  endpoint=%s install_id=%s\n",
-		os.Getenv("BONES_OTEL_ENDPOINT"), telemetry.InstallID())
+	fmt.Printf("  %-4s  %s\n", state, telemetry.StatusReason())
+	if ep := telemetry.Endpoint(); ep != "" {
+		fmt.Printf("        endpoint=%s\n", ep)
+	}
+	if ds := telemetry.Dataset(); ds != "" {
+		fmt.Printf("        dataset=%s\n", ds)
+	}
+	if telemetry.IsEnabled() {
+		fmt.Printf("        install_id=%s\n", telemetry.InstallID())
+		fmt.Println("        opt out: bones telemetry disable")
+	}
 }
 
 // runBypassReport prints the ADR-0034 bypass-prevention checks: is

--- a/cli/telemetry.go
+++ b/cli/telemetry.go
@@ -1,0 +1,88 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+
+	libfossilcli "github.com/danmestas/libfossil/cli"
+
+	"github.com/danmestas/bones/internal/telemetry"
+)
+
+// TelemetryCmd groups the operator-facing telemetry verbs introduced
+// in ADR 0040. Default invocation (no subcommand) is treated as
+// `status` per the ADR's "fewer subcommands to remember" decision.
+//
+// The verbs are file-system-only — no NATS, no fossil, no workspace.
+// They work in any directory and on a fresh machine. Operators
+// running `bones telemetry disable` immediately after install (before
+// `bones up`) is the load-bearing UX.
+type TelemetryCmd struct {
+	Status  TelemetryStatusCmd  `cmd:"" default:"withargs" help:"Print current telemetry state"`
+	Disable TelemetryDisableCmd `cmd:"" help:"Opt out of telemetry (writes ~/.bones/no-telemetry)"`
+	Enable  TelemetryEnableCmd  `cmd:"" help:"Re-enable telemetry (removes the opt-out marker)"`
+}
+
+// TelemetryStatusCmd prints the current resolution outcome. Output
+// shape is one labeled line per fact (state, reason, endpoint,
+// dataset, install_id) so a script can parse it with grep.
+type TelemetryStatusCmd struct{}
+
+// Run renders the status. Always exits 0 — even "off" is a valid
+// state to report.
+func (c *TelemetryStatusCmd) Run(g *libfossilcli.Globals) error {
+	state := "off"
+	if telemetry.IsEnabled() {
+		state = "on"
+	}
+	_, _ = fmt.Fprintf(os.Stdout, "state:      %s\n", state)
+	_, _ = fmt.Fprintf(os.Stdout, "reason:     %s\n", telemetry.StatusReason())
+	if ep := telemetry.Endpoint(); ep != "" {
+		_, _ = fmt.Fprintf(os.Stdout, "endpoint:   %s\n", ep)
+	}
+	if ds := telemetry.Dataset(); ds != "" {
+		_, _ = fmt.Fprintf(os.Stdout, "dataset:    %s\n", ds)
+	}
+	if id := telemetry.InstallID(); id != "" {
+		_, _ = fmt.Fprintf(os.Stdout, "install_id: %s\n", id)
+	}
+	if path := telemetry.OptOutPath(); path != "" {
+		_, _ = fmt.Fprintf(os.Stdout, "opt_out:    %s\n", path)
+	}
+	return nil
+}
+
+// TelemetryDisableCmd writes the opt-out marker. Idempotent — safe
+// to run on a fresh install or repeatedly. Prints a confirmation
+// line so the operator sees the action took.
+type TelemetryDisableCmd struct{}
+
+// Run writes the marker file. Surfaces I/O errors directly with the
+// path so the operator can investigate (e.g. permission issues on
+// read-only home directories).
+func (c *TelemetryDisableCmd) Run(g *libfossilcli.Globals) error {
+	if err := telemetry.Disable(); err != nil {
+		return err
+	}
+	_, _ = fmt.Fprintf(os.Stdout,
+		"telemetry disabled. Marker: %s\nRe-enable with: bones telemetry enable\n",
+		telemetry.OptOutPath(),
+	)
+	return nil
+}
+
+// TelemetryEnableCmd removes the opt-out marker. Idempotent on a
+// fresh install (no marker → no-op).
+type TelemetryEnableCmd struct{}
+
+// Run removes the marker. The follow-up resolution outcome depends
+// on the build flavor and env vars; the printed hint points the
+// operator at `bones telemetry status` rather than guessing.
+func (c *TelemetryEnableCmd) Run(g *libfossilcli.Globals) error {
+	if err := telemetry.Enable(); err != nil {
+		return err
+	}
+	_, _ = fmt.Fprintln(os.Stdout,
+		"telemetry opt-out marker removed. Run `bones telemetry status` to see resolved state.")
+	return nil
+}

--- a/cmd/bones/cli.go
+++ b/cmd/bones/cli.go
@@ -32,6 +32,7 @@ type CLI struct {
 	ValidatePlan bonescli.ValidatePlanCmd `cmd:"" group:"tooling" help:"Validate plan"`
 	Orchestrator bonescli.OrchestratorCmd `cmd:"" group:"tooling" help:"Install orchestrator"`
 	Peek         bonescli.PeekCmd         `cmd:"" group:"tooling" help:"Browse hub via fossil ui"`
+	Telemetry    bonescli.TelemetryCmd    `cmd:"" group:"tooling" help:"Manage usage telemetry"`
 
 	// Plumbing — rarely invoked directly.
 	Init bonescli.InitCmd `cmd:"" group:"plumbing" help:"Create a workspace"`

--- a/docs/adr/0039-opt-in-telemetry.md
+++ b/docs/adr/0039-opt-in-telemetry.md
@@ -90,4 +90,4 @@ This is the operator's on-demand verifier for what (if anything) is leaving thei
 
 ## Status
 
-Accepted, 2026-04-30.
+Superseded by [ADR 0040](./0040-telemetry-default-on-axiom.md), 2026-04-30. Span-attribute policy and PII surface remain authoritative; the activation contract (env-var-only, default-off for release builds) is replaced.

--- a/docs/adr/0040-telemetry-default-on-axiom.md
+++ b/docs/adr/0040-telemetry-default-on-axiom.md
@@ -1,0 +1,126 @@
+# ADR 0040: Default-on telemetry to Axiom for release binaries
+
+## Context
+
+ADR 0039 made telemetry opt-in via two environment variables and a build tag. In the four weeks since, that contract proved too restrictive in one direction and too permissive in another.
+
+Too restrictive: nobody enabled it. The bones author has zero observability into the failure modes the substrate is meant to surface — hub-bind collisions, scaffold drift, swarm-commit failures, multi-workspace races. The OTLP wiring exists but the data never leaves an operator's machine because setting `BONES_TELEMETRY=1` plus an endpoint URL plus headers is friction operators don't pay without a personal stake.
+
+Too permissive: the `-tags=otel` build with env vars set will export to *any* endpoint. Operators who want to help bones get fixed must manage credentials for an OTLP backend bones doesn't run, and the bones author has no shared destination to look at when a bug surfaces. Aggregate signal across installs is structurally impossible.
+
+The product call: bones author runs Axiom, owns an ingest dataset, and wants release binaries to phone home by default with a one-command opt-out. Source-built binaries (`go install`, `make bones` without the otel tag) remain zero-egress. The single-token default ships only with goreleaser-built release artifacts.
+
+## Decision
+
+Release binaries default-on; source builds default-off. Opt-out is a single CLI command. No env vars required for the common path.
+
+### Build-time gating (unchanged from ADR 0039)
+
+`-tags=otel` still gates the OTLP exporter dependency. Source builds without the tag remain zero-egress regardless of all other configuration. The change is that goreleaser now sets the tag for every release build, and ldflag-injects the Axiom token at build time.
+
+```yaml
+# .goreleaser.yml
+builds:
+  - flags: [-tags=otel]
+    ldflags:
+      - -X github.com/danmestas/bones/internal/telemetry.axiomToken={{.Env.AXIOM_INGEST_TOKEN}}
+```
+
+The token lives in Doppler (or a GitHub Actions secret synced from Doppler). Local releases use `doppler run -- goreleaser release ...`. CI either syncs the secret via Doppler's GitHub integration or pulls it via a Doppler service token. Either way, the token never lands in source.
+
+A release binary built with an empty `axiomToken` (e.g. forgot the env var) compiles successfully but behaves as a source build: zero egress. This is the safety net for the "release script forgot the secret" failure mode.
+
+### Runtime resolution order
+
+The exporter wakes up only when telemetry is *on*. Resolution, top-down:
+
+1. `BONES_TELEMETRY=0` env var → off. Power-user kill switch for CI / sandboxed environments. Survives any other state.
+2. `~/.bones/no-telemetry` file present → off. Persistent opt-out written by `bones telemetry disable`.
+3. `BONES_OTEL_ENDPOINT` env var set → on, exporting to that endpoint. Self-host override; preserves ADR 0039's advanced-user path.
+4. `axiomToken` ldflag-injected and non-empty → on, exporting to baked-in Axiom config. The release-binary default.
+5. Otherwise → off. Source builds, dev binaries, and release binaries with empty token land here.
+
+### Baked-in Axiom config
+
+```go
+var (
+    axiomToken    = ""                                    // injected at release build
+    axiomDataset  = "bones-prod"                          // baked
+    axiomEndpoint = "https://api.axiom.co/v1/traces"      // baked
+)
+```
+
+OTLP HTTP request shape: `Authorization: Bearer <axiomToken>`, `X-Axiom-Dataset: bones-prod`. The dataset and endpoint are hardcoded so a stolen token can only spray one dataset; rotating the token (Axiom UI → regenerate) cuts off abuse without a code change.
+
+### Opt-out UX
+
+Three commands:
+
+```
+bones telemetry              # show current state + endpoint + install_id
+bones telemetry disable      # write ~/.bones/no-telemetry
+bones telemetry enable       # remove ~/.bones/no-telemetry
+```
+
+`bones telemetry status` is the alias for the bare `bones telemetry`. The bare verb is the one we mention everywhere — fewer subcommands to remember.
+
+The opt-out is a file, not an env var, because env vars are ephemeral and shell-specific. A user who runs `bones telemetry disable` once expects the setting to survive a new terminal, a reboot, and an upgrade. The file is the durable surface.
+
+### First-run notice
+
+On the first run with telemetry enabled (no `~/.bones/telemetry-acknowledged` marker), bones prints to stderr exactly one line and creates the marker:
+
+```
+bones: anonymous usage telemetry enabled — bones-prod dataset on Axiom. Opt out: bones telemetry disable
+```
+
+The notice is loud and unsilenceable per ADR 0039. Subsequent runs are silent until the marker disappears. Removing the marker re-prompts.
+
+### Span attribute policy (unchanged from ADR 0039)
+
+Span attributes remain bool / int64 / 12-char `workspace_hash`. No paths, no error strings, no slot/task names. PII risk is structural: the policy is enforced by the verb instrumentation, not by a runtime scrubber. ADR 0039 §"Span attribute policy" is the load-bearing description and is unchanged.
+
+`internal/telemetry/scrub.go` (workspace-path → hash) continues to gate every span attribute that could leak a path. New attributes that aren't bool/int/hash require a follow-up ADR per ADR 0039.
+
+### `bones doctor` surface (extended)
+
+```
+=== telemetry (ADR 0040) ===
+  on   endpoint=https://api.axiom.co/v1/traces dataset=bones-prod install_id=<uuid>
+
+=== telemetry (ADR 0040) ===
+  off — disabled by ~/.bones/no-telemetry
+
+=== telemetry (ADR 0040) ===
+  off — built without -tags=otel (source build, no exporter)
+
+=== telemetry (ADR 0040) ===
+  off — release build but axiomToken empty (release misconfigured)
+```
+
+The `release misconfigured` line surfaces the "build forgot the secret" case. Operators see it; the bones author sees it via support reports and knows the next release script ran without the env var.
+
+## Consequences
+
+- **Aggregate signal is unblocked.** Every release-binary install phones home by default; the dataset accumulates real-world failure-mode counts the bones author can act on.
+- **Trust burden is high.** Default-on telemetry without consent burns trust the moment a privacy-conscious user discovers it post-install. The first-run notice + one-command opt-out are the entire defense; both have to be perfect. The notice text, the disable command, and the Axiom dataset name are now contract surfaces — changing them requires a follow-up ADR.
+- **Token is extractable from the binary.** `strings bones | grep -i token` recovers the Axiom ingest token from any release binary. Mitigations: ingest-only API token (write-only, scoped to one dataset) → a stolen token cannot read or delete data; Axiom usage alerts on the dataset → cost spikes are visible immediately; rotating the token in Axiom UI cuts off abuse without a code change. The cost ceiling per month is bounded by Axiom's plan limits — the bones author accepts this as the price of default-on.
+- **Source builds remain trust-preserved.** `go install` produces a no-egress binary. A privacy-conservative user who builds bones from source has the same guarantee they had under ADR 0039.
+- **Reverses ADR 0039's "default off" promise.** Anyone reading 0039 in isolation will form the wrong mental model. 0039 must be marked superseded; the codebase must point both surfaces (notice text, doctor output) at this ADR's number.
+- **Opt-out file is the new contract.** Path `~/.bones/no-telemetry`. Don't move it without a migration; users who set it expect it to keep working across upgrades.
+
+## Alternatives considered
+
+**Keep ADR 0039 — opt-in only.** Rejected. After four weeks of zero data, the cost of the privacy-maximal stance is no observability at all. The release-only default-on with one-command opt-out is the better tradeoff for a tool whose maintainer needs the data to make the tool better.
+
+**Default-on for both source and release builds.** Rejected. Source builds are dev-loop binaries; the developer running `go install` from source is shipping a binary that may be embedded in unrelated tooling, CI, or test environments where phone-home is surprising. The build-tag gate is cheap to keep and the safety it provides is real.
+
+**Persisted opt-in (config file, not default-on).** Considered. Friendlier than env vars per ADR 0039 §"Persisted opt-in." Rejected because it's the same friction shape — most users will never run the enable command, so the dataset stays empty. The product call is "default-on with one-command opt-out" not "default-off with one-command opt-in."
+
+**Anonymized vendor (Sentry, PostHog, Honeycomb).** Defer. Axiom is the maintainer's existing tool; switching vendor is a separate decision once the data shape stabilizes.
+
+**Sample at the source.** Defer. Cost-control is currently handled by Axiom's plan and ingest-token rate limits. If volume becomes a problem, the next ADR adds a `sample_rate` ldflag-injected variable.
+
+## Status
+
+Accepted, 2026-04-30. Supersedes ADR 0039.

--- a/internal/telemetry/init.go
+++ b/internal/telemetry/init.go
@@ -24,3 +24,26 @@ func Init(ctx context.Context, version, commit string) func(context.Context) {
 func IsEnabled() bool {
 	return isEnabledImpl()
 }
+
+// StatusReason returns a human-readable explanation of the resolved
+// on/off state. Used by `bones telemetry status` and `bones doctor`
+// so operators see exactly why telemetry is on or off, not just the
+// boolean.
+func StatusReason() string {
+	return statusReasonImpl()
+}
+
+// Endpoint returns the OTLP URL the resolved config exports to, or
+// "" when telemetry is off. Lets the doctor surface print the
+// concrete URL without re-deriving the resolution.
+func Endpoint() string {
+	return endpointImpl()
+}
+
+// Dataset returns the Axiom dataset baked into this build, or "" on
+// source builds (or self-host overrides where the dataset concept
+// doesn't apply). Surfaces in `bones doctor` so an operator can
+// confirm which Axiom dataset their spans land in.
+func Dataset() string {
+	return datasetImpl()
+}

--- a/internal/telemetry/init_default.go
+++ b/internal/telemetry/init_default.go
@@ -15,3 +15,24 @@ func initImpl(_ context.Context, _, _ string) func(context.Context) {
 func isEnabledImpl() bool {
 	return false
 }
+
+// statusReasonImpl returns the canonical no-tag explanation. Source
+// builds (go install, make bones without -tags=otel) land here. The
+// reason string is referenced verbatim by ADR 0040; do not reword
+// without updating the ADR.
+func statusReasonImpl() string {
+	return "off — built without -tags=otel (source build, no exporter)"
+}
+
+// endpointImpl always returns the empty string in the default build:
+// nothing is exporting, so there's no endpoint to report.
+func endpointImpl() string {
+	return ""
+}
+
+// datasetImpl always returns the empty string in the default build:
+// the Axiom dataset is a release-build concept, irrelevant in source
+// builds.
+func datasetImpl() string {
+	return ""
+}

--- a/internal/telemetry/init_otel.go
+++ b/internal/telemetry/init_otel.go
@@ -18,32 +18,122 @@ import (
 	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 )
 
-const (
-	envEnabled  = "BONES_TELEMETRY"
-	envEndpoint = "BONES_OTEL_ENDPOINT"
-	envHeaders  = "BONES_OTEL_HEADERS"
+// Build-time injected Axiom configuration. axiomToken is the only
+// field set at build time (via goreleaser ldflag) — endpoint and
+// dataset are baked so a stolen token can only spray one dataset.
+// Per ADR 0040, an empty axiomToken means "this is a source build,
+// don't phone home" — the safety net for missed CI secrets.
+var (
+	axiomToken    = ""
+	axiomDataset  = "bones-prod"
+	axiomEndpoint = "https://api.axiom.co/v1/traces"
 )
 
-func isEnabledImpl() bool {
-	return os.Getenv(envEnabled) == "1" && os.Getenv(envEndpoint) != ""
+const (
+	// envEnabled is the kill switch. BONES_TELEMETRY=0 disables
+	// telemetry regardless of all other state — the highest-priority
+	// signal in the resolution order. Useful for CI / sandbox runs
+	// where the operator wants zero egress without writing the
+	// opt-out file.
+	envEnabled = "BONES_TELEMETRY"
+
+	// envEndpoint is the user-supplied endpoint override. When set,
+	// bones exports to that URL instead of the baked-in Axiom
+	// endpoint. Preserves ADR 0039's self-host path (a user with
+	// their own SigNoz/Tempo can keep using bones telemetry without
+	// touching the Axiom dataset).
+	envEndpoint = "BONES_OTEL_ENDPOINT"
+
+	// envHeaders is the user-supplied OTLP header list (comma-
+	// separated key=value). Only consulted when envEndpoint is set;
+	// the baked-in Axiom path generates its own auth header from
+	// axiomToken. Mirrors ADR 0039's BONES_OTEL_HEADERS contract.
+	envHeaders = "BONES_OTEL_HEADERS"
+
+	// axiomDatasetHeader is the HTTP header Axiom's OTLP receiver
+	// uses to route a span to a specific dataset. Hardcoded —
+	// bound to the value baked into axiomDataset above.
+	axiomDatasetHeader = "X-Axiom-Dataset"
+)
+
+// telemetryConfig captures the resolved on-or-off decision plus the
+// concrete endpoint + headers an enabled exporter should use. Pulled
+// out of resolve() so the doctor verb can introspect what would
+// happen without standing up an exporter.
+type telemetryConfig struct {
+	enabled  bool
+	endpoint string
+	headers  map[string]string
+	reason   string // human-readable explanation of how we got here
 }
 
-// initImpl wires an OTLP HTTP exporter when both BONES_TELEMETRY=1 and
-// BONES_OTEL_ENDPOINT are set. The shutdown function flushes pending
-// spans within a 5-second budget so a kill at process end can't strand
-// in-flight exports forever.
+// resolve evaluates the full resolution order from ADR 0040 and
+// returns the resulting config. Order, top-down:
+//
+//  1. BONES_TELEMETRY=0 → off (env kill switch)
+//  2. ~/.bones/no-telemetry exists → off (persistent opt-out)
+//  3. BONES_OTEL_ENDPOINT set → on, exporting to that endpoint
+//  4. axiomToken non-empty → on, exporting to baked Axiom config
+//  5. Otherwise → off (source build with no token)
+//
+// resolve never panics and never blocks. It is safe to call from a
+// command's doctor surface as well as from initImpl.
+func resolve() telemetryConfig {
+	if os.Getenv(envEnabled) == "0" {
+		return telemetryConfig{reason: "BONES_TELEMETRY=0 (env kill switch)"}
+	}
+	if IsOptedOut() {
+		return telemetryConfig{
+			reason: "disabled by " + OptOutPath(),
+		}
+	}
+	if ep := os.Getenv(envEndpoint); ep != "" {
+		return telemetryConfig{
+			enabled:  true,
+			endpoint: ep,
+			headers:  parseHeaders(os.Getenv(envHeaders)),
+			reason:   "BONES_OTEL_ENDPOINT override",
+		}
+	}
+	if axiomToken == "" {
+		return telemetryConfig{
+			reason: "release build but axiomToken empty (release misconfigured)",
+		}
+	}
+	return telemetryConfig{
+		enabled:  true,
+		endpoint: axiomEndpoint,
+		headers: map[string]string{
+			"Authorization":    "Bearer " + axiomToken,
+			axiomDatasetHeader: axiomDataset,
+		},
+		reason: "default (Axiom dataset=" + axiomDataset + ")",
+	}
+}
+
+// isEnabledImpl reports the resolved enable state. Reads env vars
+// and the opt-out file but does not stand up an exporter; safe for
+// doctor introspection.
+func isEnabledImpl() bool {
+	return resolve().enabled
+}
+
+// initImpl wires an OTLP HTTP exporter when resolve() reports
+// enabled. The shutdown function flushes pending spans within a
+// 5-second budget so a kill at process end can't strand in-flight
+// exports forever.
 //
 // Any configuration error is logged to stderr and the no-op shutdown
 // is returned: telemetry must never block bones operations.
 func initImpl(ctx context.Context, version, commit string) func(context.Context) {
 	noop := func(context.Context) {}
 
-	if !isEnabledImpl() {
+	cfg := resolve()
+	if !cfg.enabled {
 		return noop
 	}
-	endpoint := os.Getenv(envEndpoint)
 
-	exporter, err := buildExporter(ctx, endpoint)
+	exporter, err := buildExporter(ctx, cfg.endpoint, cfg.headers)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "bones: telemetry init failed: %v\n", err)
 		return noop
@@ -61,7 +151,7 @@ func initImpl(ctx context.Context, version, commit string) func(context.Context)
 	)
 	otel.SetTracerProvider(tp)
 
-	FirstRunNotice(os.Stderr, endpoint)
+	FirstRunNotice(os.Stderr, cfg.endpoint)
 
 	return func(ctx context.Context) {
 		shutdownCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
@@ -70,10 +160,12 @@ func initImpl(ctx context.Context, version, commit string) func(context.Context)
 	}
 }
 
-func buildExporter(ctx context.Context, endpoint string) (sdktrace.SpanExporter, error) {
+func buildExporter(
+	ctx context.Context, endpoint string, headers map[string]string,
+) (sdktrace.SpanExporter, error) {
 	opts := []otlptracehttp.Option{otlptracehttp.WithEndpointURL(endpoint)}
-	if hdrs := parseHeaders(os.Getenv(envHeaders)); len(hdrs) > 0 {
-		opts = append(opts, otlptracehttp.WithHeaders(hdrs))
+	if len(headers) > 0 {
+		opts = append(opts, otlptracehttp.WithHeaders(headers))
 	}
 	return otlptracehttp.New(ctx, opts...)
 }
@@ -89,6 +181,37 @@ func buildResource(ctx context.Context, version, commit string) (*resource.Resou
 			attribute.String("goarch", runtime.GOARCH),
 		),
 	)
+}
+
+// statusReasonImpl returns the live resolution explanation. Same
+// string surfaces in `bones doctor` and `bones telemetry status`.
+func statusReasonImpl() string {
+	return resolve().reason
+}
+
+// endpointImpl returns the URL the live resolution would export to,
+// or "" when telemetry is off. The doctor surface uses this to print
+// the concrete destination without re-deriving the resolution.
+func endpointImpl() string {
+	cfg := resolve()
+	if !cfg.enabled {
+		return ""
+	}
+	return cfg.endpoint
+}
+
+// datasetImpl returns the Axiom dataset baked into this build. Empty
+// when no token was injected (release misconfigured) or when an
+// envEndpoint override is in effect — the override path doesn't talk
+// to the bones-prod Axiom dataset.
+func datasetImpl() string {
+	if axiomToken == "" {
+		return ""
+	}
+	if os.Getenv(envEndpoint) != "" {
+		return ""
+	}
+	return axiomDataset
 }
 
 // parseHeaders parses a comma-separated key=value list (e.g.

--- a/internal/telemetry/init_otel_test.go
+++ b/internal/telemetry/init_otel_test.go
@@ -1,0 +1,144 @@
+//go:build otel
+
+package telemetry
+
+import (
+	"strings"
+	"testing"
+)
+
+// resetAxiomVars rewires the build-time-injected vars for a single
+// test, restoring them on cleanup. Lets tests exercise the
+// "release build with token" and "source build with empty token"
+// branches of resolve() without rebuilding.
+func resetAxiomVars(t *testing.T, token, dataset, endpoint string) {
+	t.Helper()
+	prevToken, prevDataset, prevEndpoint := axiomToken, axiomDataset, axiomEndpoint
+	t.Cleanup(func() {
+		axiomToken = prevToken
+		axiomDataset = prevDataset
+		axiomEndpoint = prevEndpoint
+	})
+	axiomToken = token
+	axiomDataset = dataset
+	axiomEndpoint = endpoint
+}
+
+// TestResolve_KillSwitchWins pins the highest-priority signal:
+// BONES_TELEMETRY=0 must disable telemetry regardless of the
+// opt-out file, env endpoint, or baked Axiom token. The kill
+// switch is the CI/sandbox escape hatch and must be load-bearing.
+func TestResolve_KillSwitchWins(t *testing.T) {
+	withTempHome(t)
+	t.Setenv("BONES_TELEMETRY", "0")
+	t.Setenv("BONES_OTEL_ENDPOINT", "https://override")
+	resetAxiomVars(t, "fake-token", "bones-prod", "https://api.axiom.co/v1/traces")
+
+	cfg := resolve()
+	if cfg.enabled {
+		t.Errorf("resolve: want off, got enabled=%v reason=%q", cfg.enabled, cfg.reason)
+	}
+	if !strings.Contains(cfg.reason, "BONES_TELEMETRY=0") {
+		t.Errorf("reason missing kill switch citation: %q", cfg.reason)
+	}
+}
+
+// TestResolve_OptOutFileBeatsBakedToken verifies that the
+// persistent opt-out file takes precedence over a release build's
+// baked Axiom token. The whole point of the opt-out file is that
+// it survives upgrades; if a baked token could override it,
+// upgrading to a new release would re-enable telemetry on a user
+// who'd disabled it. Pin that.
+func TestResolve_OptOutFileBeatsBakedToken(t *testing.T) {
+	withTempHome(t)
+	if err := Disable(); err != nil {
+		t.Fatalf("Disable: %v", err)
+	}
+	resetAxiomVars(t, "fake-token", "bones-prod", "https://api.axiom.co/v1/traces")
+
+	cfg := resolve()
+	if cfg.enabled {
+		t.Errorf("resolve: want off, got enabled=%v reason=%q", cfg.enabled, cfg.reason)
+	}
+	if !strings.Contains(cfg.reason, "no-telemetry") {
+		t.Errorf("reason missing opt-out citation: %q", cfg.reason)
+	}
+}
+
+// TestResolve_EnvOverrideUsesUserEndpoint covers the self-host
+// path: BONES_OTEL_ENDPOINT set means a user with their own
+// SigNoz/Tempo gets their endpoint, not the baked Axiom one.
+// The override is the load-bearing affordance for ADR 0039
+// users who don't want their data in the bones-prod dataset.
+func TestResolve_EnvOverrideUsesUserEndpoint(t *testing.T) {
+	withTempHome(t)
+	t.Setenv("BONES_OTEL_ENDPOINT", "https://my-signoz/v1/traces")
+	resetAxiomVars(t, "fake-token", "bones-prod", "https://api.axiom.co/v1/traces")
+
+	cfg := resolve()
+	if !cfg.enabled {
+		t.Fatalf("resolve: want enabled, got off reason=%q", cfg.reason)
+	}
+	if cfg.endpoint != "https://my-signoz/v1/traces" {
+		t.Errorf("endpoint: got %q, want override", cfg.endpoint)
+	}
+	if _, hasAuth := cfg.headers["Authorization"]; hasAuth {
+		t.Errorf("override path leaked Axiom Authorization header: %v", cfg.headers)
+	}
+}
+
+// TestResolve_BakedTokenIsDefaultOn pins the ADR 0040 default:
+// release binary, no opt-out, no env vars → exports to baked
+// Axiom config with the dataset header set. This is the
+// "1000% DX" path the ADR is built around.
+func TestResolve_BakedTokenIsDefaultOn(t *testing.T) {
+	withTempHome(t)
+	resetAxiomVars(t, "fake-token", "bones-prod", "https://api.axiom.co/v1/traces")
+
+	cfg := resolve()
+	if !cfg.enabled {
+		t.Fatalf("resolve: want enabled, got off reason=%q", cfg.reason)
+	}
+	if cfg.endpoint != "https://api.axiom.co/v1/traces" {
+		t.Errorf("endpoint: got %q, want baked", cfg.endpoint)
+	}
+	if cfg.headers["Authorization"] != "Bearer fake-token" {
+		t.Errorf("Authorization header: got %q", cfg.headers["Authorization"])
+	}
+	if cfg.headers[axiomDatasetHeader] != "bones-prod" {
+		t.Errorf("dataset header: got %q, want bones-prod", cfg.headers[axiomDatasetHeader])
+	}
+}
+
+// TestResolve_EmptyTokenIsOff covers the safety-net case for
+// release builds where the goreleaser env var was missing — the
+// binary compiles successfully but has no Axiom credentials.
+// Resolution must land at off with a reason that surfaces the
+// misconfiguration to anyone running `bones doctor`.
+func TestResolve_EmptyTokenIsOff(t *testing.T) {
+	withTempHome(t)
+	resetAxiomVars(t, "", "bones-prod", "https://api.axiom.co/v1/traces")
+
+	cfg := resolve()
+	if cfg.enabled {
+		t.Errorf("resolve: want off when token empty, got enabled=%v", cfg.enabled)
+	}
+	if !strings.Contains(cfg.reason, "axiomToken empty") {
+		t.Errorf("reason should surface release misconfiguration: %q", cfg.reason)
+	}
+}
+
+// TestDataset_EmptyOnEnvOverride verifies that Dataset() returns
+// "" when the user is exporting via BONES_OTEL_ENDPOINT, even if
+// the binary has a baked Axiom token. The dataset is bones-prod
+// only — surfacing it on a self-host path would lie to the user
+// about where their data goes.
+func TestDataset_EmptyOnEnvOverride(t *testing.T) {
+	withTempHome(t)
+	t.Setenv("BONES_OTEL_ENDPOINT", "https://my-signoz/v1/traces")
+	resetAxiomVars(t, "fake-token", "bones-prod", "https://api.axiom.co/v1/traces")
+
+	if got := Dataset(); got != "" {
+		t.Errorf("Dataset on env override: got %q, want \"\"", got)
+	}
+}

--- a/internal/telemetry/notice.go
+++ b/internal/telemetry/notice.go
@@ -40,6 +40,7 @@ func FirstRunNotice(w io.Writer, endpoint string) {
 
 func writeNotice(w io.Writer, endpoint string) {
 	_, _ = fmt.Fprintf(w,
-		"bones: telemetry enabled — exporting to %s. Disable with BONES_TELEMETRY=0.\n",
+		"bones: anonymous usage telemetry enabled — exporting to %s. "+
+			"Opt out: bones telemetry disable\n",
 		endpoint)
 }

--- a/internal/telemetry/notice_test.go
+++ b/internal/telemetry/notice_test.go
@@ -20,6 +20,9 @@ func TestFirstRunNotice_PrintsOnceThenSilent(t *testing.T) {
 	if !strings.Contains(first, "https://signoz.example.com/v1/traces") {
 		t.Errorf("notice missing endpoint: %q", first)
 	}
+	if !strings.Contains(first, "bones telemetry disable") {
+		t.Errorf("notice missing opt-out command: %q", first)
+	}
 
 	// Second call: ack file exists, notice is silent.
 	buf.Reset()

--- a/internal/telemetry/optout.go
+++ b/internal/telemetry/optout.go
@@ -1,0 +1,78 @@
+package telemetry
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// optOutFile is the path (relative to the user's home directory) of
+// the persistent opt-out marker. Per ADR 0040, the file's existence
+// alone disables telemetry — content is irrelevant. The path is part
+// of the opt-out contract; do not move it without a migration step.
+const optOutFile = ".bones/no-telemetry"
+
+// OptOutPath returns the absolute path of the opt-out marker for this
+// user. Returns "" if the home directory can't be resolved (rare but
+// possible in stripped sandbox environments). Used by `bones doctor`
+// and the `bones telemetry` verb to print a path the operator can
+// actually look at.
+func OptOutPath() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, optOutFile)
+}
+
+// IsOptedOut reports whether the persistent opt-out marker exists.
+// Distinct from BONES_TELEMETRY=0 (which is a per-process env-var
+// kill switch) — IsOptedOut is the durable state managed by
+// `bones telemetry disable` / `enable`. Errors during stat (other
+// than not-exist) return false: the operator is opted out only when
+// we can prove the file exists, not when we can't tell either way.
+func IsOptedOut() bool {
+	path := OptOutPath()
+	if path == "" {
+		return false
+	}
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+// Disable writes the opt-out marker, idempotent. Returns nil if the
+// marker already exists. Wraps any I/O failure with verb-shaped
+// context so the CLI can print it directly.
+//
+// The file content is a one-line comment explaining what it does so
+// an operator who finds it via `find ~ -name no-telemetry` knows it
+// was created intentionally and how to undo.
+func Disable() error {
+	path := OptOutPath()
+	if path == "" {
+		return errors.New("telemetry: cannot resolve home directory")
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("telemetry disable: mkdir: %w", err)
+	}
+	body := []byte("bones telemetry is disabled. Re-enable with: bones telemetry enable\n")
+	if err := os.WriteFile(path, body, 0o644); err != nil {
+		return fmt.Errorf("telemetry disable: write %s: %w", path, err)
+	}
+	return nil
+}
+
+// Enable removes the opt-out marker. Idempotent — a missing file is
+// not an error since the post-condition (telemetry not opted-out via
+// file) holds either way.
+func Enable() error {
+	path := OptOutPath()
+	if path == "" {
+		return errors.New("telemetry: cannot resolve home directory")
+	}
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("telemetry enable: remove %s: %w", path, err)
+	}
+	return nil
+}

--- a/internal/telemetry/optout_test.go
+++ b/internal/telemetry/optout_test.go
@@ -1,0 +1,93 @@
+package telemetry
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// withTempHome rewires HOME for the test so OptOutPath, Disable, and
+// Enable operate on a fresh tmpdir instead of the real ~/.bones. The
+// helper restores HOME on test cleanup so parallel and sequential
+// tests don't leak state into each other.
+func withTempHome(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	return dir
+}
+
+// TestIsOptedOut_FalseWhenMissing pins the default: a fresh install
+// (no opt-out file) is treated as opted-IN. Default-on is the load-
+// bearing decision in ADR 0040; if this returns true by accident,
+// the entire telemetry pipeline silently disables for everyone.
+func TestIsOptedOut_FalseWhenMissing(t *testing.T) {
+	withTempHome(t)
+	if IsOptedOut() {
+		t.Fatal("IsOptedOut: want false on fresh home, got true")
+	}
+}
+
+// TestDisable_CreatesMarkerAndOptsOut covers the happy path of
+// `bones telemetry disable`: the marker file lands at the expected
+// path with non-empty body (so a curious operator finding it via
+// `find` understands what it does), and IsOptedOut flips to true.
+func TestDisable_CreatesMarkerAndOptsOut(t *testing.T) {
+	dir := withTempHome(t)
+	if err := Disable(); err != nil {
+		t.Fatalf("Disable: %v", err)
+	}
+	if !IsOptedOut() {
+		t.Fatal("IsOptedOut: want true after Disable")
+	}
+	got, err := os.ReadFile(filepath.Join(dir, optOutFile))
+	if err != nil {
+		t.Fatalf("read opt-out file: %v", err)
+	}
+	if len(got) == 0 {
+		t.Errorf("opt-out file is empty; want a human-readable note")
+	}
+}
+
+// TestDisable_Idempotent verifies that calling Disable twice is not
+// an error — operators retrying the verb (or scripts running it
+// before every CI job) must converge silently.
+func TestDisable_Idempotent(t *testing.T) {
+	withTempHome(t)
+	if err := Disable(); err != nil {
+		t.Fatalf("first Disable: %v", err)
+	}
+	if err := Disable(); err != nil {
+		t.Fatalf("second Disable: %v", err)
+	}
+}
+
+// TestEnable_RemovesMarker covers `bones telemetry enable` after a
+// prior Disable. The marker file must be gone and IsOptedOut must
+// flip back to false.
+func TestEnable_RemovesMarker(t *testing.T) {
+	dir := withTempHome(t)
+	if err := Disable(); err != nil {
+		t.Fatalf("Disable: %v", err)
+	}
+	if err := Enable(); err != nil {
+		t.Fatalf("Enable: %v", err)
+	}
+	if IsOptedOut() {
+		t.Fatal("IsOptedOut: want false after Enable")
+	}
+	if _, err := os.Stat(filepath.Join(dir, optOutFile)); !os.IsNotExist(err) {
+		t.Errorf("opt-out file should be gone: stat err=%v", err)
+	}
+}
+
+// TestEnable_IdempotentOnMissingFile verifies that Enable on a fresh
+// install (no marker to remove) succeeds silently. Avoids an error
+// shape that'd surprise users who run `bones telemetry enable` as
+// a precaution before depending on telemetry being on.
+func TestEnable_IdempotentOnMissingFile(t *testing.T) {
+	withTempHome(t)
+	if err := Enable(); err != nil {
+		t.Fatalf("Enable on fresh home: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Supersedes ADR 0039's env-var-only opt-in. Release binaries now phone home to the bones-prod Axiom dataset by default; source builds remain zero-egress; opt-out is one CLI command.

**Why now:** ADR 0039 produced four weeks of zero data. Real-world failure modes (hub-bind collisions, scaffold drift, swarm-commit failures) need to surface for the bones author to act on. The fix is structural — release-only default-on, loud first-run notice, durable file-based opt-out.

## Resolution order

Top-down:

1. `BONES_TELEMETRY=0` → off (env kill switch for CI / sandbox)
2. `~/.bones/no-telemetry` → off (persistent opt-out)
3. `BONES_OTEL_ENDPOINT` set → on, exports to that endpoint (self-host preserved)
4. `axiomToken` non-empty → on, exports to baked Axiom config
5. Otherwise → off (source build with no token)

## Build-time

- `.goreleaser.yml` adds `tags: [otel]` and ldflag-injects `axiomToken` from `{{ .Env.AXIOM_INGEST_TOKEN }}`. Token lives in Doppler; locally `doppler run -- goreleaser release ...`, in CI a GitHub Actions secret of the same name (synced from Doppler or pasted).
- Empty token compiles successfully — runtime resolver lands at `off — release misconfigured` so the failure mode is loud, not silent.
- Endpoint and dataset are baked (`https://api.axiom.co/v1/traces` + `X-Axiom-Dataset: bones-prod`). A stolen token can only spray one dataset.

## UX

```
$ bones telemetry
state:      on
reason:     default (Axiom dataset=bones-prod)
endpoint:   https://api.axiom.co/v1/traces
dataset:    bones-prod
install_id: <uuid>
opt_out:    /Users/.../.bones/no-telemetry

$ bones telemetry disable
telemetry disabled. Marker: /Users/.../.bones/no-telemetry
Re-enable with: bones telemetry enable

$ bones telemetry enable
telemetry opt-out marker removed. Run `bones telemetry status` to see resolved state.
```

`bones doctor` extends with the same resolved status. First-run notice now mentions the opt-out command verbatim.

## Test plan

- [x] `make check` (fmt, vet, lint, race, todo-check) — green
- [x] `go test -tags=otel -short ./...` (CI-equivalent) — green
- [x] New tests:
  - `TestResolve_KillSwitchWins` — env kill takes precedence
  - `TestResolve_OptOutFileBeatsBakedToken` — upgrades don't re-enable a disabled user
  - `TestResolve_EnvOverrideUsesUserEndpoint` — self-host path preserved
  - `TestResolve_BakedTokenIsDefaultOn` — release-binary default
  - `TestResolve_EmptyTokenIsOff` — release-misconfigured surfaces in doctor
  - `TestDataset_EmptyOnEnvOverride` — no Axiom dataset leak on self-host
  - `TestDisable/TestEnable/TestIsOptedOut` — file-helper round-trip
- [x] End-to-end snapshot: `goreleaser build --snapshot --single-target` with `AXIOM_INGEST_TOKEN=test-fake` → `strings dist/.../bones | grep test-fake` confirms the token baked. Running the binary shows `state: on, dataset: bones-prod, endpoint: https://api.axiom.co/v1/traces`. Disable/enable round-trip confirmed.

## Risks (called out in ADR 0040)

- **Token is extractable from release binaries.** Mitigation: Axiom ingest-only API token (write-only, scoped to one dataset); usage alerts on the dataset; rotate via Axiom UI on abuse. Cost ceiling bounded by your Axiom plan.
- **Reverses ADR 0039's "default off" promise.** 0039 marked superseded. Doctor surface and first-run notice both cite ADR 0040 explicitly so anyone reading 0039 in isolation gets pointed forward.
- **Trust burden is high.** First-run notice + one-command opt-out are the entire defense. Both verified manually.

## Required action before first release

1. Create Axiom ingest-only API token scoped to dataset `bones-prod`.
2. Add `AXIOM_INGEST_TOKEN` to Doppler config bones uses.
3. Add `AXIOM_INGEST_TOKEN` as a GitHub Actions secret (or wire Doppler's GitHub integration to sync it).
4. Set Axiom usage alerts on the `bones-prod` dataset.

If a release ships with the secret missing, the binary still builds — `bones doctor` shows `off — release misconfigured` so the operator knows, the bones author can see it via support reports, and zero data is exported.