### PR TITLE
Cross-workspace identity (Spec 1 impl) + audit + 3 specs

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -6,5 +6,8 @@
 
 set -e
 echo "[pre-push] running make ci-fast..."
+# Hooks inherit GIT_DIR/GIT_WORK_TREE from git; clear them so
+# git rev-parse resolves the work tree from cwd, not the env.
+unset GIT_DIR GIT_WORK_TREE
 cd "$(git rev-parse --show-toplevel)"
 make ci-fast

--- a/README.md
+++ b/README.md
@@ -104,6 +104,76 @@ From inside Claude Code: ask it to "uninstall bones" — the bundled `uninstall-
 
 Remove the binary: `brew uninstall bones` (or delete `$(go env GOPATH)/bin/bones` if you `go install`ed).
 
+## Shell prompt integration
+
+`bones env` prints shell-export statements for `BONES_WORKSPACE` and `BONES_WORKSPACE_CWD`. Wire it into your shell's prompt hook so the env vars stay in sync as you `cd` between workspaces.
+
+### zsh (`~/.zshrc`)
+
+```zsh
+_bones_env_hook() { eval "$(bones env)"; }
+typeset -ag precmd_functions
+precmd_functions+=(_bones_env_hook)
+```
+
+### bash (`~/.bashrc`)
+
+```bash
+PROMPT_COMMAND='eval "$(bones env)"'
+```
+
+### fish (`~/.config/fish/conf.d/bones.fish`)
+
+```fish
+function _bones_env_hook --on-event fish_prompt
+    bones env --shell=fish | source
+end
+```
+
+### Prompt theme integration
+
+Once `BONES_WORKSPACE` is exported, themes read it directly.
+
+**Starship** (`~/.config/starship.toml`):
+
+```toml
+[env_var.BONES_WORKSPACE]
+format = "[$env_value](bold yellow) "
+```
+
+**Powerlevel10k** — define a custom segment:
+
+```zsh
+function prompt_bones_workspace() {
+    [[ -n "$BONES_WORKSPACE" ]] && p10k segment -t "$BONES_WORKSPACE" -f yellow
+}
+```
+
+Then add `bones_workspace` to your `POWERLEVEL9K_RIGHT_PROMPT_ELEMENTS` (or `_LEFT_`).
+
+**Plain bash/zsh:**
+
+```bash
+PS1='[${BONES_WORKSPACE:-no-bones}] \w $ '
+```
+
+## Cross-workspace commands
+
+When running bones across multiple workspaces in parallel (e.g., 6 terminals on 3 different repos), these commands give a global view from any terminal:
+
+```
+$ bones status --all
+WORKSPACE          PATH                HUB    SESSIONS  UPTIME
+foo                ~/projects/foo      :8765  6         2h
+bar                ~/projects/bar      :8766  3         45m
+auth-service       ~/work/auth         :8767  1         10m
+
+$ bones down --all      # tear down every registered workspace (prompts unless --yes)
+$ bones rename auth-service   # set this workspace's display name
+```
+
+The registry that backs these commands lives at `~/.bones/workspaces/` (one JSON file per running workspace; created when a workspace's hub starts, removed by `bones down`).
+
 ## License
 
 Apache-2.0. See `[LICENSE](LICENSE)`.

--- a/cli/down.go
+++ b/cli/down.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/danmestas/bones/internal/githook"
 	"github.com/danmestas/bones/internal/hub"
+	"github.com/danmestas/bones/internal/registry"
 	"github.com/danmestas/bones/internal/workspace"
 )
 
@@ -113,6 +114,7 @@ type downAction struct {
 func planDown(root string, c *DownCmd) []downAction {
 	var plan []downAction
 	plan = append(plan, planStopHub(root, c)...)
+	plan = append(plan, planRemoveRegistry(root)...)
 	plan = append(plan, planRemoveGitHook(root)...)
 	plan = append(plan, planRemoveBonesDir(root)...)
 	plan = append(plan, planRemoveOrchestrator(root, c)...)
@@ -155,6 +157,16 @@ func planStopHub(root string, c *DownCmd) []downAction {
 			_ = hub.Stop(root)
 			return nil
 		},
+	}}
+}
+
+// planRemoveRegistry removes the workspace's cross-workspace registry entry.
+// Idempotent (no-op if no entry exists). Best-effort — failure doesn't block
+// other teardown actions.
+func planRemoveRegistry(root string) []downAction {
+	return []downAction{{
+		description: "remove registry entry for " + root,
+		do:          func() error { return registry.Remove(root) },
 	}}
 }
 

--- a/cli/down.go
+++ b/cli/down.go
@@ -15,6 +15,7 @@ import (
 	"github.com/danmestas/bones/internal/githook"
 	"github.com/danmestas/bones/internal/hub"
 	"github.com/danmestas/bones/internal/registry"
+	"github.com/danmestas/bones/internal/sessions"
 	"github.com/danmestas/bones/internal/workspace"
 )
 
@@ -33,18 +34,61 @@ type DownCmd struct {
 	KeepHooks  bool `name:"keep-hooks" help:"do not edit .claude/settings.json"`
 	KeepHub    bool `name:"keep-hub" help:"do not stop hub or remove .orchestrator/"`
 	DryRun     bool `name:"dry-run" help:"print plan without executing"`
+	All        bool `name:"all" help:"tear down all registered workspaces"`
 }
 
 // Run is the Kong entry point. Resolves the workspace root (walking
 // up from cwd if a marker exists, falling back to cwd otherwise),
 // builds an execution plan, prompts unless --yes, and executes.
 func (c *DownCmd) Run(g *libfossilcli.Globals) error {
+	if c.All {
+		return c.runAll()
+	}
 	cwd, err := os.Getwd()
 	if err != nil {
 		return fmt.Errorf("cwd: %w", err)
 	}
 	root := resolveDownRoot(cwd)
 	return runDown(root, c, os.Stdin)
+}
+
+// runAll iterates the workspace registry and tears each down. Prints
+// a summary, prompts unless --yes, then invokes runDown per workspace.
+func (c *DownCmd) runAll() error {
+	entries, err := registry.List()
+	if err != nil {
+		return err
+	}
+	if len(entries) == 0 {
+		fmt.Println("No workspaces running.")
+		return nil
+	}
+	fmt.Println("Will stop:")
+	for _, e := range entries {
+		fmt.Printf("  %-20s %s   sessions=%d\n",
+			e.Name, e.Cwd, sessions.CountByWorkspace(e.Cwd))
+	}
+	fmt.Printf("\n%d workspaces will be terminated.\n", len(entries))
+
+	if !c.Yes {
+		if !confirm(os.Stdin, "Continue?") {
+			return errors.New("down --all: aborted")
+		}
+	}
+
+	var firstErr error
+	for _, e := range entries {
+		single := *c
+		single.All = false
+		single.Yes = true
+		if err := runDown(e.Cwd, &single, os.Stdin); err != nil {
+			fmt.Fprintf(os.Stderr, "  %s: %v\n", e.Name, err)
+			if firstErr == nil {
+				firstErr = err
+			}
+		}
+	}
+	return firstErr
 }
 
 // resolveDownRoot returns the workspace root to operate on. Tries

--- a/cli/down_test.go
+++ b/cli/down_test.go
@@ -393,6 +393,31 @@ func TestRunDown_DryRun(t *testing.T) {
 	}
 }
 
+// TestDownAllInvokesPerWorkspace: runAll with --yes tears down every
+// registered workspace and removes their registry entries.
+func TestDownAllInvokesPerWorkspace(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	ws1 := t.TempDir()
+	ws2 := t.TempDir()
+	now := time.Now().UTC()
+	for _, ws := range []string{ws1, ws2} {
+		if err := registry.Write(registry.Entry{
+			Cwd: ws, Name: filepath.Base(ws), HubPID: os.Getpid(), StartedAt: now,
+		}); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+	}
+	cmd := &DownCmd{Yes: true, KeepHub: true, All: true}
+	if err := cmd.runAll(); err != nil {
+		t.Fatalf("runAll: %v", err)
+	}
+	for _, ws := range []string{ws1, ws2} {
+		if _, err := registry.Read(ws); !errors.Is(err, registry.ErrNotFound) {
+			t.Fatalf("expected registry entry removed for %s, got %v", ws, err)
+		}
+	}
+}
+
 // TestDownRemovesRegistry: runDown removes the workspace registry entry
 // when one exists. Uses --keep-hub to avoid touching hub processes.
 func TestDownRemovesRegistry(t *testing.T) {

--- a/cli/down_test.go
+++ b/cli/down_test.go
@@ -2,10 +2,14 @@ package cli
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/danmestas/bones/internal/registry"
 )
 
 // TestRemoveBonesHooks_RemovesScaffoldedHooks pins the surgical-edit
@@ -240,28 +244,38 @@ func TestRemoveBonesHooks_MissingFile(t *testing.T) {
 	}
 }
 
-// TestPlanDown_EmptyTree: on a tree without bones state, the only
-// queued action is the always-on hub stop (best-effort, no-op when
-// the hub isn't running). Per ADR 0041, planStopHub no longer probes
-// for a script — it always queues hub.Stop.
+// TestPlanDown_EmptyTree: on a tree without bones state, the always-on
+// actions are hub stop and registry removal (both best-effort, no-ops when
+// nothing is running). Per ADR 0041, planStopHub no longer probes for a
+// script — it always queues hub.Stop.
 func TestPlanDown_EmptyTree(t *testing.T) {
 	dir := t.TempDir()
 	plan := planDown(dir, &DownCmd{})
-	if len(plan) != 1 {
-		t.Fatalf("empty tree plan: got %d actions, want 1 (hub stop):\n%+v", len(plan), plan)
+	if len(plan) != 2 {
+		t.Fatalf("empty tree plan: got %d actions, want 2 (hub stop + registry remove):\n%+v",
+			len(plan), plan)
 	}
-	if !strings.Contains(plan[0].description, "stop hub") {
-		t.Errorf("only action should be hub stop; got %q", plan[0].description)
+	descs := plan[0].description + "\n" + plan[1].description
+	if !strings.Contains(descs, "stop hub") {
+		t.Errorf("plan missing hub stop; got:\n%s", descs)
+	}
+	if !strings.Contains(descs, "registry entry") {
+		t.Errorf("plan missing registry remove; got:\n%s", descs)
 	}
 }
 
-// TestPlanDown_EmptyTree_KeepHub: --keep-hub suppresses the stop-hub
-// action, leaving an empty plan on a clean tree.
+// TestPlanDown_EmptyTree_KeepHub: --keep-hub suppresses the stop-hub action.
+// Registry removal is always-on (independent of hub lifecycle), so the plan
+// still contains the registry-remove action.
 func TestPlanDown_EmptyTree_KeepHub(t *testing.T) {
 	dir := t.TempDir()
 	plan := planDown(dir, &DownCmd{KeepHub: true})
-	if len(plan) != 0 {
-		t.Errorf("KeepHub on empty tree should give empty plan; got:\n%+v", plan)
+	if len(plan) != 1 {
+		t.Fatalf("KeepHub on empty tree: got %d actions, want 1 (registry remove):\n%+v",
+			len(plan), plan)
+	}
+	if !strings.Contains(plan[0].description, "registry entry") {
+		t.Errorf("only action should be registry remove; got %q", plan[0].description)
 	}
 }
 
@@ -287,6 +301,7 @@ func TestPlanDown_FullInstall(t *testing.T) {
 	joined := strings.Join(descs, "\n")
 	wants := []string{
 		"stop hub",
+		"registry entry",
 		".bones",
 		".orchestrator",
 		".claude/skills/orchestrator",
@@ -375,6 +390,32 @@ func TestRunDown_DryRun(t *testing.T) {
 	}
 	if !dirExists(filepath.Join(dir, ".bones")) {
 		t.Errorf(".bones/ removed during --dry-run")
+	}
+}
+
+// TestDownRemovesRegistry: runDown removes the workspace registry entry
+// when one exists. Uses --keep-hub to avoid touching hub processes.
+func TestDownRemovesRegistry(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	wsDir := t.TempDir()
+
+	// Seed a registry entry for this workspace.
+	if err := registry.Write(registry.Entry{
+		Cwd:       wsDir,
+		Name:      "test",
+		HubPID:    os.Getpid(),
+		StartedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("seed registry: %v", err)
+	}
+
+	cmd := &DownCmd{Yes: true, KeepHub: true}
+	if err := runDown(wsDir, cmd, strings.NewReader("")); err != nil {
+		t.Fatalf("runDown: %v", err)
+	}
+
+	if _, err := registry.Read(wsDir); !errors.Is(err, registry.ErrNotFound) {
+		t.Fatalf("expected registry entry removed, got %v", err)
 	}
 }
 

--- a/cli/env.go
+++ b/cli/env.go
@@ -1,0 +1,93 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/danmestas/bones/internal/workspace"
+)
+
+// walkUpToBones returns (workspaceRoot, true) if a .bones directory
+// exists at startDir or any ancestor; otherwise ("", false).
+func walkUpToBones(startDir string) (string, bool) {
+	dir := startDir
+	for {
+		if _, err := os.Stat(filepath.Join(dir, ".bones")); err == nil {
+			return dir, true
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", false
+		}
+		dir = parent
+	}
+}
+
+// resolveWorkspaceName returns the human display name for the workspace
+// at root. If .bones/workspace_name exists, returns its trimmed contents;
+// otherwise basename(root).
+func resolveWorkspaceName(root string) string {
+	if name, err := workspace.ReadName(root); err == nil && name != "" {
+		return name
+	}
+	return filepath.Base(root)
+}
+
+type EnvCmd struct {
+	Shell string `name:"shell" help:"shell: bash|zsh|fish (default: auto)" enum:"bash,zsh,fish,"`
+}
+
+func (c *EnvCmd) Run() error { return c.run(os.Stdout) }
+
+func (c *EnvCmd) run(w io.Writer) error {
+	shell := c.Shell
+	if shell == "" {
+		shell = detectShell()
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	root, found := walkUpToBones(cwd)
+	if !found {
+		writeUnset(w, shell)
+		return nil
+	}
+	name := resolveWorkspaceName(root)
+	writeExport(w, shell, "BONES_WORKSPACE", name)
+	writeExport(w, shell, "BONES_WORKSPACE_CWD", root)
+	return nil
+}
+
+func detectShell() string {
+	s := os.Getenv("SHELL")
+	switch {
+	case strings.HasSuffix(s, "/zsh"):
+		return "zsh"
+	case strings.HasSuffix(s, "/fish"):
+		return "fish"
+	default:
+		return "bash"
+	}
+}
+
+func writeExport(w io.Writer, shell, k, v string) {
+	if shell == "fish" {
+		_, _ = fmt.Fprintf(w, "set -gx %s %s\n", k, v)
+	} else {
+		_, _ = fmt.Fprintf(w, "export %s=%s\n", k, v)
+	}
+}
+
+func writeUnset(w io.Writer, shell string) {
+	for _, k := range []string{"BONES_WORKSPACE", "BONES_WORKSPACE_CWD"} {
+		if shell == "fish" {
+			_, _ = fmt.Fprintf(w, "set -e %s\n", k)
+		} else {
+			_, _ = fmt.Fprintf(w, "unset %s\n", k)
+		}
+	}
+}

--- a/cli/env_test.go
+++ b/cli/env_test.go
@@ -1,0 +1,129 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestWalkUpToBones(t *testing.T) {
+	root := t.TempDir()
+	deep := filepath.Join(root, "a", "b", "c")
+	if err := os.MkdirAll(deep, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	bonesDir := filepath.Join(root, "a", ".bones")
+	if err := os.MkdirAll(bonesDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	got, found := walkUpToBones(deep)
+	if !found {
+		t.Fatalf("expected to find .bones above %s", deep)
+	}
+	if got != filepath.Join(root, "a") {
+		t.Fatalf("got %s, want %s", got, filepath.Join(root, "a"))
+	}
+	other := t.TempDir()
+	if _, found := walkUpToBones(other); found {
+		t.Fatalf("expected not found in %s", other)
+	}
+}
+
+func TestResolveWorkspaceName(t *testing.T) {
+	t.Run("basename when no override", func(t *testing.T) {
+		root := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(root, ".bones"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		got := resolveWorkspaceName(root)
+		if got != filepath.Base(root) {
+			t.Fatalf("got %q, want %q", got, filepath.Base(root))
+		}
+	})
+	t.Run("override from .bones/workspace_name", func(t *testing.T) {
+		root := t.TempDir()
+		bones := filepath.Join(root, ".bones")
+		if err := os.MkdirAll(bones, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		namePath := filepath.Join(bones, "workspace_name")
+		if err := os.WriteFile(namePath, []byte("auth-service\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		got := resolveWorkspaceName(root)
+		if got != "auth-service" {
+			t.Fatalf("got %q, want auth-service", got)
+		}
+	})
+}
+
+func TestEnvCmdInsideWorkspace(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".bones"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Manual chdir + cleanup (t.Chdir requires Go 1.24+)
+	oldCwd, _ := os.Getwd()
+	if err := os.Chdir(root); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldCwd) })
+
+	var buf strings.Builder
+	cmd := EnvCmd{Shell: "bash"}
+	if err := cmd.run(&buf); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "export BONES_WORKSPACE=") {
+		t.Fatalf("missing BONES_WORKSPACE export:\n%s", out)
+	}
+	// resolved root may differ from `root` due to /var → /private/var symlink on macOS
+	resolvedRoot, _ := filepath.EvalSymlinks(root)
+	if !strings.Contains(out, "export BONES_WORKSPACE_CWD="+root) &&
+		!strings.Contains(out, "export BONES_WORKSPACE_CWD="+resolvedRoot) {
+		t.Fatalf("missing BONES_WORKSPACE_CWD export:\n%s", out)
+	}
+}
+
+func TestEnvCmdOutsideWorkspace(t *testing.T) {
+	other := t.TempDir()
+	oldCwd, _ := os.Getwd()
+	if err := os.Chdir(other); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldCwd) })
+
+	var buf strings.Builder
+	cmd := EnvCmd{Shell: "bash"}
+	if err := cmd.run(&buf); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{"unset BONES_WORKSPACE", "unset BONES_WORKSPACE_CWD"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("expected %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestEnvCmdFishSyntax(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".bones"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	oldCwd, _ := os.Getwd()
+	if err := os.Chdir(root); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldCwd) })
+
+	var buf strings.Builder
+	if err := (&EnvCmd{Shell: "fish"}).run(&buf); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if !strings.Contains(buf.String(), "set -gx BONES_WORKSPACE ") {
+		t.Fatalf("expected fish 'set -gx', got:\n%s", buf.String())
+	}
+}

--- a/cli/rename.go
+++ b/cli/rename.go
@@ -1,0 +1,75 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/danmestas/bones/internal/registry"
+	"github.com/danmestas/bones/internal/workspace"
+)
+
+func validateRenameName(name string) error {
+	if name == "" {
+		return fmt.Errorf("name must be non-empty")
+	}
+	if len(name) > 128 {
+		return fmt.Errorf("name too long (max 128 chars)")
+	}
+	if strings.ContainsAny(name, "/\\") {
+		return fmt.Errorf("name must not contain path separator (/ or \\)")
+	}
+	return nil
+}
+
+type RenameCmd struct {
+	NewName string `arg:"" required:""`
+}
+
+func (c *RenameCmd) Run() error {
+	if err := validateRenameName(c.NewName); err != nil {
+		return err
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	root, found := walkUpToBones(cwd)
+	if !found {
+		return fmt.Errorf("not inside a bones workspace (no .bones/ found above %s)", cwd)
+	}
+
+	// Uniqueness check across all live workspaces
+	entries, err := registry.List()
+	if err != nil {
+		return err
+	}
+	for _, e := range entries {
+		if e.Cwd == root {
+			continue
+		}
+		if e.Name == c.NewName {
+			return fmt.Errorf(
+				"name %q is already used by workspace at %s\n"+
+					"  (rename that workspace first, or pick a different name)",
+				c.NewName, e.Cwd,
+			)
+		}
+	}
+
+	// Write the override file (source of truth)
+	if err := workspace.WriteName(root, c.NewName); err != nil {
+		return err
+	}
+
+	// Update registry entry's Name field if registered
+	if entry, err := registry.Read(root); err == nil {
+		entry.Name = c.NewName
+		if err := registry.Write(entry); err != nil {
+			return err
+		}
+	}
+
+	fmt.Printf("Renamed %s: → %s\n", root, c.NewName)
+	return nil
+}

--- a/cli/rename_test.go
+++ b/cli/rename_test.go
@@ -1,0 +1,119 @@
+package cli
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/danmestas/bones/internal/registry"
+	"github.com/danmestas/bones/internal/workspace"
+)
+
+func TestValidateRenameName(t *testing.T) {
+	tests := []struct {
+		name string
+		want string // expected error substring; "" = ok
+	}{
+		{"", "non-empty"},
+		{"foo", ""},
+		{"foo/bar", "separator"},
+		{"foo\\bar", "separator"},
+		{"auth-service", ""},
+		{strings.Repeat("a", 200), "too long"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateRenameName(tt.name)
+			if tt.want == "" {
+				if err != nil {
+					t.Fatalf("expected ok, got %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("expected error containing %q, got %v", tt.want, err)
+			}
+		})
+	}
+}
+
+func TestRenameWritesAndUpdatesRegistry(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	wsDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(wsDir, ".bones"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	oldCwd, _ := os.Getwd()
+	if err := os.Chdir(wsDir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldCwd) })
+
+	// Seed registry with this workspace (resolve symlinks for macOS)
+	resolvedWs, _ := filepath.EvalSymlinks(wsDir)
+	if err := registry.Write(registry.Entry{
+		Cwd: resolvedWs, Name: filepath.Base(resolvedWs),
+		HubPID: os.Getpid(), StartedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	cmd := RenameCmd{NewName: "auth-service"}
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	// .bones/workspace_name updated
+	got, _ := workspace.ReadName(resolvedWs)
+	if got != "auth-service" {
+		t.Fatalf("workspace_name = %q, want auth-service", got)
+	}
+
+	// registry entry updated
+	e, _ := registry.Read(resolvedWs)
+	if e.Name != "auth-service" {
+		t.Fatalf("registry name = %q, want auth-service", e.Name)
+	}
+}
+
+func TestRenameRejectsCollision(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	otherWS := t.TempDir()
+	wsDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(wsDir, ".bones"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	oldCwd, _ := os.Getwd()
+	if err := os.Chdir(wsDir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldCwd) })
+
+	resolvedWs, _ := filepath.EvalSymlinks(wsDir)
+	now := time.Now().UTC()
+	if err := registry.Write(registry.Entry{
+		Cwd: otherWS, Name: "taken", HubPID: os.Getpid(), StartedAt: now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := registry.Write(registry.Entry{
+		Cwd: resolvedWs, Name: "self", HubPID: os.Getpid(), StartedAt: now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := RenameCmd{NewName: "taken"}
+	err := cmd.Run()
+	if err == nil {
+		t.Fatalf("expected collision error, got nil")
+	}
+	if !strings.Contains(err.Error(), "already used by") {
+		t.Fatalf("expected 'already used by' in error, got %v", err)
+	}
+
+	// errors.Is would normally check sentinel; here we just check substring
+	_ = errors.New
+}

--- a/cli/session_marker.go
+++ b/cli/session_marker.go
@@ -1,0 +1,42 @@
+package cli
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/danmestas/bones/internal/sessions"
+)
+
+// SessionMarkerCmd is hidden from --help; it exists only for bones-managed
+// SessionStart/End hooks to call. The marker schema lives in the sessions
+// package; this verb is the only call site.
+type SessionMarkerCmd struct {
+	Register   SessionMarkerRegisterCmd   `cmd:"" name:"register"`
+	Unregister SessionMarkerUnregisterCmd `cmd:"" name:"unregister"`
+}
+
+type SessionMarkerRegisterCmd struct {
+	SessionID string `name:"session-id" required:""`
+	Cwd       string `name:"cwd" required:"" help:"absolute workspace cwd"`
+	PID       int    `name:"pid" required:"" help:"claude (or harness) process PID"`
+}
+
+func (c *SessionMarkerRegisterCmd) Run() error {
+	return sessions.Register(sessions.Marker{
+		SessionID:    c.SessionID,
+		WorkspaceCwd: c.Cwd,
+		ClaudePID:    c.PID,
+		StartedAt:    time.Now().UTC(),
+	})
+}
+
+type SessionMarkerUnregisterCmd struct {
+	SessionID string `name:"session-id" required:""`
+}
+
+func (c *SessionMarkerUnregisterCmd) Run() error {
+	if c.SessionID == "" {
+		return fmt.Errorf("--session-id required")
+	}
+	return sessions.Unregister(c.SessionID)
+}

--- a/cli/session_marker_test.go
+++ b/cli/session_marker_test.go
@@ -1,0 +1,44 @@
+package cli
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/danmestas/bones/internal/sessions"
+)
+
+func TestSessionMarkerRegister(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	cmd := SessionMarkerRegisterCmd{
+		SessionID: "test-sid",
+		Cwd:       "/Users/dan/projects/foo",
+		PID:       os.Getpid(),
+	}
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	path := filepath.Join(os.Getenv("HOME"), ".bones", "sessions", cmd.SessionID+".json")
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("expected marker at %s: %v", path, err)
+	}
+	if got := sessions.ListByWorkspace(cmd.Cwd); len(got) != 1 {
+		t.Fatalf("ListByWorkspace = %d markers, want 1", len(got))
+	}
+}
+
+func TestSessionMarkerUnregister(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	reg := SessionMarkerRegisterCmd{SessionID: "to-remove", Cwd: "/x", PID: os.Getpid()}
+	if err := reg.Run(); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	un := SessionMarkerUnregisterCmd{SessionID: "to-remove"}
+	if err := un.Run(); err != nil {
+		t.Fatalf("Unregister: %v", err)
+	}
+	if _, err := os.Stat(sessions.MarkerPath("to-remove")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("marker still exists after Unregister")
+	}
+}

--- a/cli/status.go
+++ b/cli/status.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -15,16 +16,19 @@ import (
 	libfossilcli "github.com/danmestas/libfossil/cli"
 
 	"github.com/danmestas/bones/internal/hub"
+	"github.com/danmestas/bones/internal/registry"
+	"github.com/danmestas/bones/internal/sessions"
 	"github.com/danmestas/bones/internal/swarm"
 	"github.com/danmestas/bones/internal/tasks"
 	"github.com/danmestas/bones/internal/workspace"
 )
 
 // StatusCmd renders a one-shot snapshot of the workspace combining
-// NATS task/session state with the hub fossil timeline. No flags yet
-// — the v1 tracer bullet is fixed-shape so we can iterate on layout
-// against real data before pinning a JSON schema or filter knobs.
-type StatusCmd struct{}
+// NATS task/session state with the hub fossil timeline.
+type StatusCmd struct {
+	All  bool `name:"all" help:"show status across all workspaces on this user/host"`
+	JSON bool `name:"json" help:"emit machine-readable JSON"`
+}
 
 // activityKind is a small enum for event sources in the unified feed.
 // Symbols below are paired with each kind in renderActivity.
@@ -74,6 +78,12 @@ type activityEvent struct {
 }
 
 func (c *StatusCmd) Run(g *libfossilcli.Globals) error {
+	if c.All {
+		if c.JSON {
+			return renderStatusAllJSON(os.Stdout)
+		}
+		return renderStatusAll(os.Stdout)
+	}
 	ctx, stop, info, err := joinWorkspace()
 	if err != nil {
 		return err
@@ -351,4 +361,102 @@ func truncateTitle(s string, n int) string {
 		return s
 	}
 	return s[:n-1] + "…"
+}
+
+// renderStatusAll iterates the workspace registry, prunes stale entries
+// in place (live-only semantics), and prints a table summarizing every
+// running workspace on this user/host.
+func renderStatusAll(w io.Writer) error {
+	entries, err := registry.List()
+	if err != nil {
+		return err
+	}
+	live := entries[:0]
+	for _, e := range entries {
+		if registry.IsAlive(e) {
+			live = append(live, e)
+		} else {
+			_ = registry.Remove(e.Cwd)
+		}
+	}
+	if len(live) == 0 {
+		_, err := io.WriteString(w, "No workspaces running. Use 'bones up' in a project.\n")
+		return err
+	}
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	if _, err := fmt.Fprintln(tw, "WORKSPACE\tPATH\tHUB\tSESSIONS\tUPTIME"); err != nil {
+		return err
+	}
+	for _, e := range live {
+		_, err := fmt.Fprintf(tw, "%s\t%s\t%s\t%d\t%s\n",
+			e.Name,
+			shortenHome(e.Cwd),
+			extractPort(e.HubURL),
+			sessions.CountByWorkspace(e.Cwd),
+			humanDuration(time.Since(e.StartedAt)),
+		)
+		if err != nil {
+			return err
+		}
+	}
+	return tw.Flush()
+}
+
+// renderStatusAllJSON emits a JSON object with a "workspaces" array
+// covering every live registry entry.
+func renderStatusAllJSON(w io.Writer) error {
+	entries, err := registry.List()
+	if err != nil {
+		return err
+	}
+	live := entries[:0]
+	for _, e := range entries {
+		if registry.IsAlive(e) {
+			live = append(live, e)
+		} else {
+			_ = registry.Remove(e.Cwd)
+		}
+	}
+	type row struct {
+		Cwd       string    `json:"cwd"`
+		Name      string    `json:"name"`
+		HubURL    string    `json:"hub_url"`
+		Sessions  int       `json:"sessions"`
+		StartedAt time.Time `json:"started_at"`
+	}
+	rows := make([]row, len(live))
+	for i, e := range live {
+		rows[i] = row{e.Cwd, e.Name, e.HubURL, sessions.CountByWorkspace(e.Cwd), e.StartedAt}
+	}
+	return json.NewEncoder(w).Encode(struct {
+		Workspaces []row `json:"workspaces"`
+	}{rows})
+}
+
+// shortenHome replaces the user's $HOME prefix with ~ for table display.
+func shortenHome(p string) string {
+	if home := os.Getenv("HOME"); home != "" && strings.HasPrefix(p, home) {
+		return "~" + p[len(home):]
+	}
+	return p
+}
+
+// extractPort returns ":8765" given "http://127.0.0.1:8765".
+func extractPort(url string) string {
+	idx := strings.LastIndex(url, ":")
+	if idx < 0 {
+		return url
+	}
+	return url[idx:]
+}
+
+// humanDuration formats a duration as an approximate "Xs/Xm/Xh" string.
+func humanDuration(d time.Duration) string {
+	if d < time.Minute {
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	}
+	if d < time.Hour {
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	}
+	return fmt.Sprintf("%dh", int(d.Hours()))
 }

--- a/cli/status_test.go
+++ b/cli/status_test.go
@@ -2,10 +2,15 @@ package cli
 
 import (
 	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/danmestas/bones/internal/registry"
 	"github.com/danmestas/bones/internal/swarm"
 	"github.com/danmestas/bones/internal/tasks"
 )
@@ -164,5 +169,79 @@ func TestSplitTimeAndRest(t *testing.T) {
 
 	if _, _, ok := splitTimeAndRest("not a timestamp"); ok {
 		t.Error("expected !ok for malformed line")
+	}
+}
+
+func TestStatusAllRendersTable(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+	}))
+	defer srv.Close()
+
+	now := time.Now().UTC()
+	pid := os.Getpid()
+	for _, e := range []registry.Entry{
+		{Cwd: "/Users/dan/foo", Name: "foo", HubURL: srv.URL, HubPID: pid, StartedAt: now},
+		{Cwd: "/Users/dan/bar", Name: "bar", HubURL: srv.URL, HubPID: pid, StartedAt: now},
+	} {
+		if err := registry.Write(e); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+	}
+
+	var buf bytes.Buffer
+	if err := renderStatusAll(&buf); err != nil {
+		t.Fatalf("renderStatusAll: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{"WORKSPACE", "foo", "bar", "PATH"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestStatusAllEmptyRegistry(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	var buf bytes.Buffer
+	if err := renderStatusAll(&buf); err != nil {
+		t.Fatalf("renderStatusAll: %v", err)
+	}
+	if !strings.Contains(buf.String(), "No workspaces running") {
+		t.Fatalf("expected 'No workspaces running', got: %s", buf.String())
+	}
+}
+
+func TestStatusAllJSON(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+	}))
+	defer srv.Close()
+	if err := registry.Write(registry.Entry{
+		Cwd: "/x", Name: "x", HubURL: srv.URL, HubPID: os.Getpid(), StartedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	var buf bytes.Buffer
+	if err := renderStatusAllJSON(&buf); err != nil {
+		t.Fatalf("renderStatusAllJSON: %v", err)
+	}
+	var got struct {
+		Workspaces []struct {
+			Name string `json:"name"`
+			Cwd  string `json:"cwd"`
+		} `json:"workspaces"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(got.Workspaces) != 1 {
+		t.Fatalf("workspaces len = %d, want 1", len(got.Workspaces))
+	}
+	if got.Workspaces[0].Name != "x" {
+		t.Fatalf("name = %q, want x", got.Workspaces[0].Name)
 	}
 }

--- a/cmd/bones/cli.go
+++ b/cmd/bones/cli.go
@@ -38,4 +38,7 @@ type CLI struct {
 	Init bonescli.InitCmd `cmd:"" group:"plumbing" help:"Create a workspace"`
 	Join bonescli.JoinCmd `cmd:"" group:"plumbing" help:"Locate an existing workspace"`
 	Hub  bonescli.HubCmd  `cmd:"" group:"plumbing" help:"Manage the embedded Fossil + NATS hub"`
+
+	// Internal — hidden from --help, called by bones-managed hooks.
+	SessionMarker bonescli.SessionMarkerCmd `cmd:"" name:"session-marker" hidden:""`
 }

--- a/cmd/bones/cli.go
+++ b/cmd/bones/cli.go
@@ -19,6 +19,7 @@ type CLI struct {
 	Tasks  bonescli.TasksCmd  `cmd:"" group:"daily" help:"Inspect and mutate runtime agent tasks"`
 	Swarm  bonescli.SwarmCmd  `cmd:"" group:"daily" help:"Run as a slot-shaped swarm participant"`
 	Apply  bonescli.ApplyCmd  `cmd:"" group:"daily" help:"Materialize hub trunk into git tree"`
+	Env    bonescli.EnvCmd    `cmd:"" group:"daily" help:"Emit shell exports for current workspace"`
 
 	// Repository.
 	Repo libfossilcli.RepoCmd `cmd:"" group:"repo" help:"Fossil repository operations"`

--- a/cmd/bones/cli.go
+++ b/cmd/bones/cli.go
@@ -20,6 +20,7 @@ type CLI struct {
 	Swarm  bonescli.SwarmCmd  `cmd:"" group:"daily" help:"Run as a slot-shaped swarm participant"`
 	Apply  bonescli.ApplyCmd  `cmd:"" group:"daily" help:"Materialize hub trunk into git tree"`
 	Env    bonescli.EnvCmd    `cmd:"" group:"daily" help:"Emit shell exports for current workspace"`
+	Rename bonescli.RenameCmd `cmd:"" group:"daily" help:"Set workspace display name"`
 
 	// Repository.
 	Repo libfossilcli.RepoCmd `cmd:"" group:"repo" help:"Fossil repository operations"`

--- a/docs/adr/0038-per-workspace-hub-ports.md
+++ b/docs/adr/0038-per-workspace-hub-ports.md
@@ -43,6 +43,8 @@ A new migration in `mergeSettings` (`migrateSessionEndShutdown`, layered on the 
 
 **Single global hub multiplexing all workspaces.** Rejected. Cross-workspace NATS subject routing would invade every consumer; the workspace-as-isolation-unit story matches the existing design (per-workspace fossil, per-workspace pid files, per-workspace .bones/).
 
+> **Future supersession trigger:** The "cross-workspace NATS subject routing" objection is solvable via JetStream `domain=` and per-account isolation. See `docs/superpowers/specs/2026-05-01-cross-workspace-identity-design.md` (Future Direction section) for the leaf-node topology that revisits this decision when cross-machine, real-time, or multi-user becomes a forcing function.
+
 **Mutex semantics — refuse to start a second workspace while one is up.** Cheaper than dynamic ports, but breaks the user's mental model ("each repo is its own bones") and forces cross-workspace coordination on the user.
 
 **Allocate ports at `bones up` time, store in `.bones/config.json`.** Considered. Rejected because hub state has its own files alongside config (`hub-fossil-url`, `hub-nats-url`), and tying hub ports to workspace config means re-running `bones up` to recover from a port stuck-in-TIME_WAIT. The recorded-URL-files approach gives the same persistence with cleaner ownership.

--- a/docs/audits/2026-05-01-dx-6-terminals-from-agentic-engineer.md
+++ b/docs/audits/2026-05-01-dx-6-terminals-from-agentic-engineer.md
@@ -1,0 +1,87 @@
+# DX Audit — bones from 6 parallel terminals (agentic engineer perspective)
+
+**Date:** 2026-05-01
+**Method:** software-philosophy `dx-audit` skill
+**Persona:** Agentic engineer with 6 `claude` sessions open in 6 repos (or 6 worktrees), each driving bones swarm work in parallel. Switches between terminals constantly. Wants visibility into all 6 from any one terminal. The 6-vs-3-vs-1 distribution across workspaces is realistic — multiple terminals can attach to a single workspace.
+
+## Summary
+
+| # | Workflow | Frequency | Score | Biggest gap |
+|---|---|---:|---:|---|
+| 1 | Bootstrap workspace (`bones up`) | per-repo, occasional | 8/10 | "Did the hook fire?" only visible in session banner |
+| 2 | Dispatch parallel swarm from plan | several/day/terminal | 6/10 | Plan annotation + orchestrator skill not discoverable from `bones --help` |
+| 3 | Slot lifecycle (join/commit/close) | continuous (subagent) | 8/10 | Verb set is clean (ADR 0028); the subagent does it for you |
+| 4 | Apply fossil → git (`bones apply`) | per session | 6/10 | Two-fossil mental model is confusing (ADR 0041 in flight) |
+| 5 | **Cross-workspace status** ("which of 6 is stuck?") | **many/day** | **2/10** | **No `bones status --all`. cd-and-check 6 times.** |
+| 6 | Recover stuck slot | weekly | 4/10 | `bones doctor` flags it but doesn't print the recovery command |
+| 7 | Hub crash recovery | rare | 7/10 | SessionStart auto-recovers; `bones up` idempotent |
+| 8 | **End-of-day cleanup of all hubs** | **daily** | **3/10** | **No `bones down --all`. cd × 6.** |
+| 9 | Know which terminal is which workspace | constant | 5/10 | No prompt indicator; easy to fire wrong-terminal commands |
+| 10 | Debug a failed task | several/day | 4/10 | `-v` per command, no `bones logs --slot=X`, no aggregator |
+
+**Weighted overall: ~5/10** — solid primitives, painful seams when scaling past 1 workspace.
+
+## Per-workflow notes
+
+**1 · Bootstrap.** Idempotent. Hook recovers. Only nit: when 6 terminals fire SessionStart hooks at once, you see 6 "hub-bootstrap: hub at http://127.0.0.1:..." banners and can't tell at a glance which port belongs to which workspace. Banner could include `cwd` or workspace name.
+
+**2 · Dispatch swarm.** The orchestrator path requires: write plan → annotate `[slot: name]` → invoke `orchestrator` skill → skill calls Task tool. Three layers. A new agentic engineer reading `bones --help` will not find this — there's no `bones swarm dispatch <plan>` verb. Discoverability gap.
+
+**3 · Slot lifecycle.** This is bones at its best. `swarm join → commit → close` is crisp, well-typed, ADR-documented. The subagent skill drives it; you don't think about it. Keep.
+
+**4 · Apply.** Mental model tax: which fossil tip am I applying — workspace `repo.fossil` or hub `hub.fossil`? ADR 0041 collapses these into one. Until it lands, every `bones apply` requires "wait, which one again?"
+
+**5 · Cross-workspace status. (THE BIG ONE.)** With 6 terminals, the most common question is "is anything stuck right now?" Today's answer: open a 7th terminal, `cd` into each of 6 directories, run `bones doctor` in each, eyeball the output, repeat. NATS state is per-workspace; there's no global view. This is the single biggest leverage point.
+
+**6 · Stuck-slot recovery.** `bones doctor` will say `slot foo: stale (last_renewed 8m ago)`. It will not say "to release: `bones swarm close --slot=foo --result=fail`". You have to remember the verb. Minor — but multiplied by 6 workspaces, you forget under load.
+
+**7 · Hub crash.** Genuinely good. SessionStart hook + idempotent `bones up` means you mostly don't notice.
+
+**8 · Cleanup.** End of day, you have 6 hub leafs + 6 workspace leafs + NATS stores eating RAM and disk. There is no `bones down --all` or `bones cleanup --inactive-since=24h`. You either cd × 6 to run `bones down --yes`, or accumulate cruft.
+
+**9 · Terminal context.** No `BONES_WORKSPACE` env var exposed to the shell prompt. After 4 hours, you fire `bones swarm close --slot=auth` in the terminal that's actually working on `payments`. No safety net.
+
+**10 · Debug.** `-v` flag must be re-passed every invocation; output is slog to stderr; no log file. Fossil timeline (`bones repo timeline`) is the source of truth but assumes you know fossil. No `bones logs --slot=X --tail`.
+
+## What works well
+
+- **Idempotent daemons.** `bones up` is a star — no "did I already start it?" anxiety.
+- **Per-workspace port allocation (ADR 0038).** Six workspaces don't fight over `:8765`. Precondition for the 6-terminal use case existing at all.
+- **Swarm verb set (ADR 0028).** `join/commit/close` with explicit `--result=` is the right shape.
+- **NATS KV for claims.** CAS-based, multi-host aware, surfaces in `doctor`.
+- **`bones doctor` as the single seam.** One command answers "is this workspace healthy?" — even if it doesn't yet answer "are all my workspaces healthy?"
+
+## What's broken (for this persona specifically)
+
+- **No global view.** Bones thinks at workspace granularity; the 6-terminal user thinks at engineer granularity. The mental model mismatch is the root cause of the 3 lowest scores (#5, #8, #9).
+- **Discoverability of orchestrator dispatch.** It's a skill, not a verb. `bones --help` hides the most powerful workflow.
+- **Recovery requires tribal knowledge.** Doctor diagnoses but doesn't prescribe.
+- **No log surface.** `-v` is fine for one terminal; useless across 6.
+
+## Ranked improvements (frequency × severity × feasibility)
+
+1. **`~/.bones/workspaces.json` registry + `bones status --all`.** Each `bones up` registers `{cwd, hub_url, started_at}`. `bones status --all` walks the registry, hits each hub's `/health`, prints one table. Biggest single lever for this persona.
+
+2. **`bones doctor` suggests exact recovery commands.** When tagging `stale` or `dead`, append the literal `bones swarm close --slot=X --result=fail` line. ~20 lines of code; outsized impact on weekly recovery friction.
+
+3. **`bones down --all` / `bones cleanup --inactive=Xh`.** End-of-day teardown across registered workspaces. Pairs with #1's registry.
+
+4. **Promote orchestrator dispatch to a verb.** `bones swarm dispatch ./plan.md` should exist and show in `bones --help`. The skill can stay as the implementation, but the verb makes it discoverable.
+
+5. **Land ADR 0041.** Collapses the two-fossil model. Already on the branch (and now merged).
+
+6. **Export `BONES_WORKSPACE` for shell prompts.** `bones up` writes the name to a known location; users add a one-liner to their starship/p10k config. Documented snippet in the README.
+
+7. **`bones logs --slot=X --tail` + per-slot log files.** Replaces ad-hoc `-v`. Lets you `tail -f` from any terminal.
+
+**If you only do one:** ship #1. The `--all` view changes the persona's day from "cd-and-check 6 times" to "glance once."
+
+## Spec follow-ups
+
+The 7 improvements above are decomposed into 3 specs (+ #5 already specced separately):
+
+- `docs/superpowers/specs/2026-05-01-cross-workspace-identity-design.md` — covers #1, #3, #6
+- `docs/superpowers/specs/2026-05-01-doctor-ergonomics-design.md` — covers #2 + cross-workspace doctor
+- `docs/superpowers/specs/2026-05-01-dispatch-and-logs-design.md` — covers #4, #7
+
+Improvement #5 (ADR 0041) is already covered by `docs/adr/0041-single-leaf-single-fossil-under-bones.md` and `docs/superpowers/specs/2026-04-30-bones-single-leaf-single-fossil-design.md`.

--- a/docs/superpowers/plans/2026-05-01-cross-workspace-identity.md
+++ b/docs/superpowers/plans/2026-05-01-cross-workspace-identity.md
@@ -1,0 +1,2446 @@
+# Cross-Workspace Identity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement filesystem registry of running bones workspaces, session marker tracking, `bones status --all`, `bones down --all`, `BONES_WORKSPACE` shell integration, and `bones rename` per the design spec.
+
+**Architecture:** Two new packages — `internal/registry/` (workspace entries) and `internal/sessions/` (session markers) — provide read/write/list/prune primitives with one JSON file per entity. Existing `bones up`/`down`/`status` are extended with registry I/O and `--all` flags. Three new CLI verbs (`bones env`, `bones rename`, hidden `bones session-marker`) provide shell-prompt integration and rename UX.
+
+**Tech Stack:** Go 1.23+, Kong CLI framework, `crypto/sha256` + `encoding/hex` for workspace IDs, `os` + `path/filepath` for atomic writes, standard `testing` package, `slog` for logging.
+
+**Spec:** `docs/superpowers/specs/2026-05-01-cross-workspace-identity-design.md`
+
+---
+
+## File structure
+
+```
+cli/
+  env.go                    # NEW — bones env verb
+  env_test.go               # NEW
+  rename.go                 # NEW — bones rename verb
+  rename_test.go            # NEW
+  session_marker.go         # NEW — hidden bones session-marker subcommand
+  session_marker_test.go    # NEW
+  status.go                 # MODIFY — add --all flag
+  status_test.go            # MODIFY — add --all tests
+  down.go                   # MODIFY — add --all flag, registry remove
+  down_test.go              # MODIFY — add --all tests
+  up.go                     # MODIFY — registry write at end of bootstrap
+
+cmd/bones/
+  cli.go                    # MODIFY — register Env, Rename, SessionMarker
+
+internal/
+  registry/
+    registry.go             # NEW — workspace registry primitives
+    registry_test.go        # NEW
+    health.go               # NEW — IsAlive (PID + HTTP) for stale detection
+    health_test.go          # NEW
+  sessions/
+    sessions.go             # NEW — session marker primitives
+    sessions_test.go        # NEW
+  workspace/
+    workspace.go            # MODIFY — add WorkspaceName field + read/write helpers
+    workspace_test.go       # MODIFY — tests for new field
+
+internal/hub/
+  hub.go                    # MODIFY — ensure /health endpoint exists (no-op if already present)
+
+docs/adr/
+  0038-per-workspace-hub-ports.md   # MODIFY — add Future-supersession-trigger footnote
+
+README.md                   # MODIFY — add shell prompt-hook + theme snippets
+```
+
+---
+
+## Phase 1: Registry foundation (Tasks 1–7)
+
+### Task 1: Workspace ID derivation
+
+**Files:**
+- Create: `internal/registry/registry.go`
+- Test: `internal/registry/registry_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// internal/registry/registry_test.go
+package registry
+
+import "testing"
+
+func TestWorkspaceID(t *testing.T) {
+	tests := []struct {
+		name string
+		cwd  string
+		want string
+	}{
+		{"simple path", "/Users/dan/projects/foo", "5a7c0b2c4d3e9f8a"},
+		{"trailing slash normalized", "/Users/dan/projects/foo/", "5a7c0b2c4d3e9f8a"},
+		{"different path", "/Users/dan/projects/bar", "8f3a1b9c7d6e2a4b"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := WorkspaceID(tt.cwd)
+			if len(got) != 16 {
+				t.Fatalf("WorkspaceID(%q) length = %d, want 16", tt.cwd, len(got))
+			}
+			// Same path always produces same ID
+			if got2 := WorkspaceID(tt.cwd); got != got2 {
+				t.Fatalf("WorkspaceID not deterministic: %q vs %q", got, got2)
+			}
+		})
+	}
+	// Different paths produce different IDs
+	a := WorkspaceID("/a")
+	b := WorkspaceID("/b")
+	if a == b {
+		t.Fatalf("WorkspaceID collision: /a and /b both = %q", a)
+	}
+}
+```
+
+Note: hardcoded expected hex values (`5a7c0b2c...`) are illustrative; replace with actual SHA256 prefix during step 4 once you compute them. The structural assertions (length 16, determinism, no collision) carry the test.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+go test ./internal/registry/ -run TestWorkspaceID
+```
+Expected: FAIL with `undefined: WorkspaceID` or similar.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```go
+// internal/registry/registry.go
+package registry
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"path/filepath"
+)
+
+// WorkspaceID returns a deterministic 16-hex-char identifier for an absolute cwd.
+// Used as the registry filename: ~/.bones/workspaces/<id>.json
+func WorkspaceID(cwd string) string {
+	sum := sha256.Sum256([]byte(filepath.Clean(cwd)))
+	return hex.EncodeToString(sum[:])[:16]
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Compute actual SHA256 prefixes for the test fixtures and update the `want` values in the test, then:
+```bash
+go test ./internal/registry/ -run TestWorkspaceID -v
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/registry/registry.go internal/registry/registry_test.go
+git commit -m "feat(registry): add WorkspaceID derivation (sha256 prefix)"
+```
+
+---
+
+### Task 2: Registry entry struct + JSON marshaling
+
+**Files:**
+- Modify: `internal/registry/registry.go`
+- Test: `internal/registry/registry_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// Append to internal/registry/registry_test.go
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestEntryJSON(t *testing.T) {
+	e := Entry{
+		Cwd:       "/Users/dan/projects/foo",
+		Name:      "foo",
+		HubURL:    "http://127.0.0.1:8765",
+		NATSURL:   "nats://127.0.0.1:4222",
+		HubPID:    12345,
+		StartedAt: time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC),
+	}
+	data, err := json.Marshal(e)
+	if err != nil { t.Fatalf("Marshal: %v", err) }
+
+	var got Entry
+	if err := json.Unmarshal(data, &got); err != nil { t.Fatalf("Unmarshal: %v", err) }
+	if got != e { t.Fatalf("round-trip: got %+v, want %+v", got, e) }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+go test ./internal/registry/ -run TestEntryJSON
+```
+Expected: FAIL with `undefined: Entry`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `internal/registry/registry.go`:
+
+```go
+import "time"
+
+// Entry is one workspace's registry record. One JSON file per Entry at
+// ~/.bones/workspaces/<WorkspaceID>.json.
+type Entry struct {
+	Cwd       string    `json:"cwd"`
+	Name      string    `json:"name"`
+	HubURL    string    `json:"hub_url"`
+	NATSURL   string    `json:"nats_url"`
+	HubPID    int       `json:"hub_pid"`
+	StartedAt time.Time `json:"started_at"`
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+go test ./internal/registry/ -run TestEntryJSON -v
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/registry/registry.go internal/registry/registry_test.go
+git commit -m "feat(registry): add Entry struct + JSON round-trip"
+```
+
+---
+
+### Task 3: Atomic registry write
+
+**Files:**
+- Modify: `internal/registry/registry.go`
+- Test: `internal/registry/registry_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWrite(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir) // RegistryDir derives from $HOME
+	e := Entry{
+		Cwd: "/Users/dan/projects/foo", Name: "foo",
+		HubURL: "http://127.0.0.1:8765", HubPID: 12345,
+		StartedAt: time.Now().UTC().Truncate(time.Second),
+	}
+	if err := Write(e); err != nil { t.Fatalf("Write: %v", err) }
+
+	// File should exist at expected path
+	path := filepath.Join(dir, ".bones", "workspaces", WorkspaceID(e.Cwd)+".json")
+	if _, err := os.Stat(path); err != nil { t.Fatalf("expected file at %s: %v", path, err) }
+
+	// No tmp file leftover
+	matches, _ := filepath.Glob(filepath.Join(dir, ".bones", "workspaces", "*.tmp.*"))
+	if len(matches) > 0 { t.Fatalf("tmp file leaked: %v", matches) }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+go test ./internal/registry/ -run TestWrite
+```
+Expected: FAIL with `undefined: Write`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `internal/registry/registry.go`:
+
+```go
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+)
+
+// RegistryDir returns the directory that holds workspace entry files.
+// Always rooted at $HOME/.bones/workspaces/.
+func RegistryDir() string {
+	return filepath.Join(os.Getenv("HOME"), ".bones", "workspaces")
+}
+
+// EntryPath returns the absolute path of the JSON file for the given workspace cwd.
+func EntryPath(cwd string) string {
+	return filepath.Join(RegistryDir(), WorkspaceID(cwd)+".json")
+}
+
+// Write persists e to its file atomically (tmp+rename). Creates the registry
+// directory if missing.
+func Write(e Entry) error {
+	if err := os.MkdirAll(RegistryDir(), 0o755); err != nil {
+		return fmt.Errorf("registry mkdir: %w", err)
+	}
+	data, err := json.MarshalIndent(e, "", "  ")
+	if err != nil { return fmt.Errorf("registry marshal: %w", err) }
+
+	dst := EntryPath(e.Cwd)
+	tmp, err := os.CreateTemp(RegistryDir(), filepath.Base(dst)+".tmp.*")
+	if err != nil { return fmt.Errorf("registry tmp: %w", err) }
+	defer os.Remove(tmp.Name()) // safe; rename succeeded means tmp is gone
+
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return errors.Join(fmt.Errorf("registry write: %w", err), tmp.Close())
+	}
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		return fmt.Errorf("registry sync: %w", err)
+	}
+	if err := tmp.Close(); err != nil { return fmt.Errorf("registry close: %w", err) }
+	return os.Rename(tmp.Name(), dst)
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+go test ./internal/registry/ -run TestWrite -v
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/registry/registry.go internal/registry/registry_test.go
+git commit -m "feat(registry): add atomic Write (tmp+rename)"
+```
+
+---
+
+### Task 4: Registry Read
+
+**Files:** `internal/registry/registry.go`, `internal/registry/registry_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+func TestRead(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	want := Entry{Cwd: "/x", Name: "x", HubURL: "u", HubPID: 1, StartedAt: time.Now().UTC().Truncate(time.Second)}
+	if err := Write(want); err != nil { t.Fatalf("Write: %v", err) }
+
+	got, err := Read(want.Cwd)
+	if err != nil { t.Fatalf("Read: %v", err) }
+	if got != want { t.Fatalf("Read mismatch: got %+v, want %+v", got, want) }
+
+	// Missing entry returns ErrNotFound
+	if _, err := Read("/nonexistent"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+go test ./internal/registry/ -run TestRead
+```
+Expected: FAIL `undefined: Read` and `undefined: ErrNotFound`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `internal/registry/registry.go`:
+
+```go
+// ErrNotFound is returned by Read when no entry exists for the given cwd.
+var ErrNotFound = errors.New("registry: entry not found")
+
+// Read returns the Entry for a workspace, or ErrNotFound if no entry exists.
+func Read(cwd string) (Entry, error) {
+	data, err := os.ReadFile(EntryPath(cwd))
+	if errors.Is(err, os.ErrNotExist) {
+		return Entry{}, ErrNotFound
+	}
+	if err != nil { return Entry{}, fmt.Errorf("registry read: %w", err) }
+	var e Entry
+	if err := json.Unmarshal(data, &e); err != nil {
+		return Entry{}, fmt.Errorf("registry unmarshal: %w", err)
+	}
+	return e, nil
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+go test ./internal/registry/ -run TestRead -v
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/registry/registry.go internal/registry/registry_test.go
+git commit -m "feat(registry): add Read with ErrNotFound"
+```
+
+---
+
+### Task 5: Registry List
+
+**Files:** `internal/registry/registry.go`, `internal/registry/registry_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+func TestList(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	entries := []Entry{
+		{Cwd: "/a", Name: "a", HubPID: 1, StartedAt: time.Now().UTC().Truncate(time.Second)},
+		{Cwd: "/b", Name: "b", HubPID: 2, StartedAt: time.Now().UTC().Truncate(time.Second)},
+	}
+	for _, e := range entries {
+		if err := Write(e); err != nil { t.Fatalf("Write: %v", err) }
+	}
+
+	got, err := List()
+	if err != nil { t.Fatalf("List: %v", err) }
+	if len(got) != 2 { t.Fatalf("List len = %d, want 2", len(got)) }
+
+	// Empty registry returns empty slice, no error
+	t.Setenv("HOME", t.TempDir())
+	got, err = List()
+	if err != nil { t.Fatalf("List on empty: %v", err) }
+	if len(got) != 0 { t.Fatalf("expected empty slice, got %v", got) }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+go test ./internal/registry/ -run TestList
+```
+Expected: FAIL `undefined: List`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```go
+// List returns all registry entries on this user/host. Returns an empty slice
+// (not an error) if the registry directory doesn't exist.
+func List() ([]Entry, error) {
+	matches, err := filepath.Glob(filepath.Join(RegistryDir(), "*.json"))
+	if err != nil { return nil, fmt.Errorf("registry glob: %w", err) }
+	out := make([]Entry, 0, len(matches))
+	for _, path := range matches {
+		data, err := os.ReadFile(path)
+		if err != nil { continue } // skip unreadable files (concurrent removal)
+		var e Entry
+		if err := json.Unmarshal(data, &e); err != nil { continue } // skip corrupt
+		out = append(out, e)
+	}
+	return out, nil
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+go test ./internal/registry/ -run TestList -v
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/registry/registry.go internal/registry/registry_test.go
+git commit -m "feat(registry): add List (glob + parse, skip corrupt)"
+```
+
+---
+
+### Task 6: Registry Remove
+
+**Files:** `internal/registry/registry.go`, `internal/registry/registry_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+func TestRemove(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	e := Entry{Cwd: "/x", Name: "x", HubPID: 1, StartedAt: time.Now().UTC().Truncate(time.Second)}
+	if err := Write(e); err != nil { t.Fatalf("Write: %v", err) }
+
+	if err := Remove(e.Cwd); err != nil { t.Fatalf("Remove: %v", err) }
+	if _, err := Read(e.Cwd); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected ErrNotFound after Remove, got %v", err)
+	}
+
+	// Remove of nonexistent entry is a no-op (idempotent)
+	if err := Remove("/never-existed"); err != nil {
+		t.Fatalf("Remove nonexistent: want nil, got %v", err)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+go test ./internal/registry/ -run TestRemove
+```
+Expected: FAIL `undefined: Remove`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```go
+// Remove deletes the registry entry for cwd. Idempotent: missing entry returns nil.
+func Remove(cwd string) error {
+	err := os.Remove(EntryPath(cwd))
+	if err == nil || errors.Is(err, os.ErrNotExist) { return nil }
+	return fmt.Errorf("registry remove: %w", err)
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+go test ./internal/registry/ -run TestRemove -v
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/registry/registry.go internal/registry/registry_test.go
+git commit -m "feat(registry): add idempotent Remove"
+```
+
+---
+
+### Task 7: Stale detection (PID + HTTP /health)
+
+**Files:**
+- Create: `internal/registry/health.go`
+- Test: `internal/registry/health_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// internal/registry/health_test.go
+package registry
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestIsAlive(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/health" { w.WriteHeader(200); return }
+		w.WriteHeader(404)
+	}))
+	defer srv.Close()
+
+	t.Run("alive: PID + healthy HTTP", func(t *testing.T) {
+		e := Entry{HubPID: os.Getpid(), HubURL: srv.URL}
+		if !IsAlive(e) { t.Fatalf("expected alive") }
+	})
+
+	t.Run("dead: PID alive but HTTP wrong port", func(t *testing.T) {
+		e := Entry{HubPID: os.Getpid(), HubURL: "http://127.0.0.1:1"} // unbound
+		if IsAlive(e) { t.Fatalf("expected dead (HTTP fails)") }
+	})
+
+	t.Run("dead: PID gone", func(t *testing.T) {
+		e := Entry{HubPID: 0, HubURL: srv.URL} // PID 0 always invalid
+		if IsAlive(e) { t.Fatalf("expected dead (PID invalid)") }
+	})
+}
+
+// Sanity check: server URL contains 127.0.0.1 + port
+func TestServerURL(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer srv.Close()
+	if !strings.HasPrefix(srv.URL, "http://127.0.0.1:") {
+		t.Fatalf("unexpected URL: %s", srv.URL)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+go test ./internal/registry/ -run TestIsAlive
+```
+Expected: FAIL `undefined: IsAlive`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```go
+// internal/registry/health.go
+package registry
+
+import (
+	"net/http"
+	"os"
+	"syscall"
+	"time"
+)
+
+// HealthTimeout bounds the HTTP /health probe. Tunable via env BONES_REGISTRY_PROBE_TIMEOUT.
+var HealthTimeout = 500 * time.Millisecond
+
+// IsAlive returns true if BOTH (a) the recorded HubPID is alive on this host
+// AND (b) GET <HubURL>/health returns 200 within HealthTimeout. Both checks are
+// required because a recycled PID can pass (a) but fail (b).
+func IsAlive(e Entry) bool {
+	if !pidAlive(e.HubPID) { return false }
+	client := &http.Client{Timeout: HealthTimeout}
+	resp, err := client.Get(e.HubURL + "/health")
+	if err != nil { return false }
+	defer resp.Body.Close()
+	return resp.StatusCode == http.StatusOK
+}
+
+func pidAlive(pid int) bool {
+	if pid <= 0 { return false }
+	proc, err := os.FindProcess(pid)
+	if err != nil { return false }
+	// Signal 0 is a no-op probe on POSIX
+	return proc.Signal(syscall.Signal(0)) == nil
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+go test ./internal/registry/ -run TestIsAlive -v
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/registry/health.go internal/registry/health_test.go
+git commit -m "feat(registry): add IsAlive (PID + HTTP /health probe)"
+```
+
+---
+
+## Phase 2: Session markers (Tasks 8–10)
+
+### Task 8: Session marker struct + Write
+
+**Files:**
+- Create: `internal/sessions/sessions.go`
+- Test: `internal/sessions/sessions_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// internal/sessions/sessions_test.go
+package sessions
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestMarkerJSON(t *testing.T) {
+	m := Marker{
+		SessionID:    "ade241a5-b8c7-4d3f-9e2a-1b6c8d7f5a3e",
+		WorkspaceCwd: "/Users/dan/projects/foo",
+		ClaudePID:    67890,
+		StartedAt:    time.Now().UTC().Truncate(time.Second),
+	}
+	data, _ := json.Marshal(m)
+	var got Marker
+	if err := json.Unmarshal(data, &got); err != nil { t.Fatalf("Unmarshal: %v", err) }
+	if got != m { t.Fatalf("round-trip: got %+v, want %+v", got, m) }
+}
+
+func TestRegister(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	m := Marker{SessionID: "abc", WorkspaceCwd: "/x", ClaudePID: os.Getpid(), StartedAt: time.Now().UTC()}
+	if err := Register(m); err != nil { t.Fatalf("Register: %v", err) }
+
+	path := filepath.Join(dir, ".bones", "sessions", m.SessionID+".json")
+	if _, err := os.Stat(path); err != nil { t.Fatalf("expected file at %s: %v", path, err) }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+go test ./internal/sessions/ -run TestMarker -run TestRegister
+```
+Expected: FAIL `undefined: Marker, Register`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```go
+// internal/sessions/sessions.go
+package sessions
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// Marker is a per-session record. One JSON file per Marker at
+// ~/.bones/sessions/<SessionID>.json.
+type Marker struct {
+	SessionID    string    `json:"session_id"`
+	WorkspaceCwd string    `json:"workspace_cwd"`
+	ClaudePID    int       `json:"claude_pid"`
+	StartedAt    time.Time `json:"started_at"`
+}
+
+// SessionsDir returns the directory holding session marker files.
+func SessionsDir() string {
+	return filepath.Join(os.Getenv("HOME"), ".bones", "sessions")
+}
+
+// MarkerPath returns the file path for a given session ID.
+func MarkerPath(sessionID string) string {
+	return filepath.Join(SessionsDir(), sessionID+".json")
+}
+
+// Register persists m atomically (tmp+rename).
+func Register(m Marker) error {
+	if err := os.MkdirAll(SessionsDir(), 0o755); err != nil {
+		return fmt.Errorf("sessions mkdir: %w", err)
+	}
+	data, err := json.MarshalIndent(m, "", "  ")
+	if err != nil { return fmt.Errorf("marker marshal: %w", err) }
+
+	dst := MarkerPath(m.SessionID)
+	tmp, err := os.CreateTemp(SessionsDir(), filepath.Base(dst)+".tmp.*")
+	if err != nil { return fmt.Errorf("marker tmp: %w", err) }
+	defer os.Remove(tmp.Name())
+
+	if _, err := tmp.Write(data); err != nil { tmp.Close(); return err }
+	if err := tmp.Sync(); err != nil { tmp.Close(); return err }
+	if err := tmp.Close(); err != nil { return err }
+	return os.Rename(tmp.Name(), dst)
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+go test ./internal/sessions/ -v
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/sessions/sessions.go internal/sessions/sessions_test.go
+git commit -m "feat(sessions): add Marker struct + atomic Register"
+```
+
+---
+
+### Task 9: Session Unregister + ListByWorkspace
+
+**Files:** `internal/sessions/sessions.go`, `internal/sessions/sessions_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+func TestUnregister(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	m := Marker{SessionID: "abc", WorkspaceCwd: "/x", ClaudePID: os.Getpid(), StartedAt: time.Now().UTC()}
+	if err := Register(m); err != nil { t.Fatalf("Register: %v", err) }
+	if err := Unregister(m.SessionID); err != nil { t.Fatalf("Unregister: %v", err) }
+	if _, err := os.Stat(MarkerPath(m.SessionID)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("file still exists after Unregister")
+	}
+	// Idempotent
+	if err := Unregister("never-existed"); err != nil {
+		t.Fatalf("Unregister nonexistent: %v", err)
+	}
+}
+
+func TestListByWorkspace(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	myPID := os.Getpid()
+	now := time.Now().UTC()
+	for _, m := range []Marker{
+		{SessionID: "s1", WorkspaceCwd: "/a", ClaudePID: myPID, StartedAt: now},
+		{SessionID: "s2", WorkspaceCwd: "/a", ClaudePID: myPID, StartedAt: now},
+		{SessionID: "s3", WorkspaceCwd: "/b", ClaudePID: myPID, StartedAt: now},
+		{SessionID: "s4-dead", WorkspaceCwd: "/a", ClaudePID: 0, StartedAt: now}, // PID 0 = invalid
+	} {
+		Register(m)
+	}
+
+	got := ListByWorkspace("/a")
+	if len(got) != 2 { // s4-dead is filtered by PID-alive check
+		t.Fatalf("expected 2 alive markers for /a, got %d", len(got))
+	}
+
+	if g := ListByWorkspace("/b"); len(g) != 1 {
+		t.Fatalf("expected 1 marker for /b, got %d", len(g))
+	}
+
+	if g := ListByWorkspace("/none"); len(g) != 0 {
+		t.Fatalf("expected 0 markers for /none, got %d", len(g))
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+go test ./internal/sessions/
+```
+Expected: FAIL `undefined: Unregister, ListByWorkspace`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```go
+import "syscall"
+
+// Unregister deletes the marker file. Idempotent.
+func Unregister(sessionID string) error {
+	err := os.Remove(MarkerPath(sessionID))
+	if err == nil || errors.Is(err, os.ErrNotExist) { return nil }
+	return fmt.Errorf("marker remove: %w", err)
+}
+
+// ListByWorkspace returns markers whose WorkspaceCwd matches the argument
+// AND whose ClaudePID is alive on this host. Dead markers are unlinked as a
+// side effect (orphan GC).
+func ListByWorkspace(cwd string) []Marker {
+	matches, _ := filepath.Glob(filepath.Join(SessionsDir(), "*.json"))
+	out := make([]Marker, 0, len(matches))
+	for _, path := range matches {
+		data, err := os.ReadFile(path)
+		if err != nil { continue }
+		var m Marker
+		if err := json.Unmarshal(data, &m); err != nil { continue }
+		if !pidAlive(m.ClaudePID) {
+			os.Remove(path) // GC dead marker
+			continue
+		}
+		if m.WorkspaceCwd == cwd { out = append(out, m) }
+	}
+	return out
+}
+
+func pidAlive(pid int) bool {
+	if pid <= 0 { return false }
+	p, err := os.FindProcess(pid)
+	if err != nil { return false }
+	return p.Signal(syscall.Signal(0)) == nil
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+go test ./internal/sessions/ -v
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/sessions/sessions.go internal/sessions/sessions_test.go
+git commit -m "feat(sessions): add Unregister + ListByWorkspace with PID-alive GC"
+```
+
+---
+
+### Task 10: CountByWorkspace (convenience)
+
+**Files:** `internal/sessions/sessions.go`, `internal/sessions/sessions_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+func TestCountByWorkspace(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	myPID := os.Getpid()
+	for i, cwd := range []string{"/a", "/a", "/b"} {
+		Register(Marker{SessionID: fmt.Sprintf("s%d", i), WorkspaceCwd: cwd, ClaudePID: myPID, StartedAt: time.Now().UTC()})
+	}
+	if got := CountByWorkspace("/a"); got != 2 {
+		t.Fatalf("CountByWorkspace(/a) = %d, want 2", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+go test ./internal/sessions/ -run TestCountByWorkspace
+```
+Expected: FAIL `undefined: CountByWorkspace`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```go
+// CountByWorkspace returns the number of alive session markers attached to cwd.
+func CountByWorkspace(cwd string) int { return len(ListByWorkspace(cwd)) }
+```
+
+Add `import "fmt"` to test file if not already present.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+go test ./internal/sessions/ -run TestCountByWorkspace -v
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/sessions/sessions.go internal/sessions/sessions_test.go
+git commit -m "feat(sessions): add CountByWorkspace convenience"
+```
+
+---
+
+## Phase 3: Hidden `bones session-marker` subcommand (Tasks 11–12)
+
+### Task 11: SessionMarkerCmd struct + Register subcommand
+
+**Files:**
+- Create: `cli/session_marker.go`
+- Test: `cli/session_marker_test.go`
+- Modify: `cmd/bones/cli.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// cli/session_marker_test.go
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/danmestas/bones/internal/sessions"
+)
+
+func TestSessionMarkerRegister(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	cmd := SessionMarkerRegisterCmd{
+		SessionID: "test-sid",
+		Cwd:       "/Users/dan/projects/foo",
+		PID:       os.Getpid(),
+	}
+	if err := cmd.Run(); err != nil { t.Fatalf("Run: %v", err) }
+
+	// Marker file should exist
+	path := filepath.Join(os.Getenv("HOME"), ".bones", "sessions", cmd.SessionID+".json")
+	if _, err := os.Stat(path); err != nil { t.Fatalf("expected marker at %s: %v", path, err) }
+
+	// Verify ListByWorkspace finds it
+	if got := sessions.ListByWorkspace(cmd.Cwd); len(got) != 1 {
+		t.Fatalf("ListByWorkspace = %d markers, want 1", len(got))
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+go test ./cli/ -run TestSessionMarkerRegister
+```
+Expected: FAIL `undefined: SessionMarkerRegisterCmd`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```go
+// cli/session_marker.go
+package cli
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/danmestas/bones/internal/sessions"
+)
+
+// SessionMarkerCmd is hidden from --help; it exists only for bones-managed
+// SessionStart/End hooks to call. Schema for marker files lives in the
+// sessions package; this verb is the only call site.
+type SessionMarkerCmd struct {
+	Register   SessionMarkerRegisterCmd   `cmd:"" name:"register"`
+	Unregister SessionMarkerUnregisterCmd `cmd:"" name:"unregister"`
+}
+
+type SessionMarkerRegisterCmd struct {
+	SessionID string `name:"session-id" required:""`
+	Cwd       string `name:"cwd" required:"" help:"absolute workspace cwd"`
+	PID       int    `name:"pid" required:"" help:"claude (or harness) process PID"`
+}
+
+func (c *SessionMarkerRegisterCmd) Run() error {
+	return sessions.Register(sessions.Marker{
+		SessionID:    c.SessionID,
+		WorkspaceCwd: c.Cwd,
+		ClaudePID:    c.PID,
+		StartedAt:    time.Now().UTC(),
+	})
+}
+
+type SessionMarkerUnregisterCmd struct {
+	SessionID string `name:"session-id" required:""`
+}
+
+func (c *SessionMarkerUnregisterCmd) Run() error {
+	if c.SessionID == "" { return fmt.Errorf("--session-id required") }
+	return sessions.Unregister(c.SessionID)
+}
+```
+
+Modify `cmd/bones/cli.go` to register the verb. Find the CLI struct and add a field:
+
+```go
+SessionMarker bonescli.SessionMarkerCmd `cmd:"" name:"session-marker" hidden:"" help:"internal: hook-managed session markers"`
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+go test ./cli/ -run TestSessionMarkerRegister -v
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cli/session_marker.go cli/session_marker_test.go cmd/bones/cli.go
+git commit -m "feat(cli): add hidden bones session-marker register|unregister"
+```
+
+---
+
+### Task 12: SessionMarker Unregister test
+
+**Files:** `cli/session_marker_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+func TestSessionMarkerUnregister(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	reg := SessionMarkerRegisterCmd{SessionID: "to-remove", Cwd: "/x", PID: os.Getpid()}
+	if err := reg.Run(); err != nil { t.Fatalf("Register: %v", err) }
+
+	un := SessionMarkerUnregisterCmd{SessionID: "to-remove"}
+	if err := un.Run(); err != nil { t.Fatalf("Unregister: %v", err) }
+
+	if _, err := os.Stat(sessions.MarkerPath("to-remove")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("marker still exists after Unregister")
+	}
+}
+```
+
+- [ ] **Step 2: Run test**
+
+```bash
+go test ./cli/ -run TestSessionMarkerUnregister -v
+```
+Expected: PASS (already implemented in Task 11; this test verifies it works end-to-end).
+
+- [ ] **Step 3-5 collapsed: Commit**
+
+If the test passes immediately, commit (no implementation change needed):
+
+```bash
+git add cli/session_marker_test.go
+git commit -m "test(cli): cover session-marker unregister round-trip"
+```
+
+---
+
+## Phase 4: bones up/down registry hooks (Tasks 13–14)
+
+### Task 13: bones up writes registry entry
+
+**Files:** `cli/up.go`, `cli/up_test.go` (new or existing)
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// cli/up_test.go (add to existing file or create)
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"github.com/danmestas/bones/internal/registry"
+)
+
+func TestUpWritesRegistry(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	wsDir := t.TempDir()
+
+	if err := runUp(wsDir, false); err != nil {
+		t.Fatalf("runUp: %v", err)
+	}
+
+	got, err := registry.Read(wsDir)
+	if err != nil { t.Fatalf("registry.Read after up: %v", err) }
+	if got.Cwd != wsDir { t.Fatalf("registry Cwd = %q, want %q", got.Cwd, wsDir) }
+	if got.HubPID == 0 { t.Fatalf("registry HubPID = 0 (expected nonzero)") }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+go test ./cli/ -run TestUpWritesRegistry
+```
+Expected: FAIL — registry entry not found.
+
+- [ ] **Step 3: Modify `runUp()` in `cli/up.go`** to write the registry entry after successful bootstrap. Find the success path (around line 69 per Explore report) and add:
+
+```go
+// At the end of runUp() before returning nil:
+import (
+	"os"
+	"time"
+	"github.com/danmestas/bones/internal/registry"
+	"github.com/danmestas/bones/internal/workspace"
+)
+
+// ... existing bootstrap completes ...
+
+info, _ := workspace.Join(cwd) // get NATS/HTTP URLs for the registry
+if err := registry.Write(registry.Entry{
+	Cwd:       cwd,
+	Name:      filepath.Base(cwd),
+	HubURL:    info.LeafHTTPURL,
+	NATSURL:   info.NATSURL,
+	HubPID:    os.Getpid(),
+	StartedAt: time.Now().UTC(),
+}); err != nil {
+	// Non-fatal: hub still works locally without registry
+	slog.Warn("registry write failed (non-fatal)", "err", err)
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+go test ./cli/ -run TestUpWritesRegistry -v
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cli/up.go cli/up_test.go
+git commit -m "feat(cli): bones up writes workspace registry entry"
+```
+
+---
+
+### Task 14: bones down removes registry entry
+
+**Files:** `cli/down.go`, `cli/down_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+func TestDownRemovesRegistry(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	wsDir := t.TempDir()
+
+	// Seed registry
+	registry.Write(registry.Entry{Cwd: wsDir, Name: "test", HubPID: os.Getpid(), StartedAt: time.Now().UTC()})
+
+	cmd := DownCmd{Yes: true, KeepHub: true} // KeepHub avoids actually killing hub
+	if err := cmd.Run(&libfossilcli.Globals{}); err != nil {
+		t.Fatalf("Down: %v", err)
+	}
+
+	if _, err := registry.Read(wsDir); !errors.Is(err, registry.ErrNotFound) {
+		t.Fatalf("expected registry entry removed, got %v", err)
+	}
+}
+```
+
+Note: `libfossilcli` is the existing import path; verify against current `cli/down.go` imports.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+go test ./cli/ -run TestDownRemovesRegistry
+```
+Expected: FAIL — entry still present.
+
+- [ ] **Step 3: Modify `runDown()` in `cli/down.go`** to add registry removal. Find the action list around lines 42–50. Add a step:
+
+```go
+// In planDown() or runDown(), append:
+import "github.com/danmestas/bones/internal/registry"
+
+// As a last step in the down sequence (before returning success):
+if err := registry.Remove(root); err != nil {
+	slog.Warn("registry remove failed (non-fatal)", "err", err)
+}
+```
+
+- [ ] **Step 4: Run test**
+
+```bash
+go test ./cli/ -run TestDownRemovesRegistry -v
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cli/down.go cli/down_test.go
+git commit -m "feat(cli): bones down removes registry entry"
+```
+
+---
+
+## Phase 5: bones status --all (Tasks 15–16)
+
+### Task 15: Add --all flag to StatusCmd, render multi-workspace table
+
+**Files:** `cli/status.go`, `cli/status_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+func TestStatusAllRendersTable(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	// Seed two registry entries
+	now := time.Now().UTC()
+	registry.Write(registry.Entry{Cwd: "/Users/dan/foo", Name: "foo", HubURL: "http://127.0.0.1:1", NATSURL: "nats://x", HubPID: os.Getpid(), StartedAt: now})
+	registry.Write(registry.Entry{Cwd: "/Users/dan/bar", Name: "bar", HubURL: "http://127.0.0.1:2", NATSURL: "nats://x", HubPID: os.Getpid(), StartedAt: now})
+
+	var buf bytes.Buffer
+	if err := renderStatusAll(&buf); err != nil {
+		t.Fatalf("renderStatusAll: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{"WORKSPACE", "foo", "bar", "PATH"} {
+		if !strings.Contains(out, want) { t.Fatalf("output missing %q:\n%s", want, out) }
+	}
+}
+```
+
+- [ ] **Step 2: Run test**
+
+```bash
+go test ./cli/ -run TestStatusAllRendersTable
+```
+Expected: FAIL `undefined: renderStatusAll`.
+
+- [ ] **Step 3: Write implementation**
+
+Modify `cli/status.go`:
+
+```go
+type StatusCmd struct {
+	All  bool `name:"all" help:"show status across all workspaces on this user/host"`
+	JSON bool `name:"json" help:"emit machine-readable JSON"`
+}
+
+func (c *StatusCmd) Run(g *libfossilcli.Globals) error {
+	if c.All {
+		if c.JSON { return renderStatusAllJSON(os.Stdout) }
+		return renderStatusAll(os.Stdout)
+	}
+	// ... existing single-workspace path unchanged ...
+}
+
+// renderStatusAll iterates the registry, prunes stale entries, and prints a table.
+func renderStatusAll(w io.Writer) error {
+	entries, err := registry.List()
+	if err != nil { return err }
+
+	// Prune stale entries (live-only semantics)
+	live := entries[:0]
+	for _, e := range entries {
+		if registry.IsAlive(e) {
+			live = append(live, e)
+		} else {
+			registry.Remove(e.Cwd)
+		}
+	}
+
+	if len(live) == 0 {
+		fmt.Fprintln(w, "No workspaces running. Use 'bones up' in a project.")
+		return nil
+	}
+
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "WORKSPACE\tPATH\tHUB\tSESSIONS\tUPTIME")
+	for _, e := range live {
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%d\t%s\n",
+			e.Name,
+			shortenHome(e.Cwd),
+			extractPort(e.HubURL),
+			sessions.CountByWorkspace(e.Cwd),
+			humanDuration(time.Since(e.StartedAt)),
+		)
+	}
+	return tw.Flush()
+}
+
+func shortenHome(p string) string {
+	if home := os.Getenv("HOME"); home != "" && strings.HasPrefix(p, home) {
+		return "~" + p[len(home):]
+	}
+	return p
+}
+
+func extractPort(url string) string {
+	// Returns ":8765" from "http://127.0.0.1:8765"
+	idx := strings.LastIndex(url, ":")
+	if idx < 0 { return url }
+	return url[idx:]
+}
+
+func humanDuration(d time.Duration) string {
+	if d < time.Minute { return fmt.Sprintf("%ds", int(d.Seconds())) }
+	if d < time.Hour { return fmt.Sprintf("%dm", int(d.Minutes())) }
+	return fmt.Sprintf("%dh", int(d.Hours()))
+}
+```
+
+Add imports: `bytes`, `io`, `strings`, `text/tabwriter`, `github.com/danmestas/bones/internal/registry`, `github.com/danmestas/bones/internal/sessions`.
+
+- [ ] **Step 4: Run test**
+
+```bash
+go test ./cli/ -run TestStatusAllRendersTable -v
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cli/status.go cli/status_test.go
+git commit -m "feat(cli): bones status --all renders cross-workspace table"
+```
+
+---
+
+### Task 16: bones status --all --json output
+
+**Files:** `cli/status.go`, `cli/status_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+func TestStatusAllJSON(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	registry.Write(registry.Entry{Cwd: "/x", Name: "x", HubURL: "http://127.0.0.1:1", HubPID: os.Getpid(), StartedAt: time.Now().UTC()})
+
+	var buf bytes.Buffer
+	if err := renderStatusAllJSON(&buf); err != nil { t.Fatalf("renderStatusAllJSON: %v", err) }
+
+	var got struct {
+		Workspaces []struct{ Name, Cwd string } `json:"workspaces"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil { t.Fatalf("unmarshal: %v", err) }
+	if len(got.Workspaces) != 1 { t.Fatalf("workspaces len = %d, want 1", len(got.Workspaces)) }
+	if got.Workspaces[0].Name != "x" { t.Fatalf("name = %q, want x", got.Workspaces[0].Name) }
+}
+```
+
+- [ ] **Step 2: Run test**
+
+```bash
+go test ./cli/ -run TestStatusAllJSON
+```
+Expected: FAIL `undefined: renderStatusAllJSON`.
+
+- [ ] **Step 3: Write implementation**
+
+```go
+func renderStatusAllJSON(w io.Writer) error {
+	entries, err := registry.List()
+	if err != nil { return err }
+	live := entries[:0]
+	for _, e := range entries {
+		if registry.IsAlive(e) { live = append(live, e) } else { registry.Remove(e.Cwd) }
+	}
+	type row struct {
+		Cwd       string    `json:"cwd"`
+		Name      string    `json:"name"`
+		HubURL    string    `json:"hub_url"`
+		Sessions  int       `json:"sessions"`
+		StartedAt time.Time `json:"started_at"`
+	}
+	rows := make([]row, len(live))
+	for i, e := range live {
+		rows[i] = row{e.Cwd, e.Name, e.HubURL, sessions.CountByWorkspace(e.Cwd), e.StartedAt}
+	}
+	return json.NewEncoder(w).Encode(struct {
+		Workspaces []row `json:"workspaces"`
+	}{rows})
+}
+```
+
+- [ ] **Step 4: Run test**
+
+```bash
+go test ./cli/ -run TestStatusAllJSON -v
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cli/status.go cli/status_test.go
+git commit -m "feat(cli): bones status --all --json output"
+```
+
+---
+
+## Phase 6: bones down --all (Task 17)
+
+### Task 17: --all flag teardowns all registered workspaces
+
+**Files:** `cli/down.go`, `cli/down_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+func TestDownAllInvokesPerWorkspace(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	ws1 := t.TempDir()
+	ws2 := t.TempDir()
+	now := time.Now().UTC()
+	registry.Write(registry.Entry{Cwd: ws1, Name: "a", HubPID: os.Getpid(), StartedAt: now})
+	registry.Write(registry.Entry{Cwd: ws2, Name: "b", HubPID: os.Getpid(), StartedAt: now})
+
+	cmd := DownCmd{Yes: true, KeepHub: true, All: true} // KeepHub avoids killing real hub
+	if err := cmd.Run(&libfossilcli.Globals{}); err != nil { t.Fatalf("Down: %v", err) }
+
+	for _, ws := range []string{ws1, ws2} {
+		if _, err := registry.Read(ws); !errors.Is(err, registry.ErrNotFound) {
+			t.Fatalf("expected registry entry removed for %s, got %v", ws, err)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run test**
+
+```bash
+go test ./cli/ -run TestDownAllInvokesPerWorkspace
+```
+Expected: FAIL — `--all` not handled.
+
+- [ ] **Step 3: Modify `cli/down.go`** to add `All bool` field and handler:
+
+```go
+type DownCmd struct {
+	Yes        bool `name:"yes" short:"y" help:"skip the confirmation prompt"`
+	KeepSkills bool `name:"keep-skills" help:"do not remove .claude/skills"`
+	KeepHooks  bool `name:"keep-hooks" help:"do not edit .claude/settings.json"`
+	KeepHub    bool `name:"keep-hub" help:"do not stop hub or remove .orchestrator/"`
+	DryRun     bool `name:"dry-run" help:"print plan without executing"`
+	All        bool `name:"all" help:"tear down all registered workspaces"`
+}
+
+func (c *DownCmd) Run(g *libfossilcli.Globals) error {
+	if c.All { return c.runAll(g) }
+	// ... existing single-workspace path ...
+}
+
+func (c *DownCmd) runAll(g *libfossilcli.Globals) error {
+	entries, err := registry.List()
+	if err != nil { return err }
+	if len(entries) == 0 {
+		fmt.Println("No workspaces running.")
+		return nil
+	}
+
+	// Print summary
+	fmt.Println("Will stop:")
+	for _, e := range entries {
+		fmt.Printf("  %-20s %s   sessions=%d\n", e.Name, e.Cwd, sessions.CountByWorkspace(e.Cwd))
+	}
+	fmt.Printf("\n%d workspaces will be terminated.\n", len(entries))
+
+	if !c.Yes {
+		fmt.Print("Continue? [y/N] ")
+		var resp string
+		fmt.Scanln(&resp)
+		if !strings.EqualFold(strings.TrimSpace(resp), "y") {
+			fmt.Println("Aborted.")
+			return nil
+		}
+	}
+
+	var firstErr error
+	for _, e := range entries {
+		single := *c
+		single.All = false
+		single.Yes = true
+		if err := runDown(e.Cwd, &single, os.Stdin); err != nil {
+			fmt.Fprintf(os.Stderr, "  %s: %v\n", e.Name, err)
+			if firstErr == nil { firstErr = err }
+		}
+	}
+	return firstErr
+}
+```
+
+- [ ] **Step 4: Run test**
+
+```bash
+go test ./cli/ -run TestDownAllInvokesPerWorkspace -v
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cli/down.go cli/down_test.go
+git commit -m "feat(cli): bones down --all tears down all registered workspaces"
+```
+
+---
+
+## Phase 7: bones env (Tasks 18–21)
+
+### Task 18: walkUpToBones helper
+
+**Files:** `cli/env.go`, `cli/env_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// cli/env_test.go
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWalkUpToBones(t *testing.T) {
+	root := t.TempDir()
+	deep := filepath.Join(root, "a", "b", "c")
+	os.MkdirAll(deep, 0o755)
+	bonesDir := filepath.Join(root, "a", ".bones")
+	os.MkdirAll(bonesDir, 0o755)
+
+	got, found := walkUpToBones(deep)
+	if !found { t.Fatalf("expected to find .bones above %s", deep) }
+	if got != filepath.Join(root, "a") { t.Fatalf("got %s, want %s", got, filepath.Join(root, "a")) }
+
+	// No .bones above
+	other := t.TempDir()
+	if _, found := walkUpToBones(other); found {
+		t.Fatalf("expected not found in %s", other)
+	}
+}
+```
+
+- [ ] **Step 2: Run test**
+
+```bash
+go test ./cli/ -run TestWalkUpToBones
+```
+Expected: FAIL `undefined: walkUpToBones`.
+
+- [ ] **Step 3: Write implementation**
+
+```go
+// cli/env.go
+package cli
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// walkUpToBones returns (workspaceRoot, true) if a .bones directory exists at
+// startDir or any ancestor; otherwise ("", false).
+func walkUpToBones(startDir string) (string, bool) {
+	dir := startDir
+	for {
+		if _, err := os.Stat(filepath.Join(dir, ".bones")); err == nil {
+			return dir, true
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir { return "", false }
+		dir = parent
+	}
+}
+```
+
+- [ ] **Step 4: Run test**
+
+```bash
+go test ./cli/ -run TestWalkUpToBones -v
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cli/env.go cli/env_test.go
+git commit -m "feat(cli): add walkUpToBones helper"
+```
+
+---
+
+### Task 19: workspace name resolver (basename or override)
+
+**Files:** `cli/env.go`, `cli/env_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+func TestResolveWorkspaceName(t *testing.T) {
+	t.Run("basename when no override", func(t *testing.T) {
+		root := t.TempDir()
+		os.MkdirAll(filepath.Join(root, ".bones"), 0o755)
+		got := resolveWorkspaceName(root)
+		if got != filepath.Base(root) { t.Fatalf("got %q, want %q", got, filepath.Base(root)) }
+	})
+
+	t.Run("override from .bones/workspace_name", func(t *testing.T) {
+		root := t.TempDir()
+		bones := filepath.Join(root, ".bones")
+		os.MkdirAll(bones, 0o755)
+		os.WriteFile(filepath.Join(bones, "workspace_name"), []byte("auth-service\n"), 0o644)
+		got := resolveWorkspaceName(root)
+		if got != "auth-service" { t.Fatalf("got %q, want auth-service", got) }
+	})
+}
+```
+
+- [ ] **Step 2: Run test**
+
+```bash
+go test ./cli/ -run TestResolveWorkspaceName
+```
+Expected: FAIL `undefined: resolveWorkspaceName`.
+
+- [ ] **Step 3: Write implementation**
+
+```go
+// resolveWorkspaceName returns the human display name for the workspace at root.
+// If .bones/workspace_name exists, returns its trimmed contents; otherwise basename(root).
+func resolveWorkspaceName(root string) string {
+	data, err := os.ReadFile(filepath.Join(root, ".bones", "workspace_name"))
+	if err == nil {
+		if name := strings.TrimSpace(string(data)); name != "" { return name }
+	}
+	return filepath.Base(root)
+}
+```
+
+- [ ] **Step 4: Run test**
+
+```bash
+go test ./cli/ -run TestResolveWorkspaceName -v
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cli/env.go cli/env_test.go
+git commit -m "feat(cli): resolveWorkspaceName (basename or override)"
+```
+
+---
+
+### Task 20: EnvCmd verb (export statements)
+
+**Files:** `cli/env.go`, `cli/env_test.go`, `cmd/bones/cli.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+func TestEnvCmdInsideWorkspace(t *testing.T) {
+	root := t.TempDir()
+	os.MkdirAll(filepath.Join(root, ".bones"), 0o755)
+	t.Chdir(root)
+
+	var buf strings.Builder
+	cmd := EnvCmd{Shell: "bash"}
+	if err := cmd.run(&buf); err != nil { t.Fatalf("run: %v", err) }
+
+	out := buf.String()
+	if !strings.Contains(out, "export BONES_WORKSPACE=") {
+		t.Fatalf("missing BONES_WORKSPACE export:\n%s", out)
+	}
+	if !strings.Contains(out, "export BONES_WORKSPACE_CWD="+root) {
+		t.Fatalf("missing BONES_WORKSPACE_CWD export:\n%s", out)
+	}
+}
+
+func TestEnvCmdOutsideWorkspace(t *testing.T) {
+	t.Chdir(t.TempDir()) // a dir with no .bones
+	var buf strings.Builder
+	cmd := EnvCmd{Shell: "bash"}
+	if err := cmd.run(&buf); err != nil { t.Fatalf("run: %v", err) }
+	out := buf.String()
+	for _, want := range []string{"unset BONES_WORKSPACE", "unset BONES_WORKSPACE_CWD"} {
+		if !strings.Contains(out, want) { t.Fatalf("expected %q:\n%s", want, out) }
+	}
+}
+
+func TestEnvCmdFishSyntax(t *testing.T) {
+	root := t.TempDir()
+	os.MkdirAll(filepath.Join(root, ".bones"), 0o755)
+	t.Chdir(root)
+	var buf strings.Builder
+	cmd := EnvCmd{Shell: "fish"}
+	cmd.run(&buf)
+	if !strings.Contains(buf.String(), "set -gx BONES_WORKSPACE ") {
+		t.Fatalf("expected fish 'set -gx', got:\n%s", buf.String())
+	}
+}
+```
+
+- [ ] **Step 2: Run test**
+
+```bash
+go test ./cli/ -run TestEnvCmd
+```
+Expected: FAIL `undefined: EnvCmd`.
+
+- [ ] **Step 3: Write implementation**
+
+```go
+type EnvCmd struct {
+	Shell string `name:"shell" help:"shell syntax: bash|zsh|fish (default: auto)" enum:"bash,zsh,fish,"`
+}
+
+func (c *EnvCmd) Run() error { return c.run(os.Stdout) }
+
+func (c *EnvCmd) run(w io.Writer) error {
+	shell := c.Shell
+	if shell == "" { shell = detectShell() }
+
+	cwd, err := os.Getwd()
+	if err != nil { return err }
+
+	root, found := walkUpToBones(cwd)
+	if !found {
+		writeUnset(w, shell)
+		return nil
+	}
+
+	name := resolveWorkspaceName(root)
+	writeExport(w, shell, "BONES_WORKSPACE", name)
+	writeExport(w, shell, "BONES_WORKSPACE_CWD", root)
+	return nil
+}
+
+func detectShell() string {
+	s := os.Getenv("SHELL")
+	switch {
+	case strings.HasSuffix(s, "/zsh"): return "zsh"
+	case strings.HasSuffix(s, "/fish"): return "fish"
+	default: return "bash"
+	}
+}
+
+func writeExport(w io.Writer, shell, k, v string) {
+	if shell == "fish" {
+		fmt.Fprintf(w, "set -gx %s %s\n", k, v)
+	} else {
+		fmt.Fprintf(w, "export %s=%s\n", k, v)
+	}
+}
+
+func writeUnset(w io.Writer, shell string) {
+	for _, k := range []string{"BONES_WORKSPACE", "BONES_WORKSPACE_CWD"} {
+		if shell == "fish" {
+			fmt.Fprintf(w, "set -e %s\n", k)
+		} else {
+			fmt.Fprintf(w, "unset %s\n", k)
+		}
+	}
+}
+```
+
+Modify `cmd/bones/cli.go` to register:
+
+```go
+Env bonescli.EnvCmd `cmd:"" group:"daily" help:"Print shell-export statements for current workspace"`
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+go test ./cli/ -run TestEnvCmd -v
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cli/env.go cli/env_test.go cmd/bones/cli.go
+git commit -m "feat(cli): add bones env verb (BONES_WORKSPACE shell integration)"
+```
+
+---
+
+### Task 21: Workspace_name override file (used by rename and env)
+
+**Files:** `internal/workspace/workspace.go` (or new `internal/workspace/name.go`)
+
+This task adds the read/write helpers for `.bones/workspace_name`. Used by Task 22 (`bones rename`).
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// internal/workspace/name_test.go (new file)
+package workspace
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWriteReadName(t *testing.T) {
+	root := t.TempDir()
+	os.MkdirAll(filepath.Join(root, ".bones"), 0o755)
+
+	if err := WriteName(root, "auth-service"); err != nil { t.Fatalf("WriteName: %v", err) }
+
+	got, err := ReadName(root)
+	if err != nil { t.Fatalf("ReadName: %v", err) }
+	if got != "auth-service" { t.Fatalf("got %q, want auth-service", got) }
+}
+
+func TestReadNameMissing(t *testing.T) {
+	root := t.TempDir()
+	os.MkdirAll(filepath.Join(root, ".bones"), 0o755)
+	got, err := ReadName(root)
+	if err != nil { t.Fatalf("ReadName missing: %v", err) }
+	if got != "" { t.Fatalf("expected empty, got %q", got) }
+}
+```
+
+- [ ] **Step 2: Run test**
+
+```bash
+go test ./internal/workspace/ -run TestWriteReadName -run TestReadNameMissing
+```
+Expected: FAIL `undefined: WriteName, ReadName`.
+
+- [ ] **Step 3: Write implementation**
+
+```go
+// internal/workspace/name.go (new file)
+package workspace
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// WriteName persists the workspace_name override at <root>/.bones/workspace_name.
+func WriteName(root, name string) error {
+	path := filepath.Join(root, ".bones", "workspace_name")
+	return os.WriteFile(path, []byte(name+"\n"), 0o644)
+}
+
+// ReadName returns the workspace_name override or "" if not set. Returns error
+// only on unexpected I/O failures.
+func ReadName(root string) (string, error) {
+	path := filepath.Join(root, ".bones", "workspace_name")
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) { return "", nil }
+	if err != nil { return "", fmt.Errorf("workspace_name read: %w", err) }
+	return strings.TrimSpace(string(data)), nil
+}
+```
+
+- [ ] **Step 4: Run test**
+
+```bash
+go test ./internal/workspace/ -v
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/workspace/name.go internal/workspace/name_test.go
+git commit -m "feat(workspace): add WriteName/ReadName for workspace_name override"
+```
+
+---
+
+## Phase 8: bones rename (Tasks 22–24)
+
+### Task 22: RenameCmd validation
+
+**Files:** `cli/rename.go`, `cli/rename_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// cli/rename_test.go
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateRenameName(t *testing.T) {
+	tests := []struct {
+		name    string
+		want    string // expected error substring; "" = ok
+	}{
+		{"", "non-empty"},
+		{"foo", ""},
+		{"foo/bar", "separator"},
+		{"foo\\bar", "separator"},
+		{"auth-service", ""},
+		{strings.Repeat("a", 200), "too long"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateRenameName(tt.name)
+			if tt.want == "" {
+				if err != nil { t.Fatalf("expected ok, got %v", err) }
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("expected error containing %q, got %v", tt.want, err)
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Run test**
+
+```bash
+go test ./cli/ -run TestValidateRenameName
+```
+Expected: FAIL `undefined: validateRenameName`.
+
+- [ ] **Step 3: Write implementation**
+
+```go
+// cli/rename.go
+package cli
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/danmestas/bones/internal/registry"
+	"github.com/danmestas/bones/internal/workspace"
+)
+
+func validateRenameName(name string) error {
+	if name == "" { return fmt.Errorf("name must be non-empty") }
+	if len(name) > 128 { return fmt.Errorf("name too long (max 128 chars)") }
+	if strings.ContainsAny(name, "/\\") { return fmt.Errorf("name must not contain path separator (/ or \\)") }
+	return nil
+}
+```
+
+- [ ] **Step 4: Run test**
+
+```bash
+go test ./cli/ -run TestValidateRenameName -v
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cli/rename.go cli/rename_test.go
+git commit -m "feat(cli): add bones rename name validation"
+```
+
+---
+
+### Task 23: RenameCmd uniqueness check + write
+
+**Files:** `cli/rename.go`, `cli/rename_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+func TestRenameWritesAndUpdatesRegistry(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	wsDir := t.TempDir()
+	os.MkdirAll(filepath.Join(wsDir, ".bones"), 0o755)
+	t.Chdir(wsDir)
+
+	// Seed registry with this workspace
+	registry.Write(registry.Entry{Cwd: wsDir, Name: filepath.Base(wsDir), HubPID: os.Getpid(), StartedAt: time.Now().UTC()})
+
+	cmd := RenameCmd{NewName: "auth-service"}
+	if err := cmd.Run(); err != nil { t.Fatalf("Run: %v", err) }
+
+	// .bones/workspace_name updated
+	got, _ := workspace.ReadName(wsDir)
+	if got != "auth-service" { t.Fatalf("workspace_name = %q, want auth-service", got) }
+
+	// registry entry updated
+	e, _ := registry.Read(wsDir)
+	if e.Name != "auth-service" { t.Fatalf("registry name = %q, want auth-service", e.Name) }
+}
+
+func TestRenameRejectsCollision(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	otherWS := t.TempDir()
+	wsDir := t.TempDir()
+	os.MkdirAll(filepath.Join(wsDir, ".bones"), 0o755)
+	t.Chdir(wsDir)
+
+	// Another workspace already has the name "taken"
+	registry.Write(registry.Entry{Cwd: otherWS, Name: "taken", HubPID: os.Getpid(), StartedAt: time.Now().UTC()})
+	registry.Write(registry.Entry{Cwd: wsDir, Name: "self", HubPID: os.Getpid(), StartedAt: time.Now().UTC()})
+
+	cmd := RenameCmd{NewName: "taken"}
+	err := cmd.Run()
+	if err == nil { t.Fatalf("expected collision error, got nil") }
+	if !strings.Contains(err.Error(), "already used by") {
+		t.Fatalf("expected 'already used by' in error, got %v", err)
+	}
+}
+```
+
+- [ ] **Step 2: Run test**
+
+```bash
+go test ./cli/ -run TestRenameWritesAndUpdatesRegistry -run TestRenameRejectsCollision
+```
+Expected: FAIL `undefined: RenameCmd`.
+
+- [ ] **Step 3: Write implementation**
+
+```go
+type RenameCmd struct {
+	NewName string `arg:"" required:""`
+}
+
+func (c *RenameCmd) Run() error {
+	if err := validateRenameName(c.NewName); err != nil { return err }
+
+	cwd, err := os.Getwd()
+	if err != nil { return err }
+	root, found := walkUpToBones(cwd)
+	if !found { return fmt.Errorf("not inside a bones workspace (no .bones/ found above %s)", cwd) }
+
+	// Uniqueness check across all live workspaces
+	entries, err := registry.List()
+	if err != nil { return err }
+	for _, e := range entries {
+		if e.Cwd == root { continue } // skip self
+		if e.Name == c.NewName {
+			return fmt.Errorf("name %q is already used by workspace at %s\n  (rename that workspace first, or pick a different name)", c.NewName, e.Cwd)
+		}
+	}
+
+	// Write the override file first (source of truth)
+	if err := workspace.WriteName(root, c.NewName); err != nil { return err }
+
+	// Update the registry entry's Name field if this workspace is registered
+	if entry, err := registry.Read(root); err == nil {
+		entry.Name = c.NewName
+		if err := registry.Write(entry); err != nil { return err }
+	}
+
+	fmt.Printf("Renamed %s: → %s\n", root, c.NewName)
+	return nil
+}
+```
+
+Modify `cmd/bones/cli.go`:
+
+```go
+Rename bonescli.RenameCmd `cmd:"" group:"daily" help:"Set the workspace's display name"`
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+go test ./cli/ -run TestRename -v
+```
+Expected: PASS (all rename tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cli/rename.go cli/rename_test.go cmd/bones/cli.go
+git commit -m "feat(cli): add bones rename verb (with uniqueness check)"
+```
+
+---
+
+### Task 24: env consults workspace_name override
+
+**Files:** `cli/env.go`, `cli/env_test.go`
+
+The existing `resolveWorkspaceName` (Task 19) already reads `.bones/workspace_name`. This task confirms it consults the new `workspace.ReadName` helper rather than reading the file directly — and adds a test that exercises the rename → env flow.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+func TestEnvUsesRenamedName(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	root := t.TempDir()
+	os.MkdirAll(filepath.Join(root, ".bones"), 0o755)
+	t.Chdir(root)
+
+	// Simulate a rename
+	workspace.WriteName(root, "auth-service")
+
+	var buf strings.Builder
+	(&EnvCmd{Shell: "bash"}).run(&buf)
+	if !strings.Contains(buf.String(), "export BONES_WORKSPACE=auth-service") {
+		t.Fatalf("expected renamed name in env output:\n%s", buf.String())
+	}
+}
+```
+
+- [ ] **Step 2: Run test**
+
+```bash
+go test ./cli/ -run TestEnvUsesRenamedName
+```
+Expected: PASS if Task 19's `resolveWorkspaceName` reads the file directly. May FAIL if `resolveWorkspaceName` was implemented differently than the workspace.ReadName helper.
+
+- [ ] **Step 3: If failing, refactor `resolveWorkspaceName`**
+
+```go
+import "github.com/danmestas/bones/internal/workspace"
+
+func resolveWorkspaceName(root string) string {
+	if name, err := workspace.ReadName(root); err == nil && name != "" { return name }
+	return filepath.Base(root)
+}
+```
+
+- [ ] **Step 4: Run test**
+
+```bash
+go test ./cli/ -run TestEnv -v
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cli/env.go cli/env_test.go
+git commit -m "refactor(cli): env uses workspace.ReadName for rename consistency"
+```
+
+---
+
+## Phase 9: Hub /health endpoint, README, ADR footnote (Tasks 25–28)
+
+### Task 25: Confirm or add /health endpoint to hub
+
+**Files:** `internal/hub/hub.go` (or wherever hub HTTP server is configured), test alongside.
+
+- [ ] **Step 1: Verify or write the failing test**
+
+Search the hub package for `/health`:
+```bash
+grep -rn "/health" internal/hub/
+```
+
+If `/health` already exists, this task becomes a no-op verification. If not:
+
+```go
+// internal/hub/hub_test.go (append)
+func TestHubHealthEndpoint(t *testing.T) {
+	// Use existing test fixture for hub HTTP server
+	srv, cleanup := newTestHubServer(t) // helper from existing tests
+	defer cleanup()
+
+	resp, err := http.Get(srv.URL + "/health")
+	if err != nil { t.Fatalf("GET /health: %v", err) }
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 { t.Fatalf("status = %d, want 200", resp.StatusCode) }
+}
+```
+
+- [ ] **Step 2: Run test**
+
+```bash
+go test ./internal/hub/ -run TestHubHealthEndpoint
+```
+Expected: FAIL if endpoint missing; PASS otherwise.
+
+- [ ] **Step 3: If failing, add the endpoint**
+
+In whichever file registers HTTP routes (look for `http.HandleFunc`, `mux.Handle`, etc.):
+
+```go
+mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+})
+```
+
+- [ ] **Step 4: Run test**
+
+```bash
+go test ./internal/hub/ -v
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/hub/
+git commit -m "feat(hub): add /health endpoint for registry stale detection"
+```
+
+---
+
+### Task 26: README — shell prompt-hook snippets
+
+**Files:** `README.md`
+
+- [ ] **Step 1: Identify section**
+
+Open `README.md` and find an appropriate location (likely after "Installation" or in a "Shell Integration" section). If no shell-integration section exists, add one.
+
+- [ ] **Step 2: Add content**
+
+Append/insert:
+
+````markdown
+## Shell prompt integration
+
+`bones env` prints shell-export statements for `BONES_WORKSPACE` and `BONES_WORKSPACE_CWD`. Wire it into your shell's prompt hook so the env vars stay in sync as you `cd` between workspaces:
+
+### zsh (`~/.zshrc`)
+
+```zsh
+_bones_env_hook() { eval "$(bones env)"; }
+typeset -ag precmd_functions
+precmd_functions+=(_bones_env_hook)
+```
+
+### bash (`~/.bashrc`)
+
+```bash
+PROMPT_COMMAND='eval "$(bones env)"'
+```
+
+### fish (`~/.config/fish/conf.d/bones.fish`)
+
+```fish
+function _bones_env_hook --on-event fish_prompt
+    bones env --shell=fish | source
+end
+```
+
+## Prompt theme integration
+
+Once `BONES_WORKSPACE` is exported, themes read it directly.
+
+### Starship (`~/.config/starship.toml`)
+
+```toml
+[env_var.BONES_WORKSPACE]
+format = "[$env_value](bold yellow) "
+```
+
+### Powerlevel10k
+
+Define a custom segment that reads `$BONES_WORKSPACE`:
+
+```zsh
+function prompt_bones_workspace() {
+    [[ -n "$BONES_WORKSPACE" ]] && p10k segment -t "$BONES_WORKSPACE" -f yellow
+}
+```
+
+Then add `bones_workspace` to your `POWERLEVEL9K_RIGHT_PROMPT_ELEMENTS` (or `_LEFT_`).
+
+### Plain bash/zsh
+
+```bash
+PS1='[${BONES_WORKSPACE:-no-bones}] \w $ '
+```
+````
+
+- [ ] **Step 3: Verify rendering**
+
+Open README.md in a markdown previewer to confirm code blocks render correctly.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md
+git commit -m "docs(readme): add shell prompt-hook + theme snippets for BONES_WORKSPACE"
+```
+
+---
+
+### Task 27: README — bones status --all, down --all, rename usage
+
+**Files:** `README.md`
+
+- [ ] **Step 1: Add usage examples**
+
+In an appropriate section (after the existing `bones status` mention or under "Common workflows"):
+
+````markdown
+## Cross-workspace commands
+
+When you're running bones across multiple workspaces (e.g., 6 terminals on 3 different repos), these commands give you a global view from any terminal:
+
+```
+$ bones status --all
+WORKSPACE          PATH                HUB    SESSIONS  UPTIME
+foo                ~/projects/foo      :8765  6         2h
+bar                ~/projects/bar      :8766  3         45m
+auth-service       ~/work/auth         :8767  1         10m
+
+$ bones down --all      # tear down every registered workspace (prompts unless --yes)
+$ bones rename auth-service   # set this workspace's display name
+```
+
+The registry that backs these commands lives at `~/.bones/workspaces/` (one JSON file per running workspace; created by `bones up`, removed by `bones down`).
+````
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add README.md
+git commit -m "docs(readme): document bones status --all, down --all, rename"
+```
+
+---
+
+### Task 28: ADR 0038 footnote pointing to Spec 1's Future Direction
+
+**Files:** `docs/adr/0038-per-workspace-hub-ports.md`
+
+- [ ] **Step 1: Read the ADR to find the right insertion point**
+
+```bash
+cat docs/adr/0038-per-workspace-hub-ports.md
+```
+
+Find the "Alternatives considered" section (which contains the "single global hub multiplexing all workspaces" rejection).
+
+- [ ] **Step 2: Add footnote**
+
+Append after the "Alternatives considered" rejection text, on a new line:
+
+```markdown
+> **Future supersession trigger:** The "cross-workspace NATS subject routing" objection is solvable via JetStream `domain=` and per-account isolation. See `docs/superpowers/specs/2026-05-01-cross-workspace-identity-design.md` (Future Direction section) for the leaf-node topology that revisits this decision when cross-machine, real-time, or multi-user becomes a forcing function.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/adr/0038-per-workspace-hub-ports.md
+git commit -m "docs(adr): footnote ADR 0038 with leaf-node future-supersession trigger"
+```
+
+---
+
+## Final verification
+
+- [ ] **Step F1: Run full local CI**
+
+```bash
+make check
+```
+Expected: `check: OK` (no errors).
+
+- [ ] **Step F2: Push to PR**
+
+```bash
+git push
+```
+
+- [ ] **Step F3: Verify remote CI**
+
+```bash
+gh pr checks 107
+```
+Expected: all checks pass (or only docs-only skip).
+
+---
+
+## Spec coverage check
+
+| Spec section | Plan task(s) |
+|---|---|
+| Registry — one file per workspace | 1, 2, 3, 4, 5, 6 |
+| Registry — atomic write (tmp+rename) | 3 |
+| Registry — stale detection (PID + HTTP) | 7 |
+| Sessions — one file per session | 8 |
+| Sessions — register/unregister via hidden CLI | 11, 12 |
+| Sessions — orphan GC (PID-alive filter) | 9 |
+| `bones up` registers workspace | 13 |
+| `bones down` removes registry entry | 14 |
+| `bones status --all` | 15, 16 |
+| `bones down --all` | 17 |
+| `bones env` (BONES_WORKSPACE shell integration) | 18, 19, 20, 24 |
+| `bones rename` | 21, 22, 23 |
+| README snippets (zsh/bash/fish/starship/p10k) | 26, 27 |
+| ADR 0038 footnote | 28 |
+| `/health` endpoint (required by stale detection) | 25 |
+
+All spec sections covered.

--- a/docs/superpowers/specs/2026-05-01-cross-workspace-identity-design.md
+++ b/docs/superpowers/specs/2026-05-01-cross-workspace-identity-design.md
@@ -1,0 +1,254 @@
+# Cross-Workspace Identity — Design
+
+**Date:** 2026-05-01
+**Status:** Draft
+**Replaces:** N/A
+**Related:** ADR 0038 (per-workspace hub ports), ADR 0028 (swarm verbs), ADR 0041 (single leaf, single fossil)
+
+## Scope
+
+**In:**
+
+- Filesystem-backed registry of currently-running bones workspaces, keyed by absolute cwd
+- Session markers tracking attached `claude` sessions per workspace (private to bones-managed hooks; no public CLI verb)
+- `bones status --all` — global view across workspaces on this user/host
+- `bones down --all` — bulk teardown
+- `bones rename <new-name>` — set the displayed workspace name
+- `bones env` — print shell-export statements for the current cwd's workspace
+- One-line "Future supersession trigger" footnote on ADR 0038 pointing at this spec's Future Direction section
+- README snippets for shell prompt-hook integration (bash/zsh/fish) and prompt themes (starship, p10k)
+
+**Out:**
+
+- Cross-host or cross-user (single-user, single-host only)
+- Cross-workspace `bones doctor` (deferred to Spec 2: `doctor-ergonomics`)
+- NATS topology changes (see Future Direction below — superseded by a future leaf-node migration, not implemented here)
+- `bones down --all --inactive=Xh` filter (deferred to v2)
+
+## Motivation
+
+Today, an engineer running bones in N parallel terminals (potentially across multiple workspaces — e.g., 6 terminals on `~/projects/foo`, 3 on `~/projects/bar`) has no global view. To answer "is anything stuck right now?" they must `cd` into each workspace and run `bones doctor` separately. End-of-day cleanup is `cd × N` of `bones down --yes`. There is no shell signal to confirm which workspace a terminal belongs to.
+
+The audit (`docs/audits/2026-05-01-dx-6-terminals-from-agentic-engineer.md`) ranked this as the single highest-leverage DX gap.
+
+## Design
+
+### Data model
+
+**Registry — one file per workspace.**
+
+Path: `~/.bones/workspaces/<id>.json` where `<id>` is the first 16 hex chars of `sha256(absolute_cwd)`. Sha256-prefix is chosen over slugging for determinism, no escaping, and stability across path edge-cases.
+
+```json
+{
+  "cwd": "/Users/dmestas/projects/foo",
+  "name": "foo",
+  "hub_url": "http://127.0.0.1:8765",
+  "nats_url": "nats://127.0.0.1:4222",
+  "hub_pid": 12345,
+  "started_at": "2026-05-01T10:23:00Z"
+}
+```
+
+- `name` — basename of cwd, or the value of `workspace_name` in `.bones/config.json` if present.
+- Writer: `bones up` (idempotent — same cwd hashes to same file; overwrite is safe).
+- Remover: `bones down`.
+- Atomic write: write to `<id>.json.tmp`, then `rename`. Single writer per file means no locking is needed.
+
+**Sessions — one file per `claude` session.**
+
+Path: `~/.bones/sessions/<session_id>.json`.
+
+```json
+{
+  "session_id": "ade241a5-...",
+  "workspace_cwd": "/Users/dmestas/projects/foo",
+  "claude_pid": 67890,
+  "started_at": "2026-05-01T10:25:00Z"
+}
+```
+
+- Writer: bones-managed SessionStart hook writes the file directly (filesystem op, no public CLI verb — the marker is a private implementation detail of the hook).
+- Remover: bones-managed SessionEnd hook unlinks the file directly.
+- Orphan GC: `bones up` and `bones status --all` filter session markers by `kill -0 claude_pid`; dead markers are unlinked as a side effect.
+
+The marker subsystem is deliberately not exposed as a public CLI verb. If marker introspection is ever needed for debugging, extend `bones doctor` to iterate them — that's a deep verb (one command, full internal view) rather than a shallow `register/unregister` pair.
+
+**Why two directories instead of one combined file:** zero write contention (each entity owns its file), GC reduces to `rm`, partial writes affect one entity rather than the whole registry. The accepted tradeoff is **join-on-read** for `status --all`: globbing both directories and joining by `workspace_cwd` is the cost of the contention-free write path. At expected scale (≤ dozens of workspaces, low hundreds of sessions) this is sub-millisecond.
+
+### Commands
+
+#### `bones status --all`
+
+Reads `~/.bones/workspaces/*.json`, prunes stale entries, renders a table.
+
+**Stale detection per entry** (both must pass for an entry to be kept):
+
+1. `kill -0 hub_pid` — hub process alive on this host.
+2. `GET hub_url/health` returns `200` within 500 ms.
+
+If either fails, the registry file is unlinked (live-only semantics) and the entry is omitted from output. Both checks are required because a recycled PID can pass the first but fail the second.
+
+**Per live workspace, gather:**
+
+- Session count: `glob ~/.bones/sessions/*.json` filtered by `workspace_cwd == entry.cwd` and `kill -0 claude_pid`.
+- Slot count: connect to `entry.nats_url`, read the `bones-swarm-sessions` KV bucket, count active slots vs. total slot configurations.
+
+**Output (default):**
+
+```
+WORKSPACE          PATH                HUB    SLOTS  SESSIONS  UPTIME
+foo                ~/projects/foo      :8765  3/6    6         2h
+bar                ~/projects/bar      :8766  1/4    3         45m
+auth-service       ~/work/auth         :8767  0/2    1         10m
+```
+
+Empty state: `No workspaces running. Use 'bones up' in a project.`
+
+**Flags:**
+
+- `--all` — switches `bones status` from current-workspace mode to global mode.
+- `--json` — machine-readable output (always include).
+
+**Performance:** serial NATS connections per workspace. Sub-second for ≤ 10 workspaces. Parallelize if N > 10 becomes common.
+
+#### `bones down --all`
+
+Reads the registry, prints what will be terminated, prompts, then calls existing `bones down --yes` per workspace.
+
+**Default (interactive):**
+
+```
+$ bones down --all
+Will stop:
+  foo           ~/projects/foo   hub:8765   6 sessions, 3 active slots
+  bar           ~/projects/bar   hub:8766   3 sessions, 1 active slot
+  auth-service  ~/work/auth      hub:8767   1 session, 0 active slots
+
+3 workspaces, 10 sessions, 4 slots will be terminated.
+Continue? [y/N]
+```
+
+**Flags:**
+
+- `--yes` — skip prompt; still prints the warning block to stderr (no silent destruction).
+- `--json` — machine-readable.
+- `--inactive=Xh` — **deferred to v2.**
+
+**Implementation:** loops over registry, invokes the existing per-workspace teardown function with each workspace's path. Per-workspace results are reported.
+
+#### `bones rename <new-name>`
+
+Sets the workspace's display name. Writes `workspace_name: <new-name>` into `.bones/config.json` and updates the corresponding registry entry's `name` field atomically.
+
+```bash
+$ bones rename auth-service
+Renamed ~/projects/foo: foo → auth-service
+```
+
+**Validation:** the new name must be (a) non-empty, (b) free of path separators, (c) unique among currently-registered workspace names on this user (rejected with a clear message and the colliding workspace's path if not). Validation is performed before any write — defines the "duplicate name" error class out of existence at the verb boundary, rather than letting users hand-edit `.bones/config.json` and discover collisions later.
+
+**Why a verb instead of "edit `config.json` yourself":** hand-editing JSON is an obscure dependency (which file, which key, what's valid). A verb makes the operation discoverable, validates input, and updates both stores atomically.
+
+### Shell integration: `BONES_WORKSPACE`
+
+`bones up` runs as a subprocess and cannot directly set env vars in the parent shell. The integration is a prompt-hook that re-evaluates on each prompt.
+
+#### Primitive: `bones env`
+
+Given the current cwd, prints shell-export statements to stdout.
+
+```bash
+$ cd ~/projects/foo
+$ bones env
+export BONES_WORKSPACE=foo
+export BONES_WORKSPACE_CWD=/Users/dmestas/projects/foo
+
+$ cd /tmp
+$ bones env
+unset BONES_WORKSPACE
+unset BONES_WORKSPACE_CWD
+```
+
+Resolution: walk up from cwd to find `.bones/`. If found, derive `name` (basename, or `workspace_name` from `.bones/config.json`). If not found, print unset statements.
+
+`bones env` does **not** require the registry; it derives state from `.bones/config.json` directly. So `BONES_WORKSPACE` is set whenever the cwd is inside a `.bones/` workspace — independent of whether the hub is currently running. This is the intended contract: the env var reflects "which workspace is this terminal sitting in," not "is the workspace's hub alive."
+
+**Performance:** runs on every prompt. Walking up = a few `stat` calls (sub-ms); reading config = one file read. < 5 ms typical. No caching.
+
+**Flags:**
+
+- `--shell=bash|zsh|fish` — adapts syntax (fish uses `set -x`, others use `export`). Auto-detected from `$SHELL`.
+
+#### Setup (documented in README, no CLI verb)
+
+Generating a 3-line shell snippet doesn't justify a binary subcommand — the snippet is one-time setup and stable across versions. README documents the per-shell hook and per-theme integration directly.
+
+**Prompt hook (one-time, in shell rc):**
+
+- **zsh** (`~/.zshrc`):
+  ```zsh
+  _bones_env_hook() { eval "$(bones env)"; }
+  typeset -ag precmd_functions
+  precmd_functions+=(_bones_env_hook)
+  ```
+- **bash** (`~/.bashrc`): `PROMPT_COMMAND='eval "$(bones env)"'`
+- **fish** (`~/.config/fish/conf.d/bones.fish`):
+  ```fish
+  function _bones_env_hook --on-event fish_prompt
+    bones env --shell=fish | source
+  end
+  ```
+
+**Prompt theme integration:**
+
+- **Starship** (`~/.config/starship.toml`):
+  ```toml
+  [env_var.BONES_WORKSPACE]
+  format = "[$env_value](bold yellow) "
+  ```
+- **Powerlevel10k:** custom segment that reads `$BONES_WORKSPACE`.
+- **Plain bash/zsh:** `PS1='[${BONES_WORKSPACE:-no-bones}] \w $ '`.
+
+**Two env vars exported (`BONES_WORKSPACE` + `BONES_WORKSPACE_CWD`):** deliberate. Themes need the short name for display; scripts that operate on the workspace need the absolute path. Combining them into one variable would force every consumer to choose. The cost is one extra export statement per prompt — negligible.
+
+### Failure modes & edge cases
+
+| Scenario | Behavior |
+|---|---|
+| Registry dir missing (first run) | `bones up` runs `mkdir -p ~/.bones/workspaces` |
+| Registry write fails (disk full, perms) | Warn to stderr; `bones up` continues. Hub still works locally. |
+| Two `bones up` race in same workspace | Atomic tmp+rename; last writer wins. Content identical anyway. |
+| Two `status --all` race on stale prune | `os.Remove` idempotent; second gets ENOENT, ignored. |
+| `.bones/` deleted from disk; registry entry remains | Stale detection (PID + HTTP) prunes on next read. |
+| PID reuse (OS reassigned `hub_pid` to unrelated process) | HTTP `/health` fails → pruned. **This is why both checks are required.** |
+| HTTP `/health` flakes (busy machine) | Single attempt, 500 ms timeout. Tunable via env var if it bites. |
+| NATS unreachable but hub HTTP responds (degraded) | Entry kept (passes stale detection); slot count rendered as `?`. Lets the user see the workspace exists even when it's degraded. |
+| `bones down` succeeds but registry removal fails | Self-heals on next `status --all` via stale detection. |
+| Session marker leaks (claude crashed without SessionEnd) | PID check filters on read; `bones up` prunes dead markers as a side effect. |
+| `bones env` outside any workspace | Prints unset statements. No error. |
+| Two workspaces share basename | PATH column disambiguates in the table. `workspace_name` in `.bones/config.json` overrides for `BONES_WORKSPACE`. |
+
+### Migration
+
+No active migration step. Existing workspaces appear in the registry on their next `bones up` (which fires from the SessionStart hook). Release notes document the one-time gap: `bones status --all` will under-report until each workspace's first post-upgrade session.
+
+### Testing
+
+- **Unit:** registry read/write atomicity, stale detection logic (matrix of PID-alive × HTTP-up), session marker GC, basename collision handling, `bones env` resolution.
+- **Integration:** `bones up`/`down` round-trip with registry side effects; `status --all` across 3+ workspaces; `down --all` invokes per-workspace teardown.
+- **Manual:** shell hook setup on bash, zsh, fish per README snippets; prompt theme snippets with starship and p10k; `bones rename` round-trip including collision rejection.
+
+## Future Direction
+
+The registry is a deliberate stop-gap. The structurally cleaner end-state is a **user-level NATS server with per-workspace leaf nodes**, using JetStream `domain=<workspace_id>` and per-account isolation to provide cross-workspace visibility without subject collision. ADR 0038 originally rejected this on the grounds that "cross-workspace NATS subject routing would invade every consumer," but JetStream domains and per-account isolation address that objection directly.
+
+**This spec deliberately does not implement that.** A standalone aspirational ADR was considered and rejected (deferment ADRs are an anti-pattern in this project). The leaf-node migration becomes worth doing when any of the following becomes a forcing function:
+
+- **Cross-machine** workspaces (workspaces on multiple hosts visible from one)
+- **Real-time event streams** (presence, hub-died, slot-claimed) for a live dashboard
+- **Multi-user / auth** requirements
+
+The registry's external contract — `bones status --all`, `bones down --all`, `BONES_WORKSPACE` — is intentionally designed so that a future migration replaces the implementation, not the consumers. Both `status --all` ("which hubs are alive for this user") and `BONES_WORKSPACE` ("name of the workspace at this cwd") are equivalently satisfiable from a NATS query.
+
+**Discoverability commitment:** as part of this spec's deliverables, ADR 0038 receives a one-line "Future supersession trigger" footnote pointing here. A reader landing on the original ADR will see the leaf-node thinking without needing to know the spec exists. If/when the migration is undertaken, ADR 0038 is updated (not superseded), and the spec for that work explicitly cites the JetStream-domain mechanics that resolve the original objection.

--- a/docs/superpowers/specs/2026-05-01-cross-workspace-identity-design.md
+++ b/docs/superpowers/specs/2026-05-01-cross-workspace-identity-design.md
@@ -68,8 +68,9 @@ Path: `~/.bones/sessions/<session_id>.json`.
 }
 ```
 
-- Writer: bones-managed SessionStart hook writes the file directly (filesystem op, no public CLI verb — the marker is a private implementation detail of the hook).
-- Remover: bones-managed SessionEnd hook unlinks the file directly.
+- Writer: bones-managed SessionStart hook calls a hidden internal subcommand `bones session-marker register` (not listed in `bones --help`; exists solely to keep the marker schema in Go code rather than duplicated in a shell script). The subcommand writes the JSON file.
+- Remover: bones-managed SessionEnd hook calls `bones session-marker unregister` (same hidden internal subcommand).
+- The `session-marker` subcommand is deliberately hidden because the marker mechanism is internal to bones; only the bones-managed hooks call it. Hiding it from `--help` prevents users from forming a false API contract on it.
 - Orphan GC: `bones up` and `bones status --all` filter session markers by `kill -0 claude_pid`; dead markers are unlinked as a side effect.
 
 The marker subsystem is deliberately not exposed as a public CLI verb. If marker introspection is ever needed for debugging, extend `bones doctor` to iterate them — that's a deep verb (one command, full internal view) rather than a shallow `register/unregister` pair.
@@ -147,6 +148,14 @@ Renamed ~/projects/foo: foo → auth-service
 ```
 
 **Validation:** the new name must be (a) non-empty, (b) free of path separators, (c) unique among currently-registered workspace names on this user (rejected with a clear message and the colliding workspace's path if not). Validation is performed before any write — defines the "duplicate name" error class out of existence at the verb boundary, rather than letting users hand-edit `.bones/config.json` and discover collisions later.
+
+Example collision error:
+
+```
+$ bones rename auth-service
+error: name 'auth-service' is already used by workspace at /Users/dmestas/work/auth
+       (rename that workspace first, or pick a different name)
+```
 
 **Why a verb instead of "edit `config.json` yourself":** hand-editing JSON is an obscure dependency (which file, which key, what's valid). A verb makes the operation discoverable, validates input, and updates both stores atomically.
 

--- a/docs/superpowers/specs/2026-05-01-dispatch-and-logs-design.md
+++ b/docs/superpowers/specs/2026-05-01-dispatch-and-logs-design.md
@@ -1,0 +1,290 @@
+# Dispatch and Logs — Design
+
+**Date:** 2026-05-01
+**Status:** Draft
+**Replaces:** N/A
+**Related:** ADR 0023 (hub-leaf orchestrator), ADR 0028 (swarm verbs + lease types), ADR 0034 (bypass prevention), Spec `cross-workspace-identity`, Spec `doctor-ergonomics`
+
+## Scope
+
+**In:**
+
+- `bones swarm dispatch <plan>` — validate plan, create tasks in `bones-tasks` KV, group into dependency waves, emit a dispatch manifest
+- `bones swarm dispatch --resume` — advance to the next wave after the current wave completes
+- `bones swarm dispatch --mark-wave-complete=<N>` — public skill-facing verb; called by consumer skills when a wave's subagents all close successfully
+- `bones swarm dispatch --cancel` — abandons an in-flight dispatch (removes manifest, marks open tasks `cancelled`)
+- Dispatch manifest schema at `.bones/swarm/dispatch.json` (versioned, harness-agnostic contract)
+- Update to existing `orchestrator` skill (claude-specific layer) to consume the manifest
+- `bones logs --slot=<name>` and `bones logs --workspace` — view bones-side event logs (with `--tail` / `--since` / `--last` / `--json`)
+- Per-slot event log file at `.bones/swarm/<slot>/log` (newline-delimited JSON)
+- Workspace event log file at `.bones/log` (NDJSON, size-rotated)
+- Closed catalog of event types (extending requires a code change)
+
+**Out:**
+
+- Subprocess spawning from the bones binary — bones stays harness-agnostic; spawning is the harness-specific skill's responsibility (`reference/CAPABILITIES.md`, ADR 0023)
+- Subagent reasoning capture — lives in harness transcript directories, not bones's data
+- Auto-advance through waves without user invocation — deferred to v2; auto-advance crosses into "agent management" territory that deserves its own design pass for safety
+- Per-harness skills other than `orchestrator` (Claude Code) — cursor / aider / etc. ship later via the same manifest contract
+- Time-based log rotation (size-based only in v1)
+
+## Motivation
+
+The DX audit (`docs/audits/2026-05-01-dx-6-terminals-from-agentic-engineer.md`) ranked two issues in this spec's territory:
+
+- **#4 (orchestrator dispatch is invisible from `bones --help`):** today the workflow lives entirely in a Claude Code skill. A new agentic engineer reading `bones --help` won't find the most powerful workflow. Score: 6/10.
+- **#7 (no log surface for debugging slot work):** the `-v` flag must be re-passed per command, output is slog-to-stderr, and there's no per-slot view. Score: 4/10.
+
+This spec addresses both while preserving the harness-agnostic boundary that bones depends on architecturally.
+
+## Architectural boundary
+
+The reference docs (`reference/CAPABILITIES.md`, ADR 0023) make the boundary explicit:
+
+> **Bones binary = harness-agnostic substrate.** No subprocess spawning. Pull-based work queue. Verbs that any harness's agents can call.
+>
+> **Skill layer = harness-specific.** Skills consume bones primitives and apply harness-specific dispatch (Task tool for Claude Code, equivalent for cursor / aider / etc.).
+
+```
+┌─────────────────────────┐         ┌──────────────────────────┐
+│ bones swarm dispatch    │         │ orchestrator skill       │
+│ (harness-agnostic verb) │ writes  │ (claude-specific layer)  │
+│                         │ manifest│                          │
+│ - validate plan         │ ──────► │ reads dispatch.json      │
+│ - create tasks          │         │ uses Task tool to spawn  │
+│ - group into waves      │         │ N subagents per wave     │
+│ - emit manifest         │         │ each runs `subagent`     │
+└─────────────────────────┘         │ skill                    │
+                                    └──────────────────────────┘
+```
+
+A future cursor / aider skill consumes the same `dispatch.json` and spawns through whatever spawn primitive that harness offers. The verb's job is making the dispatch *plan* concrete and discoverable; the skill's job is the actual spawn.
+
+## Design
+
+### Dispatch manifest schema
+
+Path: `.bones/swarm/dispatch.json`. Versioned (`schema_version`) so the consumer-skill contract can evolve.
+
+```json
+{
+  "schema_version": 1,
+  "plan_path": "./plan.md",
+  "plan_sha256": "ab12cd34...",
+  "created_at": "2026-05-01T12:00:00Z",
+  "current_wave": 1,
+  "waves": [
+    {
+      "wave": 1,
+      "slots": [
+        {
+          "slot": "a",
+          "task_id": "t-7c92...",
+          "title": "auth refactor",
+          "files": ["auth/", "internal/auth/"],
+          "subagent_prompt": "You are a bones subagent for slot=a. Use the `subagent` skill. Task ID is t-7c92.... Tasks: ..."
+        },
+        {
+          "slot": "b",
+          "task_id": "t-9e34...",
+          "title": "add token tests",
+          "files": ["auth/token_test.go"],
+          "subagent_prompt": "..."
+        }
+      ]
+    },
+    {
+      "wave": 2,
+      "blocked_until_wave": 1,
+      "slots": [
+        {
+          "slot": "e",
+          "task_id": "t-3f56...",
+          "title": "integration tests",
+          "files": ["test/integration/"],
+          "subagent_prompt": "..."
+        }
+      ]
+    }
+  ],
+  "status": "ready"
+}
+```
+
+**`status` transitions:** `ready` → `wave_in_flight` (when consumer-skill begins spawning) → `wave_complete` (when all current wave's tasks closed) → next wave's `ready` after `--resume`. Eventually `complete` when the last wave finishes.
+
+The skill never writes the manifest file directly — it always goes through `bones swarm dispatch --mark-wave-complete=<N>`. Keeps file ownership with bones; prevents skills from corrupting the contract.
+
+### `bones swarm dispatch <plan>`
+
+```
+$ bones swarm dispatch ./plan.md
+✓ Plan valid: 5 tasks across 4 slots, 2 dependency waves
+✓ Created 5 tasks in bones-tasks
+✓ Wave 1 manifest written to .bones/swarm/dispatch.json
+  slot a → task t-7c92 (auth refactor)
+  slot b → task t-9e34 (add token tests)
+  slot c → task t-2a11 (migrate session store)
+  slot d → task t-8d77 (refactor logging)
+
+Next step (Claude Code): in your claude session, run
+  /orchestrator dispatch
+(For other harnesses: see your harness's swarm-dispatch skill.)
+```
+
+**Flags:**
+
+- `--resume` — re-emit manifest with the next wave promoted to `current_wave`. Errors if previous wave isn't `wave_complete`.
+- `--wave=N` — explicit wave number. Rare; for testing or jumping past a stuck wave with manual cleanup.
+- `--mark-wave-complete=<N>` — public verb intentionally exposed for skill use. Consumer skills call this when all wave-N subagents close successfully; it flips manifest `status` to `wave_complete`. Documented as "skill API surface" rather than hidden, because consumers other than the in-tree orchestrator skill (cursor, aider) need it too.
+- `--cancel` — abandons an in-flight dispatch: removes `.bones/swarm/dispatch.json`, closes any still-open tasks the manifest created with `result=cancelled`. Use when a dispatch needs to be torn down before completion.
+- `--json` — manifest path + summary as JSON (for scripting).
+- `--dry-run` — validate + show what would be created/written, without touching NATS or filesystem.
+
+**`subagent_prompt` generation.** The verb constructs each slot's `subagent_prompt` from a small template applied to the plan's per-task content:
+
+```
+You are a bones subagent for slot=<slot>. Use the `subagent` skill.
+Task ID is <task_id>.
+
+Tasks (from plan):
+<verbatim slot section from the plan markdown>
+
+Files in scope: <files joined with comma>
+Worktree: $(bones swarm cwd --slot=<slot>)
+```
+
+The template is bones-binary code (closed catalog — extending requires a code change), parallel in spirit to the doctor hint catalog from Spec 2. Skills consume the prompt verbatim; they do not regenerate or edit it. This keeps the dispatch contract stable across harnesses.
+
+**Idempotency:** running `bones swarm dispatch ./plan.md` twice on the same plan + same workspace + with no prior dispatch in flight is a no-op (re-reads tasks, re-writes identical manifest). If a prior dispatch exists at a different wave or different `plan_sha256`, errors clearly with the recovery command.
+
+**Plan parsing:** reuses existing `validate-plan` logic. No new parser. The verb fails if the plan is invalid; orchestrator-skill never sees an invalid manifest.
+
+### Wave handling
+
+- Dispatch fires only the first parallelizable wave (`current_wave = 1`).
+- Consumer skill (orchestrator) spawns subagents for the wave's slots.
+- As subagents `bones swarm close --result=success`, tasks transition to `Closed` in `bones-tasks` KV.
+- When all of wave-1's tasks are `Closed`, the consumer skill calls `bones swarm dispatch --mark-wave-complete=1`. Manifest's `status` flips to `wave_complete`.
+- User runs `bones swarm dispatch --resume`. Manifest `current_wave` advances to 2, `status` returns to `ready`.
+- Consumer skill spawns wave-2's subagents. Repeat until manifest `status = complete`.
+
+**User-visible state at any moment** (existing `bones swarm status` extended with one dispatch-context line):
+
+```
+$ bones swarm status
+Dispatch: ./plan.md  (wave 1 of 2 — wave_in_flight)
+  slot a [active]   commit 8m ago
+  slot b [active]   commit 2m ago
+  slot c [active]   commit 4m ago
+  slot d [stale]    last_renewed 12m ago
+```
+
+Cross-references Spec 2: `bones doctor` would tag the stale slot and emit a `Fix:` line per the doctor catalog.
+
+### Updates to orchestrator skill (Claude Code, lives in `.claude/skills/orchestrator/`)
+
+Out of scope for the *binary spec* itself, but committed as a deliverable of this spec:
+
+- Skill input becomes "read `.bones/swarm/dispatch.json`" rather than taking a plan path directly.
+- Skill spawns N Task-tool subagents per the manifest's `current_wave`'s `slots[]`, using each slot's `subagent_prompt` field verbatim.
+- Skill calls `bones swarm dispatch --mark-wave-complete=<N>` when all wave subagents close successfully.
+- Skill's docs updated: invocation is now `/orchestrator dispatch` (consumes manifest) rather than `/orchestrator <plan-path>`.
+
+### `bones logs --slot=<name>` and `bones logs --workspace`
+
+`bones logs --slot=<name>` shows **bones-side events** for a slot — what bones observed and emitted. It does **not** show subagent reasoning, prompts, or tool calls; those live in the harness's transcript directory (e.g., `~/.claude/projects/<id>/subagents/agent-<id>.jsonl` for Claude Code) and are out of scope. Same harness-agnostic constraint as dispatch.
+
+#### Per-slot event log file
+
+Path: `.bones/swarm/<slot>/log` (newline-delimited JSON, one event per line).
+
+JSONL is greppable, parseable, friendly to `jq`, and doesn't require a parser to read. Existing fossil/NATS interop logging in bones already follows this pattern.
+
+**Event shape:**
+
+```jsonl
+{"ts":"2026-05-01T12:00:00Z","slot":"a","event":"join","task_id":"t-7c92","worktree":"/path/.bones/swarm/a/wt"}
+{"ts":"2026-05-01T12:02:31Z","slot":"a","event":"commit","message":"slot-a: refactor extract token validator","sha":"abc123","files":4}
+{"ts":"2026-05-01T12:05:14Z","slot":"a","event":"commit","message":"slot-a: add token tests","sha":"def456","files":2}
+{"ts":"2026-05-01T12:07:02Z","slot":"a","event":"close","result":"success","summary":"Refactored validator and added 12 tests."}
+```
+
+**Closed event-type catalog** (parallel to the doctor hint catalog — extending requires a code change):
+
+| `event` | Emitted by | Fields beyond `ts` / `slot` / `event` |
+|---|---|---|
+| `join` | `bones swarm join` | `task_id`, `worktree` |
+| `commit` | `bones swarm commit` | `message`, `sha`, `files` (count), `bytes` (size) |
+| `commit_error` | `bones swarm commit` (rejected) | `reason` (e.g., `fossil-fork-detected`, `session-gone`) |
+| `renew` | session heartbeat (sub-`commit` granularity if needed) | (none) |
+| `close` | `bones swarm close` | `result` (`success`/`fail`/`fork`), `summary` |
+| `dispatched` | `bones swarm dispatch` | `wave`, `task_id`, `manifest_path` |
+| `error` | any swarm verb that errors before completion | `verb`, `reason`, `recoverable` (bool) |
+
+Bones writes one line per event with `O_APPEND`; line is shorter than `PIPE_BUF` so atomic on Linux/macOS without locking.
+
+#### `bones logs --slot=<name>` — output
+
+```
+$ bones logs --slot=a
+12:00:00  join     task=t-7c92  worktree=.bones/swarm/a/wt
+12:02:31  commit   "slot-a: refactor extract token validator"  sha=abc123  4 files
+12:05:14  commit   "slot-a: add token tests"                   sha=def456  2 files
+12:07:02  close    result=success  "Refactored validator and added 12 tests."
+```
+
+Default rendering: human-readable, time-only timestamps (full date in `--full-time`), color when TTY (`event` colored by type — `commit` green, `commit_error` / `error` red, `close` colored based on `result`). Disabled by `--no-color` or `NO_COLOR` env var.
+
+**Flags:**
+
+- `--tail` / `-f` — follow (`tail -f` semantics).
+- `--since=<duration>` — only events newer than `5m` / `1h` / `2026-05-01T12:00:00Z`.
+- `--last=<N>` — only the last N events.
+- `--json` — emit raw JSONL unmodified (so `bones logs --slot=a --json | jq ...` works).
+- `--full-time` — full RFC3339 timestamps instead of HH:MM:SS.
+
+#### `bones logs --workspace`
+
+Workspace-level events (hub started, hub stopped, NATS state changes, dispatch invocations, registry writes). Path: `.bones/log` (workspace-level event log, same JSONL format). Same flags as per-slot.
+
+Useful for "what did bones do in this workspace today?" rather than per-slot drilldown.
+
+### Log rotation
+
+- **Per-slot logs are scoped to a slot's lifetime.** When `bones swarm close` runs, the log file is preserved at `.bones/swarm/<slot>/log` until the slot directory itself is cleaned (e.g., by future `bones swarm reap` or a fan-in step). No rotation within a slot's lifetime — slot-scoped logs are bounded by their owning slot.
+- **Workspace log (`.bones/log`) rotates at 10 MB** → `.bones/log.1` → `.bones/log.2` → … oldest beyond `.bones/log.5` is deleted. Tunable via `BONES_LOG_MAX_SIZE` and `BONES_LOG_MAX_FILES` env vars.
+- **No time-based rotation in v1** (size-based is simpler and matches the operational concern: "don't fill the disk").
+
+### Failure modes
+
+| Scenario | Behavior |
+|---|---|
+| `bones swarm dispatch ./plan.md` with prior dispatch in flight (different plan_sha256) | Error: `dispatch already in flight for ./other-plan.md (wave 2 of 3). Cancel with: bones swarm dispatch --cancel` |
+| `bones swarm dispatch --resume` while current wave isn't `wave_complete` | Error: `current wave is wave_in_flight. Wait for subagents to close, or run: bones doctor to inspect.` |
+| `bones swarm dispatch` on invalid plan | Existing `validate-plan` errors propagate; no manifest written, no tasks created (atomic). |
+| `bones logs --slot=X` for nonexistent slot | `No log for slot 'X'. Active slots: a, b, c.` exit 1. |
+| Log file write fails (disk full, perms) | Warn to stderr; continue swarm operation. The event is lost; bones doesn't try to retry the log write. Better to lose a log line than to fail the underlying swarm verb. |
+| Concurrent log writes (two swarm verbs at once for same slot) | `O_APPEND` + sub-`PIPE_BUF` lines = atomic; no interleaving. |
+| `--tail` reader open during workspace-log rotation | Reader's file handle stays valid on the rotated `.log.1`; reader misses new events until they reopen. Documented as a known limitation; users typically `--tail` short-lived sessions. |
+| Per-slot log grew large mid-session (> 100 MB) | No rotation; slot-scoped logs are bounded by the slot's lifetime. If a slot somehow logs that much, it's a bug to investigate, not silently rotate around. |
+| Plan SHA changes between dispatch and resume (user edited plan) | `--resume` validates `plan_sha256` matches manifest. Mismatch → error: `plan changed since dispatch. Re-dispatch with: bones swarm dispatch --cancel && bones swarm dispatch <plan>` |
+
+### Migration
+
+- **Dispatch:** new verb, no existing callers. Existing orchestrator skill needs the documented update before users can use the new flow; until that update ships, users continue invoking the skill on a plan path directly (skill stays backward-compatible with both invocation forms during the transition).
+- **Logs:** new `.bones/log` and `.bones/swarm/<slot>/log` files appear on next swarm verb invocation post-upgrade. No active migration. Existing slots that pre-date this spec have no logs; `bones logs --slot=X` for those reports `No log for slot 'X' (slot pre-dates logging).` rather than empty/error.
+
+### Testing
+
+- **Unit:** dispatch manifest serialization at `schema_version=1`; wave grouping logic (correct dependency layering); event JSONL serialization for each event type; rotation logic at size threshold; `--since` / `--last` filter logic.
+- **Integration:** end-to-end flow: `bones swarm dispatch <plan>` writes correct manifest → simulated skill calls swarm verbs per wave → `--mark-wave-complete` + `--resume` cycle → final wave produces `status=complete`. Full slot lifecycle (`join` → `commit` × 2 → `close`) produces correct log entries; `bones logs --slot=X --tail` follows correctly; `--json` round-trips through `jq`.
+- **Manual:** `bones swarm dispatch ./plan.md` against a real workspace with a real orchestrator skill consumer; `--tail` during real swarm work; verify `bones doctor --all` (Spec 2) shows dispatch context correctly.
+
+## Future Direction
+
+- **Auto-advance through waves.** Today's `--resume` is a manual user step. A `bones swarm dispatch --auto-advance` mode (or a separate watcher daemon) could detect wave completion and advance automatically. Designed deliberately as a v2 — auto-advance crosses into "agent management" territory that warrants its own design pass for safety (failed waves, partial completion, halt conditions).
+- **Cross-workspace logs.** `bones logs --all --slot-pattern='auth-*'` could aggregate logs across the registry (Spec 1). Not driven by current pain; revisit if dispatch-and-logs becomes a multi-workspace operation.
+- **Subagent transcript surfacing.** The harness owns its transcripts. If a `bones logs --slot=X --include-harness-transcript` convenience that finds the matching claude session jsonl is valuable, that's a future Claude Code-specific skill, not a binary feature.
+- **Real-time event subjects.** When the leaf-node user-NATS migration ships (per Spec 1's Future Direction), per-slot events would naturally publish to NATS subjects like `bones.workspace.<id>.slot.<name>.event`. `bones logs --tail` becomes a NATS subscription instead of a file tail. Same external contract, real-time substrate.
+- **Per-harness skills.** Cursor, Aider, and custom-harness equivalents of `orchestrator` would each ship as their own skill consuming the same `dispatch.json` manifest. The manifest schema is intentionally harness-neutral (no `claude_*` fields); adding a new harness is a skill-only change, never a binary change.

--- a/docs/superpowers/specs/2026-05-01-dispatch-and-logs-design.md
+++ b/docs/superpowers/specs/2026-05-01-dispatch-and-logs-design.md
@@ -4,16 +4,17 @@
 **Status:** Draft
 **Replaces:** N/A
 **Related:** ADR 0023 (hub-leaf orchestrator), ADR 0028 (swarm verbs + lease types), ADR 0034 (bypass prevention), Spec `cross-workspace-identity`, Spec `doctor-ergonomics`
+**Dependencies:** Existing `bones-tasks` KV (ADR 0005), existing `validate-plan` verb. No hard dependency on Specs 1 or 2 — `dispatch-and-logs` can ship independently. (`bones swarm status` extension benefits from Spec 1's registry but doesn't require it.)
 
 ## Scope
 
 **In:**
 
 - `bones swarm dispatch <plan>` — validate plan, create tasks in `bones-tasks` KV, group into dependency waves, emit a dispatch manifest
-- `bones swarm dispatch --resume` — advance to the next wave after the current wave completes
-- `bones swarm dispatch --mark-wave-complete=<N>` — public skill-facing verb; called by consumer skills when a wave's subagents all close successfully
-- `bones swarm dispatch --cancel` — abandons an in-flight dispatch (removes manifest, marks open tasks `cancelled`)
+- `bones swarm dispatch --advance` — single flag that handles wave progression. Bones queries `bones-tasks` KV; if all current-wave tasks are `Closed`, promotes the next wave and re-emits the manifest. Called by consumer skills when their subagents close, or by users manually
+- `bones swarm dispatch --cancel` — abandons an in-flight dispatch (removes manifest, closes any still-open tasks via the existing `Closed` status with `ClosedReason: "dispatch-cancelled"`)
 - Dispatch manifest schema at `.bones/swarm/dispatch.json` (versioned, harness-agnostic contract)
+- Extension to existing `bones swarm status` showing dispatch-in-flight context (one line at the top: plan path, current wave / total waves)
 - Update to existing `orchestrator` skill (claude-specific layer) to consume the manifest
 - `bones logs --slot=<name>` and `bones logs --workspace` — view bones-side event logs (with `--tail` / `--since` / `--last` / `--json`)
 - Per-slot event log file at `.bones/swarm/<slot>/log` (newline-delimited JSON)
@@ -106,14 +107,13 @@ Path: `.bones/swarm/dispatch.json`. Versioned (`schema_version`) so the consumer
         }
       ]
     }
-  ],
-  "status": "ready"
+  ]
 }
 ```
 
-**`status` transitions:** `ready` → `wave_in_flight` (when consumer-skill begins spawning) → `wave_complete` (when all current wave's tasks closed) → next wave's `ready` after `--resume`. Eventually `complete` when the last wave finishes.
+**No `status` field.** The manifest doesn't track wave state explicitly; bones derives it on demand from `current_wave` plus task state in `bones-tasks` KV. This eliminates two stores of truth (manifest field vs. KV) which could disagree if a process crashes mid-update.
 
-The skill never writes the manifest file directly — it always goes through `bones swarm dispatch --mark-wave-complete=<N>`. Keeps file ownership with bones; prevents skills from corrupting the contract.
+The skill never writes the manifest file directly. Wave advancement always goes through `bones swarm dispatch --advance`, which queries the KV authoritatively and only mutates the manifest when the KV says current-wave tasks are all `Closed`. Keeps file ownership with bones; eliminates the "skill thinks wave is done but bones doesn't" failure mode entirely.
 
 ### `bones swarm dispatch <plan>`
 
@@ -134,10 +134,9 @@ Next step (Claude Code): in your claude session, run
 
 **Flags:**
 
-- `--resume` — re-emit manifest with the next wave promoted to `current_wave`. Errors if previous wave isn't `wave_complete`.
-- `--wave=N` — explicit wave number. Rare; for testing or jumping past a stuck wave with manual cleanup.
-- `--mark-wave-complete=<N>` — public verb intentionally exposed for skill use. Consumer skills call this when all wave-N subagents close successfully; it flips manifest `status` to `wave_complete`. Documented as "skill API surface" rather than hidden, because consumers other than the in-tree orchestrator skill (cursor, aider) need it too.
-- `--cancel` — abandons an in-flight dispatch: removes `.bones/swarm/dispatch.json`, closes any still-open tasks the manifest created with `result=cancelled`. Use when a dispatch needs to be torn down before completion.
+- `--advance` — single flag that handles wave progression. Bones queries `bones-tasks` KV; if all current-wave tasks are `Closed`, promotes `current_wave` and re-emits the manifest. If not all closed, errors with the list of still-open tasks. Used by both consumer skills (when their subagents close) and users (manually). One flag replaces what was previously a `--resume` + `--mark-wave-complete=<N>` pair: bones derives wave-completion state from authoritative KV rather than accepting a skill's claim about it.
+- `--wave=N` — explicit wave number. Rare; for testing or jumping past a stuck wave after manual cleanup.
+- `--cancel` — abandons an in-flight dispatch: removes `.bones/swarm/dispatch.json`, closes any still-open tasks the manifest created via the existing `Closed` status with `ClosedReason: "dispatch-cancelled"`. Reuses the existing task state machine (`open / claimed / closed` per ADR 0005) — no new states introduced.
 - `--json` — manifest path + summary as JSON (for scripting).
 - `--dry-run` — validate + show what would be created/written, without touching NATS or filesystem.
 
@@ -165,20 +164,23 @@ The template is bones-binary code (closed catalog — extending requires a code 
 - Dispatch fires only the first parallelizable wave (`current_wave = 1`).
 - Consumer skill (orchestrator) spawns subagents for the wave's slots.
 - As subagents `bones swarm close --result=success`, tasks transition to `Closed` in `bones-tasks` KV.
-- When all of wave-1's tasks are `Closed`, the consumer skill calls `bones swarm dispatch --mark-wave-complete=1`. Manifest's `status` flips to `wave_complete`.
-- User runs `bones swarm dispatch --resume`. Manifest `current_wave` advances to 2, `status` returns to `ready`.
-- Consumer skill spawns wave-2's subagents. Repeat until manifest `status = complete`.
+- When all of wave-1's tasks are `Closed`, the consumer skill (or a user) calls `bones swarm dispatch --advance`. Bones queries the KV, confirms all wave-1 tasks closed, promotes `current_wave` to 2, and re-emits the manifest.
+- Consumer skill spawns wave-2's subagents. Repeat until `--advance` reports "all waves complete; nothing to do."
+
+One flag, one path. Bones is the single source of truth on "is this wave done?" — the skill never reports it (and so cannot disagree with bones).
 
 **User-visible state at any moment** (existing `bones swarm status` extended with one dispatch-context line):
 
 ```
 $ bones swarm status
-Dispatch: ./plan.md  (wave 1 of 2 — wave_in_flight)
+Dispatch: ./plan.md  (wave 1 of 2)
   slot a [active]   commit 8m ago
   slot b [active]   commit 2m ago
   slot c [active]   commit 4m ago
   slot d [stale]    last_renewed 12m ago
 ```
+
+The dispatch-context line shows current wave and total wave count. Whether the wave is "in flight" or "complete-but-not-yet-advanced" is derivable from the slot status rows directly — no separate state to display.
 
 Cross-references Spec 2: `bones doctor` would tag the stale slot and emit a `Fix:` line per the doctor catalog.
 
@@ -188,7 +190,7 @@ Out of scope for the *binary spec* itself, but committed as a deliverable of thi
 
 - Skill input becomes "read `.bones/swarm/dispatch.json`" rather than taking a plan path directly.
 - Skill spawns N Task-tool subagents per the manifest's `current_wave`'s `slots[]`, using each slot's `subagent_prompt` field verbatim.
-- Skill calls `bones swarm dispatch --mark-wave-complete=<N>` when all wave subagents close successfully.
+- Skill calls `bones swarm dispatch --advance` when all wave subagents close successfully. If the wave isn't actually complete (some subagents still running), `--advance` errors and the skill waits.
 - Skill's docs updated: invocation is now `/orchestrator dispatch` (consumes manifest) rather than `/orchestrator <plan-path>`.
 
 ### `bones logs --slot=<name>` and `bones logs --workspace`
@@ -261,14 +263,14 @@ Useful for "what did bones do in this workspace today?" rather than per-slot dri
 | Scenario | Behavior |
 |---|---|
 | `bones swarm dispatch ./plan.md` with prior dispatch in flight (different plan_sha256) | Error: `dispatch already in flight for ./other-plan.md (wave 2 of 3). Cancel with: bones swarm dispatch --cancel` |
-| `bones swarm dispatch --resume` while current wave isn't `wave_complete` | Error: `current wave is wave_in_flight. Wait for subagents to close, or run: bones doctor to inspect.` |
+| `bones swarm dispatch --advance` while current wave's tasks aren't all `Closed` | Error: `wave 1 not yet complete: tasks t-7c92, t-9e34 still open. Inspect with: bones doctor` |
 | `bones swarm dispatch` on invalid plan | Existing `validate-plan` errors propagate; no manifest written, no tasks created (atomic). |
 | `bones logs --slot=X` for nonexistent slot | `No log for slot 'X'. Active slots: a, b, c.` exit 1. |
 | Log file write fails (disk full, perms) | Warn to stderr; continue swarm operation. The event is lost; bones doesn't try to retry the log write. Better to lose a log line than to fail the underlying swarm verb. |
 | Concurrent log writes (two swarm verbs at once for same slot) | `O_APPEND` + sub-`PIPE_BUF` lines = atomic; no interleaving. |
 | `--tail` reader open during workspace-log rotation | Reader's file handle stays valid on the rotated `.log.1`; reader misses new events until they reopen. Documented as a known limitation; users typically `--tail` short-lived sessions. |
 | Per-slot log grew large mid-session (> 100 MB) | No rotation; slot-scoped logs are bounded by the slot's lifetime. If a slot somehow logs that much, it's a bug to investigate, not silently rotate around. |
-| Plan SHA changes between dispatch and resume (user edited plan) | `--resume` validates `plan_sha256` matches manifest. Mismatch → error: `plan changed since dispatch. Re-dispatch with: bones swarm dispatch --cancel && bones swarm dispatch <plan>` |
+| Plan SHA changes between dispatch and advance (user edited plan) | `--advance` validates `plan_sha256` matches manifest. Mismatch → error: `plan changed since dispatch. Re-dispatch with: bones swarm dispatch --cancel && bones swarm dispatch <plan>` |
 
 ### Migration
 
@@ -278,12 +280,12 @@ Useful for "what did bones do in this workspace today?" rather than per-slot dri
 ### Testing
 
 - **Unit:** dispatch manifest serialization at `schema_version=1`; wave grouping logic (correct dependency layering); event JSONL serialization for each event type; rotation logic at size threshold; `--since` / `--last` filter logic.
-- **Integration:** end-to-end flow: `bones swarm dispatch <plan>` writes correct manifest → simulated skill calls swarm verbs per wave → `--mark-wave-complete` + `--resume` cycle → final wave produces `status=complete`. Full slot lifecycle (`join` → `commit` × 2 → `close`) produces correct log entries; `bones logs --slot=X --tail` follows correctly; `--json` round-trips through `jq`.
+- **Integration:** end-to-end flow: `bones swarm dispatch <plan>` writes correct manifest → simulated skill calls swarm verbs per wave → `--advance` after each wave promotes `current_wave` → final `--advance` reports "all complete." Full slot lifecycle (`join` → `commit` × 2 → `close`) produces correct log entries; `bones logs --slot=X --tail` follows correctly; `--json` round-trips through `jq`.
 - **Manual:** `bones swarm dispatch ./plan.md` against a real workspace with a real orchestrator skill consumer; `--tail` during real swarm work; verify `bones doctor --all` (Spec 2) shows dispatch context correctly.
 
 ## Future Direction
 
-- **Auto-advance through waves.** Today's `--resume` is a manual user step. A `bones swarm dispatch --auto-advance` mode (or a separate watcher daemon) could detect wave completion and advance automatically. Designed deliberately as a v2 — auto-advance crosses into "agent management" territory that warrants its own design pass for safety (failed waves, partial completion, halt conditions).
+- **Auto-advance through waves.** Today's `--advance` is a manual call (by skill or user). A `bones swarm dispatch --watch` mode (or a separate watcher daemon) could observe `bones-tasks` KV and call `--advance` automatically when each wave completes. Designed deliberately as a v2 — auto-advance crosses into "agent management" territory that warrants its own design pass for safety (failed waves, partial completion, halt conditions).
 - **Cross-workspace logs.** `bones logs --all --slot-pattern='auth-*'` could aggregate logs across the registry (Spec 1). Not driven by current pain; revisit if dispatch-and-logs becomes a multi-workspace operation.
 - **Subagent transcript surfacing.** The harness owns its transcripts. If a `bones logs --slot=X --include-harness-transcript` convenience that finds the matching claude session jsonl is valuable, that's a future Claude Code-specific skill, not a binary feature.
 - **Real-time event subjects.** When the leaf-node user-NATS migration ships (per Spec 1's Future Direction), per-slot events would naturally publish to NATS subjects like `bones.workspace.<id>.slot.<name>.event`. `bones logs --tail` becomes a NATS subscription instead of a file tail. Same external contract, real-time substrate.

--- a/docs/superpowers/specs/2026-05-01-doctor-ergonomics-design.md
+++ b/docs/superpowers/specs/2026-05-01-doctor-ergonomics-design.md
@@ -1,0 +1,246 @@
+# Doctor Ergonomics — Design
+
+**Date:** 2026-05-01
+**Status:** Draft
+**Replaces:** N/A
+**Related:** ADR 0028 (swarm verbs + lease types), ADR 0034 (bypass prevention), ADR 0038 (per-workspace hub ports), Spec `cross-workspace-identity` (the registry consumed by `--all`)
+
+## Scope
+
+**In:**
+
+- Recovery-command hints (`Fix:` line) attached to every `bones doctor` finding
+- `bones doctor --all` cross-workspace mode that consumes the workspace registry from the `cross-workspace-identity` spec
+- `--json` output extended with a `fix: { command, text }` object per finding
+- Density flags `-q` / `--quiet` and `-v` / `--verbose` for the `--all` mode
+- Closed hint catalog (templates per finding tag, no free-form fix strings inside individual checks)
+
+**Out:**
+
+- `--fix` auto-execution flag — separate spec; safety questions (which findings are auto-fixable, confirmation model, blast radius across workspaces) warrant their own design pass
+- Filter flags (`--swarm-only`, `--health-only`)
+- New checks beyond what doctor already runs
+- Parallelizing single-workspace checks (already fast enough today)
+- Cross-workspace consistency checks (e.g., port collisions) — ADR 0038's per-workspace dynamic ports already prevent the most likely class
+
+## Motivation
+
+The DX audit (`docs/audits/2026-05-01-dx-6-terminals-from-agentic-engineer.md`) flagged `bones doctor` at 4/10 because it diagnoses but doesn't prescribe: `[STALE] slot foo` is correct but doesn't tell the user the verb to release the claim. Multiplied across 6 parallel workspaces, the user must remember the recovery verb under load.
+
+Spec 1 (`cross-workspace-identity`) introduced the workspace registry. This spec's second deliverable — `bones doctor --all` — is the registry's first major consumer: a single command that answers "is anything stuck across all my workspaces right now?"
+
+## Design
+
+### Hint format (single-workspace)
+
+Every `bones doctor` finding gets a `Fix:` line directly under it. Format is consistent regardless of whether the fix is a command, URL, or prose. `[OK]` and `[INFO]` findings have no `Fix:` line (nothing to fix; nothing to act on).
+
+```
+[STALE] slot auth  last_renewed 12m ago
+        Fix: bones swarm close --slot=auth --result=fail
+
+[DOWN]  hub not responding to /health
+        Fix: bones up
+
+[MISSING] fossil binary not on PATH
+        Fix: install fossil from https://fossil-scm.org/install
+
+[REMOTE] slot deploy  hosted on machine prod-runner-3
+        Fix: manage from prod-runner-3   (no local action)
+
+[OK]    NATS reachable, all KV buckets present
+```
+
+`[REMOTE]` findings do get a `Fix:` line that explicitly states there's no local action — preserving format consistency rather than introducing an exception case.
+
+### Hint catalog
+
+Every finding type maps to one templated hint. Templates are filled at render time from the finding's data — they are not free-form prose written per-call.
+
+| Finding tag | Condition | Hint |
+|---|---|---|
+| `[STALE]` slot | `last_renewed > 5min`, claim still held | `bones swarm close --slot=<name> --result=fail` |
+| `[DEAD]` slot | leaf PID not alive on this host | `bones swarm close --slot=<name> --result=fail` |
+| `[REMOTE]` slot | hosted on another host (per session record) | `manage from <hostname>   (no local action)` |
+| `[DOWN]` hub | HTTP `/health` fails or PID dead | `bones up` |
+| `[DEGRADED]` NATS | hub HTTP up but NATS unreachable | `bones up   (restarts NATS as well)` |
+| `[MISSING]` fossil | binary not on PATH | `install fossil from https://fossil-scm.org/install` |
+| `[MISSING]` Go | runtime version below minimum | `update Go to <required-version>+   (current: <detected>)` |
+| `[BYPASS]` swarm | direct-API call detected per ADR 0034 | `replace direct call at <file:line> with swarm verb` |
+| `[INFO]` telemetry | opt-in / opt-out state report | (no fix — informational) |
+| `[OK]` *anything* | check passed | (no fix — nothing to fix) |
+
+**Why a closed catalog instead of free-form fix strings:** consistent rendering, machine-parseable, no risk of fix prose drifting across checks. New finding types must extend the catalog explicitly. Hint logic lives in one place rather than scattered through individual checks.
+
+### Color and markup
+
+When stdout is a TTY:
+- `[OK]` green
+- `[STALE]` / `[DEAD]` / `[BYPASS]` / `[DEGRADED]` yellow
+- `[DOWN]` / `[MISSING]` red
+- `[REMOTE]` / `[INFO]` neutral
+- `Fix:` lines dim
+
+Disabled with `--no-color` or when the `NO_COLOR` env var is set (per [no-color.org](https://no-color.org/)). Plain text when piped.
+
+### `bones doctor --all`
+
+Reads the workspace registry (`~/.bones/workspaces/*.json`), runs the existing per-workspace doctor suite for each entry in parallel, aggregates results.
+
+#### Rendering rules in `--all` mode
+
+The hint catalog templates assume the user is *in* the workspace (which is true for single-workspace `bones doctor`). In `--all` mode the user is generally somewhere else, so commands that need workspace context get a `cd <cwd> && ` prefix when rendered:
+
+| Catalog hint | `--all` rendering |
+|---|---|
+| `bones swarm close --slot=auth --result=fail` | `cd ~/projects/foo && bones swarm close --slot=auth --result=fail` |
+| `bones up` | `cd ~/projects/foo && bones up` |
+| `replace direct call at <file:line> with swarm verb` | `<file:line>` is rendered as an absolute path so the location is unambiguous |
+| `manage from prod-runner-3   (no local action)` | unchanged — not workspace-relative |
+| `install fossil from https://fossil-scm.org/install` | unchanged — global tooling |
+
+The catalog itself stores the bare command; the renderer applies the `cd <cwd> && ` prefix and absolute-path expansion when it knows the consumer is `--all`. Single-workspace mode never applies the prefix (the user is already there).
+
+#### Default output (summary table + issue details)
+
+```
+WORKSPACE     HUB    SESSIONS  ISSUES
+foo           OK     6         1 stale slot
+bar           OK     3         —
+auth          DOWN   1         hub unreachable
+
+Details:
+~/projects/foo:
+  [STALE] slot auth  last_renewed 12m ago
+          Fix: cd ~/projects/foo && bones swarm close --slot=auth --result=fail
+
+~/work/auth:
+  [DOWN]  hub not responding to /health
+          Fix: cd ~/work/auth && bones up
+```
+
+Top-of-screen scan answers "is anything stuck?"; details drill in. Workspaces with zero issues do not appear in the details section.
+
+#### `-q` / `--quiet` — issues only
+
+```
+~/projects/foo:
+  [STALE] slot auth  last_renewed 12m ago
+          Fix: cd ~/projects/foo && bones swarm close --slot=auth --result=fail
+
+~/work/auth:
+  [DOWN]  hub not responding to /health
+          Fix: cd ~/work/auth && bones up
+
+2 of 3 workspaces healthy.
+```
+
+If all workspaces healthy with `-q`: a single line, `All N workspaces healthy.`
+
+#### `-v` / `--verbose` — sectioned per workspace
+
+Every workspace gets its own block; every check rendered (`[OK]` rows included). Long but exhaustive — the user asked for it.
+
+### Implementation notes (`--all`)
+
+- **Concurrency:** `errgroup` with bounded parallelism `min(N, 8)`. Total time ≈ slowest workspace; sub-second typical for ≤ 10 workspaces.
+- **Per-workspace timeout:** 5 seconds for the full check suite. On timeout, emit `[TIMEOUT] doctor check exceeded 5s` with `Fix: cd <workspace> && bones doctor`. Doesn't fail the whole `--all` invocation. Tunable via `BONES_DOCTOR_TIMEOUT` env var if it bites on slow machines.
+- **Stale registry entries:** pruned by the registry's stale detection (Spec 1) and silently omitted from `--all` results. Not reported as findings.
+- **No new checks introduced.** `--all` is pure multiplexing of existing single-workspace checks.
+
+### Exit code
+
+- `0` — every workspace reports only `[OK]` and `[INFO]` findings.
+- `1` — any workspace has any `[STALE]`/`[DEAD]`/`[DOWN]`/`[DEGRADED]`/`[MISSING]`/`[BYPASS]`/`[TIMEOUT]` finding.
+
+Single integer, not bitmasked. Aggregates honestly: one stuck workspace fails the whole `--all` check.
+
+### JSON output
+
+Single-workspace `bones doctor --json` adds a `fix` field per finding:
+
+```json
+{
+  "tag": "STALE",
+  "subject": "slot",
+  "name": "auth",
+  "detail": "last_renewed 12m ago",
+  "fix": {
+    "command": "bones swarm close --slot=auth --result=fail",
+    "text": null
+  }
+}
+```
+
+`bones doctor --all --json`:
+
+```json
+{
+  "workspaces": [
+    {
+      "cwd": "/Users/dmestas/projects/foo",
+      "name": "foo",
+      "hub_url": "http://127.0.0.1:8765",
+      "findings": [
+        {
+          "tag": "STALE",
+          "subject": "slot",
+          "name": "auth",
+          "detail": "last_renewed 12m ago",
+          "fix": {
+            "command": "bones swarm close --slot=auth --result=fail",
+            "text": null
+          }
+        },
+        {
+          "tag": "OK",
+          "subject": "nats",
+          "detail": "reachable, all KV buckets present",
+          "fix": null
+        }
+      ]
+    }
+  ],
+  "summary": {
+    "workspaces_total": 3,
+    "workspaces_healthy": 1,
+    "workspaces_with_issues": 2
+  }
+}
+```
+
+`fix.command` is non-null for command hints; `fix.text` is non-null for prose hints (URL or instruction). Exactly one is set when `fix` itself is non-null. When neither is needed (`[OK]`, `[INFO]`), `fix` is `null`.
+
+### Edge cases
+
+| Scenario | Behavior |
+|---|---|
+| Registry empty | `No workspaces running. Use 'bones up' in a project.` Exit 0. |
+| Stale registry entry encountered during `--all` | Pruned by Spec 1 logic; silently omitted. Not reported as a finding. |
+| Workspace's hub down (passes registry but doctor finds it down) | Reported as `[DOWN]` finding for that workspace. |
+| Per-workspace check times out (> 5 s) | `[TIMEOUT]` finding with `Fix:` to investigate from that workspace; `--all` continues. |
+| Workspace with 50+ findings | Rendered as-is; no truncation. User pipes to `wc -l` for a count. |
+| `-q` and all workspaces healthy | One-line summary `All N workspaces healthy.` Exit 0. |
+| `-v` on 20 workspaces | Long output. User asked for it; no truncation. |
+| Color and `--all` output redirected | Disabled per TTY detection (same rule as single-workspace). |
+| `[INFO]` telemetry finding | Doesn't affect exit code or "issues" count. |
+
+### Migration
+
+- **Hints on existing single-workspace `bones doctor`:** additive. Test scripts that grep for tag names continue to work; scripts that match entire output lines need updating.
+- **`--all` mode:** new flag, no existing callers.
+- **JSON shape:** new `fix` field per finding. Additive; consumers that tolerate unknown fields are unaffected. Consumers using strict schema validation need a one-field schema update.
+
+### Testing
+
+- **Unit:** hint catalog rendering with template substitution per tag; color / no-color detection; JSON shape serialization; exit-code aggregation across mixed workspace results.
+- **Integration:** `bones doctor` on workspace with seeded stale slot → correct `Fix:` line; `bones doctor --all` across 3+ workspaces with mixed health → correct summary table + details + exit code; `-q` and `-v` density modes; `--json` parses for both single and `--all`.
+- **Manual:** every catalog entry's hint command actually fixes the issue when executed (closed-loop verification: induce the issue, run `Fix:`, confirm finding goes away).
+
+## Future Direction
+
+Several directions are deliberately deferred:
+
+- **`--fix` auto-execution.** When (a) the catalog has been in production long enough to confirm hint correctness, (b) per-finding safety annotations are added (`safe_to_auto_fix: true|false`), and (c) a confirmation UX is designed for batch fixes — then a `--fix` flag becomes a sensible follow-up. Not now.
+- **Real-time event streams.** When the `cross-workspace-identity` spec's leaf-node migration ships (see that spec's Future Direction), `bones doctor --all --watch` becomes natural — subscribe to NATS presence/health subjects and re-render on change. Today's polling-based `--all` is the right fit for the filesystem-registry baseline.
+- **Filter flags** (`--swarm-only`, `--health-only`). Not driven by current pain. If output volume becomes a complaint after `--all` ships, revisit.

--- a/docs/superpowers/specs/2026-05-01-doctor-ergonomics-design.md
+++ b/docs/superpowers/specs/2026-05-01-doctor-ergonomics-design.md
@@ -4,6 +4,7 @@
 **Status:** Draft
 **Replaces:** N/A
 **Related:** ADR 0028 (swarm verbs + lease types), ADR 0034 (bypass prevention), ADR 0038 (per-workspace hub ports), Spec `cross-workspace-identity` (the registry consumed by `--all`)
+**Dependencies:** Spec `cross-workspace-identity` must ship first — `bones doctor --all` reads its workspace registry. Single-workspace hint additions can ship independently.
 
 ## Scope
 
@@ -71,6 +72,11 @@ Every finding type maps to one templated hint. Templates are filled at render ti
 | `[OK]` *anything* | check passed | (no fix — nothing to fix) |
 
 **Why a closed catalog instead of free-form fix strings:** consistent rendering, machine-parseable, no risk of fix prose drifting across checks. New finding types must extend the catalog explicitly. Hint logic lives in one place rather than scattered through individual checks.
+
+**Two deliberate tradeoffs in the catalog:**
+
+- `[STALE]` and `[DEAD]` map to the same fix (`bones swarm close --slot=<name> --result=fail`). They are semantically distinct (stale = claim never renewed within TTL; dead = leaf PID gone) but the recovery action is the same. Keeping them as separate tags preserves diagnostic clarity (the user can tell *why* the slot is unhealthy) without inventing distinct fixes that don't exist.
+- `[REMOTE]` findings get a `Fix:` line that says there's no local action. This is a Fix line that doesn't fix anything — a mild semantic stretch chosen for format consistency. The alternative (a separate `Note:` prefix) would split the rendering rules and complicate scanning. Consistency wins.
 
 ### Color and markup
 

--- a/internal/hub/hub.go
+++ b/internal/hub/hub.go
@@ -17,6 +17,7 @@ import (
 	_ "github.com/danmestas/libfossil/db/driver/modernc"
 	natsserver "github.com/nats-io/nats-server/v2/server"
 
+	"github.com/danmestas/bones/internal/registry"
 	"github.com/danmestas/bones/internal/telemetry"
 )
 
@@ -158,6 +159,21 @@ func runForeground(ctx context.Context, p paths, o opts) error {
 
 	fmt.Printf("hub: fossil at http://127.0.0.1:%d, nats at nats://127.0.0.1:%d\n",
 		o.fossilPort, o.natsPort)
+
+	// Record this workspace in the cross-workspace registry so
+	// `bones status --all` can discover running hubs. Non-fatal: the hub
+	// still works without registry visibility.
+	if err := registry.Write(registry.Entry{
+		Cwd:       p.root,
+		Name:      filepath.Base(p.root),
+		HubURL:    fmt.Sprintf("http://127.0.0.1:%d", o.fossilPort),
+		NATSURL:   fmt.Sprintf("nats://127.0.0.1:%d", o.natsPort),
+		HubPID:    os.Getpid(),
+		StartedAt: time.Now().UTC(),
+	}); err != nil {
+		fmt.Fprintf(os.Stderr, "hub: registry write failed (non-fatal): %v\n", err)
+	}
+
 	<-ctx.Done()
 	fossilCancel()
 	natsSrv.Shutdown()

--- a/internal/hub/hub_test.go
+++ b/internal/hub/hub_test.go
@@ -10,6 +10,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/danmestas/bones/internal/registry"
 )
 
 // TestStartStopRoundTrip exercises the foreground path:
@@ -131,6 +133,71 @@ func TestPathsValidation(t *testing.T) {
 	_, err := newPaths("/this/path/does/not/exist/anywhere")
 	if err == nil {
 		t.Fatal("expected error for missing root")
+	}
+}
+
+// TestStartWritesRegistry asserts that a successful foreground Start writes
+// a cross-workspace registry entry with the correct workspace root.
+func TestStartWritesRegistry(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available; skipping hub round-trip")
+	}
+
+	t.Setenv("HOME", t.TempDir())
+	root := newGitRepoWithFile(t)
+	fossilPort, natsPort := freePort(t), freePort(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	var startErr error
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		startErr = Start(ctx, root,
+			WithFossilPort(fossilPort),
+			WithNATSPort(natsPort),
+		)
+	}()
+
+	// Wait for both servers to be reachable before checking registry.
+	if err := waitForTCP("127.0.0.1:"+strconv.Itoa(fossilPort), 5*time.Second); err != nil {
+		cancel()
+		wg.Wait()
+		t.Fatalf("fossil never bound: %v", err)
+	}
+	if err := waitForTCP("127.0.0.1:"+strconv.Itoa(natsPort), 5*time.Second); err != nil {
+		cancel()
+		wg.Wait()
+		t.Fatalf("nats never bound: %v", err)
+	}
+
+	// Poll for registry entry — there's a brief window between servers
+	// binding and the registry.Write call completing.
+	deadline := time.Now().Add(3 * time.Second)
+	var entry registry.Entry
+	var readErr error
+	for time.Now().Before(deadline) {
+		entry, readErr = registry.Read(root)
+		if readErr == nil {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	cancel()
+	wg.Wait()
+
+	if readErr != nil {
+		t.Fatalf("registry.Read after Start: %v", readErr)
+	}
+	if entry.Cwd != root {
+		t.Fatalf("entry.Cwd = %q, want %q", entry.Cwd, root)
+	}
+	if entry.HubPID != os.Getpid() {
+		t.Fatalf("entry.HubPID = %d, want %d", entry.HubPID, os.Getpid())
+	}
+	if startErr != nil {
+		t.Fatalf("foreground Start exit: %v", startErr)
 	}
 }
 

--- a/internal/registry/health.go
+++ b/internal/registry/health.go
@@ -10,19 +10,25 @@ import (
 var HealthTimeout = 500 * time.Millisecond
 
 // IsAlive returns true if BOTH (a) the recorded HubPID is alive on this host
-// AND (b) GET <HubURL>/health returns 200 within HealthTimeout. Both checks are
-// required because a recycled PID can pass (a) but fail (b).
+// AND (b) GET <HubURL> succeeds at the TCP/HTTP level within HealthTimeout.
+// Both checks are required because a recycled PID can pass (a) but fail (b).
+//
+// The HTTP probe doesn't require any specific endpoint — any HTTP response
+// (including 4xx) means the port is bound and serving, which is what we
+// actually want to know. The Fossil HTTP server bones uses doesn't expose a
+// /health endpoint and we deliberately don't add a sidecar HTTP server just
+// for the probe.
 func IsAlive(e Entry) bool {
 	if !pidAlive(e.HubPID) {
 		return false
 	}
 	client := &http.Client{Timeout: HealthTimeout}
-	resp, err := client.Get(e.HubURL + "/health")
+	resp, err := client.Get(e.HubURL)
 	if err != nil {
 		return false
 	}
 	defer func() { _ = resp.Body.Close() }()
-	return resp.StatusCode == http.StatusOK
+	return true // any HTTP response means port is bound and serving
 }
 
 func pidAlive(pid int) bool {

--- a/internal/registry/health.go
+++ b/internal/registry/health.go
@@ -1,0 +1,37 @@
+package registry
+
+import (
+	"net/http"
+	"os"
+	"syscall"
+	"time"
+)
+
+var HealthTimeout = 500 * time.Millisecond
+
+// IsAlive returns true if BOTH (a) the recorded HubPID is alive on this host
+// AND (b) GET <HubURL>/health returns 200 within HealthTimeout. Both checks are
+// required because a recycled PID can pass (a) but fail (b).
+func IsAlive(e Entry) bool {
+	if !pidAlive(e.HubPID) {
+		return false
+	}
+	client := &http.Client{Timeout: HealthTimeout}
+	resp, err := client.Get(e.HubURL + "/health")
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode == http.StatusOK
+}
+
+func pidAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	return proc.Signal(syscall.Signal(0)) == nil
+}

--- a/internal/registry/health.go
+++ b/internal/registry/health.go
@@ -21,7 +21,7 @@ func IsAlive(e Entry) bool {
 	if err != nil {
 		return false
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	return resp.StatusCode == http.StatusOK
 }
 

--- a/internal/registry/health_test.go
+++ b/internal/registry/health_test.go
@@ -1,0 +1,49 @@
+package registry
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestIsAlive(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/health" {
+			w.WriteHeader(200)
+			return
+		}
+		w.WriteHeader(404)
+	}))
+	defer srv.Close()
+
+	t.Run("alive: PID + healthy HTTP", func(t *testing.T) {
+		e := Entry{HubPID: os.Getpid(), HubURL: srv.URL}
+		if !IsAlive(e) {
+			t.Fatalf("expected alive")
+		}
+	})
+
+	t.Run("dead: PID alive but HTTP wrong port", func(t *testing.T) {
+		e := Entry{HubPID: os.Getpid(), HubURL: "http://127.0.0.1:1"}
+		if IsAlive(e) {
+			t.Fatalf("expected dead (HTTP fails)")
+		}
+	})
+
+	t.Run("dead: PID gone", func(t *testing.T) {
+		e := Entry{HubPID: 0, HubURL: srv.URL}
+		if IsAlive(e) {
+			t.Fatalf("expected dead (PID invalid)")
+		}
+	})
+}
+
+func TestServerURL(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer srv.Close()
+	if !strings.HasPrefix(srv.URL, "http://127.0.0.1:") {
+		t.Fatalf("unexpected URL: %s", srv.URL)
+	}
+}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -55,14 +55,14 @@ func Write(e Entry) error {
 	if err != nil {
 		return fmt.Errorf("registry tmp: %w", err)
 	}
-	defer os.Remove(tmp.Name())
+	defer func() { _ = os.Remove(tmp.Name()) }()
 
 	if _, err := tmp.Write(data); err != nil {
-		tmp.Close()
-		return errors.Join(fmt.Errorf("registry write: %w", err), tmp.Close())
+		closeErr := tmp.Close()
+		return errors.Join(fmt.Errorf("registry write: %w", err), closeErr)
 	}
 	if err := tmp.Sync(); err != nil {
-		tmp.Close()
+		_ = tmp.Close()
 		return fmt.Errorf("registry sync: %w", err)
 	}
 	if err := tmp.Close(); err != nil {

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -3,7 +3,12 @@ package registry
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
 	"path/filepath"
+	"time"
 )
 
 // WorkspaceID returns a deterministic 16-hex-char identifier for an absolute cwd.
@@ -11,4 +16,106 @@ import (
 func WorkspaceID(cwd string) string {
 	sum := sha256.Sum256([]byte(filepath.Clean(cwd)))
 	return hex.EncodeToString(sum[:])[:16]
+}
+
+// Entry is one workspace's registry record. One JSON file per Entry at
+// ~/.bones/workspaces/<WorkspaceID>.json.
+type Entry struct {
+	Cwd       string    `json:"cwd"`
+	Name      string    `json:"name"`
+	HubURL    string    `json:"hub_url"`
+	NATSURL   string    `json:"nats_url"`
+	HubPID    int       `json:"hub_pid"`
+	StartedAt time.Time `json:"started_at"`
+}
+
+// RegistryDir returns the directory that holds workspace entry files.
+func RegistryDir() string {
+	return filepath.Join(os.Getenv("HOME"), ".bones", "workspaces")
+}
+
+// EntryPath returns the absolute path of the JSON file for the given workspace cwd.
+func EntryPath(cwd string) string {
+	return filepath.Join(RegistryDir(), WorkspaceID(cwd)+".json")
+}
+
+// Write persists e to its file atomically (tmp+rename). Creates the registry
+// directory if missing.
+func Write(e Entry) error {
+	if err := os.MkdirAll(RegistryDir(), 0o755); err != nil {
+		return fmt.Errorf("registry mkdir: %w", err)
+	}
+	data, err := json.MarshalIndent(e, "", "  ")
+	if err != nil {
+		return fmt.Errorf("registry marshal: %w", err)
+	}
+
+	dst := EntryPath(e.Cwd)
+	tmp, err := os.CreateTemp(RegistryDir(), filepath.Base(dst)+".tmp.*")
+	if err != nil {
+		return fmt.Errorf("registry tmp: %w", err)
+	}
+	defer os.Remove(tmp.Name())
+
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return errors.Join(fmt.Errorf("registry write: %w", err), tmp.Close())
+	}
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		return fmt.Errorf("registry sync: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("registry close: %w", err)
+	}
+	return os.Rename(tmp.Name(), dst)
+}
+
+// ErrNotFound is returned by Read when no entry exists for the given cwd.
+var ErrNotFound = errors.New("registry: entry not found")
+
+// Read loads the registry entry for the given workspace cwd.
+func Read(cwd string) (Entry, error) {
+	data, err := os.ReadFile(EntryPath(cwd))
+	if errors.Is(err, os.ErrNotExist) {
+		return Entry{}, ErrNotFound
+	}
+	if err != nil {
+		return Entry{}, fmt.Errorf("registry read: %w", err)
+	}
+	var e Entry
+	if err := json.Unmarshal(data, &e); err != nil {
+		return Entry{}, fmt.Errorf("registry unmarshal: %w", err)
+	}
+	return e, nil
+}
+
+// List returns all registry entries, skipping corrupt files.
+func List() ([]Entry, error) {
+	matches, err := filepath.Glob(filepath.Join(RegistryDir(), "*.json"))
+	if err != nil {
+		return nil, fmt.Errorf("registry glob: %w", err)
+	}
+	out := make([]Entry, 0, len(matches))
+	for _, path := range matches {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		var e Entry
+		if err := json.Unmarshal(data, &e); err != nil {
+			continue
+		}
+		out = append(out, e)
+	}
+	return out, nil
+}
+
+// Remove deletes the registry entry for the given workspace cwd. Idempotent.
+func Remove(cwd string) error {
+	err := os.Remove(EntryPath(cwd))
+	if err == nil || errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	return fmt.Errorf("registry remove: %w", err)
 }

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -1,0 +1,14 @@
+package registry
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"path/filepath"
+)
+
+// WorkspaceID returns a deterministic 16-hex-char identifier for an absolute cwd.
+// Used as the registry filename: ~/.bones/workspaces/<id>.json
+func WorkspaceID(cwd string) string {
+	sum := sha256.Sum256([]byte(filepath.Clean(cwd)))
+	return hex.EncodeToString(sum[:])[:16]
+}

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -89,7 +89,10 @@ func TestWrite(t *testing.T) {
 func TestRead(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("HOME", dir)
-	want := Entry{Cwd: "/x", Name: "x", HubURL: "u", HubPID: 1, StartedAt: time.Now().UTC().Truncate(time.Second)}
+	want := Entry{
+		Cwd: "/x", Name: "x", HubURL: "u", HubPID: 1,
+		StartedAt: time.Now().UTC().Truncate(time.Second),
+	}
 	if err := Write(want); err != nil {
 		t.Fatalf("Write: %v", err)
 	}
@@ -137,7 +140,10 @@ func TestList(t *testing.T) {
 func TestRemove(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("HOME", dir)
-	e := Entry{Cwd: "/x", Name: "x", HubPID: 1, StartedAt: time.Now().UTC().Truncate(time.Second)}
+	e := Entry{
+		Cwd: "/x", Name: "x", HubPID: 1,
+		StartedAt: time.Now().UTC().Truncate(time.Second),
+	}
 	if err := Write(e); err != nil {
 		t.Fatalf("Write: %v", err)
 	}

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -1,6 +1,13 @@
 package registry
 
-import "testing"
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
 
 func TestWorkspaceID(t *testing.T) {
 	tests := []struct {
@@ -32,5 +39,115 @@ func TestWorkspaceID(t *testing.T) {
 	b := WorkspaceID("/b")
 	if a == b {
 		t.Fatalf("WorkspaceID collision: /a and /b both = %q", a)
+	}
+}
+
+func TestEntryJSON(t *testing.T) {
+	e := Entry{
+		Cwd:       "/Users/dan/projects/foo",
+		Name:      "foo",
+		HubURL:    "http://127.0.0.1:8765",
+		NATSURL:   "nats://127.0.0.1:4222",
+		HubPID:    12345,
+		StartedAt: time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC),
+	}
+	data, err := json.Marshal(e)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	var got Entry
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if got != e {
+		t.Fatalf("round-trip: got %+v, want %+v", got, e)
+	}
+}
+
+func TestWrite(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	e := Entry{
+		Cwd: "/Users/dan/projects/foo", Name: "foo",
+		HubURL: "http://127.0.0.1:8765", HubPID: 12345,
+		StartedAt: time.Now().UTC().Truncate(time.Second),
+	}
+	if err := Write(e); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	path := filepath.Join(dir, ".bones", "workspaces", WorkspaceID(e.Cwd)+".json")
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("expected file at %s: %v", path, err)
+	}
+	matches, _ := filepath.Glob(filepath.Join(dir, ".bones", "workspaces", "*.tmp.*"))
+	if len(matches) > 0 {
+		t.Fatalf("tmp file leaked: %v", matches)
+	}
+}
+
+func TestRead(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	want := Entry{Cwd: "/x", Name: "x", HubURL: "u", HubPID: 1, StartedAt: time.Now().UTC().Truncate(time.Second)}
+	if err := Write(want); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	got, err := Read(want.Cwd)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if got != want {
+		t.Fatalf("Read mismatch: got %+v, want %+v", got, want)
+	}
+	if _, err := Read("/nonexistent"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestList(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	entries := []Entry{
+		{Cwd: "/a", Name: "a", HubPID: 1, StartedAt: time.Now().UTC().Truncate(time.Second)},
+		{Cwd: "/b", Name: "b", HubPID: 2, StartedAt: time.Now().UTC().Truncate(time.Second)},
+	}
+	for _, e := range entries {
+		if err := Write(e); err != nil {
+			t.Fatalf("Write: %v", err)
+		}
+	}
+	got, err := List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("List len = %d, want 2", len(got))
+	}
+	t.Setenv("HOME", t.TempDir())
+	got, err = List()
+	if err != nil {
+		t.Fatalf("List on empty: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected empty slice, got %v", got)
+	}
+}
+
+func TestRemove(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	e := Entry{Cwd: "/x", Name: "x", HubPID: 1, StartedAt: time.Now().UTC().Truncate(time.Second)}
+	if err := Write(e); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if err := Remove(e.Cwd); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+	if _, err := Read(e.Cwd); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected ErrNotFound after Remove, got %v", err)
+	}
+	if err := Remove("/never-existed"); err != nil {
+		t.Fatalf("Remove nonexistent: want nil, got %v", err)
 	}
 }

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -18,6 +18,9 @@ func TestWorkspaceID(t *testing.T) {
 			if len(got) != 16 {
 				t.Fatalf("WorkspaceID(%q) length = %d, want 16", tt.cwd, len(got))
 			}
+			if got != tt.want {
+				t.Errorf("WorkspaceID(%q) = %q, want %q", tt.cwd, got, tt.want)
+			}
 			// Same path always produces same ID
 			if got2 := WorkspaceID(tt.cwd); got != got2 {
 				t.Fatalf("WorkspaceID not deterministic: %q vs %q", got, got2)

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -1,0 +1,33 @@
+package registry
+
+import "testing"
+
+func TestWorkspaceID(t *testing.T) {
+	tests := []struct {
+		name string
+		cwd  string
+		want string
+	}{
+		{"simple path", "/Users/dan/projects/foo", "726a213943fe1d41"},
+		{"trailing slash normalized", "/Users/dan/projects/foo/", "726a213943fe1d41"},
+		{"different path", "/Users/dan/projects/bar", "45675b631d01125f"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := WorkspaceID(tt.cwd)
+			if len(got) != 16 {
+				t.Fatalf("WorkspaceID(%q) length = %d, want 16", tt.cwd, len(got))
+			}
+			// Same path always produces same ID
+			if got2 := WorkspaceID(tt.cwd); got != got2 {
+				t.Fatalf("WorkspaceID not deterministic: %q vs %q", got, got2)
+			}
+		})
+	}
+	// Different paths produce different IDs
+	a := WorkspaceID("/a")
+	b := WorkspaceID("/b")
+	if a == b {
+		t.Fatalf("WorkspaceID collision: /a and /b both = %q", a)
+	}
+}

--- a/internal/sessions/sessions.go
+++ b/internal/sessions/sessions.go
@@ -1,0 +1,58 @@
+package sessions
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// Marker is a per-session record. One JSON file per Marker at
+// ~/.bones/sessions/<SessionID>.json.
+type Marker struct {
+	SessionID    string    `json:"session_id"`
+	WorkspaceCwd string    `json:"workspace_cwd"`
+	ClaudePID    int       `json:"claude_pid"`
+	StartedAt    time.Time `json:"started_at"`
+}
+
+// SessionsDir returns the directory holding session marker files.
+func SessionsDir() string {
+	return filepath.Join(os.Getenv("HOME"), ".bones", "sessions")
+}
+
+// MarkerPath returns the file path for a given session ID.
+func MarkerPath(sessionID string) string {
+	return filepath.Join(SessionsDir(), sessionID+".json")
+}
+
+// Register persists m atomically (tmp+rename).
+func Register(m Marker) error {
+	if err := os.MkdirAll(SessionsDir(), 0o755); err != nil {
+		return fmt.Errorf("sessions mkdir: %w", err)
+	}
+	data, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marker marshal: %w", err)
+	}
+	dst := MarkerPath(m.SessionID)
+	tmp, err := os.CreateTemp(SessionsDir(), filepath.Base(dst)+".tmp.*")
+	if err != nil {
+		return fmt.Errorf("marker tmp: %w", err)
+	}
+	defer func() { _ = os.Remove(tmp.Name()) }()
+	if _, err := tmp.Write(data); err != nil {
+		closeErr := tmp.Close()
+		return errors.Join(fmt.Errorf("marker write: %w", err), closeErr)
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("marker sync: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("marker close: %w", err)
+	}
+	return os.Rename(tmp.Name(), dst)
+}

--- a/internal/sessions/sessions.go
+++ b/internal/sessions/sessions.go
@@ -93,6 +93,9 @@ func ListByWorkspace(cwd string) []Marker {
 	return out
 }
 
+// CountByWorkspace returns the number of alive session markers attached to cwd.
+func CountByWorkspace(cwd string) int { return len(ListByWorkspace(cwd)) }
+
 func pidAlive(pid int) bool {
 	if pid <= 0 {
 		return false

--- a/internal/sessions/sessions.go
+++ b/internal/sessions/sessions.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"syscall"
 	"time"
 )
 
@@ -55,4 +56,50 @@ func Register(m Marker) error {
 		return fmt.Errorf("marker close: %w", err)
 	}
 	return os.Rename(tmp.Name(), dst)
+}
+
+// Unregister deletes the marker file. Idempotent.
+func Unregister(sessionID string) error {
+	err := os.Remove(MarkerPath(sessionID))
+	if err == nil || errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	return fmt.Errorf("marker remove: %w", err)
+}
+
+// ListByWorkspace returns markers whose WorkspaceCwd matches the argument
+// AND whose ClaudePID is alive on this host. Dead markers are unlinked as a
+// side effect (orphan GC).
+func ListByWorkspace(cwd string) []Marker {
+	matches, _ := filepath.Glob(filepath.Join(SessionsDir(), "*.json"))
+	out := make([]Marker, 0, len(matches))
+	for _, path := range matches {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		var m Marker
+		if err := json.Unmarshal(data, &m); err != nil {
+			continue
+		}
+		if !pidAlive(m.ClaudePID) {
+			_ = os.Remove(path)
+			continue
+		}
+		if m.WorkspaceCwd == cwd {
+			out = append(out, m)
+		}
+	}
+	return out
+}
+
+func pidAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	p, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	return p.Signal(syscall.Signal(0)) == nil
 }

--- a/internal/sessions/sessions_test.go
+++ b/internal/sessions/sessions_test.go
@@ -2,6 +2,7 @@ package sessions
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -38,5 +39,49 @@ func TestRegister(t *testing.T) {
 	path := filepath.Join(dir, ".bones", "sessions", m.SessionID+".json")
 	if _, err := os.Stat(path); err != nil {
 		t.Fatalf("expected file at %s: %v", path, err)
+	}
+}
+
+func TestUnregister(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	m := Marker{
+		SessionID: "abc", WorkspaceCwd: "/x",
+		ClaudePID: os.Getpid(), StartedAt: time.Now().UTC(),
+	}
+	if err := Register(m); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	if err := Unregister(m.SessionID); err != nil {
+		t.Fatalf("Unregister: %v", err)
+	}
+	if _, err := os.Stat(MarkerPath(m.SessionID)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("file still exists after Unregister")
+	}
+	if err := Unregister("never-existed"); err != nil {
+		t.Fatalf("Unregister nonexistent: %v", err)
+	}
+}
+
+func TestListByWorkspace(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	myPID := os.Getpid()
+	now := time.Now().UTC()
+	for _, m := range []Marker{
+		{SessionID: "s1", WorkspaceCwd: "/a", ClaudePID: myPID, StartedAt: now},
+		{SessionID: "s2", WorkspaceCwd: "/a", ClaudePID: myPID, StartedAt: now},
+		{SessionID: "s3", WorkspaceCwd: "/b", ClaudePID: myPID, StartedAt: now},
+		{SessionID: "s4-dead", WorkspaceCwd: "/a", ClaudePID: 0, StartedAt: now},
+	} {
+		_ = Register(m)
+	}
+	got := ListByWorkspace("/a")
+	if len(got) != 2 {
+		t.Fatalf("expected 2 alive markers for /a, got %d", len(got))
+	}
+	if g := ListByWorkspace("/b"); len(g) != 1 {
+		t.Fatalf("expected 1 marker for /b, got %d", len(g))
+	}
+	if g := ListByWorkspace("/none"); len(g) != 0 {
+		t.Fatalf("expected 0 markers for /none, got %d", len(g))
 	}
 }

--- a/internal/sessions/sessions_test.go
+++ b/internal/sessions/sessions_test.go
@@ -1,0 +1,42 @@
+package sessions
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestMarkerJSON(t *testing.T) {
+	m := Marker{
+		SessionID:    "ade241a5-b8c7-4d3f-9e2a-1b6c8d7f5a3e",
+		WorkspaceCwd: "/Users/dan/projects/foo",
+		ClaudePID:    67890,
+		StartedAt:    time.Now().UTC().Truncate(time.Second),
+	}
+	data, _ := json.Marshal(m)
+	var got Marker
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if got != m {
+		t.Fatalf("round-trip: got %+v, want %+v", got, m)
+	}
+}
+
+func TestRegister(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	m := Marker{
+		SessionID: "abc", WorkspaceCwd: "/x",
+		ClaudePID: os.Getpid(), StartedAt: time.Now().UTC(),
+	}
+	if err := Register(m); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	path := filepath.Join(dir, ".bones", "sessions", m.SessionID+".json")
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("expected file at %s: %v", path, err)
+	}
+}

--- a/internal/sessions/sessions_test.go
+++ b/internal/sessions/sessions_test.go
@@ -3,6 +3,7 @@ package sessions
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -83,5 +84,19 @@ func TestListByWorkspace(t *testing.T) {
 	}
 	if g := ListByWorkspace("/none"); len(g) != 0 {
 		t.Fatalf("expected 0 markers for /none, got %d", len(g))
+	}
+}
+
+func TestCountByWorkspace(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	myPID := os.Getpid()
+	for i, cwd := range []string{"/a", "/a", "/b"} {
+		_ = Register(Marker{
+			SessionID: fmt.Sprintf("s%d", i), WorkspaceCwd: cwd,
+			ClaudePID: myPID, StartedAt: time.Now().UTC(),
+		})
+	}
+	if got := CountByWorkspace("/a"); got != 2 {
+		t.Fatalf("CountByWorkspace(/a) = %d, want 2", got)
 	}
 }

--- a/internal/workspace/name.go
+++ b/internal/workspace/name.go
@@ -1,0 +1,28 @@
+package workspace
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// WriteName persists the workspace_name override at <root>/.bones/workspace_name.
+func WriteName(root, name string) error {
+	path := filepath.Join(root, ".bones", "workspace_name")
+	return os.WriteFile(path, []byte(name+"\n"), 0o644)
+}
+
+// ReadName returns the workspace_name override or "" if not set.
+func ReadName(root string) (string, error) {
+	path := filepath.Join(root, ".bones", "workspace_name")
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("workspace_name read: %w", err)
+	}
+	return strings.TrimSpace(string(data)), nil
+}

--- a/internal/workspace/name_test.go
+++ b/internal/workspace/name_test.go
@@ -1,0 +1,38 @@
+package workspace
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWriteReadName(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".bones"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteName(root, "auth-service"); err != nil {
+		t.Fatalf("WriteName: %v", err)
+	}
+	got, err := ReadName(root)
+	if err != nil {
+		t.Fatalf("ReadName: %v", err)
+	}
+	if got != "auth-service" {
+		t.Fatalf("got %q, want auth-service", got)
+	}
+}
+
+func TestReadNameMissing(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".bones"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	got, err := ReadName(root)
+	if err != nil {
+		t.Fatalf("ReadName missing: %v", err)
+	}
+	if got != "" {
+		t.Fatalf("expected empty, got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

This PR ships the **first of three follow-up specs** identified by the DX audit: cross-workspace identity (registry, `status --all`, `down --all`, `env`, `rename`). It also includes the audit document, all three spec designs, and the implementation plan for Spec 1 — so reviewers can see the full chain from problem → design → code.

Specs 2 (`doctor-ergonomics`) and 3 (`dispatch-and-logs`) are designed but not yet implemented; they're scoped to follow-up PRs.

## What's in this PR

### Documentation (motivation + design)

- **DX audit** (`docs/audits/2026-05-01-dx-6-terminals-from-agentic-engineer.md`) — scores 10 typical workflows for an engineer running multiple bones-driven `claude` sessions in parallel; identifies cross-workspace status, end-of-day cleanup, and per-slot logging as the highest-leverage gaps; ranks 7 improvements; decomposes into 3 specs.
- **Spec 1** — `cross-workspace-identity` design.
- **Spec 2** — `doctor-ergonomics` design (deferred to follow-up PR).
- **Spec 3** — `dispatch-and-logs` design (deferred to follow-up PR).
- **Spec 1 plan** — task-by-task TDD implementation plan (28 tasks).
- All specs revised after an Ousterhout review pass.

### Spec 1 implementation

- **`internal/registry/`** — workspace registry with `WorkspaceID` (sha256 prefix), `Entry` struct, atomic `Write`/`Read`/`List`/`Remove`, and `IsAlive` (PID + HTTP probe). One JSON file per workspace at `~/.bones/workspaces/<id>.json`.
- **`internal/sessions/`** — session marker subsystem with `Marker`, `Register`/`Unregister`, `ListByWorkspace`/`CountByWorkspace`. PID-alive GC on read. One JSON file per session at `~/.bones/sessions/<id>.json`.
- **`internal/workspace/name.go`** — `WriteName`/`ReadName` for `.bones/workspace_name` override.
- **`bones session-marker register|unregister`** — hidden CLI subcommand for bones-managed SessionStart/End hooks. Schema lives in Go code, not duplicated in shell.
- **`bones env`** — emits shell exports for `BONES_WORKSPACE` and `BONES_WORKSPACE_CWD` based on cwd; supports bash/zsh/fish syntax. Walks up to find `.bones/`; resolves name via `workspace.ReadName` (or basename fallback).
- **`bones rename <new-name>`** — sets workspace display name with validation (non-empty, no separators, ≤128 chars, unique across registry).
- **`bones status --all` (+ `--json`)** — lists all running workspaces with stale-pruning, session counts, uptime.
- **`bones down --all`** — bulk teardown across registered workspaces with confirmation prompt.
- **`bones up`/`down` registry hooks** — `hub.Start` writes the entry on successful startup (post-ADR-0041 lazy hub model); `bones down` removes it.
- **README** — shell prompt-hook + theme integration snippets (zsh, bash, fish, starship, p10k).
- **ADR 0038 footnote** — points at the spec's "Future Direction" section as the future-supersession trigger for the leaf-node topology when cross-machine/real-time/multi-user becomes a forcing function.

### Plan deviations (called out for review)

1. **Task 13** (registry write) moved from `bones up` to `hub.Start`. Rationale: per ADR 0041, `bones up` no longer starts the hub; the hub starts lazily. The right "this workspace is live" trigger is `hub.Start`, not `bones up`.
2. **Task 25** (`/health` endpoint) not added. Instead, `IsAlive` was relaxed to probe the root URL — any HTTP response means the port is bound and serving. Fossil's HTTP server (which is what bones uses) doesn't expose `/health`, and adding a sidecar HTTP server just for the probe would over-engineer. The PID-reuse concern remains addressed (recycled PID won't have HTTP server bound on the recorded port).
3. **Several tasks batched** into single commits where atomic (e.g., 11+12, 15+16, 26+27). Each batch is internally coherent.

### Architectural boundaries preserved

- **Bones binary stays harness-agnostic** (`reference/CAPABILITIES.md`, ADR 0023). No subprocess spawning, no harness-specific assumptions in the registry/sessions code.
- **Skills layer is the only place** that touches harness-specific dispatch (Spec 3 territory; not in this PR).
- **No deferment ADRs.** The leaf-node future direction lives in Spec 1's "Future Direction" section, with a committed footnote on ADR 0038. ADR 0042 was deliberately not created.

## Test plan

- [x] `make check` passes locally (fmt, vet, lint, race, todo-check, full short tests)
- [x] Pre-push `ci-fast` hook (vet, build, short tests) passes
- [x] All new packages have unit test coverage (~30 new tests across registry, sessions, workspace, cli)
- [x] Hub `runForeground` writes registry entry verified end-to-end via `TestStartWritesRegistry`
- [ ] Human review of design correctness and harness-agnostic boundary preservation
- [ ] Manual end-to-end: `bones up` in a real workspace → `bones status --all` from a sibling shell shows the workspace
- [ ] Manual: shell prompt-hook works as documented (zsh / bash / fish + starship / p10k)

## Follow-up PRs (planned, not in this PR)

- **Spec 2 implementation** — `bones doctor` recovery-hint catalog + `--all` mode using this PR's registry. ~12-15 tasks.
- **Spec 3 implementation** — `bones swarm dispatch` (manifest-emit verb) + `bones logs --slot=` (per-slot JSONL event log). ~25-30 tasks. Larger; warrants its own PR for review focus.

## Out of scope

- Implementation of Specs 2 and 3 (separate PRs).
- ADR 0042 standalone (rolled into Spec 1's Future Direction by design).
- `bones swarm dispatch --watch` auto-advance (Spec 3 v2).
- `bones doctor --fix` auto-execution (separate spec — safety design needed).