### PR TITLE
fix(workspace): self-explaining ErrLeafUnreachable message

### DIFF
--- a/cli/init.go
+++ b/cli/init.go
@@ -85,9 +85,6 @@ func reportWorkspace(op string, info workspace.Info, err error) error {
 	case errors.Is(err, workspace.ErrNoWorkspace):
 		fmt.Fprintln(os.Stderr,
 			"no bones workspace found; run `bones init` first")
-	case errors.Is(err, workspace.ErrLeafUnreachable):
-		fmt.Fprintln(os.Stderr,
-			"leaf daemon not reachable; its PID file may be stale")
 	case errors.Is(err, workspace.ErrLeafStartTimeout):
 		fmt.Fprintln(os.Stderr, "leaf failed to start within timeout")
 	}

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -243,10 +243,16 @@ func joinLogic(ctx context.Context, cwd string) (Info, error) {
 		return Info{}, fmt.Errorf("parse pid %q: %w", pidData, err)
 	}
 	if !pidAlive(pid) {
-		return Info{}, ErrLeafUnreachable
+		return Info{}, fmt.Errorf(
+			"%w: pid %d recorded in %s is not running; run `bones up` to rebind this workspace",
+			ErrLeafUnreachable, pid,
+			filepath.Join(workspaceDir, markerDirName, "leaf.pid"))
 	}
 	if !healthzOK(cfg.LeafHTTPURL+"/healthz", 500*time.Millisecond) {
-		return Info{}, ErrLeafUnreachable
+		return Info{}, fmt.Errorf(
+			"%w: pid %d alive but %s/healthz did not respond within 500ms;"+
+				" leaf may be hung — try `bones down && bones up`",
+			ErrLeafUnreachable, pid, cfg.LeafHTTPURL)
 	}
 	return Info{
 		AgentID:      cfg.AgentID,

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -370,6 +370,89 @@ func TestJoin_StaleLeaf(t *testing.T) {
 	if !errors.Is(err, ErrLeafUnreachable) {
 		t.Fatalf("Join: got %v, want ErrLeafUnreachable", err)
 	}
+	msg := err.Error()
+	for _, want := range []string{"leaf.pid", "bones up"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("Join error %q missing %q", msg, want)
+		}
+	}
+}
+
+// TestJoin_DeadPID_Message exercises the wrapped error without spawning a
+// real leaf. The marker is hand-built and points at a PID that is not a
+// running process; Join must wrap ErrLeafUnreachable with actionable detail.
+func TestJoin_DeadPID_Message(t *testing.T) {
+	dir := t.TempDir()
+	markerDir := filepath.Join(dir, markerDirName)
+	if err := os.MkdirAll(markerDir, 0o755); err != nil {
+		t.Fatalf("mkdir marker: %v", err)
+	}
+	cfg := config{
+		Version: configVersion, AgentID: "agent-x",
+		NATSURL: "nats://127.0.0.1:1", LeafHTTPURL: "http://127.0.0.1:1",
+		RepoPath: "repo.fossil", CreatedAt: "2026-04-30T00:00:00Z",
+	}
+	if err := saveConfig(filepath.Join(markerDir, "config.json"), cfg); err != nil {
+		t.Fatalf("saveConfig: %v", err)
+	}
+	// PID 1 exists but is init/launchd; pidAlive returns true. Use a high
+	// PID very unlikely to be in use so pidAlive returns false.
+	pidPath := filepath.Join(markerDir, "leaf.pid")
+	if err := os.WriteFile(pidPath, []byte("99999999"), 0o644); err != nil {
+		t.Fatalf("write pid: %v", err)
+	}
+
+	_, err := Join(context.Background(), dir)
+	if !errors.Is(err, ErrLeafUnreachable) {
+		t.Fatalf("Join: got %v, want ErrLeafUnreachable", err)
+	}
+	msg := err.Error()
+	for _, want := range []string{"99999999", "leaf.pid", "bones up"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error %q missing %q", msg, want)
+		}
+	}
+}
+
+// TestJoin_HealthzFail_Message: PID is live (this test process), but the
+// recorded LeafHTTPURL points at a closed port — Join should report the
+// healthz-timeout branch with the URL in the message.
+func TestJoin_HealthzFail_Message(t *testing.T) {
+	dir := t.TempDir()
+	markerDir := filepath.Join(dir, markerDirName)
+	if err := os.MkdirAll(markerDir, 0o755); err != nil {
+		t.Fatalf("mkdir marker: %v", err)
+	}
+	// Bind-then-close to grab a port that's almost certainly free.
+	port, err := pickFreePort()
+	if err != nil {
+		t.Fatalf("pickFreePort: %v", err)
+	}
+	closedURL := "http://127.0.0.1:" + strconv.Itoa(port)
+	cfg := config{
+		Version: configVersion, AgentID: "agent-x",
+		NATSURL: "nats://127.0.0.1:1", LeafHTTPURL: closedURL,
+		RepoPath: "repo.fossil", CreatedAt: "2026-04-30T00:00:00Z",
+	}
+	if err := saveConfig(filepath.Join(markerDir, "config.json"), cfg); err != nil {
+		t.Fatalf("saveConfig: %v", err)
+	}
+	livePID := strconv.Itoa(os.Getpid())
+	pidPath := filepath.Join(markerDir, "leaf.pid")
+	if err := os.WriteFile(pidPath, []byte(livePID), 0o644); err != nil {
+		t.Fatalf("write pid: %v", err)
+	}
+
+	_, err = Join(context.Background(), dir)
+	if !errors.Is(err, ErrLeafUnreachable) {
+		t.Fatalf("Join: got %v, want ErrLeafUnreachable", err)
+	}
+	msg := err.Error()
+	for _, want := range []string{closedURL, "healthz", "bones down"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error %q missing %q", msg, want)
+		}
+	}
 }
 
 func TestInit_EmitsSlogEvents(t *testing.T) {


### PR DESCRIPTION
## Summary

- `workspace.Join` now wraps `ErrLeafUnreachable` with the `leaf.pid` path, the recorded pid/url, and the recovery command (`bones up` for the dead-PID branch, `bones down && bones up` for the healthz-hung branch).
- `errors.Is(_, ErrLeafUnreachable)` still matches, so `ExitCode` mapping (4) and the `cli/init.go` switch keep working unchanged.
- Drops the now-redundant "PID file may be stale" suffix in `reportWorkspace` — the wrapped error already says exactly that, with specifics. Tasks/swarm/doctor commands that bypass that switch now self-explain too.

## Why

Norman's gulf of evaluation: when the marker pointed at a dead leaf, every call (`bones tasks status`, `bones swarm status`, `bones doctor`) printed bare `leaf daemon not reachable` with no signifier of *what* was checked or *what to do*. Same root cause produced different message quality depending on which command you ran.

Now from this checkout (which had `.bones/leaf.pid` pointing at a dead pid):

```
error: leaf daemon not reachable: pid 69608 recorded in
/path/to/.bones/leaf.pid is not running; run `bones up` to rebind this workspace
```

## Test plan

- [x] `go test -tags=otel -short ./...` passes
- [x] `make check` passes (fmt-check, vet, lint, race, todo-check)
- [x] New `TestJoin_DeadPID_Message` covers the dead-pid branch without spawning a real leaf
- [x] New `TestJoin_HealthzFail_Message` covers the healthz-hung branch (live pid, closed port)
- [x] Existing `TestJoin_StaleLeaf` strengthened to assert wrapped message contents
- [x] `errors.Is(err, ErrLeafUnreachable)` still matches in workspace_test.go