### PR TITLE
build(release): depend on danmestas/tap/leaf in brew formula

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -127,6 +127,14 @@ brews:
     homepage: https://github.com/danmestas/bones
     description: "Unified CLI for the bones agent-infrastructure substrate (workspace, orchestrator, tasks)."
     license: Apache-2.0
+    # bones spawns the leaf daemon via exec (see cli/up.go ensureLeafBinary).
+    # Brew users would otherwise hit "leaf daemon failed to start within
+    # timeout" because the leaf binary lives in the sibling EdgeSync repo.
+    # Pulling it as a brew dep makes `brew install danmestas/tap/bones`
+    # produce a working install without manual EdgeSync setup.
+    dependencies:
+      - name: danmestas/tap/leaf
+        type: required
     install: |
       bin.install "bones"
     test: |


### PR DESCRIPTION
## Summary
- Adds \`depends_on "danmestas/tap/leaf" => :required\` to the bones brew formula via goreleaser's \`brews.dependencies\` field.

## Why
Brew users hit \`leaf daemon failed to start within timeout\` immediately after \`brew install danmestas/tap/bones\` because the leaf binary lives in the sibling EdgeSync repo and isn't shipped. The fallback chain in cli/up.go (\$LEAF_BIN, \$ROOT/bin/leaf, \$EDGESYNC_DIR/bin/leaf, PATH, source build) only works for contributors who clone EdgeSync alongside bones and run \`make leaf\` — broken for end users.

Pulling leaf as a brew dep means \`brew install danmestas/tap/bones\` produces a working install.

## Test plan
- [x] \`goreleaser check\` passes.
- [x] \`AXIOM_INGEST_TOKEN= goreleaser release --snapshot --clean --skip=publish\` generates a formula with \`depends_on "danmestas/tap/leaf" => :required\`.
- [x] \`make check\` clean.
- [x] \`go test -tags=otel -short ./...\` clean.
- [ ] After merge + tag: confirm \`brew install danmestas/tap/bones\` pulls leaf and \`bones up\` works in a fresh dir.

## Coordination
**Land EdgeSync PR (danmestas/EdgeSync#94) and tag a release first**, otherwise the next bones release would have an unsatisfiable brew dep. The fallback resolution in \`ensureLeafBinary\` is intentionally left in place so contributors building from source still work.