### PR TITLE
feat(up): default to one-line output, --verbose for full status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,9 @@ go.work.sum
 docs/code-review/
 docs/plans/
 
+# Git worktrees (per-feature isolated checkouts)
+.worktrees/
+
 # Hugo build artifacts (docs site)
 docs/site/public/
 docs/site/resources/

--- a/cli/init.go
+++ b/cli/init.go
@@ -42,15 +42,22 @@ func (c *JoinCmd) Run(g *libfossilcli.Globals) error {
 // install, agent guidance, and Fossil drift check. The hub itself is no
 // longer started by `bones up`; per ADR 0041 it auto-starts on the first
 // verb that needs it via workspace.Join.
+//
+// Default output: a single confirmation line. With -v / --verbose: the
+// banner plus per-step status lines. WARN lines (drift, missing git)
+// print regardless because they describe real issues the operator must
+// see. Verbosity comes from the global -v flag on libfossilcli.Globals.
 type UpCmd struct{}
 
 func (c *UpCmd) Run(g *libfossilcli.Globals) error {
-	banner.Print()
+	if g.Verbose {
+		banner.Print()
+	}
 	cwd, err := os.Getwd()
 	if err != nil {
 		return fmt.Errorf("cwd: %w", err)
 	}
-	return runUp(cwd)
+	return runUp(cwd, g.Verbose)
 }
 
 // reportWorkspace formats the standard workspace report and returns nil

--- a/cli/up.go
+++ b/cli/up.go
@@ -22,7 +22,11 @@ import (
 //
 // Per ADR 0041 the hub is no longer started here. Any verb that needs the
 // hub auto-starts it lazily via workspace.Join.
-func runUp(cwd string) (err error) {
+//
+// Default output is a single confirmation line. With verbose=true, prints
+// per-step status lines. WARN lines from drift / missing-git checks
+// always print because they describe real issues operators must see.
+func runUp(cwd string, verbose bool) (err error) {
 	ctx, end := telemetry.RecordCommand(context.Background(), "bones.up",
 		telemetry.String("workspace_hash", telemetry.WorkspaceHash(cwd)),
 	)
@@ -33,14 +37,18 @@ func runUp(cwd string) (err error) {
 		return fmt.Errorf("workspace: %w", err)
 	}
 	wsDir := info.WorkspaceDir
-	fmt.Printf("up: workspace at %s\n", wsDir)
+	if verbose {
+		fmt.Printf("up: workspace at %s\n", wsDir)
+	}
 
 	if err := scaffoldOrchestrator(wsDir); err != nil {
 		return fmt.Errorf("orchestrator scaffold: %w", err)
 	}
-	fmt.Println("up: orchestrator skills, hooks, and gitignore installed")
+	if verbose {
+		fmt.Println("up: orchestrator skills, hooks, and gitignore installed")
+	}
 
-	if err := installGitHook(wsDir); err != nil {
+	if err := installGitHook(wsDir, verbose); err != nil {
 		return fmt.Errorf("git hook: %w", err)
 	}
 
@@ -52,8 +60,12 @@ func runUp(cwd string) (err error) {
 		fmt.Fprintf(os.Stderr, "up: WARN  %v\n", err)
 	}
 
-	fmt.Println("up: workspace ready. Run any verb (e.g., `bones tasks status`) " +
-		"and the hub will start automatically; or run `bones hub start` now.")
+	if verbose {
+		fmt.Println("up: workspace ready. Run any verb (e.g., `bones tasks status`) " +
+			"and the hub will start automatically; or run `bones hub start` now.")
+	} else {
+		fmt.Printf("up: ready at %s\n", wsDir)
+	}
 	return nil
 }
 
@@ -74,7 +86,11 @@ func initOrJoinWorkspace(ctx context.Context, cwd string) (workspace.Info, error
 // repository's .git/hooks directory. Per ADR 0034, this is the
 // enforcement seam that prevents agents from silently bypassing the
 // shadow trunk.
-func installGitHook(wsDir string) error {
+//
+// The "no .git found" line prints regardless of verbose because it
+// signals a missing enforcement gate the operator should know about.
+// The success line is verbose-only.
+func installGitHook(wsDir string, verbose bool) error {
 	gitDir := githook.FindGitDir(wsDir)
 	if gitDir == "" {
 		fmt.Println("up: no .git found — skipping pre-commit hook install")
@@ -83,7 +99,9 @@ func installGitHook(wsDir string) error {
 	if err := githook.Install(gitDir); err != nil {
 		return err
 	}
-	fmt.Printf("up: pre-commit hook installed at %s/hooks/pre-commit\n", gitDir)
+	if verbose {
+		fmt.Printf("up: pre-commit hook installed at %s/hooks/pre-commit\n", gitDir)
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Summary

`bones up` happy path now prints just one line:

```
$ bones up
up: ready at /path/to/workspace
```

With `-v` / `--verbose` (the existing global flag from `libfossilcli.Globals`), full output returns:
- ASCII banner (TTY-gated)
- Per-step status lines (`up: workspace at ...`, `up: orchestrator skills...`, `up: pre-commit hook installed at ...`)
- Long "workspace ready..." tagline explaining the auto-start model

WARN lines from drift / missing-git checks print regardless because they describe real issues operators must act on.

## Why

`bones up` is idempotent and frequently re-run. Default verbose output is noise; the operator wants to know it succeeded, not how. `-v` opens the firehose when something looks off.

## Notes

- Replaces #105, which got polluted by the test-fixture-corrupts-branch flakiness tracked in #106. Force-push recovered the local branch, but #105's GraphQL state was left referencing a vanished ref. Same content, fresh PR.
- `runUp` signature changed `(cwd string)` → `(cwd string, verbose bool)`. Single in-package caller (`UpCmd.Run`).
- `installGitHook` signature changed `(wsDir string)` → `(wsDir string, verbose bool)` for the same reason.
- `.worktrees/` added to `.gitignore` for per-feature isolated checkouts.

## Test plan

- [x] `make check` passes (fmt-check, vet, lint, race, todo-check)
- [x] Manual: `bones up` from a fresh git repo prints exactly `up: ready at <path>`
- [x] Manual: `bones up -v` from same prints banner (in TTY) + 4 status lines + WARN-or-not + the long tagline
- [x] Verified `--verbose` resolves to the existing global flag, not a duplicate