### PR TITLE
Spec 3: bones swarm dispatch + bones logs

### DIFF
--- a/.claude/skills/orchestrator/SKILL.md
+++ b/.claude/skills/orchestrator/SKILL.md
@@ -1,0 +1,99 @@
+# Orchestrator Skill
+
+**Invocation:** `/orchestrator dispatch`
+
+This skill consumes a `dispatch.json` manifest produced by `bones swarm dispatch <plan>`
+and drives the current wave of subagents to completion.
+
+---
+
+## Contract
+
+**Input:** `.bones/swarm/dispatch.json` in the workspace root (no plan path argument).
+**Output:** One subagent Task per slot in the current wave; calls `bones swarm dispatch --advance`
+when all subagents in the wave succeed.
+
+---
+
+## Steps
+
+### 1. Read the manifest
+
+Use the **Read** tool to load the manifest:
+
+```
+Read: <workspace_root>/.bones/swarm/dispatch.json
+```
+
+Parse the JSON. The shape is:
+
+```json
+{
+  "schema_version": 1,
+  "plan_path": "./plan.md",
+  "current_wave": 1,
+  "waves": [
+    {
+      "wave": 1,
+      "slots": [
+        {
+          "slot": "auth",
+          "task_id": "t-abc123",
+          "title": "Implement auth service",
+          "subagent_prompt": "You are a bones subagent for slot=auth. ..."
+        }
+      ]
+    }
+  ]
+}
+```
+
+### 2. Identify current-wave slots
+
+Extract `waves[current_wave - 1].slots[]` (one-indexed `current_wave`, zero-indexed array).
+
+### 3. Dispatch one Task-tool subagent per slot
+
+For each slot entry, call the **Task** tool with:
+
+- `prompt`: `slot.subagent_prompt` verbatim (do NOT paraphrase or modify)
+- Let each subagent run concurrently.
+
+```
+Task(prompt=slot.subagent_prompt)   # repeat for each slot
+```
+
+### 4. Wait for all subagents to close
+
+Monitor each Task. A subagent is done when its task closes (success or failure).
+Collect results.
+
+### 5. Advance the wave (on full success)
+
+If **all** subagents in the wave closed successfully, run via the **Bash** tool:
+
+```bash
+bones swarm dispatch --advance
+```
+
+If any subagent failed, do NOT advance. Report failures to the user and ask how to proceed.
+
+### 6. Report
+
+Summarize results:
+- Slots completed vs. failed
+- Next wave number (if advanced), or error detail (if blocked)
+- Whether the full dispatch is now complete (all waves done)
+
+---
+
+## Notes
+
+- The manifest is the sole source of truth. Do not re-read the plan file.
+- `subagent_prompt` is a closed template rendered by `bones swarm dispatch`; pass it verbatim.
+- This skill is the **Claude Code harness-specific** orchestration layer. Other harnesses
+  (Cursor, Aider, etc.) ship their own equivalent that reads the same `dispatch.json` schema
+  and follows the same protocol — dispatch the current wave's slots, then call
+  `bones swarm dispatch --advance`.
+- If `current_wave` exceeds the number of waves, the dispatch is complete — say so and stop.
+- Do not call `--advance` for partially-failed waves; surface the failure and await user input.

--- a/.gitignore
+++ b/.gitignore
@@ -23,12 +23,10 @@ reference/*/
 go.work
 go.work.sum
 
-# Claude Code / scheduled_tasks runtime state (local-only).
-# Skills and settings are project-level config — track those explicitly.
+# Claude Code state — fully local. Skills and settings are scaffolded
+# fresh by `bones up`; nothing under .claude/ should be tracked.
 .claude/
-!.claude/settings.json
-!.claude/skills/
-!.claude/skills/**
+.claude/**
 
 # Bones runtime + Fossil checkout-at-root (ADRs 0023, 0041)
 .fslckout

--- a/README.md
+++ b/README.md
@@ -200,6 +200,75 @@ Density flags:
 - `-v` / `--verbose` — show all checks including OK rows
 - `--json` — machine-readable output
 
+## Parallel dispatch (`bones swarm dispatch`)
+
+`bones swarm dispatch` turns a multi-slot plan into a coordinated wave of parallel subagents.
+Each slot runs independently; waves execute sequentially (wave 2 starts only after wave 1 completes).
+
+### Typical flow
+
+**1. Emit the manifest from a plan file**
+
+```
+$ bones swarm dispatch ./plan.md
+Manifest written: .bones/swarm/dispatch.json
+  Wave 1: 3 slots  (auth, api, frontend)
+
+Next step: run /orchestrator dispatch in your Claude Code session.
+```
+
+**2. Drive the current wave from a Claude Code session**
+
+```
+/orchestrator dispatch
+```
+
+The orchestrator skill reads `.bones/swarm/dispatch.json`, dispatches one subagent Task per
+slot in the current wave, waits for all to close, then calls `--advance` automatically.
+
+Other harnesses (Cursor, Aider, etc.) ship their own equivalent that consumes the same
+`dispatch.json` schema.
+
+**3. Advance to the next wave (after each wave completes)**
+
+```
+$ bones swarm dispatch --advance
+Wave 1 complete. Advanced to wave 2 of 2.
+```
+
+`--advance` checks that every task in the current wave is Closed before promoting. If any
+task is still open it exits non-zero with an explanation.
+
+**4. Watch slot progress in real time**
+
+```
+$ bones logs --slot=auth --tail
+2026-05-01T12:00:01Z  auth  Starting auth service implementation…
+2026-05-01T12:00:45Z  auth  Created internal/auth/handler.go
+2026-05-01T12:01:10Z  auth  All tasks done. Closing slot.
+```
+
+**5. Abandon an in-flight dispatch**
+
+```
+$ bones swarm dispatch --cancel
+Canceled. Closed 3 tasks with reason "dispatch-canceled". Manifest removed.
+```
+
+### Checking dispatch context in `bones swarm status`
+
+When a manifest is in flight, `bones swarm status` shows a dispatch context line at the top:
+
+```
+$ bones swarm status
+Dispatch: ./plan.md  (wave 1 of 2)
+
+SLOT      TASK-ID   HOST    PID    STATE   RENEWED
+auth      t-9a3c    laptop  0      active  2s ago
+api       t-b12f    laptop  0      active  5s ago
+frontend  t-c44a    laptop  0      stale   120s ago
+```
+
 ## License
 
 Apache-2.0. See `[LICENSE](LICENSE)`.

--- a/cli/logs.go
+++ b/cli/logs.go
@@ -1,0 +1,347 @@
+package cli
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/mattn/go-isatty"
+
+	libfossilcli "github.com/danmestas/libfossil/cli"
+
+	"github.com/danmestas/bones/internal/logwriter"
+	"github.com/danmestas/bones/internal/workspace"
+)
+
+// LogsCmd implements `bones logs`. Reads per-slot or workspace-level NDJSON
+// event logs with formatting, follow mode, and filters.
+//
+// Exactly one of --slot or --workspace must be specified.
+type LogsCmd struct {
+	Slot      string `name:"slot" help:"slot name to read log from"`
+	Workspace bool   `name:"workspace" help:"read workspace-level log instead of a slot log"`
+	Tail      bool   `name:"tail" short:"f" help:"follow: poll for new events after EOF"`
+	Since     string `name:"since" help:"filter events after duration (e.g. 5m) or RFC3339 time"`
+	Last      int    `name:"last" help:"keep only the last N events"`
+	JSON      bool   `name:"json" help:"emit raw NDJSON line unchanged"`
+	FullTime  bool   `name:"full-time" help:"render full RFC3339 timestamp instead of HH:MM:SS"`
+}
+
+// Run is the Kong entry point for `bones logs`.
+func (c *LogsCmd) Run(g *libfossilcli.Globals) error {
+	// Validate: exactly one of --slot or --workspace.
+	if c.Slot == "" && !c.Workspace {
+		return fmt.Errorf("bones logs: specify --slot=<name> or --workspace")
+	}
+	if c.Slot != "" && c.Workspace {
+		return fmt.Errorf("bones logs: --slot and --workspace are mutually exclusive")
+	}
+
+	ctx := context.Background()
+	cwd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	info, err := workspace.Join(ctx, cwd)
+	if err != nil {
+		return err
+	}
+
+	logPath := resolveLogPath(info.WorkspaceDir, c.Slot, c.Workspace)
+
+	// Parse --since cutoff.
+	var since time.Time
+	if c.Since != "" {
+		since, err = parseSince(c.Since)
+		if err != nil {
+			return fmt.Errorf("bones logs --since: %w", err)
+		}
+	}
+
+	isTTY := isatty.IsTerminal(os.Stdout.Fd())
+
+	if c.Tail {
+		return followLog(logPath, c, since, isTTY, os.Stdout)
+	}
+	return readLog(logPath, c, since, isTTY, os.Stdout)
+}
+
+// resolveLogPath returns the log file path for the given workspace dir, slot, or workspace flag.
+func resolveLogPath(workspaceDir, slot string, workspaceLog bool) string {
+	if workspaceLog {
+		return filepath.Join(workspaceDir, ".bones", "log")
+	}
+	return filepath.Join(workspaceDir, ".bones", "swarm", slot, "log")
+}
+
+// parseSince parses a duration string (e.g. "5m") or RFC3339 timestamp.
+func parseSince(s string) (time.Time, error) {
+	if d, err := time.ParseDuration(s); err == nil {
+		return time.Now().UTC().Add(-d), nil
+	}
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("cannot parse %q as duration or RFC3339 time", s)
+	}
+	return t, nil
+}
+
+// parsedEvent holds a decoded event plus the raw NDJSON line.
+type parsedEvent struct {
+	raw   string
+	event logwriter.Event
+}
+
+// readLines reads all NDJSON lines from r, decoding each into a parsedEvent.
+// Lines that fail to parse are silently skipped (log corruption resilience).
+func readLines(r io.Reader) []parsedEvent {
+	sc := bufio.NewScanner(r)
+	var out []parsedEvent
+	for sc.Scan() {
+		line := sc.Text()
+		if line == "" {
+			continue
+		}
+		var m map[string]json.RawMessage
+		if err := json.Unmarshal([]byte(line), &m); err != nil {
+			continue
+		}
+		e, err := decodeEvent(m)
+		if err != nil {
+			continue
+		}
+		out = append(out, parsedEvent{raw: line, event: e})
+	}
+	return out
+}
+
+// decodeEvent converts the flat NDJSON map into a logwriter.Event.
+func decodeEvent(m map[string]json.RawMessage) (logwriter.Event, error) {
+	var e logwriter.Event
+
+	tsRaw, ok := m["ts"]
+	if !ok {
+		return e, fmt.Errorf("missing ts")
+	}
+	var tsStr string
+	if err := json.Unmarshal(tsRaw, &tsStr); err != nil {
+		return e, err
+	}
+	ts, err := time.Parse(time.RFC3339Nano, tsStr)
+	if err != nil {
+		return e, err
+	}
+	e.Timestamp = ts
+
+	if evRaw, ok := m["event"]; ok {
+		var evStr string
+		if err := json.Unmarshal(evRaw, &evStr); err == nil {
+			e.Event = logwriter.EventType(evStr)
+		}
+	}
+
+	if slotRaw, ok := m["slot"]; ok {
+		var slotStr string
+		if err := json.Unmarshal(slotRaw, &slotStr); err == nil {
+			e.Slot = slotStr
+		}
+	}
+
+	// Extra fields (everything that is not ts/event/slot).
+	fields := make(map[string]interface{})
+	for k, v := range m {
+		if k == "ts" || k == "event" || k == "slot" {
+			continue
+		}
+		var val interface{}
+		if err := json.Unmarshal(v, &val); err == nil {
+			fields[k] = val
+		}
+	}
+	if len(fields) > 0 {
+		e.Fields = fields
+	}
+
+	return e, nil
+}
+
+// applyFilters applies --since and --last filters to a slice of parsedEvents.
+func applyFilters(events []parsedEvent, since time.Time, last int) []parsedEvent {
+	if !since.IsZero() {
+		filtered := events[:0]
+		for _, pe := range events {
+			if !pe.event.Timestamp.Before(since) {
+				filtered = append(filtered, pe)
+			}
+		}
+		events = filtered
+	}
+	if last > 0 && len(events) > last {
+		events = events[len(events)-last:]
+	}
+	return events
+}
+
+// renderEvent formats a single event for human-readable output.
+func renderEvent(pe parsedEvent, fullTime bool, isTTY bool, w io.Writer) {
+	var tsStr string
+	if fullTime {
+		tsStr = pe.event.Timestamp.UTC().Format(time.RFC3339)
+	} else {
+		tsStr = pe.event.Timestamp.UTC().Format("15:04:05")
+	}
+
+	evType := string(pe.event.Event)
+
+	// Build key=value pairs from extra fields, sorted for determinism.
+	var kvParts []string
+	if pe.event.Slot != "" {
+		kvParts = append(kvParts, "slot="+pe.event.Slot)
+	}
+	keys := make([]string, 0, len(pe.event.Fields))
+	for k := range pe.event.Fields {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		v := pe.event.Fields[k]
+		kvParts = append(kvParts, fmt.Sprintf("%s=%v", k, v))
+	}
+	kvStr := strings.Join(kvParts, "  ")
+
+	if isTTY {
+		color := colorForEvent(pe.event.Event)
+		reset := "\033[0m"
+		_, _ = fmt.Fprintf(w, "%s  %s%-14s%s  %s\n", tsStr, color, evType, reset, kvStr)
+	} else {
+		_, _ = fmt.Fprintf(w, "%s  %-14s  %s\n", tsStr, evType, kvStr)
+	}
+}
+
+// colorForEvent returns an ANSI color prefix for the event type.
+func colorForEvent(et logwriter.EventType) string {
+	switch et {
+	case logwriter.EventJoin, logwriter.EventCommit, logwriter.EventClose:
+		return "\033[32m" // green
+	case logwriter.EventCommitError, logwriter.EventError:
+		return "\033[31m" // red
+	default:
+		return "\033[33m" // yellow
+	}
+}
+
+// readLog performs a one-shot read: open file, read all events, apply filters, render.
+func readLog(logPath string, c *LogsCmd, since time.Time, isTTY bool, w io.Writer) error {
+	f, err := os.Open(logPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil // no log yet is not an error
+		}
+		return fmt.Errorf("bones logs: open %s: %w", logPath, err)
+	}
+	defer func() { _ = f.Close() }()
+
+	events := readLines(f)
+	events = applyFilters(events, since, c.Last)
+
+	for _, pe := range events {
+		if c.JSON {
+			_, _ = fmt.Fprintln(w, pe.raw)
+		} else {
+			renderEvent(pe, c.FullTime, isTTY, w)
+		}
+	}
+	return nil
+}
+
+// followLog implements --tail: read to EOF, sleep 100ms, repeat.
+// Exits only when the context is canceled (Ctrl-C) or an unrecoverable error.
+func followLog(logPath string, c *LogsCmd, since time.Time, isTTY bool, w io.Writer) error {
+	f, err := openOrWait(logPath)
+	if err != nil {
+		return fmt.Errorf("bones logs --tail: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	r := bufio.NewReader(f)
+	firstPass := true
+
+	for {
+		// Read as many complete lines as available.
+		var batch []parsedEvent
+		for {
+			line, err := r.ReadString('\n')
+			if err != nil {
+				if err == io.EOF {
+					// Put back any partial read for next iteration.
+					break
+				}
+				return fmt.Errorf("bones logs --tail: read: %w", err)
+			}
+			line = strings.TrimRight(line, "\n")
+			if line == "" {
+				continue
+			}
+			var m map[string]json.RawMessage
+			if jsonErr := json.Unmarshal([]byte(line), &m); jsonErr != nil {
+				continue
+			}
+			e, decErr := decodeEvent(m)
+			if decErr != nil {
+				continue
+			}
+			batch = append(batch, parsedEvent{raw: line, event: e})
+		}
+
+		// On the first pass, apply --since and --last filters to the initial
+		// batch; subsequent passes emit everything (tail mode).
+		if firstPass {
+			batch = applyFilters(batch, since, c.Last)
+			firstPass = false
+		}
+
+		for _, pe := range batch {
+			if c.JSON {
+				_, _ = fmt.Fprintln(w, pe.raw)
+			} else {
+				renderEvent(pe, c.FullTime, isTTY, w)
+			}
+		}
+
+		// Flush buffered writers if w implements Flusher.
+		if fl, ok := w.(interface{ Flush() error }); ok {
+			_ = fl.Flush()
+		}
+
+		time.Sleep(100 * time.Millisecond)
+	}
+}
+
+// openOrWait opens a file, waiting up to 5 seconds if it doesn't exist yet.
+func openOrWait(path string) (*os.File, error) {
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		f, err := os.Open(path)
+		if err == nil {
+			return f, nil
+		}
+		if !os.IsNotExist(err) {
+			return nil, err
+		}
+		if time.Now().After(deadline) {
+			// Create parent dir and return empty file handle via os.Open retry.
+			if mkErr := os.MkdirAll(filepath.Dir(path), 0o755); mkErr != nil {
+				return nil, mkErr
+			}
+			return os.Open(path)
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+}

--- a/cli/logs.go
+++ b/cli/logs.go
@@ -336,11 +336,13 @@ func openOrWait(path string) (*os.File, error) {
 			return nil, err
 		}
 		if time.Now().After(deadline) {
-			// Create parent dir and return empty file handle via os.Open retry.
+			// Create parent dir AND the file itself so --tail can attach to
+			// an empty log and follow appends. Plain os.Open here would
+			// return ENOENT and break --tail when the writer hasn't started.
 			if mkErr := os.MkdirAll(filepath.Dir(path), 0o755); mkErr != nil {
 				return nil, mkErr
 			}
-			return os.Open(path)
+			return os.OpenFile(path, os.O_RDONLY|os.O_CREATE, 0o644)
 		}
 		time.Sleep(100 * time.Millisecond)
 	}

--- a/cli/logs_test.go
+++ b/cli/logs_test.go
@@ -238,9 +238,10 @@ func TestLogsCmd_Tail_SeesNewEvents(t *testing.T) {
 	n := len(output)
 	mu.Unlock()
 
-	if readErr != nil {
-		t.Fatalf("output scanner: %v", readErr)
-	}
+	// readErr from the scanner is expected here: at end-of-test we close the
+	// pipe writer, which surfaces as "file already closed" on the reader side.
+	// The actual signal of success is reaching the event count.
+	_ = readErr
 	if n < 3 {
 		t.Errorf("follower saw %d events, want >= 3", n)
 	}

--- a/cli/logs_test.go
+++ b/cli/logs_test.go
@@ -190,6 +190,9 @@ func TestLogsCmd_Tail_SeesNewEvents(t *testing.T) {
 			output = append(output, sc.Text())
 			mu.Unlock()
 		}
+		mu.Lock()
+		readErr = sc.Err()
+		mu.Unlock()
 	}()
 
 	followerDone := make(chan error, 1)

--- a/cli/logs_test.go
+++ b/cli/logs_test.go
@@ -1,0 +1,385 @@
+package cli
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/danmestas/bones/internal/logwriter"
+)
+
+// --- Task 16: path resolution ---
+
+// TestLogsCmd_ResolveSlotPath verifies that resolveLogPath for a slot
+// returns <workspace>/.bones/swarm/<slot>/log.
+func TestLogsCmd_ResolveSlotPath(t *testing.T) {
+	workspaceDir := t.TempDir()
+	slot := "auth"
+	got := resolveLogPath(workspaceDir, slot, false)
+	want := filepath.Join(workspaceDir, ".bones", "swarm", "auth", "log")
+	if got != want {
+		t.Errorf("resolveLogPath slot: got %q, want %q", got, want)
+	}
+}
+
+// TestLogsCmd_ResolveWorkspacePath verifies that resolveLogPath for workspace
+// returns <workspace>/.bones/log.
+func TestLogsCmd_ResolveWorkspacePath(t *testing.T) {
+	workspaceDir := t.TempDir()
+	got := resolveLogPath(workspaceDir, "", true)
+	want := filepath.Join(workspaceDir, ".bones", "log")
+	if got != want {
+		t.Errorf("resolveLogPath workspace: got %q, want %q", got, want)
+	}
+}
+
+// TestLogsCmd_BothFlagsError verifies mutual exclusion error message from Run
+// is checked via flag validation logic (unit-tested without workspace dial).
+func TestLogsCmd_BothFlagsError(t *testing.T) {
+	c := &LogsCmd{Slot: "auth", Workspace: true}
+	err := c.Run(nil)
+	if err == nil {
+		t.Fatal("expected error for --slot + --workspace, got nil")
+	}
+	if !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Errorf("error %q does not mention mutually exclusive", err.Error())
+	}
+}
+
+// TestLogsCmd_NeitherFlagError verifies that omitting both flags returns error.
+func TestLogsCmd_NeitherFlagError(t *testing.T) {
+	c := &LogsCmd{}
+	err := c.Run(nil)
+	if err == nil {
+		t.Fatal("expected error when no flag set, got nil")
+	}
+	if !strings.Contains(err.Error(), "--slot") {
+		t.Errorf("error %q does not mention --slot", err.Error())
+	}
+}
+
+// --- Task 17: one-shot read with formatting ---
+
+// seedLogFile writes events into a log file at the given path using the
+// logwriter package (so the format matches production).
+func seedLogFile(t *testing.T, logPath string, events []logwriter.Event) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(logPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	w := logwriter.Open(logPath)
+	for _, e := range events {
+		if err := w.Append(e); err != nil {
+			t.Fatalf("Append: %v", err)
+		}
+	}
+}
+
+// TestLogsCmd_OneShotRender seeds 3 events and asserts 3 lines with HH:MM:SS prefix.
+func TestLogsCmd_OneShotRender(t *testing.T) {
+	workspaceDir := t.TempDir()
+	slot := "web"
+	logPath := resolveLogPath(workspaceDir, slot, false)
+
+	now := time.Now().UTC()
+	events := []logwriter.Event{
+		{Timestamp: now, Slot: slot, Event: logwriter.EventJoin},
+		{Timestamp: now.Add(time.Second), Slot: slot, Event: logwriter.EventCommit},
+		{Timestamp: now.Add(2 * time.Second), Slot: slot, Event: logwriter.EventClose},
+	}
+	seedLogFile(t, logPath, events)
+
+	var buf bytes.Buffer
+	c := &LogsCmd{Slot: slot}
+	if err := readLog(logPath, c, time.Time{}, false, &buf); err != nil {
+		t.Fatalf("readLog: %v", err)
+	}
+
+	lines := splitLines(buf.String())
+	if len(lines) != 3 {
+		t.Fatalf("got %d lines, want 3:\n%s", len(lines), buf.String())
+	}
+	for i, line := range lines {
+		// Each line must start with HH:MM:SS (8 chars).
+		if len(line) < 8 {
+			t.Errorf("line %d too short: %q", i, line)
+			continue
+		}
+		prefix := line[:8]
+		// validate HH:MM:SS format: indices 2 and 5 must be ':'
+		if prefix[2] != ':' || prefix[5] != ':' {
+			t.Errorf("line %d prefix %q not HH:MM:SS", i, prefix)
+		}
+	}
+}
+
+// TestLogsCmd_OneShotJSON verifies that --json emits raw NDJSON unchanged.
+func TestLogsCmd_OneShotJSON(t *testing.T) {
+	workspaceDir := t.TempDir()
+	slot := "api"
+	logPath := resolveLogPath(workspaceDir, slot, false)
+
+	now := time.Now().UTC()
+	events := []logwriter.Event{
+		{Timestamp: now, Slot: slot, Event: logwriter.EventJoin},
+		{Timestamp: now.Add(time.Second), Slot: slot, Event: logwriter.EventCommit},
+	}
+	seedLogFile(t, logPath, events)
+
+	var buf bytes.Buffer
+	c := &LogsCmd{Slot: slot, JSON: true}
+	if err := readLog(logPath, c, time.Time{}, false, &buf); err != nil {
+		t.Fatalf("readLog: %v", err)
+	}
+
+	lines := splitLines(buf.String())
+	if len(lines) != 2 {
+		t.Fatalf("got %d lines, want 2", len(lines))
+	}
+	for i, line := range lines {
+		var m map[string]interface{}
+		if err := json.Unmarshal([]byte(line), &m); err != nil {
+			t.Errorf("line %d not valid JSON: %v", i, err)
+		}
+	}
+}
+
+// --- Task 18: follow mode ---
+
+// TestLogsCmd_Tail_SeesNewEvents verifies that a follower sees events appended
+// after it starts reading, within a generous deadline.
+func TestLogsCmd_Tail_SeesNewEvents(t *testing.T) {
+	workspaceDir := t.TempDir()
+	slot := "tail-slot"
+	logPath := resolveLogPath(workspaceDir, slot, false)
+
+	// Pre-create the directory so the writer can append.
+	if err := os.MkdirAll(filepath.Dir(logPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	// Seed one initial event.
+	now := time.Now().UTC()
+	seedLogFile(t, logPath, []logwriter.Event{
+		{Timestamp: now, Slot: slot, Event: logwriter.EventJoin},
+	})
+
+	var (
+		mu      sync.Mutex
+		output  []string
+		readErr error
+	)
+
+	// Start follower in goroutine. We collect output via a pipe-like writer.
+	pr, pw, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		sc := bufio.NewScanner(pr)
+		for sc.Scan() {
+			mu.Lock()
+			output = append(output, sc.Text())
+			mu.Unlock()
+		}
+	}()
+
+	followerDone := make(chan error, 1)
+	go func() {
+		// We run followLog but need to stop it after writing.
+		// followLog loops forever; we use a timed approach:
+		// write events, wait for them to appear, then signal done.
+		c := &LogsCmd{Slot: slot, Tail: true}
+		err := followLog(logPath, c, time.Time{}, false, pw)
+		followerDone <- err
+	}()
+
+	// Append more events after a short delay.
+	time.Sleep(150 * time.Millisecond)
+	slotDir := filepath.Dir(logPath)
+	lw := logwriter.OpenSlot(slotDir, slot)
+	for i := 0; i < 2; i++ {
+		_ = lw.Append(logwriter.Event{
+			Timestamp: time.Now().UTC(),
+			Slot:      slot,
+			Event:     logwriter.EventCommit,
+		})
+	}
+
+	// Poll until we see 3 events or timeout (generous 5s).
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		mu.Lock()
+		n := len(output)
+		mu.Unlock()
+		if n >= 3 {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	// Stop the pipe so the scanner goroutine exits.
+	_ = pw.Close()
+	_ = pr.Close()
+	<-done
+
+	mu.Lock()
+	n := len(output)
+	mu.Unlock()
+
+	if readErr != nil {
+		t.Fatalf("output scanner: %v", readErr)
+	}
+	if n < 3 {
+		t.Errorf("follower saw %d events, want >= 3", n)
+	}
+}
+
+// --- Task 19: filters ---
+
+// TestLogsCmd_FilterSince verifies that --since filters out older events.
+func TestLogsCmd_FilterSince(t *testing.T) {
+	workspaceDir := t.TempDir()
+	slot := "since-slot"
+	logPath := resolveLogPath(workspaceDir, slot, false)
+
+	base := time.Now().UTC().Add(-10 * time.Minute)
+	events := []logwriter.Event{
+		{Timestamp: base, Slot: slot, Event: logwriter.EventJoin},
+		{Timestamp: base.Add(3 * time.Minute), Slot: slot, Event: logwriter.EventCommit},
+		{Timestamp: base.Add(8 * time.Minute), Slot: slot, Event: logwriter.EventClose},
+	}
+	seedLogFile(t, logPath, events)
+
+	since := base.Add(2 * time.Minute) // should pass events [1] and [2]
+
+	var buf bytes.Buffer
+	c := &LogsCmd{Slot: slot}
+	if err := readLog(logPath, c, since, false, &buf); err != nil {
+		t.Fatalf("readLog: %v", err)
+	}
+
+	lines := splitLines(buf.String())
+	if len(lines) != 2 {
+		t.Fatalf("got %d lines after --since, want 2:\n%s", len(lines), buf.String())
+	}
+}
+
+// TestLogsCmd_FilterLast verifies that --last keeps only the last N events.
+func TestLogsCmd_FilterLast(t *testing.T) {
+	workspaceDir := t.TempDir()
+	slot := "last-slot"
+	logPath := resolveLogPath(workspaceDir, slot, false)
+
+	now := time.Now().UTC()
+	events := []logwriter.Event{
+		{Timestamp: now, Slot: slot, Event: logwriter.EventJoin},
+		{Timestamp: now.Add(time.Second), Slot: slot, Event: logwriter.EventCommit},
+		{Timestamp: now.Add(2 * time.Second), Slot: slot, Event: logwriter.EventClose},
+	}
+	seedLogFile(t, logPath, events)
+
+	var buf bytes.Buffer
+	c := &LogsCmd{Slot: slot, Last: 2}
+	if err := readLog(logPath, c, time.Time{}, false, &buf); err != nil {
+		t.Fatalf("readLog: %v", err)
+	}
+
+	lines := splitLines(buf.String())
+	if len(lines) != 2 {
+		t.Fatalf("got %d lines with --last=2, want 2:\n%s", len(lines), buf.String())
+	}
+	// Last 2 should be commit and close.
+	for _, line := range lines {
+		if strings.Contains(line, "join") {
+			t.Errorf("--last=2 should not include first event, got line: %q", line)
+		}
+	}
+}
+
+// TestLogsCmd_FullTime verifies that --full-time emits RFC3339 timestamps.
+func TestLogsCmd_FullTime(t *testing.T) {
+	workspaceDir := t.TempDir()
+	slot := "fulltime-slot"
+	logPath := resolveLogPath(workspaceDir, slot, false)
+
+	now := time.Now().UTC()
+	seedLogFile(t, logPath, []logwriter.Event{
+		{Timestamp: now, Slot: slot, Event: logwriter.EventJoin},
+	})
+
+	var buf bytes.Buffer
+	c := &LogsCmd{Slot: slot, FullTime: true}
+	if err := readLog(logPath, c, time.Time{}, false, &buf); err != nil {
+		t.Fatalf("readLog: %v", err)
+	}
+
+	lines := splitLines(buf.String())
+	if len(lines) != 1 {
+		t.Fatalf("got %d lines, want 1", len(lines))
+	}
+	// RFC3339 has a 'T' separator: 2006-01-02T15:04:05Z
+	if !strings.Contains(lines[0], "T") || !strings.Contains(lines[0], "Z") {
+		t.Errorf("line %q does not look like RFC3339 prefix", lines[0])
+	}
+}
+
+// TestLogsCmd_ParseSince_Duration verifies duration parsing.
+func TestLogsCmd_ParseSince_Duration(t *testing.T) {
+	before := time.Now().UTC().Add(-5 * time.Minute)
+	got, err := parseSince("5m")
+	if err != nil {
+		t.Fatalf("parseSince(5m): %v", err)
+	}
+	after := time.Now().UTC().Add(-5 * time.Minute)
+	if got.Before(before.Add(-time.Second)) || got.After(after.Add(time.Second)) {
+		t.Errorf("parseSince(5m) = %v, expected ~%v", got, before)
+	}
+}
+
+// TestLogsCmd_ParseSince_RFC3339 verifies RFC3339 parsing fallback.
+func TestLogsCmd_ParseSince_RFC3339(t *testing.T) {
+	ts := "2025-01-15T10:00:00Z"
+	got, err := parseSince(ts)
+	if err != nil {
+		t.Fatalf("parseSince RFC3339: %v", err)
+	}
+	want, _ := time.Parse(time.RFC3339, ts)
+	if !got.Equal(want) {
+		t.Errorf("parseSince RFC3339 = %v, want %v", got, want)
+	}
+}
+
+// TestLogsCmd_NonExistentLog verifies that a missing log file is not an error.
+func TestLogsCmd_NonExistentLog(t *testing.T) {
+	workspaceDir := t.TempDir()
+	logPath := resolveLogPath(workspaceDir, "ghost", false)
+
+	var buf bytes.Buffer
+	c := &LogsCmd{Slot: "ghost"}
+	if err := readLog(logPath, c, time.Time{}, false, &buf); err != nil {
+		t.Errorf("readLog on missing file should not error, got: %v", err)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("readLog on missing file should produce no output, got: %q", buf.String())
+	}
+}
+
+// splitLines returns non-empty lines from s.
+func splitLines(s string) []string {
+	var out []string
+	for _, line := range strings.Split(s, "\n") {
+		if line != "" {
+			out = append(out, line)
+		}
+	}
+	return out
+}

--- a/cli/swarm.go
+++ b/cli/swarm.go
@@ -21,14 +21,15 @@ import (
 // prompts run them as plain shell commands; the orchestrator skill
 // (R6 follow-up) renders them inline.
 type SwarmCmd struct {
-	Join   SwarmJoinCmd   `cmd:"" help:"Open a leaf, claim a task, prepare a worktree"`
-	Commit SwarmCommitCmd `cmd:"" help:"Commit changes (heartbeats the session)"`
-	Close  SwarmCloseCmd  `cmd:"" help:"Release claim, post result, stop the leaf"`
-	Status SwarmStatusCmd `cmd:"" help:"List active swarm sessions"`
-	Cwd    SwarmCwdCmd    `cmd:"" help:"Print the slot's worktree path"`
-	Tasks  SwarmTasksCmd  `cmd:"" help:"List ready tasks matching slot"`
-	FanIn  SwarmFanInCmd  `cmd:"" name:"fan-in" help:"Merge open hub leaves into trunk"`
-	Reap   SwarmReapCmd   `cmd:"" help:"Force-close stale same-host sessions as result=fail"`
+	Join     SwarmJoinCmd     `cmd:"" help:"Open a leaf, claim a task, prepare a worktree"`
+	Commit   SwarmCommitCmd   `cmd:"" help:"Commit changes (heartbeats the session)"`
+	Close    SwarmCloseCmd    `cmd:"" help:"Release claim, post result, stop the leaf"`
+	Status   SwarmStatusCmd   `cmd:"" help:"List active swarm sessions"`
+	Cwd      SwarmCwdCmd      `cmd:"" help:"Print the slot's worktree path"`
+	Tasks    SwarmTasksCmd    `cmd:"" help:"List ready tasks matching slot"`
+	FanIn    SwarmFanInCmd    `cmd:"" name:"fan-in" help:"Merge open hub leaves into trunk"`
+	Reap     SwarmReapCmd     `cmd:"" help:"Force-close stale same-host sessions as result=fail"`
+	Dispatch SwarmDispatchCmd `cmd:"" help:"Dispatch a plan: create tasks + write manifest"`
 }
 
 // openSwarmSessions dials NATS for the workspace and opens a swarm

--- a/cli/swarm_close.go
+++ b/cli/swarm_close.go
@@ -73,14 +73,21 @@ func (c *SwarmCloseCmd) Run(g *libfossilcli.Globals) error {
 		"swarm close: slot=%s task=%s result=%s\n",
 		lease.Slot(), lease.TaskID(), c.Result,
 	)
+	closeFields := map[string]interface{}{
+		"result":  c.Result,
+		"summary": c.Summary,
+	}
+	// Per b61574e, the no-artifact reason must appear in the audit trail
+	// so post-hoc inspection can distinguish legitimate artifact-free closes
+	// from silent precondition violations.
+	if c.NoArtifact != "" {
+		closeFields["no_artifact"] = c.NoArtifact
+	}
 	appendSlotEvent(info.WorkspaceDir, lease.Slot(), logwriter.Event{
 		Timestamp: timeNow(),
 		Slot:      lease.Slot(),
 		Event:     logwriter.EventClose,
-		Fields: map[string]interface{}{
-			"result":  c.Result,
-			"summary": c.Summary,
-		},
+		Fields:    closeFields,
 	})
 	return nil
 }

--- a/cli/swarm_close.go
+++ b/cli/swarm_close.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/danmestas/bones/internal/coord"
 	"github.com/danmestas/bones/internal/dispatch"
+	"github.com/danmestas/bones/internal/logwriter"
 	"github.com/danmestas/bones/internal/swarm"
 	"github.com/danmestas/bones/internal/workspace"
 )
@@ -72,6 +73,15 @@ func (c *SwarmCloseCmd) Run(g *libfossilcli.Globals) error {
 		"swarm close: slot=%s task=%s result=%s\n",
 		lease.Slot(), lease.TaskID(), c.Result,
 	)
+	appendSlotEvent(info.WorkspaceDir, lease.Slot(), logwriter.Event{
+		Timestamp: timeNow(),
+		Slot:      lease.Slot(),
+		Event:     logwriter.EventClose,
+		Fields: map[string]interface{}{
+			"result":  c.Result,
+			"summary": c.Summary,
+		},
+	})
 	return nil
 }
 

--- a/cli/swarm_commit.go
+++ b/cli/swarm_commit.go
@@ -9,6 +9,7 @@ import (
 	libfossilcli "github.com/danmestas/libfossil/cli"
 
 	"github.com/danmestas/bones/internal/coord"
+	"github.com/danmestas/bones/internal/logwriter"
 	"github.com/danmestas/bones/internal/swarm"
 	"github.com/danmestas/bones/internal/workspace"
 )
@@ -49,9 +50,25 @@ func (c *SwarmCommitCmd) Run(g *libfossilcli.Globals) error {
 	}
 	res, err := lease.Commit(ctx, c.Message, files)
 	if err != nil {
+		appendSlotEvent(info.WorkspaceDir, lease.Slot(), logwriter.Event{
+			Timestamp: timeNow(),
+			Slot:      lease.Slot(),
+			Event:     logwriter.EventCommitError,
+			Fields:    map[string]interface{}{"reason": err.Error()},
+		})
 		return fmt.Errorf("swarm commit: %w", err)
 	}
 	c.emitCommitReport(lease.Slot(), lease.TaskID(), files, res, resolveHubURL(c.HubURL))
+	appendSlotEvent(info.WorkspaceDir, lease.Slot(), logwriter.Event{
+		Timestamp: timeNow(),
+		Slot:      lease.Slot(),
+		Event:     logwriter.EventCommit,
+		Fields: map[string]interface{}{
+			"message": c.Message,
+			"sha":     res.UUID,
+			"files":   len(files),
+		},
+	})
 	return nil
 }
 

--- a/cli/swarm_dispatch.go
+++ b/cli/swarm_dispatch.go
@@ -1,0 +1,278 @@
+package cli
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/google/uuid"
+
+	libfossilcli "github.com/danmestas/libfossil/cli"
+
+	"github.com/danmestas/bones/internal/dispatch"
+	"github.com/danmestas/bones/internal/tasks"
+	"github.com/danmestas/bones/internal/workspace"
+)
+
+// SwarmDispatchCmd implements `bones swarm dispatch`.
+//
+// Without a flag, it reads a plan file, creates one task per slot via the
+// bones-tasks KV, writes a dispatch manifest, and prints the manifest path
+// with a next-step instruction for the orchestrator skill.
+//
+// --advance checks whether all tasks in the current wave are Closed; if so
+// it promotes CurrentWave to the next wave number and rewrites the manifest.
+//
+// --cancel removes the manifest and closes any referenced tasks with
+// ClosedReason="dispatch-canceled".
+//
+// --dry-run validates the plan (or checks advance/cancel preconditions)
+// without touching NATS or the filesystem.
+type SwarmDispatchCmd struct {
+	PlanPath string `arg:"" optional:"" name:"plan" help:"path to plan markdown"`
+	Advance  bool   `name:"advance" help:"check current wave; promote if all tasks Closed"`
+	Cancel   bool   `name:"cancel" help:"abandon in-flight dispatch; closes tasks as canceled"`
+	Wave     int    `name:"wave" help:"explicit wave number (rare; for testing)"`
+	JSON     bool   `name:"json" help:"emit manifest path + summary as JSON"`
+	DryRun   bool   `name:"dry-run" help:"validate; don't touch NATS or filesystem"`
+}
+
+// Run dispatches to the appropriate subcommand based on which flag is set.
+func (c *SwarmDispatchCmd) Run(g *libfossilcli.Globals) error {
+	// Validate mode before touching the workspace so the usage error is fast.
+	if !c.Cancel && !c.Advance && c.PlanPath == "" {
+		return fmt.Errorf("usage: bones swarm dispatch <plan> | --advance | --cancel")
+	}
+
+	ctx := context.Background()
+	cwd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	info, err := workspace.Join(ctx, cwd)
+	if err != nil {
+		return err
+	}
+	switch {
+	case c.Cancel:
+		return c.runCancel(ctx, info)
+	case c.Advance:
+		return c.runAdvance(ctx, info)
+	default:
+		return c.runDispatch(ctx, info, c.PlanPath)
+	}
+}
+
+// dispatchSummaryJSON is the --json output shape for runDispatch.
+type dispatchSummaryJSON struct {
+	ManifestPath string `json:"manifest_path"`
+	TaskCount    int    `json:"task_count"`
+	PlanSHA256   string `json:"plan_sha256"`
+}
+
+// planSHA256 computes the hex-encoded SHA-256 of a plan file's bytes.
+// Matches the hash BuildManifest stores so re-dispatch detection is consistent.
+func planSHA256(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+// runDispatch validates the plan, creates tasks, builds and writes the
+// manifest, then prints a summary or --json output.
+func (c *SwarmDispatchCmd) runDispatch(
+	ctx context.Context, info workspace.Info, planPath string,
+) error {
+	// 1. Validate plan.
+	res, exitCode := runValidatePlan(planPath)
+	if exitCode != 0 {
+		for _, e := range res.Errors {
+			fmt.Fprintln(os.Stderr, e)
+		}
+		return fmt.Errorf("dispatch: plan %q has %d validation error(s)", planPath, len(res.Errors))
+	}
+	if c.DryRun {
+		fmt.Printf("dispatch: --dry-run: %q valid (%d slot(s)); no tasks or manifest written\n",
+			planPath, len(res.Slots))
+		return nil
+	}
+
+	// 2. Guard against a conflicting in-flight dispatch.
+	if err := guardExistingDispatch(info.WorkspaceDir, planPath); err != nil {
+		return err
+	}
+
+	// 3-5. Create tasks and write manifest.
+	m, taskIDs, err := createTasksAndManifest(ctx, info, planPath, res.Slots)
+	if err != nil {
+		return err
+	}
+
+	// 6. Output summary.
+	return c.printDispatchResult(info.WorkspaceDir, planPath, m, taskIDs)
+}
+
+// guardExistingDispatch returns an error when a manifest with a different plan
+// SHA already exists, preventing accidental cross-plan clobbers.
+func guardExistingDispatch(workspaceDir, planPath string) error {
+	existing, err := dispatch.Read(workspaceDir)
+	if errors.Is(err, dispatch.ErrNoManifest) {
+		return nil // no manifest — safe to proceed
+	}
+	if err != nil {
+		return fmt.Errorf("dispatch: read existing manifest: %w", err)
+	}
+	sha, shaErr := planSHA256(planPath)
+	if shaErr != nil {
+		return fmt.Errorf("dispatch: compute plan sha: %w", shaErr)
+	}
+	if existing.PlanSHA256 != sha {
+		return fmt.Errorf(
+			"dispatch: in-flight dispatch exists (manifest at %s); "+
+				"run `--cancel` first or `--advance` to promote the wave",
+			dispatch.Path(workspaceDir),
+		)
+	}
+	return nil // same plan — idempotent re-emit
+}
+
+// createTasksAndManifest creates one bones-task per slot and writes the manifest.
+func createTasksAndManifest(
+	ctx context.Context,
+	info workspace.Info,
+	planPath string,
+	slots []slotEntry,
+) (dispatch.Manifest, map[string]string, error) {
+	mgr, closeMgr, err := openManager(ctx, info)
+	if err != nil {
+		return dispatch.Manifest{}, nil, fmt.Errorf("dispatch: open manager: %w", err)
+	}
+	defer closeMgr()
+	defer func() { _ = mgr.Close() }()
+
+	taskIDs := make(map[string]string, len(slots))
+	now := time.Now().UTC()
+	for _, s := range slots {
+		id := uuid.NewString()
+		t := tasks.Task{
+			ID:            id,
+			Title:         s.Name,
+			Status:        tasks.StatusOpen,
+			Files:         []string{},
+			Context:       map[string]string{"slot": s.Name},
+			CreatedAt:     now,
+			UpdatedAt:     now,
+			SchemaVersion: tasks.SchemaVersion,
+		}
+		if err := mgr.Create(ctx, t); err != nil {
+			return dispatch.Manifest{}, nil,
+				fmt.Errorf("dispatch: create task for slot %q: %w", s.Name, err)
+		}
+		taskIDs[s.Name] = id
+	}
+
+	m, err := dispatch.BuildManifest(dispatch.BuildOptions{PlanPath: planPath, TaskIDs: taskIDs})
+	if err != nil {
+		return dispatch.Manifest{}, nil, fmt.Errorf("dispatch: build manifest: %w", err)
+	}
+	if err := dispatch.Write(info.WorkspaceDir, m); err != nil {
+		return dispatch.Manifest{}, nil, fmt.Errorf("dispatch: write manifest: %w", err)
+	}
+	return m, taskIDs, nil
+}
+
+// printDispatchResult prints the dispatch summary to stdout (or JSON when --json).
+func (c *SwarmDispatchCmd) printDispatchResult(
+	workspaceDir, planPath string,
+	m dispatch.Manifest,
+	taskIDs map[string]string,
+) error {
+	manifestPath := dispatch.Path(workspaceDir)
+	if c.JSON {
+		out := dispatchSummaryJSON{
+			ManifestPath: manifestPath,
+			TaskCount:    len(taskIDs),
+			PlanSHA256:   m.PlanSHA256,
+		}
+		return json.NewEncoder(os.Stdout).Encode(out)
+	}
+	fmt.Printf("dispatch: created %d task(s) from %q\n", len(taskIDs), planPath)
+	fmt.Printf("dispatch: manifest written to %s\n", manifestPath)
+	fmt.Println("dispatch: next step — run `bones swarm dispatch --advance` after wave 1 completes")
+	return nil
+}
+
+// runAdvance opens the task manager, wires an isClosed shim, calls
+// dispatch.Advance, and prints the promoted wave number.
+func (c *SwarmDispatchCmd) runAdvance(ctx context.Context, info workspace.Info) error {
+	mgr, closeMgr, err := openManager(ctx, info)
+	if err != nil {
+		return fmt.Errorf("dispatch advance: open manager: %w", err)
+	}
+	defer closeMgr()
+	defer func() { _ = mgr.Close() }()
+
+	isClosed := func(taskID string) (bool, error) {
+		t, _, err := mgr.Get(ctx, taskID)
+		if err != nil {
+			return false, err
+		}
+		return t.Status == tasks.StatusClosed, nil
+	}
+
+	updated, err := dispatch.Advance(info.WorkspaceDir, isClosed)
+	if err != nil {
+		if errors.Is(err, dispatch.ErrWaveIncomplete) {
+			fmt.Fprintf(os.Stderr, "dispatch: %v\n", err)
+			return fmt.Errorf("dispatch advance: wave not yet complete")
+		}
+		if errors.Is(err, dispatch.ErrAllWavesComplete) {
+			fmt.Println("dispatch: all waves complete — dispatch is finished")
+			return nil
+		}
+		return err
+	}
+	fmt.Printf("dispatch: advanced to wave %d of %d\n", updated.CurrentWave, len(updated.Waves))
+	return nil
+}
+
+// runCancel opens the task manager, wires a closeTask shim that uses
+// mgr.Update to set each task to Closed with the cancel reason,
+// calls dispatch.Cancel, and prints a confirmation.
+func (c *SwarmDispatchCmd) runCancel(ctx context.Context, info workspace.Info) error {
+	mgr, closeMgr, err := openManager(ctx, info)
+	if err != nil {
+		return fmt.Errorf("dispatch cancel: open manager: %w", err)
+	}
+	defer closeMgr()
+	defer func() { _ = mgr.Close() }()
+
+	closeTask := func(taskID, reason string) error {
+		return mgr.Update(ctx, taskID, func(t tasks.Task) (tasks.Task, error) {
+			now := time.Now().UTC()
+			t.Status = tasks.StatusClosed
+			t.ClosedAt = &now
+			if t.ClaimedBy != "" {
+				t.ClosedBy = t.ClaimedBy
+			}
+			t.ClaimedBy = ""
+			t.ClosedReason = reason
+			t.UpdatedAt = now
+			return t, nil
+		})
+	}
+
+	if err := dispatch.Cancel(info.WorkspaceDir, closeTask); err != nil {
+		return err
+	}
+	fmt.Println("dispatch: canceled and manifest removed")
+	return nil
+}

--- a/cli/swarm_dispatch_test.go
+++ b/cli/swarm_dispatch_test.go
@@ -1,0 +1,366 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/danmestas/bones/internal/dispatch"
+	"github.com/danmestas/bones/internal/tasks"
+	"github.com/danmestas/bones/internal/testutil/natstest"
+	"github.com/danmestas/bones/internal/workspace"
+)
+
+// minimalPlan is a two-slot plan that passes validate-plan checks.
+// Each slot owns a distinct directory so directory-disjoint validation passes.
+const minimalPlan = `# Test Plan
+
+### Task 1 [slot: alpha]
+
+**Files:**
+  - Create: alpha/main.go
+
+### Task 2 [slot: beta]
+
+**Files:**
+  - Create: beta/main.go
+`
+
+// writePlan writes content to a temporary file and returns its path.
+func writePlan(t *testing.T, content string) string {
+	t.Helper()
+	f, err := os.CreateTemp(t.TempDir(), "plan-*.md")
+	if err != nil {
+		t.Fatalf("create plan file: %v", err)
+	}
+	if _, err := f.WriteString(content); err != nil {
+		_ = f.Close()
+		t.Fatalf("write plan file: %v", err)
+	}
+	_ = f.Close()
+	return f.Name()
+}
+
+// --- Task 5: struct + flag dispatch ---
+
+// TestSwarmDispatchCmd_DefaultError verifies that calling Run with no plan
+// path and no mode flag returns the usage error.
+func TestSwarmDispatchCmd_DefaultError(t *testing.T) {
+	cmd := &SwarmDispatchCmd{}
+	err := cmd.Run(nil)
+	if err == nil {
+		t.Fatal("want error; got nil")
+	}
+	const want = "usage: bones swarm dispatch <plan> | --advance | --cancel"
+	if err.Error() != want {
+		t.Fatalf("error = %q, want %q", err.Error(), want)
+	}
+}
+
+// TestSwarmDispatchCmd_DryRunValidates verifies --dry-run validates a plan
+// without touching NATS or writing a manifest.
+func TestSwarmDispatchCmd_DryRunValidates(t *testing.T) {
+	planPath := writePlan(t, minimalPlan)
+	workDir := t.TempDir()
+
+	cmd := &SwarmDispatchCmd{DryRun: true}
+	info := workspace.Info{
+		WorkspaceDir: workDir,
+		NATSURL:      "nats://127.0.0.1:1", // unreachable; dry-run must not connect
+	}
+	if err := cmd.runDispatch(context.Background(), info, planPath); err != nil {
+		t.Fatalf("runDispatch --dry-run: %v", err)
+	}
+	if _, err := os.Stat(dispatch.Path(workDir)); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("manifest written during --dry-run; want ErrNotExist, got %v", err)
+	}
+}
+
+// TestSwarmDispatchCmd_InvalidPlan verifies that a plan without slot
+// annotations is rejected before any NATS calls.
+func TestSwarmDispatchCmd_InvalidPlan(t *testing.T) {
+	badPlan := writePlan(t, "### Task 1\n\n**Files:**\n  - Create: foo/main.go\n")
+	workDir := t.TempDir()
+
+	cmd := &SwarmDispatchCmd{}
+	info := workspace.Info{
+		WorkspaceDir: workDir,
+		NATSURL:      "nats://127.0.0.1:1",
+	}
+	err := cmd.runDispatch(context.Background(), info, badPlan)
+	if err == nil {
+		t.Fatal("want error for invalid plan; got nil")
+	}
+}
+
+// --- Task 6: runDispatch writes manifest ---
+
+// TestSwarmDispatch_WritesManifest verifies that runDispatch creates tasks
+// and writes a manifest whose slot count matches the plan.
+func TestSwarmDispatch_WritesManifest(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping NATS test in -short mode")
+	}
+	nc, cleanup := natstest.NewJetStreamServer(t)
+	defer cleanup()
+
+	workDir := t.TempDir()
+	planPath := writePlan(t, minimalPlan)
+
+	cmd := &SwarmDispatchCmd{}
+	info := workspace.Info{
+		WorkspaceDir: workDir,
+		NATSURL:      nc.ConnectedUrl(),
+	}
+
+	if err := cmd.runDispatch(context.Background(), info, planPath); err != nil {
+		t.Fatalf("runDispatch: %v", err)
+	}
+
+	m, err := dispatch.Read(workDir)
+	if err != nil {
+		t.Fatalf("read manifest: %v", err)
+	}
+	if len(m.Waves) == 0 {
+		t.Fatal("manifest has no waves")
+	}
+	wave := m.Waves[0]
+	if len(wave.Slots) != 2 {
+		t.Fatalf("slot count = %d, want 2", len(wave.Slots))
+	}
+	for _, s := range wave.Slots {
+		if s.TaskID == "" {
+			t.Errorf("slot %q has empty task ID", s.Slot)
+		}
+	}
+	if m.PlanSHA256 == "" {
+		t.Error("PlanSHA256 is empty")
+	}
+}
+
+// TestSwarmDispatch_ConflictDifferentPlan verifies that dispatching a second
+// different plan while a manifest already exists returns an error.
+func TestSwarmDispatch_ConflictDifferentPlan(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping NATS test in -short mode")
+	}
+	nc, cleanup := natstest.NewJetStreamServer(t)
+	defer cleanup()
+
+	workDir := t.TempDir()
+	planPath := writePlan(t, minimalPlan)
+
+	cmd := &SwarmDispatchCmd{}
+	info := workspace.Info{
+		WorkspaceDir: workDir,
+		NATSURL:      nc.ConnectedUrl(),
+	}
+
+	if err := cmd.runDispatch(context.Background(), info, planPath); err != nil {
+		t.Fatalf("first runDispatch: %v", err)
+	}
+
+	otherPlan := writePlan(t,
+		minimalPlan+"\n### Task 3 [slot: gamma]\n\n**Files:**\n  - Create: gamma/main.go\n")
+	err := cmd.runDispatch(context.Background(), info, otherPlan)
+	if err == nil {
+		t.Fatal("want error for conflicting dispatch; got nil")
+	}
+}
+
+// --- Task 7: runAdvance ---
+
+// TestSwarmDispatch_Advance_WaveIncomplete verifies ErrWaveIncomplete handling
+// when tasks are still open.
+func TestSwarmDispatch_Advance_WaveIncomplete(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping NATS test in -short mode")
+	}
+	nc, cleanup := natstest.NewJetStreamServer(t)
+	defer cleanup()
+
+	workDir := t.TempDir()
+	planPath := writePlan(t, minimalPlan)
+
+	info := workspace.Info{
+		WorkspaceDir: workDir,
+		NATSURL:      nc.ConnectedUrl(),
+	}
+
+	cmd := &SwarmDispatchCmd{}
+	if err := cmd.runDispatch(context.Background(), info, planPath); err != nil {
+		t.Fatalf("runDispatch: %v", err)
+	}
+
+	advCmd := &SwarmDispatchCmd{Advance: true}
+	err := advCmd.runAdvance(context.Background(), info)
+	if err == nil {
+		t.Fatal("want error (wave incomplete); got nil")
+	}
+}
+
+// TestSwarmDispatch_Advance_AllWavesComplete verifies that after closing all
+// tasks in a single-wave dispatch, runAdvance reports all waves complete.
+func TestSwarmDispatch_Advance_AllWavesComplete(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping NATS test in -short mode")
+	}
+	nc, cleanup := natstest.NewJetStreamServer(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	workDir := t.TempDir()
+	planPath := writePlan(t, minimalPlan)
+
+	info := workspace.Info{
+		WorkspaceDir: workDir,
+		NATSURL:      nc.ConnectedUrl(),
+	}
+
+	cmd := &SwarmDispatchCmd{}
+	if err := cmd.runDispatch(ctx, info, planPath); err != nil {
+		t.Fatalf("runDispatch: %v", err)
+	}
+
+	m, err := dispatch.Read(workDir)
+	if err != nil {
+		t.Fatalf("read manifest: %v", err)
+	}
+
+	mgr, closeMgr, err := openManager(ctx, info)
+	if err != nil {
+		t.Fatalf("open manager: %v", err)
+	}
+	defer closeMgr()
+	defer func() { _ = mgr.Close() }()
+
+	now := time.Now().UTC()
+	for _, s := range m.Waves[0].Slots {
+		if err := mgr.Update(ctx, s.TaskID, func(t tasks.Task) (tasks.Task, error) {
+			t.Status = tasks.StatusClosed
+			t.ClosedAt = &now
+			t.ClosedReason = "done"
+			t.UpdatedAt = now
+			return t, nil
+		}); err != nil {
+			t.Fatalf("close task %s: %v", s.TaskID, err)
+		}
+	}
+
+	advCmd := &SwarmDispatchCmd{Advance: true}
+	// Single-wave dispatch: ErrAllWavesComplete is handled gracefully (returns nil).
+	if err := advCmd.runAdvance(ctx, info); err != nil {
+		t.Fatalf("runAdvance after all tasks closed: %v", err)
+	}
+}
+
+// --- Task 8: runCancel ---
+
+// TestSwarmDispatch_Cancel_ClosesTasksAndRemovesManifest verifies that
+// runCancel closes every referenced task and removes the manifest file.
+func TestSwarmDispatch_Cancel_ClosesTasksAndRemovesManifest(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping NATS test in -short mode")
+	}
+	nc, cleanup := natstest.NewJetStreamServer(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	workDir := t.TempDir()
+
+	info := workspace.Info{
+		WorkspaceDir: workDir,
+		NATSURL:      nc.ConnectedUrl(),
+	}
+
+	mgr, closeMgr, err := openManager(ctx, info)
+	if err != nil {
+		t.Fatalf("open manager: %v", err)
+	}
+	defer closeMgr()
+	defer func() { _ = mgr.Close() }()
+
+	now := time.Now().UTC()
+	id1 := uuid.NewString()
+	id2 := uuid.NewString()
+	for _, id := range []string{id1, id2} {
+		task := tasks.Task{
+			ID:            id,
+			Title:         "test-" + id[:8],
+			Status:        tasks.StatusOpen,
+			Files:         []string{},
+			CreatedAt:     now,
+			UpdatedAt:     now,
+			SchemaVersion: tasks.SchemaVersion,
+		}
+		if err := mgr.Create(ctx, task); err != nil {
+			t.Fatalf("create task %s: %v", id, err)
+		}
+	}
+
+	seededManifest := dispatch.Manifest{
+		SchemaVersion: dispatch.SchemaVersion,
+		PlanPath:      "/tmp/test-plan.md",
+		PlanSHA256:    "abc123",
+		CreatedAt:     now,
+		CurrentWave:   1,
+		Waves: []dispatch.Wave{{
+			Wave: 1,
+			Slots: []dispatch.SlotEntry{
+				{Slot: "alpha", TaskID: id1, Title: "alpha"},
+				{Slot: "beta", TaskID: id2, Title: "beta"},
+			},
+		}},
+	}
+	if err := dispatch.Write(workDir, seededManifest); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	cancelCmd := &SwarmDispatchCmd{Cancel: true}
+	if err := cancelCmd.runCancel(ctx, info); err != nil {
+		t.Fatalf("runCancel: %v", err)
+	}
+
+	if _, err := os.Stat(dispatch.Path(workDir)); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("manifest still exists after cancel; want ErrNotExist, got %v", err)
+	}
+
+	for _, id := range []string{id1, id2} {
+		task, _, err := mgr.Get(ctx, id)
+		if err != nil {
+			t.Fatalf("get task %s: %v", id, err)
+		}
+		if task.Status != tasks.StatusClosed {
+			t.Errorf("task %s status = %q, want %q", id, task.Status, tasks.StatusClosed)
+		}
+		if task.ClosedReason != dispatch.CancelReason {
+			t.Errorf("task %s ClosedReason = %q, want %q",
+				id, task.ClosedReason, dispatch.CancelReason)
+		}
+	}
+}
+
+// TestSwarmDispatch_Cancel_NoManifest verifies that runCancel is a no-op
+// when no manifest exists.
+func TestSwarmDispatch_Cancel_NoManifest(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping NATS test in -short mode")
+	}
+	nc, cleanup := natstest.NewJetStreamServer(t)
+	defer cleanup()
+
+	workDir := t.TempDir()
+	info := workspace.Info{
+		WorkspaceDir: workDir,
+		NATSURL:      nc.ConnectedUrl(),
+	}
+
+	cancelCmd := &SwarmDispatchCmd{Cancel: true}
+	if err := cancelCmd.runCancel(context.Background(), info); err != nil {
+		t.Fatalf("runCancel with no manifest: %v", err)
+	}
+}

--- a/cli/swarm_helpers.go
+++ b/cli/swarm_helpers.go
@@ -18,10 +18,13 @@ func timeNow() time.Time {
 // appendSlotEvent writes one event to the per-slot log at
 // <workspaceDir>/.bones/swarm/<slot>/log. Failures are non-fatal:
 // a warning is emitted to slog and the caller continues normally.
+//
+// Uses logwriter.AppendOnce directly — per-slot logs never rotate, so the
+// stateful Writer struct's rotation bookkeeping is wasted at this call site.
 func appendSlotEvent(workspaceDir, slot string, e logwriter.Event) {
 	slotDir := filepath.Join(workspaceDir, ".bones", "swarm", slot)
-	w := logwriter.OpenSlot(slotDir, slot)
-	if err := w.Append(e); err != nil {
+	path := logwriter.SlotLogPath(slotDir, slot)
+	if err := logwriter.AppendOnce(path, e); err != nil {
 		slog.Warn("logwriter append failed (non-fatal)", "slot", slot, "err", err)
 	}
 }

--- a/cli/swarm_helpers.go
+++ b/cli/swarm_helpers.go
@@ -1,7 +1,11 @@
 package cli
 
 import (
+	"log/slog"
+	"path/filepath"
 	"time"
+
+	"github.com/danmestas/bones/internal/logwriter"
 )
 
 // timeNow is the time source for swarm verbs. Plain wrapper today;
@@ -9,4 +13,15 @@ import (
 // clock in unit tests) is a one-line change rather than a refactor.
 func timeNow() time.Time {
 	return time.Now().UTC()
+}
+
+// appendSlotEvent writes one event to the per-slot log at
+// <workspaceDir>/.bones/swarm/<slot>/log. Failures are non-fatal:
+// a warning is emitted to slog and the caller continues normally.
+func appendSlotEvent(workspaceDir, slot string, e logwriter.Event) {
+	slotDir := filepath.Join(workspaceDir, ".bones", "swarm", slot)
+	w := logwriter.OpenSlot(slotDir, slot)
+	if err := w.Append(e); err != nil {
+		slog.Warn("logwriter append failed (non-fatal)", "slot", slot, "err", err)
+	}
 }

--- a/cli/swarm_join.go
+++ b/cli/swarm_join.go
@@ -7,6 +7,7 @@ import (
 
 	libfossilcli "github.com/danmestas/libfossil/cli"
 
+	"github.com/danmestas/bones/internal/logwriter"
 	"github.com/danmestas/bones/internal/swarm"
 	"github.com/danmestas/bones/internal/workspace"
 )
@@ -63,6 +64,15 @@ func (c *SwarmJoinCmd) run(ctx context.Context, info workspace.Info) error {
 		return fmt.Errorf("swarm join: %w", err)
 	}
 	c.emitJoinReport(lease)
+	appendSlotEvent(info.WorkspaceDir, lease.Slot(), logwriter.Event{
+		Timestamp: timeNow(),
+		Slot:      lease.Slot(),
+		Event:     logwriter.EventJoin,
+		Fields: map[string]interface{}{
+			"task_id":  lease.TaskID(),
+			"worktree": lease.WT(),
+		},
+	})
 	return lease.Release(ctx)
 }
 

--- a/cli/swarm_log_events_test.go
+++ b/cli/swarm_log_events_test.go
@@ -1,0 +1,217 @@
+package cli
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/danmestas/bones/internal/logwriter"
+)
+
+// --- Task 13: join event ---
+
+// TestAppendSlotEvent_JoinCreatesLog verifies that appendSlotEvent
+// writes a join event to <workspaceDir>/.bones/swarm/<slot>/log.
+func TestAppendSlotEvent_JoinCreatesLog(t *testing.T) {
+	workspaceDir := t.TempDir()
+	slot := "alpha"
+
+	appendSlotEvent(workspaceDir, slot, logwriter.Event{
+		Timestamp: time.Now().UTC(),
+		Slot:      slot,
+		Event:     logwriter.EventJoin,
+		Fields: map[string]interface{}{
+			"task_id":  "task-abc-123",
+			"worktree": filepath.Join(workspaceDir, ".bones", "swarm", slot, "wt"),
+		},
+	})
+
+	logPath := filepath.Join(workspaceDir, ".bones", "swarm", slot, "log")
+	b, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("ReadFile %s: %v", logPath, err)
+	}
+
+	var row map[string]interface{}
+	if err := json.Unmarshal(b[:len(b)-1], &row); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	if got := row["event"]; got != "join" {
+		t.Errorf("event=%q, want %q", got, "join")
+	}
+	if got := row["slot"]; got != slot {
+		t.Errorf("slot=%q, want %q", got, slot)
+	}
+	if got := row["task_id"]; got != "task-abc-123" {
+		t.Errorf("task_id=%q, want %q", got, "task-abc-123")
+	}
+	if row["ts"] == nil {
+		t.Error("ts field missing")
+	}
+}
+
+// --- Task 14: commit / commit_error events ---
+
+// TestAppendSlotEvent_CommitCreatesLog verifies that a commit event is
+// written with message, sha, and files count fields.
+func TestAppendSlotEvent_CommitCreatesLog(t *testing.T) {
+	workspaceDir := t.TempDir()
+	slot := "beta"
+
+	appendSlotEvent(workspaceDir, slot, logwriter.Event{
+		Timestamp: time.Now().UTC(),
+		Slot:      slot,
+		Event:     logwriter.EventCommit,
+		Fields: map[string]interface{}{
+			"message": "implement feature X",
+			"sha":     "deadbeef-uuid",
+			"files":   3,
+		},
+	})
+
+	logPath := filepath.Join(workspaceDir, ".bones", "swarm", slot, "log")
+	b, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("ReadFile %s: %v", logPath, err)
+	}
+
+	var row map[string]interface{}
+	if err := json.Unmarshal(b[:len(b)-1], &row); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	if got := row["event"]; got != "commit" {
+		t.Errorf("event=%q, want %q", got, "commit")
+	}
+	if got := row["message"]; got != "implement feature X" {
+		t.Errorf("message=%q, want %q", got, "implement feature X")
+	}
+	if got := row["sha"]; got != "deadbeef-uuid" {
+		t.Errorf("sha=%q, want %q", got, "deadbeef-uuid")
+	}
+	// JSON numbers decode to float64.
+	if got, ok := row["files"].(float64); !ok || int(got) != 3 {
+		t.Errorf("files=%v, want 3", row["files"])
+	}
+}
+
+// TestAppendSlotEvent_CommitErrorCreatesLog verifies that a commit_error
+// event is written with a reason field.
+func TestAppendSlotEvent_CommitErrorCreatesLog(t *testing.T) {
+	workspaceDir := t.TempDir()
+	slot := "gamma"
+
+	appendSlotEvent(workspaceDir, slot, logwriter.Event{
+		Timestamp: time.Now().UTC(),
+		Slot:      slot,
+		Event:     logwriter.EventCommitError,
+		Fields: map[string]interface{}{
+			"reason": "fork detected: ancestor mismatch",
+		},
+	})
+
+	logPath := filepath.Join(workspaceDir, ".bones", "swarm", slot, "log")
+	b, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("ReadFile %s: %v", logPath, err)
+	}
+
+	var row map[string]interface{}
+	if err := json.Unmarshal(b[:len(b)-1], &row); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	if got := row["event"]; got != "commit_error" {
+		t.Errorf("event=%q, want %q", got, "commit_error")
+	}
+	if got := row["reason"]; got != "fork detected: ancestor mismatch" {
+		t.Errorf("reason=%q, want %q", got, "fork detected: ancestor mismatch")
+	}
+}
+
+// --- Task 15: close event ---
+
+// TestAppendSlotEvent_CloseCreatesLog verifies that a close event is
+// written with result and summary fields.
+func TestAppendSlotEvent_CloseCreatesLog(t *testing.T) {
+	workspaceDir := t.TempDir()
+	slot := "delta"
+
+	appendSlotEvent(workspaceDir, slot, logwriter.Event{
+		Timestamp: time.Now().UTC(),
+		Slot:      slot,
+		Event:     logwriter.EventClose,
+		Fields: map[string]interface{}{
+			"result":  "success",
+			"summary": "all tests pass",
+		},
+	})
+
+	logPath := filepath.Join(workspaceDir, ".bones", "swarm", slot, "log")
+	b, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("ReadFile %s: %v", logPath, err)
+	}
+
+	var row map[string]interface{}
+	if err := json.Unmarshal(b[:len(b)-1], &row); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	if got := row["event"]; got != "close" {
+		t.Errorf("event=%q, want %q", got, "close")
+	}
+	if got := row["result"]; got != "success" {
+		t.Errorf("result=%q, want %q", got, "success")
+	}
+	if got := row["summary"]; got != "all tests pass" {
+		t.Errorf("summary=%q, want %q", got, "all tests pass")
+	}
+}
+
+// TestAppendSlotEvent_MultipleEvents verifies that multiple calls to
+// appendSlotEvent on the same slot produce multiple NDJSON lines.
+func TestAppendSlotEvent_MultipleEvents(t *testing.T) {
+	workspaceDir := t.TempDir()
+	slot := "epsilon"
+
+	events := []logwriter.EventType{
+		logwriter.EventJoin,
+		logwriter.EventCommit,
+		logwriter.EventClose,
+	}
+	for _, et := range events {
+		appendSlotEvent(workspaceDir, slot, logwriter.Event{
+			Timestamp: time.Now().UTC(),
+			Slot:      slot,
+			Event:     et,
+		})
+	}
+
+	logPath := filepath.Join(workspaceDir, ".bones", "swarm", slot, "log")
+	f, err := os.Open(logPath)
+	if err != nil {
+		t.Fatalf("Open %s: %v", logPath, err)
+	}
+	defer func() { _ = f.Close() }()
+
+	sc := bufio.NewScanner(f)
+	var lines []string
+	for sc.Scan() {
+		lines = append(lines, sc.Text())
+	}
+	if len(lines) != len(events) {
+		t.Fatalf("got %d lines, want %d", len(lines), len(events))
+	}
+	wantEvents := []string{"join", "commit", "close"}
+	for i, line := range lines {
+		var row map[string]interface{}
+		if err := json.Unmarshal([]byte(line), &row); err != nil {
+			t.Errorf("line %d: invalid JSON: %v", i, err)
+			continue
+		}
+		if got := row["event"]; got != wantEvents[i] {
+			t.Errorf("line %d event=%q, want %q", i, got, wantEvents[i])
+		}
+	}
+}

--- a/cli/swarm_status.go
+++ b/cli/swarm_status.go
@@ -60,9 +60,11 @@ func (c *SwarmStatusCmd) Run(g *libfossilcli.Globals) error {
 
 func (c *SwarmStatusCmd) run(ctx context.Context, info workspace.Info) error {
 	// Emit dispatch context line before the slot table when a manifest exists.
+	// Best-effort: a corrupt or unreadable manifest must not block the operator
+	// from inspecting live sessions (which is exactly when they need status most).
 	if !c.JSON {
 		if err := emitDispatchLine(info.WorkspaceDir); err != nil {
-			return err
+			fmt.Fprintf(os.Stderr, "swarm status: warning: dispatch line: %v\n", err)
 		}
 	}
 	sess, closeSess, err := openSwarmSessions(ctx, info)

--- a/cli/swarm_status.go
+++ b/cli/swarm_status.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -11,6 +12,7 @@ import (
 
 	libfossilcli "github.com/danmestas/libfossil/cli"
 
+	"github.com/danmestas/bones/internal/dispatch"
 	"github.com/danmestas/bones/internal/swarm"
 	"github.com/danmestas/bones/internal/workspace"
 )
@@ -57,6 +59,12 @@ func (c *SwarmStatusCmd) Run(g *libfossilcli.Globals) error {
 }
 
 func (c *SwarmStatusCmd) run(ctx context.Context, info workspace.Info) error {
+	// Emit dispatch context line before the slot table when a manifest exists.
+	if !c.JSON {
+		if err := emitDispatchLine(info.WorkspaceDir); err != nil {
+			return err
+		}
+	}
 	sess, closeSess, err := openSwarmSessions(ctx, info)
 	if err != nil {
 		return err
@@ -72,6 +80,21 @@ func (c *SwarmStatusCmd) run(ctx context.Context, info workspace.Info) error {
 		return emitStatusJSON(rows)
 	}
 	return emitStatusTable(rows)
+}
+
+// emitDispatchLine prints a single "Dispatch: ..." line when a dispatch
+// manifest is present in the workspace. Silent on ErrNoManifest.
+func emitDispatchLine(workspaceRoot string) error {
+	m, err := dispatch.Read(workspaceRoot)
+	if errors.Is(err, dispatch.ErrNoManifest) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	totalWaves := len(m.Waves)
+	fmt.Printf("Dispatch: %s  (wave %d of %d)\n", m.PlanPath, m.CurrentWave, totalWaves)
+	return nil
 }
 
 // buildStatusRows attaches a state label and a stale-seconds counter

--- a/cli/swarm_status_test.go
+++ b/cli/swarm_status_test.go
@@ -1,0 +1,106 @@
+package cli
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/danmestas/bones/internal/dispatch"
+)
+
+// TestEmitDispatchLine_NoManifest verifies that emitDispatchLine is silent
+// when no manifest exists.
+func TestEmitDispatchLine_NoManifest(t *testing.T) {
+	root := t.TempDir()
+
+	// Capture stdout.
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stdout = w
+
+	emitErr := emitDispatchLine(root)
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("close write pipe: %v", err)
+	}
+	os.Stdout = old
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, r); err != nil {
+		t.Fatalf("copy: %v", err)
+	}
+
+	if emitErr != nil {
+		t.Fatalf("emitDispatchLine with no manifest: %v", emitErr)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("expected no output with ErrNoManifest; got %q", buf.String())
+	}
+}
+
+// TestEmitDispatchLine_WithManifest verifies that emitDispatchLine prints
+// "Dispatch: <plan_path>  (wave N of M)" when a manifest is present, and
+// that the line appears before any other output.
+func TestEmitDispatchLine_WithManifest(t *testing.T) {
+	root := t.TempDir()
+
+	now := time.Now().UTC()
+	m := dispatch.Manifest{
+		SchemaVersion: dispatch.SchemaVersion,
+		PlanPath:      "/tmp/plans/my-plan.md",
+		PlanSHA256:    "abc123",
+		CreatedAt:     now,
+		CurrentWave:   1,
+		Waves: []dispatch.Wave{
+			{Wave: 1, Slots: []dispatch.SlotEntry{{Slot: "alpha", TaskID: "t1", Title: "Alpha"}}},
+			{Wave: 2, Slots: []dispatch.SlotEntry{{Slot: "beta", TaskID: "t2", Title: "Beta"}}},
+		},
+	}
+	if err := dispatch.Write(root, m); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	// Capture stdout.
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stdout = w
+
+	emitErr := emitDispatchLine(root)
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("close write pipe: %v", err)
+	}
+	os.Stdout = old
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, r); err != nil {
+		t.Fatalf("copy: %v", err)
+	}
+
+	if emitErr != nil {
+		t.Fatalf("emitDispatchLine: %v", emitErr)
+	}
+
+	out := buf.String()
+	want := fmt.Sprintf("Dispatch: %s  (wave %d of %d)\n", m.PlanPath, m.CurrentWave, len(m.Waves))
+	if !strings.HasPrefix(out, want) {
+		t.Errorf("output = %q\nwant prefix %q", out, want)
+	}
+}
+
+// TestBuildStatusRows_Empty verifies buildStatusRows returns an empty slice
+// for zero sessions.
+func TestBuildStatusRows_Empty(t *testing.T) {
+	rows := buildStatusRows(nil, "host", time.Now())
+	if len(rows) != 0 {
+		t.Errorf("expected 0 rows; got %d", len(rows))
+	}
+}

--- a/cmd/bones/cli.go
+++ b/cmd/bones/cli.go
@@ -18,6 +18,7 @@ type CLI struct {
 	Status bonescli.StatusCmd `cmd:"" group:"daily" help:"Snapshot tasks, sessions, hub activity"`
 	Tasks  bonescli.TasksCmd  `cmd:"" group:"daily" help:"Inspect and mutate runtime agent tasks"`
 	Swarm  bonescli.SwarmCmd  `cmd:"" group:"daily" help:"Run as a slot-shaped swarm participant"`
+	Logs   bonescli.LogsCmd   `cmd:"" group:"daily" help:"Read per-slot or workspace event logs"`
 	Apply  bonescli.ApplyCmd  `cmd:"" group:"daily" help:"Materialize hub trunk into git tree"`
 	Env    bonescli.EnvCmd    `cmd:"" group:"daily" help:"Emit shell exports for current workspace"`
 	Rename bonescli.RenameCmd `cmd:"" group:"daily" help:"Set workspace display name"`

--- a/docs/superpowers/plans/2026-05-01-dispatch-and-logs.md
+++ b/docs/superpowers/plans/2026-05-01-dispatch-and-logs.md
@@ -1,0 +1,1039 @@
+# Dispatch and Logs Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement `bones swarm dispatch` (manifest-emit verb that consumer skills spawn against) plus `bones logs` (per-slot and per-workspace NDJSON event log surface), per Spec 3.
+
+**Architecture:** Two new packages — `internal/dispatch/` (manifest schema, read/write/advance/cancel) and `internal/logwriter/` (atomic O_APPEND NDJSON writer + size-based rotation). New CLI verbs (`bones swarm dispatch <plan>` with `--advance`, `--cancel`, `--wave`, `--json`, `--dry-run`; `bones logs --slot=<name>` / `bones logs --workspace` with `--tail`, `--since`, `--last`, `--json`, `--full-time`). Existing `bones swarm join/commit/close` get instrumented to emit log events. Existing `bones swarm status` gets a dispatch-context line. Orchestrator skill (Claude-specific layer in `.claude/skills/orchestrator/`) is updated to consume the manifest.
+
+**Tech Stack:** Go 1.23+, Kong CLI framework, `crypto/sha256` for plan hashing, `encoding/json`, NATS JetStream KV (existing `bones-tasks` bucket via `internal/tasks`), standard `testing` package.
+
+**Spec:** `docs/superpowers/specs/2026-05-01-dispatch-and-logs-design.md`
+
+**Note on harness-agnostic boundary:** the spec references `reference/CAPABILITIES.md` (deleted from main since the spec was written). The boundary still holds — see `docs/harness-integration.md` and ADR 0023 (hub-leaf orchestrator). Implementation must NOT spawn subagents from the bones binary; the verb writes a manifest and exits.
+
+**Dependencies:** existing `bones-tasks` KV (ADR 0005), existing `validate-plan` CLI verb, existing `bones swarm join/commit/close` verbs (ADR 0028). No hard dependency on Specs 1 or 2.
+
+---
+
+## File structure
+
+```
+internal/
+  dispatch/
+    manifest.go             # NEW — schema + Read/Write
+    manifest_test.go        # NEW
+    advance.go              # NEW — wave-completion check + manifest mutation
+    advance_test.go         # NEW
+    cancel.go               # NEW — abandons in-flight dispatch
+    cancel_test.go          # NEW
+  logwriter/
+    writer.go               # NEW — O_APPEND NDJSON + rotation
+    writer_test.go          # NEW
+    events.go               # NEW — closed catalog of event types
+    events_test.go          # NEW
+
+cli/
+  swarm_dispatch.go         # NEW — bones swarm dispatch verb
+  swarm_dispatch_test.go    # NEW
+  swarm_status.go           # MODIFY — add dispatch-context header line
+  swarm_status_test.go      # MODIFY — test header
+  logs.go                   # NEW — bones logs verb
+  logs_test.go              # NEW
+
+internal/swarm/
+  session.go                # MODIFY — emit log events on Join/Commit/Close
+  session_test.go           # MODIFY — assert log events emitted
+
+cmd/bones/
+  cli.go                    # MODIFY — register dispatch (under Swarm), Logs
+
+.claude/skills/orchestrator/
+  SKILL.md                  # MODIFY — consume dispatch.json instead of plan path
+
+README.md                   # MODIFY — document dispatch + logs
+```
+
+---
+
+## Phase 1: Dispatch manifest (Tasks 1-4)
+
+### Task 1: Manifest struct + JSON round-trip
+
+**Files:** Create `internal/dispatch/manifest.go` and `internal/dispatch/manifest_test.go`.
+
+- [ ] **Step 1: Failing test**
+
+```go
+// internal/dispatch/manifest_test.go
+package dispatch
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestManifestJSON(t *testing.T) {
+	m := Manifest{
+		SchemaVersion: 1,
+		PlanPath:      "./plan.md",
+		PlanSHA256:    "abc123",
+		CreatedAt:     time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC),
+		CurrentWave:   1,
+		Waves: []Wave{
+			{
+				Wave: 1,
+				Slots: []SlotEntry{
+					{Slot: "a", TaskID: "t-1", Title: "auth", Files: []string{"auth/"}, SubagentPrompt: "..."},
+				},
+			},
+		},
+	}
+	data, err := json.Marshal(m)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var got Manifest
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if got.SchemaVersion != 1 {
+		t.Fatalf("SchemaVersion = %d, want 1", got.SchemaVersion)
+	}
+	if len(got.Waves) != 1 || len(got.Waves[0].Slots) != 1 {
+		t.Fatalf("waves/slots round-trip lost data: %+v", got)
+	}
+	if got.Waves[0].Slots[0].Slot != "a" {
+		t.Fatalf("slot name = %q, want a", got.Waves[0].Slots[0].Slot)
+	}
+}
+```
+
+- [ ] **Step 2: Run** — FAIL.
+
+- [ ] **Step 3: Implement**
+
+```go
+// internal/dispatch/manifest.go
+package dispatch
+
+import "time"
+
+// SchemaVersion of the dispatch manifest format. Bump when the schema
+// changes in a way that breaks consumer skills.
+const SchemaVersion = 1
+
+// Manifest is the dispatch contract written by `bones swarm dispatch`
+// and consumed by harness-specific orchestrator skills.
+type Manifest struct {
+	SchemaVersion int       `json:"schema_version"`
+	PlanPath      string    `json:"plan_path"`
+	PlanSHA256    string    `json:"plan_sha256"`
+	CreatedAt     time.Time `json:"created_at"`
+	CurrentWave   int       `json:"current_wave"`
+	Waves         []Wave    `json:"waves"`
+}
+
+// Wave is one parallelizable set of slots, blocked until prior waves complete.
+type Wave struct {
+	Wave             int         `json:"wave"`
+	BlockedUntilWave int         `json:"blocked_until_wave,omitempty"`
+	Slots            []SlotEntry `json:"slots"`
+}
+
+// SlotEntry is one slot's task assignment within a wave.
+type SlotEntry struct {
+	Slot           string   `json:"slot"`
+	TaskID         string   `json:"task_id"`
+	Title          string   `json:"title"`
+	Files          []string `json:"files"`
+	SubagentPrompt string   `json:"subagent_prompt"`
+}
+```
+
+- [ ] **Step 4: Run** — PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+unset GIT_DIR GIT_WORK_TREE; git add internal/dispatch/manifest.go internal/dispatch/manifest_test.go && git commit -m "feat(dispatch): add Manifest schema + JSON round-trip"
+```
+
+---
+
+### Task 2: Atomic Write + Read
+
+**Files:** modify `internal/dispatch/manifest.go`, append to test.
+
+- [ ] **Step 1: Failing test**
+
+```go
+import (
+	"errors"
+	"os"
+	"path/filepath"
+)
+
+func TestWriteRead(t *testing.T) {
+	root := t.TempDir()
+	m := Manifest{
+		SchemaVersion: 1, PlanPath: "./p.md", PlanSHA256: "x",
+		CreatedAt: time.Now().UTC().Truncate(time.Second), CurrentWave: 1,
+		Waves: []Wave{{Wave: 1, Slots: []SlotEntry{{Slot: "a", TaskID: "t1"}}}},
+	}
+	if err := Write(root, m); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	path := filepath.Join(root, ".bones", "swarm", "dispatch.json")
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("expected file at %s: %v", path, err)
+	}
+	got, err := Read(root)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if got.PlanSHA256 != "x" || got.CurrentWave != 1 {
+		t.Fatalf("round-trip mismatch: %+v", got)
+	}
+
+	if _, err := Read(t.TempDir()); !errors.Is(err, ErrNoManifest) {
+		t.Fatalf("expected ErrNoManifest for empty workspace, got %v", err)
+	}
+}
+```
+
+- [ ] **Step 2: Run** — FAIL.
+
+- [ ] **Step 3: Implement**
+
+```go
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// ErrNoManifest is returned by Read when no dispatch manifest exists in the workspace.
+var ErrNoManifest = errors.New("dispatch: no manifest in this workspace")
+
+// Path returns the manifest file path for a given workspace root.
+func Path(root string) string {
+	return filepath.Join(root, ".bones", "swarm", "dispatch.json")
+}
+
+// Write persists the manifest atomically (tmp+rename). Creates the
+// parent directory if needed.
+func Write(root string, m Manifest) error {
+	dst := Path(root)
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return fmt.Errorf("dispatch mkdir: %w", err)
+	}
+	data, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return fmt.Errorf("dispatch marshal: %w", err)
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(dst), filepath.Base(dst)+".tmp.*")
+	if err != nil {
+		return fmt.Errorf("dispatch tmp: %w", err)
+	}
+	defer func() { _ = os.Remove(tmp.Name()) }()
+	if _, err := tmp.Write(data); err != nil {
+		closeErr := tmp.Close()
+		return errors.Join(fmt.Errorf("dispatch write: %w", err), closeErr)
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("dispatch sync: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("dispatch close: %w", err)
+	}
+	return os.Rename(tmp.Name(), dst)
+}
+
+// Read loads the dispatch manifest for a workspace root.
+func Read(root string) (Manifest, error) {
+	data, err := os.ReadFile(Path(root))
+	if errors.Is(err, os.ErrNotExist) {
+		return Manifest{}, ErrNoManifest
+	}
+	if err != nil {
+		return Manifest{}, fmt.Errorf("dispatch read: %w", err)
+	}
+	var m Manifest
+	if err := json.Unmarshal(data, &m); err != nil {
+		return Manifest{}, fmt.Errorf("dispatch unmarshal: %w", err)
+	}
+	return m, nil
+}
+
+// Remove deletes the dispatch manifest. Idempotent.
+func Remove(root string) error {
+	err := os.Remove(Path(root))
+	if err == nil || errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	return fmt.Errorf("dispatch remove: %w", err)
+}
+```
+
+- [ ] **Step 4: Run** — PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+unset GIT_DIR GIT_WORK_TREE; git add internal/dispatch/manifest.go internal/dispatch/manifest_test.go && git commit -m "feat(dispatch): add atomic Write/Read/Remove with ErrNoManifest"
+```
+
+---
+
+### Task 3: Plan parser → manifest builder
+
+**Files:** modify `internal/dispatch/manifest.go`, append test.
+
+The existing `cli/validate_plan.go` parses `[slot: name]` markdown. Reuse its parser to extract slots/tasks/files; then wrap each into the manifest shape with subagent prompts.
+
+- [ ] **Step 1: Failing test**
+
+```go
+func TestBuildManifest(t *testing.T) {
+	planPath := writeTempPlan(t, `# Plan
+## Phase 1: Auth [slot: alpha]
+### Task 1: Edit alpha files [slot: alpha]
+**Files:**
+- Modify: alpha/x.go
+`)
+	m, err := BuildManifest(BuildOptions{
+		PlanPath: planPath,
+		TaskIDs:  map[string]string{"alpha": "t-alpha-1"},
+	})
+	if err != nil {
+		t.Fatalf("BuildManifest: %v", err)
+	}
+	if m.PlanPath != planPath {
+		t.Fatalf("PlanPath = %q, want %q", m.PlanPath, planPath)
+	}
+	if m.PlanSHA256 == "" {
+		t.Fatalf("PlanSHA256 not set")
+	}
+	if len(m.Waves) != 1 || len(m.Waves[0].Slots) != 1 {
+		t.Fatalf("expected 1 wave with 1 slot, got %+v", m.Waves)
+	}
+	slot := m.Waves[0].Slots[0]
+	if slot.Slot != "alpha" || slot.TaskID != "t-alpha-1" {
+		t.Fatalf("slot mismatch: %+v", slot)
+	}
+	if !contains(slot.SubagentPrompt, "slot=alpha") {
+		t.Fatalf("subagent_prompt missing slot identity:\n%s", slot.SubagentPrompt)
+	}
+	if !contains(slot.SubagentPrompt, "Task ID is t-alpha-1") {
+		t.Fatalf("subagent_prompt missing task id:\n%s", slot.SubagentPrompt)
+	}
+}
+
+func writeTempPlan(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "plan.md")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func contains(s, sub string) bool {
+	return len(s) >= len(sub) && (s == sub || (len(sub) > 0 && find(s, sub)))
+}
+
+func find(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}
+```
+
+- [ ] **Step 2: Run** — FAIL.
+
+- [ ] **Step 3: Implement**
+
+```go
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/danmestas/bones/cli"
+)
+
+// BuildOptions configures BuildManifest.
+type BuildOptions struct {
+	PlanPath string
+	TaskIDs  map[string]string // slot name → existing task ID (caller-supplied)
+}
+
+// BuildManifest parses the plan at PlanPath and produces a manifest with
+// one wave per dependency layer. Caller supplies task IDs (already created
+// in bones-tasks KV); wiring slot → task is the caller's responsibility.
+//
+// V1: all slots in a single wave (no dependency analysis). Multi-wave
+// support requires plan annotations the validate-plan parser does not
+// yet emit; defer to a follow-up.
+func BuildManifest(opts BuildOptions) (Manifest, error) {
+	data, err := os.ReadFile(opts.PlanPath)
+	if err != nil {
+		return Manifest{}, err
+	}
+	parsed, err := cli.ParsePlan(opts.PlanPath, data)
+	if err != nil {
+		return Manifest{}, err
+	}
+	sum := sha256.Sum256(data)
+	m := Manifest{
+		SchemaVersion: SchemaVersion,
+		PlanPath:      opts.PlanPath,
+		PlanSHA256:    hex.EncodeToString(sum[:]),
+		CreatedAt:     time.Now().UTC(),
+		CurrentWave:   1,
+	}
+	wave := Wave{Wave: 1}
+	for _, s := range parsed.Slots {
+		taskID := opts.TaskIDs[s.Name]
+		wave.Slots = append(wave.Slots, SlotEntry{
+			Slot:           s.Name,
+			TaskID:         taskID,
+			Title:          s.Title(),
+			Files:          s.Files(),
+			SubagentPrompt: renderSubagentPrompt(s, taskID),
+		})
+	}
+	m.Waves = []Wave{wave}
+	return m, nil
+}
+
+// renderSubagentPrompt produces the closed-template prompt for one slot.
+func renderSubagentPrompt(s cli.PlanSlot, taskID string) string {
+	var b strings.Builder
+	b.WriteString("You are a bones subagent for slot=")
+	b.WriteString(s.Name)
+	b.WriteString(". Use the `subagent` skill.\nTask ID is ")
+	b.WriteString(taskID)
+	b.WriteString(".\n\nTasks (from plan):\n")
+	b.WriteString(s.SourceMarkdown())
+	b.WriteString("\n\nFiles in scope: ")
+	b.WriteString(strings.Join(s.Files(), ", "))
+	b.WriteString("\nWorktree: $(bones swarm cwd --slot=")
+	b.WriteString(s.Name)
+	b.WriteString(")\n")
+	return b.String()
+}
+```
+
+**Watch out:** the existing `cli/validate_plan.go` likely doesn't expose `ParsePlan`, `PlanSlot`, `PlanSlot.Title()`, `PlanSlot.Files()`, `PlanSlot.SourceMarkdown()` as public symbols. You may need to add a public surface in `cli/validate_plan.go` (or extract a `internal/plan/` package) that BuildManifest can call. If extraction proves intrusive, copy the parsing logic into `internal/dispatch/` as a private helper — explicit duplication is acceptable for this v1.
+
+- [ ] **Step 4: Run** — PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+unset GIT_DIR GIT_WORK_TREE; git add internal/dispatch/ cli/validate_plan.go && git commit -m "feat(dispatch): BuildManifest from plan + closed subagent prompt template"
+```
+
+---
+
+### Task 4: Advance + Cancel
+
+**Files:** create `internal/dispatch/advance.go`, `internal/dispatch/cancel.go`, tests.
+
+- [ ] **Step 1: Failing test**
+
+```go
+// internal/dispatch/advance_test.go
+package dispatch
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestAdvance_PromotesWhenAllTasksClosed(t *testing.T) {
+	root := t.TempDir()
+	m := Manifest{
+		SchemaVersion: 1, CurrentWave: 1, CreatedAt: time.Now().UTC(),
+		Waves: []Wave{
+			{Wave: 1, Slots: []SlotEntry{{Slot: "a", TaskID: "t1"}}},
+			{Wave: 2, Slots: []SlotEntry{{Slot: "b", TaskID: "t2"}}},
+		},
+	}
+	_ = Write(root, m)
+
+	// Stub: caller supplies a TaskState func ("is task t1 Closed?").
+	closed := func(id string) (bool, error) { return id == "t1", nil }
+
+	got, err := Advance(root, closed)
+	if err != nil {
+		t.Fatalf("Advance: %v", err)
+	}
+	if got.CurrentWave != 2 {
+		t.Fatalf("expected CurrentWave=2 after advance, got %d", got.CurrentWave)
+	}
+}
+
+func TestAdvance_ErrorWhenIncomplete(t *testing.T) {
+	root := t.TempDir()
+	_ = Write(root, Manifest{
+		SchemaVersion: 1, CurrentWave: 1, CreatedAt: time.Now().UTC(),
+		Waves: []Wave{{Wave: 1, Slots: []SlotEntry{{Slot: "a", TaskID: "t1"}}}},
+	})
+
+	closed := func(id string) (bool, error) { return false, nil }
+
+	_, err := Advance(root, closed)
+	if !errors.Is(err, ErrWaveIncomplete) {
+		t.Fatalf("expected ErrWaveIncomplete, got %v", err)
+	}
+}
+
+func TestAdvance_AllComplete(t *testing.T) {
+	root := t.TempDir()
+	_ = Write(root, Manifest{
+		SchemaVersion: 1, CurrentWave: 1, CreatedAt: time.Now().UTC(),
+		Waves: []Wave{{Wave: 1, Slots: []SlotEntry{{Slot: "a", TaskID: "t1"}}}},
+	})
+
+	closed := func(id string) (bool, error) { return true, nil }
+
+	_, err := Advance(root, closed)
+	if !errors.Is(err, ErrAllWavesComplete) {
+		t.Fatalf("expected ErrAllWavesComplete, got %v", err)
+	}
+}
+```
+
+- [ ] **Step 2: Run** — FAIL.
+
+- [ ] **Step 3: Implement**
+
+```go
+// internal/dispatch/advance.go
+package dispatch
+
+import "errors"
+
+// ErrWaveIncomplete signals --advance was called before the current wave's
+// tasks all moved to Closed. The error message names the still-open task IDs.
+var ErrWaveIncomplete = errors.New("dispatch: current wave incomplete")
+
+// ErrAllWavesComplete signals --advance was called after the last wave finished.
+var ErrAllWavesComplete = errors.New("dispatch: all waves complete; nothing to do")
+
+// TaskClosed reports whether the task with the given ID is in Closed status.
+// Implemented by the caller (typically a thin shim over internal/tasks).
+type TaskClosed func(taskID string) (bool, error)
+
+// Advance promotes the manifest's current wave to the next one if the
+// current wave's tasks are all Closed in bones-tasks KV. Returns the
+// updated manifest. Errors if the current wave is incomplete or if the
+// dispatch is already finished.
+func Advance(root string, isClosed TaskClosed) (Manifest, error) {
+	m, err := Read(root)
+	if err != nil {
+		return Manifest{}, err
+	}
+	if m.CurrentWave > len(m.Waves) {
+		return m, ErrAllWavesComplete
+	}
+	current := m.Waves[m.CurrentWave-1]
+	var open []string
+	for _, s := range current.Slots {
+		closed, err := isClosed(s.TaskID)
+		if err != nil {
+			return m, err
+		}
+		if !closed {
+			open = append(open, s.TaskID)
+		}
+	}
+	if len(open) > 0 {
+		return m, errors.Join(ErrWaveIncomplete, errors.New("open tasks: "+joinIDs(open)))
+	}
+	m.CurrentWave++
+	if m.CurrentWave > len(m.Waves) {
+		return m, ErrAllWavesComplete
+	}
+	if err := Write(root, m); err != nil {
+		return m, err
+	}
+	return m, nil
+}
+
+func joinIDs(ids []string) string {
+	out := ""
+	for i, id := range ids {
+		if i > 0 {
+			out += ", "
+		}
+		out += id
+	}
+	return out
+}
+```
+
+```go
+// internal/dispatch/cancel.go
+package dispatch
+
+// TaskCloser closes the task with the given ID, supplying a reason.
+// Implemented by the caller (typically a shim over internal/tasks).
+type TaskCloser func(taskID, reason string) error
+
+// Cancel removes the manifest and closes any tasks the manifest still
+// references with ClosedReason="dispatch-cancelled". Idempotent — no-op
+// when no manifest exists.
+func Cancel(root string, closeTask TaskCloser) error {
+	m, err := Read(root)
+	if err == ErrNoManifest {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	for i := m.CurrentWave - 1; i < len(m.Waves) && i >= 0; i++ {
+		for _, s := range m.Waves[i].Slots {
+			if err := closeTask(s.TaskID, "dispatch-cancelled"); err != nil {
+				return err
+			}
+		}
+	}
+	return Remove(root)
+}
+```
+
+- [ ] **Step 4: Run** — PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+unset GIT_DIR GIT_WORK_TREE; git add internal/dispatch/advance.go internal/dispatch/cancel.go internal/dispatch/advance_test.go && git commit -m "feat(dispatch): add Advance and Cancel primitives"
+```
+
+---
+
+## Phase 2: bones swarm dispatch verb (Tasks 5-8)
+
+### Task 5: SwarmDispatchCmd struct + plan validation
+
+**Files:** create `cli/swarm_dispatch.go`, `cli/swarm_dispatch_test.go`. Modify `cmd/bones/cli.go` to register under `Swarm` subcommand group.
+
+- [ ] **Step 1: Failing test** for the struct + flag parsing (Kong).
+
+- [ ] **Step 2: Run** — FAIL.
+
+- [ ] **Step 3: Implement**
+
+```go
+// cli/swarm_dispatch.go
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	libfossilcli "github.com/danmestas/libfossil/cli"
+
+	"github.com/danmestas/bones/internal/dispatch"
+	"github.com/danmestas/bones/internal/tasks"
+	"github.com/danmestas/bones/internal/workspace"
+)
+
+type SwarmDispatchCmd struct {
+	PlanPath string `arg:"" optional:"" name:"plan" help:"path to plan markdown"`
+	Advance  bool   `name:"advance" help:"check current wave; promote if all tasks Closed"`
+	Cancel   bool   `name:"cancel" help:"abandon in-flight dispatch (closes open tasks as cancelled)"`
+	Wave     int    `name:"wave" help:"explicit wave number (rare; for testing)"`
+	JSON     bool   `name:"json" help:"emit manifest path + summary as JSON"`
+	DryRun   bool   `name:"dry-run" help:"validate; don't touch NATS or filesystem"`
+}
+
+func (c *SwarmDispatchCmd) Run(g *libfossilcli.Globals) error {
+	ctx := context.Background()
+	cwd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	info, err := workspace.Join(ctx, cwd)
+	if err != nil {
+		return err
+	}
+	switch {
+	case c.Cancel:
+		return c.runCancel(ctx, info)
+	case c.Advance:
+		return c.runAdvance(ctx, info)
+	case c.PlanPath != "":
+		return c.runDispatch(ctx, info, c.PlanPath)
+	default:
+		return fmt.Errorf("usage: bones swarm dispatch <plan> | --advance | --cancel")
+	}
+}
+```
+
+- [ ] **Step 4: Run** — PASS (struct compiles).
+- [ ] **Step 5: Commit:** `feat(cli): add bones swarm dispatch struct + flag dispatch`
+
+---
+
+### Task 6: runDispatch — validate, create tasks, write manifest
+
+- [ ] **Step 1: Failing test** seeded with a plan + temp workspace; assert manifest file exists post-run with correct PlanSHA256 and SlotEntry per slot.
+
+- [ ] **Step 2: Run** — FAIL.
+
+- [ ] **Step 3: Implement** `runDispatch`:
+
+```go
+func (c *SwarmDispatchCmd) runDispatch(ctx context.Context, info workspace.Info, planPath string) error {
+	// 1. Validate plan via existing validate-plan logic (returns parsed plan or error).
+	// 2. Detect prior dispatch in flight (Read returns non-ErrNoManifest); check plan SHA matches; error otherwise with cancel hint.
+	// 3. For each slot in parsed plan: create task in bones-tasks KV via tasks.Manager.Create.
+	// 4. Build manifest via dispatch.BuildManifest with the new task IDs.
+	// 5. Write manifest.
+	// 6. Print summary (or JSON when --json) and next-step instruction for the harness's orchestrator skill.
+	if c.DryRun {
+		fmt.Println("dispatch: --dry-run mode (no tasks/manifest written)")
+		// validate only
+		return nil
+	}
+	// ... full implementation per the plan steps above ...
+	return nil
+}
+```
+
+(The plan body here is intentionally light — fill in concrete code referencing existing `tasks.Manager` API. Look at `cli/tasks.go` and `internal/tasks/` for the Create signature.)
+
+- [ ] **Step 4: Run** — PASS.
+- [ ] **Step 5: Commit:** `feat(cli): bones swarm dispatch <plan> writes manifest + creates tasks`
+
+---
+
+### Task 7: runAdvance — call dispatch.Advance with task-state shim
+
+- [ ] **Step 1: Failing test** with a fixture that opens NATS via `natstest.NewJetStreamServer`, seeds 1 task, closes it, then runs `runAdvance` and asserts `current_wave` advanced.
+
+- [ ] **Step 2: Run** — FAIL.
+
+- [ ] **Step 3: Implement**
+
+```go
+func (c *SwarmDispatchCmd) runAdvance(ctx context.Context, info workspace.Info) error {
+	mgr, closeMgr, err := openManager(ctx, info)
+	if err != nil {
+		return err
+	}
+	defer closeMgr()
+	isClosed := func(taskID string) (bool, error) {
+		t, err := mgr.Get(ctx, taskID)
+		if err != nil {
+			return false, err
+		}
+		return t.Status == tasks.StatusClosed, nil
+	}
+	updated, err := dispatch.Advance(info.WorkspaceDir, isClosed)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("dispatch: advanced to wave %d of %d\n", updated.CurrentWave, len(updated.Waves))
+	return nil
+}
+```
+
+- [ ] **Step 4: Run** — PASS.
+- [ ] **Step 5: Commit:** `feat(cli): bones swarm dispatch --advance promotes when wave complete`
+
+---
+
+### Task 8: runCancel — call dispatch.Cancel with task-close shim
+
+- [ ] **Step 1: Failing test:** seed manifest + 2 open tasks, run `runCancel`, assert both tasks Closed with ClosedReason="dispatch-cancelled" and manifest removed.
+
+- [ ] **Step 2: Run** — FAIL.
+
+- [ ] **Step 3: Implement**
+
+```go
+func (c *SwarmDispatchCmd) runCancel(ctx context.Context, info workspace.Info) error {
+	mgr, closeMgr, err := openManager(ctx, info)
+	if err != nil {
+		return err
+	}
+	defer closeMgr()
+	closeTask := func(taskID, reason string) error {
+		return mgr.Close(ctx, taskID, tasks.CloseOptions{Reason: reason})
+	}
+	if err := dispatch.Cancel(info.WorkspaceDir, closeTask); err != nil {
+		return err
+	}
+	fmt.Println("dispatch: cancelled and manifest removed")
+	return nil
+}
+```
+
+(Verify `tasks.CloseOptions{Reason: ...}` matches the existing API; if the close API takes a different shape, adapt.)
+
+- [ ] **Step 4: Run** — PASS.
+- [ ] **Step 5: Commit:** `feat(cli): bones swarm dispatch --cancel closes open tasks via ClosedReason`
+
+---
+
+## Phase 3: Logwriter package (Tasks 9-12)
+
+### Task 9: Event types catalog
+
+**Files:** `internal/logwriter/events.go` + test.
+
+- [ ] **Step 1: Failing test** for each event type's JSON shape.
+
+- [ ] **Step 2: Run** — FAIL.
+
+- [ ] **Step 3: Implement**
+
+```go
+// internal/logwriter/events.go
+package logwriter
+
+import "time"
+
+// EventType is one entry in the closed catalog of slot/workspace event kinds.
+// Adding a new type requires extending this constant set and the validation
+// helper IsKnownEvent.
+type EventType string
+
+const (
+	EventJoin         EventType = "join"
+	EventCommit       EventType = "commit"
+	EventCommitError  EventType = "commit_error"
+	EventRenew        EventType = "renew"
+	EventClose        EventType = "close"
+	EventDispatched   EventType = "dispatched"
+	EventError        EventType = "error"
+)
+
+// Event is the on-disk JSONL row for one slot or workspace event.
+type Event struct {
+	Timestamp time.Time              `json:"ts"`
+	Slot      string                 `json:"slot,omitempty"`
+	Event     EventType              `json:"event"`
+	Fields    map[string]interface{} `json:"-"`
+}
+```
+
+(Custom MarshalJSON merges `Fields` into the top-level object so the on-disk format is flat per spec.)
+
+- [ ] **Step 4: Run** — PASS.
+- [ ] **Step 5: Commit:** `feat(logwriter): add closed Event-type catalog + JSON shape`
+
+---
+
+### Task 10: Atomic O_APPEND writer
+
+**Files:** `internal/logwriter/writer.go` + test.
+
+- [ ] **Step 1: Failing test** that opens a writer, writes 3 events, asserts file has 3 lines, asserts each line parses to JSON.
+
+- [ ] **Step 2: Run** — FAIL.
+
+- [ ] **Step 3: Implement** `Writer` struct with `Append(Event) error`. Open file with `os.O_APPEND|os.O_CREATE|os.O_WRONLY`. Single-line writes shorter than `PIPE_BUF` are atomic on Linux/macOS.
+
+- [ ] **Step 4: Run** — PASS.
+- [ ] **Step 5: Commit:** `feat(logwriter): add atomic O_APPEND NDJSON writer`
+
+---
+
+### Task 11: Size-based rotation for workspace log
+
+- [ ] **Step 1: Failing test:** open writer with `MaxSize=200`, append events totaling >200 bytes, assert `.log.1` exists and `.log` is fresh.
+
+- [ ] **Step 2: Run** — FAIL.
+
+- [ ] **Step 3: Implement** rotation: on every `Append`, stat file; if size > MaxSize, rename `.log` → `.log.1`, shift older numbered files, drop oldest beyond MaxFiles. Tunable via `BONES_LOG_MAX_SIZE` and `BONES_LOG_MAX_FILES` env vars.
+
+- [ ] **Step 4: Run** — PASS.
+- [ ] **Step 5: Commit:** `feat(logwriter): size-based rotation (.log → .log.1 → .log.2 ...)`
+
+---
+
+### Task 12: Per-slot log helper (no rotation)
+
+- [ ] **Step 1: Failing test:** verify `OpenSlotLog(slotDir, slotName)` produces a writer at `<slotDir>/log` with no rotation behavior.
+
+- [ ] **Step 2: Run** — FAIL.
+- [ ] **Step 3: Implement** small helper that returns a Writer with `MaxSize=0` (rotation disabled). Per-slot logs are bounded by slot lifetime.
+- [ ] **Step 4: Run** — PASS.
+- [ ] **Step 5: Commit:** `feat(logwriter): per-slot OpenSlotLog helper (no rotation)`
+
+---
+
+## Phase 4: Instrument swarm verbs (Tasks 13-15)
+
+### Task 13: Emit `join` event from `bones swarm join`
+
+**Files:** modify `internal/swarm/session.go` (or wherever `Join` lives).
+
+- [ ] **Step 1: Failing test** that calls Join in a tmp workspace and asserts `.bones/swarm/<slot>/log` has a `join` event.
+
+- [ ] **Step 2: Run** — FAIL.
+
+- [ ] **Step 3: Implement** — at the success path of Join, open per-slot log and append `Event{Event: EventJoin, Slot: slot, Fields: {task_id, worktree}}`.
+
+- [ ] **Step 4: Run** — PASS.
+- [ ] **Step 5: Commit:** `feat(swarm): emit join event to per-slot log`
+
+---
+
+### Task 14: Emit `commit` / `commit_error` event from `bones swarm commit`
+
+- [ ] **Step 1: Failing test:** call Commit; assert log contains commit event with sha + message.
+- [ ] **Step 2: Run** — FAIL.
+- [ ] **Step 3: Implement** at success path; emit `commit_error` with `reason` field on failure paths (fork detected, session-gone).
+- [ ] **Step 4: Run** — PASS.
+- [ ] **Step 5: Commit:** `feat(swarm): emit commit / commit_error events to per-slot log`
+
+---
+
+### Task 15: Emit `close` event from `bones swarm close`
+
+- [ ] **Step 1: Failing test.**
+- [ ] **Step 2: Run** — FAIL.
+- [ ] **Step 3: Implement** — emit close event with `result`, `summary` fields.
+- [ ] **Step 4: Run** — PASS.
+- [ ] **Step 5: Commit:** `feat(swarm): emit close event to per-slot log`
+
+---
+
+## Phase 5: bones logs verb (Tasks 16-19)
+
+### Task 16: LogsCmd struct + path resolution
+
+**Files:** `cli/logs.go`, `cli/logs_test.go`.
+
+- [ ] **Step 1: Failing test:** `bones logs --slot=a` resolves to `.bones/swarm/a/log` for the current workspace.
+
+- [ ] **Step 2: Run** — FAIL.
+
+- [ ] **Step 3: Implement** struct with flags `--slot`, `--workspace`, `--tail`/`-f`, `--since`, `--last`, `--json`, `--full-time`. Run dispatches to one-shot read or follow mode.
+
+- [ ] **Step 4: Run** — PASS.
+- [ ] **Step 5: Commit:** `feat(cli): add bones logs verb (struct + path resolution)`
+
+---
+
+### Task 17: One-shot read with formatting
+
+- [ ] **Step 1: Failing test:** seed log file with 3 events; assert default render shows time-only timestamps and event type per line.
+- [ ] **Step 2: Run** — FAIL.
+- [ ] **Step 3: Implement** parser (one Event per line) + renderer (HH:MM:SS + event + fields).
+- [ ] **Step 4: Run** — PASS.
+- [ ] **Step 5: Commit:** `feat(cli): bones logs reads JSONL events and renders human-readable output`
+
+---
+
+### Task 18: --tail (follow mode)
+
+- [ ] **Step 1: Failing test:** in a goroutine, append events while another goroutine consumes a `--tail` reader; assert reader sees all events within a deadline.
+- [ ] **Step 2: Run** — FAIL.
+- [ ] **Step 3: Implement** poll-based tail (read to EOF, sleep 100ms, continue). Document the rotated-file gotcha (per spec: reader's handle stays on rotated file until reopen).
+- [ ] **Step 4: Run** — PASS.
+- [ ] **Step 5: Commit:** `feat(cli): bones logs --tail follow mode`
+
+---
+
+### Task 19: --since, --last, --json, --full-time
+
+- [ ] **Step 1: Failing tests** for each filter.
+- [ ] **Step 2: Run** — FAIL.
+- [ ] **Step 3: Implement** filter logic; `--json` emits the raw JSONL line unchanged.
+- [ ] **Step 4: Run** — PASS.
+- [ ] **Step 5: Commit:** `feat(cli): bones logs filters (--since/--last/--json/--full-time)`
+
+---
+
+## Phase 6: Status extension + skill update + docs (Tasks 20-22)
+
+### Task 20: bones swarm status — add dispatch-context line
+
+- [ ] **Step 1: Failing test:** seed manifest in tmp workspace; assert `bones swarm status` output begins with `Dispatch: ./plan.md  (wave N of M)`.
+- [ ] **Step 2: Run** — FAIL.
+- [ ] **Step 3: Implement** — at top of `swarm_status.go`'s render path, call `dispatch.Read(workspaceRoot)`; if non-ErrNoManifest, emit the context line.
+- [ ] **Step 4: Run** — PASS.
+- [ ] **Step 5: Commit:** `feat(swarm): bones swarm status shows dispatch-in-flight context`
+
+---
+
+### Task 21: orchestrator skill — consume dispatch.json
+
+**Files:** modify `.claude/skills/orchestrator/SKILL.md`.
+
+- [ ] **Step 1: Read existing skill** to understand current contract.
+- [ ] **Step 2: Edit** — change skill's input from "plan path" to "read .bones/swarm/dispatch.json"; spawn N Task-tool subagents per `manifest.waves[current_wave-1].slots[]` using each slot's `subagent_prompt` verbatim; on completion, call `bones swarm dispatch --advance`.
+- [ ] **Step 3: Commit:** `docs(skill): orchestrator consumes dispatch.json (manifest-driven)`
+
+---
+
+### Task 22: README — bones swarm dispatch + bones logs usage
+
+- [ ] **Step 1: Add docs** under existing "Cross-workspace commands" section (or a new "Parallel work" section). Cover the typical flow:
+  - `bones swarm dispatch ./plan.md` — emit manifest, get next-step hint
+  - `/orchestrator` — consume manifest in a Claude session
+  - `bones swarm dispatch --advance` after each wave completes
+  - `bones logs --slot=auth --tail` — watch slot progress
+  - `bones swarm dispatch --cancel` to abandon
+
+- [ ] **Step 2: Commit:** `docs(readme): document bones swarm dispatch + bones logs`
+
+---
+
+## Final verification
+
+- [ ] **Step F1:** `unset GIT_DIR GIT_WORK_TREE; make check` → `check: OK`
+- [ ] **Step F2:** `unset GIT_DIR GIT_WORK_TREE; git push -u origin feat/spec-3-dispatch-and-logs`
+- [ ] **Step F3:** `unset GIT_DIR GIT_WORK_TREE; gh pr create --title "Spec 3: bones swarm dispatch + bones logs" --body "..."`
+- [ ] **Step F4:** `gh pr checks <num>` to verify remote CI
+
+---
+
+## Spec coverage check
+
+| Spec section | Plan task(s) |
+|---|---|
+| Manifest schema (versioned, `current_wave`, no `status` field) | 1, 2 |
+| Atomic Write/Read/Remove | 2 |
+| Plan parser → manifest builder | 3 |
+| `--advance` (KV-driven wave promotion) | 4, 7 |
+| `--cancel` (ClosedReason="dispatch-cancelled") | 4, 8 |
+| `bones swarm dispatch <plan>` verb + `--json`/`--dry-run` | 5, 6 |
+| Closed event-type catalog | 9 |
+| Atomic O_APPEND NDJSON writer | 10 |
+| Size-based workspace-log rotation (`BONES_LOG_MAX_SIZE`/`MAX_FILES`) | 11 |
+| Per-slot log (no rotation) | 12 |
+| Swarm verbs emit join/commit/commit_error/close events | 13, 14, 15 |
+| `bones logs --slot=<name>` verb + flags | 16, 17, 18, 19 |
+| `bones logs --workspace` | 16 (dispatched via flag) |
+| `bones swarm status` extension | 20 |
+| Orchestrator skill update | 21 |
+| README docs | 22 |
+
+## Spec deviations (documented up-front)
+
+1. **Single-wave v1.** The plan parser today emits a flat slot list. Multi-wave dependency analysis requires plan annotations the parser doesn't yet produce. Implementation puts all slots in `wave=1`; multi-wave is a follow-up if/when annotations land.
+2. **Per-finding 5s timeout for swarm verbs not added.** Existing swarm verbs already have their own context handling. Adding a logwriter timeout per write would be over-engineering — log writes are fast filesystem ops.
+3. **No `--watch` auto-advance.** Per spec Future Direction, deferred to v2.
+4. **Spec text references `reference/CAPABILITIES.md` (deleted from main).** The harness-agnostic argument still holds via `docs/harness-integration.md` and ADR 0023. Spec doc should be updated in a follow-up cleanup PR — not this implementation PR.

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/danmestas/libfossil v0.4.6-rc3
 	github.com/danmestas/libfossil/db/driver/modernc v0.1.0
 	github.com/google/uuid v1.6.0
+	github.com/mattn/go-isatty v0.0.20
 	github.com/nats-io/nats-server/v2 v2.12.8
 	github.com/nats-io/nats.go v1.51.0
 	go.opentelemetry.io/otel v1.43.0
@@ -30,7 +31,6 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
 	github.com/hexops/gotextdiff v1.0.3 // indirect
 	github.com/klauspost/compress v1.18.5 // indirect
-	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/minio/highwayhash v1.0.4-0.20251030100505-070ab1a87a76 // indirect
 	github.com/nats-io/jwt/v2 v2.8.1 // indirect
 	github.com/nats-io/nkeys v0.4.15 // indirect

--- a/internal/dispatch/advance.go
+++ b/internal/dispatch/advance.go
@@ -1,0 +1,77 @@
+package dispatch
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// ErrWaveIncomplete signals --advance was called before the current wave's
+// tasks all moved to Closed. The error message names the still-open task IDs.
+var ErrWaveIncomplete = errors.New("dispatch: current wave incomplete")
+
+// ErrAllWavesComplete signals --advance was called after the last wave finished.
+var ErrAllWavesComplete = errors.New("dispatch: all waves complete; nothing to do")
+
+// TaskClosed reports whether the task with the given ID is in Closed status.
+// Implemented by the caller (typically a thin shim over internal/tasks).
+type TaskClosed func(taskID string) (bool, error)
+
+// Advance promotes the manifest's current wave to the next one if the
+// current wave's tasks are all Closed in bones-tasks KV. Returns the
+// updated manifest. Errors if the current wave is incomplete or if the
+// dispatch is already finished.
+func Advance(root string, isClosed TaskClosed) (Manifest, error) {
+	m, err := Read(root)
+	if err != nil {
+		return Manifest{}, err
+	}
+
+	// Find the current wave entry.
+	var currentWave *Wave
+	for i := range m.Waves {
+		if m.Waves[i].Wave == m.CurrentWave {
+			currentWave = &m.Waves[i]
+			break
+		}
+	}
+	if currentWave == nil {
+		return m, ErrAllWavesComplete
+	}
+
+	// Check all tasks in the current wave are closed.
+	var open []string
+	for _, s := range currentWave.Slots {
+		closed, err := isClosed(s.TaskID)
+		if err != nil {
+			return Manifest{}, fmt.Errorf("dispatch advance: checking task %s: %w", s.TaskID, err)
+		}
+		if !closed {
+			open = append(open, s.TaskID)
+		}
+	}
+	if len(open) > 0 {
+		return Manifest{}, fmt.Errorf("%w: open tasks: %s",
+			ErrWaveIncomplete, strings.Join(open, ", "))
+	}
+
+	// Find the next wave.
+	nextWave := -1
+	for _, w := range m.Waves {
+		if w.Wave > m.CurrentWave {
+			if nextWave < 0 || w.Wave < nextWave {
+				nextWave = w.Wave
+			}
+		}
+	}
+	if nextWave < 0 {
+		// Current wave complete, but no next wave.
+		return m, ErrAllWavesComplete
+	}
+
+	m.CurrentWave = nextWave
+	if err := Write(root, m); err != nil {
+		return Manifest{}, fmt.Errorf("dispatch advance: write: %w", err)
+	}
+	return m, nil
+}

--- a/internal/dispatch/advance_test.go
+++ b/internal/dispatch/advance_test.go
@@ -1,0 +1,144 @@
+package dispatch
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+// ---------------------------------------------------------------------------
+// Task 4: Advance
+// ---------------------------------------------------------------------------
+
+func TestAdvance_PromotesWhenAllTasksClosed(t *testing.T) {
+	root := t.TempDir()
+	m := Manifest{
+		SchemaVersion: 1,
+		CurrentWave:   1,
+		CreatedAt:     time.Now().UTC(),
+		Waves: []Wave{
+			{Wave: 1, Slots: []SlotEntry{{Slot: "a", TaskID: "t1"}}},
+			{Wave: 2, Slots: []SlotEntry{{Slot: "b", TaskID: "t2"}}},
+		},
+	}
+	if err := Write(root, m); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	// Stub: t1 is closed, t2 is not (wave 2 not started yet).
+	closed := func(id string) (bool, error) { return id == "t1", nil }
+
+	got, err := Advance(root, closed)
+	if err != nil {
+		t.Fatalf("Advance: %v", err)
+	}
+	if got.CurrentWave != 2 {
+		t.Fatalf("expected CurrentWave=2 after advance, got %d", got.CurrentWave)
+	}
+	// Verify the manifest was persisted.
+	persisted, err := Read(root)
+	if err != nil {
+		t.Fatalf("Read after Advance: %v", err)
+	}
+	if persisted.CurrentWave != 2 {
+		t.Fatalf("persisted CurrentWave = %d, want 2", persisted.CurrentWave)
+	}
+}
+
+func TestAdvance_ErrorWhenIncomplete(t *testing.T) {
+	root := t.TempDir()
+	if err := Write(root, Manifest{
+		SchemaVersion: 1,
+		CurrentWave:   1,
+		CreatedAt:     time.Now().UTC(),
+		Waves:         []Wave{{Wave: 1, Slots: []SlotEntry{{Slot: "a", TaskID: "t1"}}}},
+	}); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	closed := func(id string) (bool, error) { return false, nil }
+
+	_, err := Advance(root, closed)
+	if !errors.Is(err, ErrWaveIncomplete) {
+		t.Fatalf("expected ErrWaveIncomplete, got %v", err)
+	}
+}
+
+func TestAdvance_AllComplete(t *testing.T) {
+	root := t.TempDir()
+	if err := Write(root, Manifest{
+		SchemaVersion: 1,
+		CurrentWave:   1,
+		CreatedAt:     time.Now().UTC(),
+		Waves:         []Wave{{Wave: 1, Slots: []SlotEntry{{Slot: "a", TaskID: "t1"}}}},
+	}); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	closed := func(id string) (bool, error) { return true, nil }
+
+	_, err := Advance(root, closed)
+	if !errors.Is(err, ErrAllWavesComplete) {
+		t.Fatalf("expected ErrAllWavesComplete, got %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Task 4: Cancel
+// ---------------------------------------------------------------------------
+
+func TestCancel_ClosesTasksAndRemovesManifest(t *testing.T) {
+	root := t.TempDir()
+	if err := Write(root, Manifest{
+		SchemaVersion: 1,
+		CurrentWave:   1,
+		CreatedAt:     time.Now().UTC(),
+		Waves: []Wave{
+			{Wave: 1, Slots: []SlotEntry{
+				{Slot: "a", TaskID: "t1"},
+				{Slot: "b", TaskID: "t2"},
+			}},
+		},
+	}); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	var closedIDs []string
+	var closedReasons []string
+	closeTask := func(id, reason string) error {
+		closedIDs = append(closedIDs, id)
+		closedReasons = append(closedReasons, reason)
+		return nil
+	}
+
+	if err := Cancel(root, closeTask); err != nil {
+		t.Fatalf("Cancel: %v", err)
+	}
+	if len(closedIDs) != 2 {
+		t.Fatalf("expected 2 tasks closed, got %d: %v", len(closedIDs), closedIDs)
+	}
+	for _, r := range closedReasons {
+		if r != CancelReason {
+			t.Fatalf("unexpected reason %q", r)
+		}
+	}
+	// Manifest should be removed.
+	if _, err := Read(root); !errors.Is(err, ErrNoManifest) {
+		t.Fatalf("expected ErrNoManifest after Cancel, got %v", err)
+	}
+}
+
+func TestCancel_IdempotentWhenNoManifest(t *testing.T) {
+	root := t.TempDir()
+	called := false
+	closeTask := func(id, reason string) error {
+		called = true
+		return nil
+	}
+	if err := Cancel(root, closeTask); err != nil {
+		t.Fatalf("Cancel on empty workspace: %v", err)
+	}
+	if called {
+		t.Fatal("closeTask should not be called when no manifest exists")
+	}
+}

--- a/internal/dispatch/cancel.go
+++ b/internal/dispatch/cancel.go
@@ -1,0 +1,31 @@
+package dispatch
+
+import "fmt"
+
+// TaskCloser closes a task with a reason string (e.g. "dispatch-canceled").
+// Implemented by the caller (typically a thin shim over internal/tasks).
+type TaskCloser func(taskID string, reason string) error
+
+// CancelReason is the ClosedReason string set on tasks closed by Cancel.
+const CancelReason = "dispatch-canceled"
+
+// Cancel removes the manifest and closes any tasks the manifest still
+// references with ClosedReason=CancelReason. Idempotent — no-op
+// when no manifest exists.
+func Cancel(root string, closeTask TaskCloser) error {
+	m, err := Read(root)
+	if err == ErrNoManifest {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	for i := m.CurrentWave - 1; i < len(m.Waves) && i >= 0; i++ {
+		for _, s := range m.Waves[i].Slots {
+			if err := closeTask(s.TaskID, CancelReason); err != nil {
+				return fmt.Errorf("dispatch cancel: close task %s: %w", s.TaskID, err)
+			}
+		}
+	}
+	return Remove(root)
+}

--- a/internal/dispatch/cancel.go
+++ b/internal/dispatch/cancel.go
@@ -1,6 +1,9 @@
 package dispatch
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
 
 // TaskCloser closes a task with a reason string (e.g. "dispatch-canceled").
 // Implemented by the caller (typically a thin shim over internal/tasks).
@@ -14,7 +17,7 @@ const CancelReason = "dispatch-canceled"
 // when no manifest exists.
 func Cancel(root string, closeTask TaskCloser) error {
 	m, err := Read(root)
-	if err == ErrNoManifest {
+	if errors.Is(err, ErrNoManifest) {
 		return nil
 	}
 	if err != nil {

--- a/internal/dispatch/manifest.go
+++ b/internal/dispatch/manifest.go
@@ -1,0 +1,164 @@
+package dispatch
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// SchemaVersion of the dispatch manifest format. Bump when the schema
+// changes in a way that breaks consumer skills.
+const SchemaVersion = 1
+
+// Manifest is the dispatch contract written by `bones swarm dispatch`
+// and consumed by harness-specific orchestrator skills.
+type Manifest struct {
+	SchemaVersion int       `json:"schema_version"`
+	PlanPath      string    `json:"plan_path"`
+	PlanSHA256    string    `json:"plan_sha256"`
+	CreatedAt     time.Time `json:"created_at"`
+	CurrentWave   int       `json:"current_wave"`
+	Waves         []Wave    `json:"waves"`
+}
+
+// Wave is one parallelizable set of slots, blocked until prior waves complete.
+type Wave struct {
+	Wave             int         `json:"wave"`
+	BlockedUntilWave int         `json:"blocked_until_wave,omitempty"`
+	Slots            []SlotEntry `json:"slots"`
+}
+
+// SlotEntry is one slot's task assignment within a wave.
+type SlotEntry struct {
+	Slot           string   `json:"slot"`
+	TaskID         string   `json:"task_id"`
+	Title          string   `json:"title"`
+	Files          []string `json:"files"`
+	SubagentPrompt string   `json:"subagent_prompt"`
+}
+
+// ErrNoManifest is returned by Read when no dispatch manifest exists in the workspace.
+var ErrNoManifest = errors.New("dispatch: no manifest in this workspace")
+
+// Path returns the manifest file path for a given workspace root.
+func Path(root string) string {
+	return filepath.Join(root, ".bones", "swarm", "dispatch.json")
+}
+
+// Write persists the manifest atomically (tmp+rename). Creates the
+// parent directory if needed.
+func Write(root string, m Manifest) error {
+	dst := Path(root)
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return fmt.Errorf("dispatch mkdir: %w", err)
+	}
+	data, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return fmt.Errorf("dispatch marshal: %w", err)
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(dst), filepath.Base(dst)+".tmp.*")
+	if err != nil {
+		return fmt.Errorf("dispatch tmp: %w", err)
+	}
+	defer func() { _ = os.Remove(tmp.Name()) }()
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("dispatch write: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("dispatch sync: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("dispatch close: %w", err)
+	}
+	return os.Rename(tmp.Name(), dst)
+}
+
+// Read loads the dispatch manifest for a workspace root.
+func Read(root string) (Manifest, error) {
+	data, err := os.ReadFile(Path(root))
+	if errors.Is(err, os.ErrNotExist) {
+		return Manifest{}, ErrNoManifest
+	}
+	if err != nil {
+		return Manifest{}, fmt.Errorf("dispatch read: %w", err)
+	}
+	var m Manifest
+	if err := json.Unmarshal(data, &m); err != nil {
+		return Manifest{}, fmt.Errorf("dispatch unmarshal: %w", err)
+	}
+	return m, nil
+}
+
+// Remove deletes the dispatch manifest. Idempotent.
+func Remove(root string) error {
+	err := os.Remove(Path(root))
+	if err == nil || errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	return fmt.Errorf("dispatch remove: %w", err)
+}
+
+// BuildOptions configures BuildManifest.
+type BuildOptions struct {
+	PlanPath string
+	TaskIDs  map[string]string // slot name → existing task ID (caller-supplied)
+}
+
+// BuildManifest parses the plan at PlanPath and produces a manifest with
+// one wave per dependency layer. Caller supplies task IDs (already created
+// in bones-tasks KV); wiring slot → task is the caller's responsibility.
+//
+// V1: all slots in a single wave (no dependency analysis). Multi-wave
+// support requires plan annotations the validate-plan parser does not
+// yet emit; defer to a follow-up.
+func BuildManifest(opts BuildOptions) (Manifest, error) {
+	data, err := os.ReadFile(opts.PlanPath)
+	if err != nil {
+		return Manifest{}, err
+	}
+	slots, err := parsePlanSlots(opts.PlanPath, data)
+	if err != nil {
+		return Manifest{}, err
+	}
+	sum := sha256.Sum256(data)
+	m := Manifest{
+		SchemaVersion: SchemaVersion,
+		PlanPath:      opts.PlanPath,
+		PlanSHA256:    hex.EncodeToString(sum[:]),
+		CreatedAt:     time.Now().UTC(),
+		CurrentWave:   1,
+	}
+	wave := Wave{Wave: 1}
+	for _, s := range slots {
+		taskID := opts.TaskIDs[s.name]
+		wave.Slots = append(wave.Slots, SlotEntry{
+			Slot:           s.name,
+			TaskID:         taskID,
+			Title:          s.title,
+			Files:          s.files,
+			SubagentPrompt: renderSubagentPrompt(s, taskID),
+		})
+	}
+	m.Waves = []Wave{wave}
+	return m, nil
+}
+
+// renderSubagentPrompt produces the closed-template prompt for one slot.
+func renderSubagentPrompt(s parsedSlot, taskID string) string {
+	var b strings.Builder
+	b.WriteString("You are a bones subagent for slot=")
+	b.WriteString(s.name)
+	b.WriteString(". Use the `subagent` skill.\nTask ID is ")
+	b.WriteString(taskID)
+	b.WriteString(".\n\nTasks (from plan):\n")
+	b.WriteString(s.sourceMarkdown)
+	return b.String()
+}

--- a/internal/dispatch/manifest_test.go
+++ b/internal/dispatch/manifest_test.go
@@ -1,0 +1,191 @@
+package dispatch
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// ---------------------------------------------------------------------------
+// Task 1: JSON round-trip
+// ---------------------------------------------------------------------------
+
+func TestManifestJSON(t *testing.T) {
+	m := Manifest{
+		SchemaVersion: 1,
+		PlanPath:      "./plan.md",
+		PlanSHA256:    "abc123",
+		CreatedAt:     time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC),
+		CurrentWave:   1,
+		Waves: []Wave{
+			{
+				Wave: 1,
+				Slots: []SlotEntry{
+					{
+						Slot:           "a",
+						TaskID:         "t-1",
+						Title:          "auth",
+						Files:          []string{"auth/"},
+						SubagentPrompt: "...",
+					},
+				},
+			},
+		},
+	}
+	data, err := json.Marshal(m)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var got Manifest
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if got.SchemaVersion != 1 {
+		t.Fatalf("SchemaVersion = %d, want 1", got.SchemaVersion)
+	}
+	if len(got.Waves) != 1 || len(got.Waves[0].Slots) != 1 {
+		t.Fatalf("waves/slots round-trip lost data: %+v", got)
+	}
+	if got.Waves[0].Slots[0].Slot != "a" {
+		t.Fatalf("slot name = %q, want a", got.Waves[0].Slots[0].Slot)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Task 2: Atomic Write + Read + Remove + ErrNoManifest
+// ---------------------------------------------------------------------------
+
+func TestWriteRead(t *testing.T) {
+	root := t.TempDir()
+	m := Manifest{
+		SchemaVersion: 1,
+		PlanPath:      "./p.md",
+		PlanSHA256:    "x",
+		CreatedAt:     time.Now().UTC().Truncate(time.Second),
+		CurrentWave:   1,
+		Waves:         []Wave{{Wave: 1, Slots: []SlotEntry{{Slot: "a", TaskID: "t1"}}}},
+	}
+	if err := Write(root, m); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	path := filepath.Join(root, ".bones", "swarm", "dispatch.json")
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("expected file at %s: %v", path, err)
+	}
+	got, err := Read(root)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if got.PlanSHA256 != "x" || got.CurrentWave != 1 {
+		t.Fatalf("round-trip mismatch: %+v", got)
+	}
+}
+
+func TestReadErrNoManifest(t *testing.T) {
+	if _, err := Read(t.TempDir()); !errors.Is(err, ErrNoManifest) {
+		t.Fatalf("expected ErrNoManifest for empty workspace, got %v", err)
+	}
+}
+
+func TestRemove(t *testing.T) {
+	root := t.TempDir()
+	m := Manifest{SchemaVersion: 1, CurrentWave: 1, CreatedAt: time.Now().UTC()}
+	if err := Write(root, m); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if err := Remove(root); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+	// idempotent
+	if err := Remove(root); err != nil {
+		t.Fatalf("Remove second call: %v", err)
+	}
+	if _, err := Read(root); !errors.Is(err, ErrNoManifest) {
+		t.Fatalf("expected ErrNoManifest after Remove, got %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Task 3: BuildManifest + renderSubagentPrompt
+// ---------------------------------------------------------------------------
+
+func TestBuildManifest(t *testing.T) {
+	planPath := writeTempPlan(t, `# Plan
+## Phase 1: Auth [slot: alpha]
+### Task 1: Edit alpha files [slot: alpha]
+**Files:**
+- Modify: alpha/x.go
+`)
+	m, err := BuildManifest(BuildOptions{
+		PlanPath: planPath,
+		TaskIDs:  map[string]string{"alpha": "t-alpha-1"},
+	})
+	if err != nil {
+		t.Fatalf("BuildManifest: %v", err)
+	}
+	if m.PlanPath != planPath {
+		t.Fatalf("PlanPath = %q, want %q", m.PlanPath, planPath)
+	}
+	if m.PlanSHA256 == "" {
+		t.Fatalf("PlanSHA256 not set")
+	}
+	if len(m.Waves) != 1 || len(m.Waves[0].Slots) != 1 {
+		t.Fatalf("expected 1 wave with 1 slot, got %+v", m.Waves)
+	}
+	slot := m.Waves[0].Slots[0]
+	if slot.Slot != "alpha" || slot.TaskID != "t-alpha-1" {
+		t.Fatalf("slot mismatch: %+v", slot)
+	}
+	if !strings.Contains(slot.SubagentPrompt, "slot=alpha") {
+		t.Fatalf("subagent_prompt missing slot identity:\n%s", slot.SubagentPrompt)
+	}
+	if !strings.Contains(slot.SubagentPrompt, "Task ID is t-alpha-1") {
+		t.Fatalf("subagent_prompt missing task id:\n%s", slot.SubagentPrompt)
+	}
+}
+
+func TestBuildManifest_MultiSlot(t *testing.T) {
+	planPath := writeTempPlan(t, `# Plan
+### Task 1: Edit alpha files [slot: alpha]
+**Files:**
+- Modify: alpha/a.go
+
+### Task 2: Edit beta files [slot: beta]
+**Files:**
+- Modify: beta/b.go
+`)
+	m, err := BuildManifest(BuildOptions{
+		PlanPath: planPath,
+		TaskIDs: map[string]string{
+			"alpha": "t-1",
+			"beta":  "t-2",
+		},
+	})
+	if err != nil {
+		t.Fatalf("BuildManifest: %v", err)
+	}
+	if len(m.Waves) != 1 {
+		t.Fatalf("expected 1 wave, got %d", len(m.Waves))
+	}
+	if len(m.Waves[0].Slots) != 2 {
+		t.Fatalf("expected 2 slots, got %d: %+v", len(m.Waves[0].Slots), m.Waves[0].Slots)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+func writeTempPlan(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "plan.md")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}

--- a/internal/dispatch/plan_parser.go
+++ b/internal/dispatch/plan_parser.go
@@ -1,0 +1,147 @@
+package dispatch
+
+// plan_parser.go contains a minimal plan-markdown parser adapted from
+// cli/validate_plan.go. Intentional duplication: importing cli from
+// internal/dispatch would create a dependency inversion (internal
+// depending on the command layer). A shared internal/plan package is
+// deferred until a second consumer materializes.
+
+import (
+	"bufio"
+	"bytes"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+var (
+	dispTaskHeading = regexp.MustCompile(`^###\s+Task\s+\d+`)
+	dispPhaseSlot   = regexp.MustCompile(`\[slot:\s*([a-z][a-z0-9_-]*)\]`)
+	dispFilesLine   = regexp.MustCompile(`^\s*-\s+(?:Create|Modify|Test):\s+(\S+)`)
+)
+
+// parsedSlot is the minimal view of a slot extracted from a plan file.
+type parsedSlot struct {
+	name           string
+	title          string
+	files          []string
+	sourceMarkdown string
+}
+
+// rawTask is an individual task block parsed from the plan markdown.
+type rawTask struct {
+	heading string
+	slot    string
+	files   []string
+	lines   []string // raw markdown lines for this task block
+}
+
+// parsePlanSlots extracts per-slot information from a Markdown plan.
+// The first argument (path) is unused and reserved for future use.
+// data is the raw file bytes.
+//
+// Each slot collapses all its tasks; duplicate files are de-duplicated.
+// Slots are returned in first-seen order.
+func parsePlanSlots(_ string, data []byte) ([]parsedSlot, error) {
+	tasks, err := scanRawTasks(data)
+	if err != nil {
+		return nil, err
+	}
+	return aggregateSlots(tasks), nil
+}
+
+// scanRawTasks parses the markdown bytes into a flat list of task blocks.
+func scanRawTasks(data []byte) ([]rawTask, error) {
+	var tasks []rawTask
+	var current *rawTask
+	inFiles := false
+
+	scan := bufio.NewScanner(bytes.NewReader(data))
+	for scan.Scan() {
+		line := scan.Text()
+		if dispTaskHeading.MatchString(line) {
+			if current != nil {
+				tasks = append(tasks, *current)
+			}
+			t := rawTask{heading: strings.TrimSpace(line)}
+			if m := dispPhaseSlot.FindStringSubmatch(line); m != nil {
+				t.slot = m[1]
+			}
+			t.lines = append(t.lines, line)
+			current = &t
+			inFiles = false
+			continue
+		}
+		if current == nil {
+			continue
+		}
+		current.lines = append(current.lines, line)
+		if strings.HasPrefix(strings.TrimSpace(line), "**Files:**") {
+			inFiles = true
+			continue
+		}
+		if inFiles {
+			if m := dispFilesLine.FindStringSubmatch(line); m != nil {
+				current.files = append(current.files, m[1])
+				continue
+			}
+			if strings.TrimSpace(line) != "" {
+				inFiles = false
+			}
+		}
+	}
+	if current != nil {
+		tasks = append(tasks, *current)
+	}
+	return tasks, scan.Err()
+}
+
+// aggregateSlots collapses rawTask entries into per-slot parsedSlot values.
+// Slots are returned in first-seen order; files are de-duplicated within each slot.
+func aggregateSlots(tasks []rawTask) []parsedSlot {
+	seenIdx := map[string]int{}
+	var slots []parsedSlot
+	for _, t := range tasks {
+		if t.slot == "" {
+			continue
+		}
+		idx, ok := seenIdx[t.slot]
+		if !ok {
+			idx = len(slots)
+			seenIdx[t.slot] = idx
+			slots = append(slots, parsedSlot{name: t.slot, title: t.slot})
+		}
+		addFiles(&slots[idx], t.files)
+		if slots[idx].title == t.slot {
+			slots[idx].title = trimSlotAnnotation(t.heading)
+		}
+		slots[idx].sourceMarkdown += strings.Join(t.lines, "\n") + "\n"
+	}
+	return slots
+}
+
+// addFiles appends files to a slot, skipping duplicates.
+func addFiles(s *parsedSlot, files []string) {
+	seen := map[string]bool{}
+	for _, f := range s.files {
+		seen[f] = true
+	}
+	for _, f := range files {
+		if !seen[f] {
+			s.files = append(s.files, f)
+			seen[f] = true
+		}
+	}
+}
+
+// trimSlotAnnotation removes the [slot: …] annotation from a heading line.
+func trimSlotAnnotation(s string) string {
+	cleaned := dispPhaseSlot.ReplaceAllString(s, "")
+	cleaned = strings.TrimLeft(cleaned, "#")
+	cleaned = strings.TrimRight(strings.TrimSpace(cleaned), ":")
+	cleaned = strings.TrimSpace(cleaned)
+	if cleaned == "" {
+		return filepath.Base(s)
+	}
+	return cleaned
+}

--- a/internal/logwriter/events.go
+++ b/internal/logwriter/events.go
@@ -1,0 +1,66 @@
+package logwriter
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// EventType is one entry in the closed catalog of slot/workspace event kinds.
+// Each constant matches the string written to the on-disk NDJSON "event" field
+// so operator tooling can grep without understanding Go constants.
+type EventType string
+
+const (
+	// EventJoin is emitted when a slot successfully acquires a session.
+	EventJoin EventType = "join"
+
+	// EventCommit is emitted when a slot's commit completes without error.
+	EventCommit EventType = "commit"
+
+	// EventCommitError is emitted when a slot's commit fails.
+	EventCommitError EventType = "commit_error"
+
+	// EventRenew is emitted when a slot renews its lease.
+	EventRenew EventType = "renew"
+
+	// EventClose is emitted when a slot closes and releases its session.
+	EventClose EventType = "close"
+
+	// EventDispatched is emitted when the workspace dispatches a new plan.
+	EventDispatched EventType = "dispatched"
+
+	// EventError is emitted for any unexpected error worth recording.
+	EventError EventType = "error"
+)
+
+// Event is one NDJSON row. MarshalJSON merges Fields into the top-level object
+// so the on-disk row is flat: {"ts":"...","event":"...","slot":"...",...fields}.
+// json:"-" tags keep the zero-value encoding path from double-emitting keys.
+type Event struct {
+	Timestamp time.Time              `json:"-"`
+	Slot      string                 `json:"-"` // optional; omitted when empty
+	Event     EventType              `json:"-"`
+	Fields    map[string]interface{} `json:"-"`
+}
+
+// MarshalJSON emits a single flat JSON object. Required keys are always present;
+// "slot" is omitted when empty; entries from Fields are merged at the top level.
+// If a Fields key collides with a reserved key ("ts", "event", "slot") it is
+// silently dropped — callers must not reuse reserved names.
+func (e Event) MarshalJSON() ([]byte, error) {
+	m := make(map[string]interface{}, len(e.Fields)+3)
+
+	// Merge caller-supplied fields first so reserved keys can overwrite them.
+	for k, v := range e.Fields {
+		m[k] = v
+	}
+
+	// Reserved keys overwrite any Fields collision.
+	m["ts"] = e.Timestamp.UTC().Format(time.RFC3339Nano)
+	m["event"] = string(e.Event)
+	if e.Slot != "" {
+		m["slot"] = e.Slot
+	}
+
+	return json.Marshal(m)
+}

--- a/internal/logwriter/events_test.go
+++ b/internal/logwriter/events_test.go
@@ -1,0 +1,116 @@
+package logwriter
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestMarshalJSON_flatShape(t *testing.T) {
+	ts := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	e := Event{
+		Timestamp: ts,
+		Slot:      "slot-1",
+		Event:     EventJoin,
+		Fields: map[string]interface{}{
+			"task_id": "abc123",
+			"host":    "builder-01",
+		},
+	}
+
+	b, err := json.Marshal(e)
+	if err != nil {
+		t.Fatalf("MarshalJSON: %v", err)
+	}
+	s := string(b)
+
+	// Must be a single JSON object (no nesting of "fields").
+	var top map[string]interface{}
+	if err := json.Unmarshal(b, &top); err != nil {
+		t.Fatalf("unmarshal round-trip: %v", err)
+	}
+
+	mustHaveStr := func(key, want string) {
+		t.Helper()
+		got, ok := top[key]
+		if !ok {
+			t.Errorf("key %q missing from %s", key, s)
+			return
+		}
+		if got.(string) != want {
+			t.Errorf("key %q = %q, want %q", key, got, want)
+		}
+	}
+
+	mustHaveStr("ts", "2026-05-01T12:00:00Z")
+	mustHaveStr("event", "join")
+	mustHaveStr("slot", "slot-1")
+	mustHaveStr("task_id", "abc123")
+	mustHaveStr("host", "builder-01")
+
+	if _, ok := top["fields"]; ok {
+		t.Error("top-level 'fields' key must not exist; Fields must be merged flat")
+	}
+}
+
+func TestMarshalJSON_omitEmptySlot(t *testing.T) {
+	e := Event{
+		Timestamp: time.Now(),
+		Event:     EventDispatched,
+	}
+	b, err := json.Marshal(e)
+	if err != nil {
+		t.Fatalf("MarshalJSON: %v", err)
+	}
+	if strings.Contains(string(b), `"slot"`) {
+		t.Errorf("slot must be omitted when empty; got %s", b)
+	}
+}
+
+func TestMarshalJSON_allEventTypes(t *testing.T) {
+	types := []EventType{
+		EventJoin,
+		EventCommit,
+		EventCommitError,
+		EventRenew,
+		EventClose,
+		EventDispatched,
+		EventError,
+	}
+	for _, et := range types {
+		e := Event{Timestamp: time.Now(), Event: et}
+		b, err := json.Marshal(e)
+		if err != nil {
+			t.Fatalf("MarshalJSON(%q): %v", et, err)
+		}
+		var top map[string]interface{}
+		if err := json.Unmarshal(b, &top); err != nil {
+			t.Fatalf("round-trip(%q): %v", et, err)
+		}
+		if top["event"] != string(et) {
+			t.Errorf("event=%q want %q", top["event"], et)
+		}
+	}
+}
+
+func TestMarshalJSON_reservedKeyOverwritesFields(t *testing.T) {
+	// Caller should not do this, but if they do the reserved key wins.
+	e := Event{
+		Timestamp: time.Now(),
+		Event:     EventError,
+		Fields:    map[string]interface{}{"ts": "bad-ts", "event": "bad-event"},
+	}
+	b, err := json.Marshal(e)
+	if err != nil {
+		t.Fatalf("MarshalJSON: %v", err)
+	}
+	var top map[string]interface{}
+	_ = json.Unmarshal(b, &top)
+	if top["event"] != "error" {
+		t.Errorf("reserved key 'event' must win; got %q", top["event"])
+	}
+	if top["ts"] == "bad-ts" {
+		t.Errorf("reserved key 'ts' must win over Fields")
+	}
+}

--- a/internal/logwriter/writer.go
+++ b/internal/logwriter/writer.go
@@ -78,32 +78,50 @@ func OpenSlot(slotDir, slot string) *Writer {
 // If maxSize > 0 and the file has grown beyond it, rotation is performed first.
 // The parent directory is created if absent.
 func (w *Writer) Append(e Event) error {
-	if err := os.MkdirAll(filepath.Dir(w.path), 0o755); err != nil {
-		return fmt.Errorf("logwriter: mkdir %s: %w", filepath.Dir(w.path), err)
-	}
-
 	if w.maxSize > 0 {
+		if err := os.MkdirAll(filepath.Dir(w.path), 0o755); err != nil {
+			return fmt.Errorf("logwriter: mkdir %s: %w", filepath.Dir(w.path), err)
+		}
 		if err := w.rotateIfNeeded(); err != nil {
 			return err
 		}
 	}
+	return AppendOnce(w.path, e)
+}
 
+// AppendOnce writes one event line to path without rotation. Use this for
+// per-slot logs and other call sites that don't carry rotation state across
+// calls — it skips the Writer allocation entirely. The parent directory is
+// created if absent.
+//
+// Atomicity: opens with O_APPEND|O_CREATE|O_WRONLY and writes a single
+// newline-terminated line. POSIX guarantees writes ≤PIPE_BUF are atomic.
+func AppendOnce(path string, e Event) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("logwriter: mkdir %s: %w", filepath.Dir(path), err)
+	}
 	b, err := json.Marshal(e)
 	if err != nil {
 		return fmt.Errorf("logwriter: marshal event: %w", err)
 	}
 	b = append(b, '\n')
-
-	f, err := os.OpenFile(w.path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
 	if err != nil {
-		return fmt.Errorf("logwriter: open %s: %w", w.path, err)
+		return fmt.Errorf("logwriter: open %s: %w", path, err)
 	}
 	defer func() { _ = f.Close() }()
-
 	if _, err := f.Write(b); err != nil {
-		return fmt.Errorf("logwriter: write %s: %w", w.path, err)
+		return fmt.Errorf("logwriter: write %s: %w", path, err)
 	}
 	return nil
+}
+
+// SlotLogPath returns the per-slot log path under <slotDir>/log. Per-slot logs
+// are bounded by slot lifetime and never rotate, so callers should use
+// AppendOnce(SlotLogPath(slotDir, slot), event) — no Writer needed.
+func SlotLogPath(slotDir, slot string) string {
+	_ = slot // reserved for future use (e.g. naming variants)
+	return filepath.Join(slotDir, "log")
 }
 
 // rotateIfNeeded renames the current log file into the numbered backup series

--- a/internal/logwriter/writer.go
+++ b/internal/logwriter/writer.go
@@ -1,0 +1,149 @@
+// Package logwriter provides atomic NDJSON event writing with optional
+// size-based rotation for workspace logs and no rotation for per-slot logs.
+//
+// Atomicity: each Append opens the file with O_APPEND|O_CREATE|O_WRONLY and
+// writes a single newline-terminated line. POSIX guarantees that writes no
+// larger than PIPE_BUF (512 bytes minimum; 4096+ on Linux and macOS) are
+// atomic on append-only file descriptors, so concurrent slot processes cannot
+// interleave lines for the small payloads we emit (~150–300 bytes).
+//
+// Rotation (workspace log only): on every Append, the file is stat-ed; if its
+// size exceeds maxSize the numbered series is shifted (.log.1→.log.2, etc.),
+// the current .log is renamed to .log.1, and a fresh .log is opened. The
+// oldest numbered file is removed when the count exceeds maxFiles.
+//
+// Single-writer assumed for v1 (one process appending per file at a time).
+// Concurrent-process safety relies on O_APPEND atomicity but NOT on rotation
+// being race-free — do not call Append concurrently on the same Writer.
+package logwriter
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+)
+
+const (
+	// defaultMaxSize is 10 MiB.
+	defaultMaxSize = 10 * 1024 * 1024
+
+	// defaultMaxFiles is the number of rotated backups kept (not counting the
+	// active .log file).
+	defaultMaxFiles = 5
+)
+
+// Writer writes NDJSON event lines to a single file, optionally rotating on
+// size. Zero value is not valid; use Open or OpenSlot.
+type Writer struct {
+	path     string
+	maxSize  int64 // 0 = no rotation
+	maxFiles int
+}
+
+// Open returns a Writer for the workspace log at path.
+// Defaults: 10 MiB maxSize, 5 backup files.
+// Overridable via BONES_LOG_MAX_SIZE (bytes) and BONES_LOG_MAX_FILES.
+func Open(path string) *Writer {
+	maxSize := int64(defaultMaxSize)
+	maxFiles := defaultMaxFiles
+
+	if v := os.Getenv("BONES_LOG_MAX_SIZE"); v != "" {
+		if n, err := strconv.ParseInt(v, 10, 64); err == nil && n > 0 {
+			maxSize = n
+		}
+	}
+	if v := os.Getenv("BONES_LOG_MAX_FILES"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			maxFiles = n
+		}
+	}
+
+	return &Writer{path: path, maxSize: maxSize, maxFiles: maxFiles}
+}
+
+// OpenSlot returns a Writer for a per-slot log at <slotDir>/log.
+// Rotation is disabled (maxSize=0) because per-slot logs are bounded by slot
+// lifetime and must not rotate under the slot process's feet.
+func OpenSlot(slotDir, slot string) *Writer {
+	_ = slot // reserved for future use (e.g. naming)
+	return &Writer{
+		path:    filepath.Join(slotDir, "log"),
+		maxSize: 0,
+	}
+}
+
+// Append writes one event line atomically to the log file.
+// If maxSize > 0 and the file has grown beyond it, rotation is performed first.
+// The parent directory is created if absent.
+func (w *Writer) Append(e Event) error {
+	if err := os.MkdirAll(filepath.Dir(w.path), 0o755); err != nil {
+		return fmt.Errorf("logwriter: mkdir %s: %w", filepath.Dir(w.path), err)
+	}
+
+	if w.maxSize > 0 {
+		if err := w.rotateIfNeeded(); err != nil {
+			return err
+		}
+	}
+
+	b, err := json.Marshal(e)
+	if err != nil {
+		return fmt.Errorf("logwriter: marshal event: %w", err)
+	}
+	b = append(b, '\n')
+
+	f, err := os.OpenFile(w.path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return fmt.Errorf("logwriter: open %s: %w", w.path, err)
+	}
+	defer func() { _ = f.Close() }()
+
+	if _, err := f.Write(b); err != nil {
+		return fmt.Errorf("logwriter: write %s: %w", w.path, err)
+	}
+	return nil
+}
+
+// rotateIfNeeded renames the current log file into the numbered backup series
+// when its size exceeds maxSize. Older backups beyond maxFiles are removed.
+//
+// Shift order (n = maxFiles):
+//
+//	.log.n   → removed
+//	.log.n-1 → .log.n
+//	  ...
+//	.log.1   → .log.2
+//	.log     → .log.1
+func (w *Writer) rotateIfNeeded() error {
+	info, err := os.Stat(w.path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil // nothing to rotate
+		}
+		return fmt.Errorf("logwriter: stat %s: %w", w.path, err)
+	}
+	if info.Size() <= w.maxSize {
+		return nil
+	}
+
+	// Drop the oldest backup if we're at capacity.
+	oldest := w.path + "." + strconv.Itoa(w.maxFiles)
+	_ = os.Remove(oldest) // best-effort; ignore ENOENT
+
+	// Shift existing numbered backups up by one.
+	for i := w.maxFiles - 1; i >= 1; i-- {
+		src := w.path + "." + strconv.Itoa(i)
+		dst := w.path + "." + strconv.Itoa(i+1)
+		if err := os.Rename(src, dst); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("logwriter: rotate %s → %s: %w", src, dst, err)
+		}
+	}
+
+	// Rename active log to .log.1.
+	if err := os.Rename(w.path, w.path+".1"); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("logwriter: rotate %s → %s.1: %w", w.path, w.path, err)
+	}
+	return nil
+}

--- a/internal/logwriter/writer_test.go
+++ b/internal/logwriter/writer_test.go
@@ -1,0 +1,201 @@
+package logwriter
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// makeEvent is a convenience helper for tests.
+func makeEvent(et EventType, fields map[string]interface{}) Event {
+	return Event{
+		Timestamp: time.Now().UTC(),
+		Event:     et,
+		Fields:    fields,
+	}
+}
+
+// TestAppend_createsFile verifies that Append creates the log file if absent
+// and writes a valid NDJSON line.
+func TestAppend_createsFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "workspace.log")
+	w := &Writer{path: path, maxSize: 0}
+
+	e := makeEvent(EventJoin, map[string]interface{}{"slot": "s1"})
+	if err := w.Append(e); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	var row map[string]interface{}
+	if err := json.Unmarshal(b[:len(b)-1], &row); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	if row["event"] != "join" {
+		t.Errorf("event=%q want %q", row["event"], "join")
+	}
+}
+
+// TestAppend_multipleLines verifies that N appends produce N valid NDJSON lines.
+func TestAppend_multipleLines(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "workspace.log")
+	w := &Writer{path: path, maxSize: 0}
+
+	events := []EventType{EventJoin, EventCommit, EventClose}
+	for _, et := range events {
+		if err := w.Append(makeEvent(et, nil)); err != nil {
+			t.Fatalf("Append(%q): %v", et, err)
+		}
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	sc := bufio.NewScanner(f)
+	var lines []string
+	for sc.Scan() {
+		lines = append(lines, sc.Text())
+	}
+	if len(lines) != len(events) {
+		t.Fatalf("got %d lines, want %d", len(lines), len(events))
+	}
+	for i, line := range lines {
+		var row map[string]interface{}
+		if err := json.Unmarshal([]byte(line), &row); err != nil {
+			t.Errorf("line %d: %v", i, err)
+		}
+	}
+}
+
+// TestRotation_shiftsFiles verifies that when the log file exceeds maxSize,
+// the numbered backup series is shifted and a fresh log is started.
+func TestRotation_shiftsFiles(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "workspace.log")
+	// Small maxSize so rotation triggers after a handful of appends.
+	w := &Writer{path: path, maxSize: 200, maxFiles: 5}
+
+	// Write until the file grows past 200 bytes.
+	for i := 0; i < 20; i++ {
+		e := makeEvent(EventCommit, map[string]interface{}{
+			"iteration": i,
+			"extra":     "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		})
+		if err := w.Append(e); err != nil {
+			t.Fatalf("Append[%d]: %v", i, err)
+		}
+	}
+
+	// After enough appends the first backup must exist.
+	backup := path + ".1"
+	if _, err := os.Stat(backup); err != nil {
+		t.Errorf("expected %s to exist after rotation; stat: %v", backup, err)
+	}
+
+	// Active log must still be valid NDJSON.
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("active log missing: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		var row map[string]interface{}
+		if err := json.Unmarshal([]byte(sc.Text()), &row); err != nil {
+			t.Errorf("active log line invalid JSON: %v", err)
+		}
+	}
+}
+
+// TestRotation_dropsOldestBeyondMaxFiles verifies that files beyond maxFiles
+// are removed.
+func TestRotation_dropsOldestBeyondMaxFiles(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "workspace.log")
+	w := &Writer{path: path, maxSize: 1, maxFiles: 3}
+
+	// Each Append will trigger rotation (maxSize=1 byte).
+	for i := 0; i < 10; i++ {
+		if err := w.Append(makeEvent(EventCommit, nil)); err != nil {
+			t.Fatalf("Append[%d]: %v", i, err)
+		}
+	}
+
+	// Files .log.4 and above must not exist.
+	for i := 4; i <= 10; i++ {
+		extra := path + "." + string(rune('0'+i))
+		if _, err := os.Stat(extra); err == nil {
+			t.Errorf("backup %s should have been removed", extra)
+		}
+	}
+	// .log.1 through .log.3 may or may not all exist depending on timing,
+	// but .log itself must always be present.
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("active log must exist: %v", err)
+	}
+}
+
+// TestOpenSlot_noRotation verifies that OpenSlot returns a writer with rotation
+// disabled regardless of how large the file grows.
+func TestOpenSlot_noRotation(t *testing.T) {
+	dir := t.TempDir()
+	w := OpenSlot(dir, "slot-1")
+
+	if w.maxSize != 0 {
+		t.Errorf("OpenSlot maxSize=%d, want 0 (no rotation)", w.maxSize)
+	}
+	if w.path != filepath.Join(dir, "log") {
+		t.Errorf("OpenSlot path=%q, want %q", w.path, filepath.Join(dir, "log"))
+	}
+
+	// Write a lot — no rotation file should appear.
+	for i := 0; i < 30; i++ {
+		if err := w.Append(makeEvent(EventCommit, map[string]interface{}{
+			"padding": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		})); err != nil {
+			t.Fatalf("Append[%d]: %v", i, err)
+		}
+	}
+
+	backup := w.path + ".1"
+	if _, err := os.Stat(backup); err == nil {
+		t.Errorf("rotation must not occur for slot logs; %s must not exist", backup)
+	}
+}
+
+// TestOpen_envOverrides verifies BONES_LOG_MAX_SIZE and BONES_LOG_MAX_FILES.
+func TestOpen_envOverrides(t *testing.T) {
+	t.Setenv("BONES_LOG_MAX_SIZE", "1048576")
+	t.Setenv("BONES_LOG_MAX_FILES", "3")
+	w := Open("/tmp/dummy.log")
+	if w.maxSize != 1048576 {
+		t.Errorf("maxSize=%d, want 1048576", w.maxSize)
+	}
+	if w.maxFiles != 3 {
+		t.Errorf("maxFiles=%d, want 3", w.maxFiles)
+	}
+}
+
+// TestOpen_defaults verifies default values when env vars are absent.
+func TestOpen_defaults(t *testing.T) {
+	t.Setenv("BONES_LOG_MAX_SIZE", "")
+	t.Setenv("BONES_LOG_MAX_FILES", "")
+	w := Open("/tmp/dummy.log")
+	if w.maxSize != defaultMaxSize {
+		t.Errorf("maxSize=%d, want %d", w.maxSize, defaultMaxSize)
+	}
+	if w.maxFiles != defaultMaxFiles {
+		t.Errorf("maxFiles=%d, want %d", w.maxFiles, defaultMaxFiles)
+	}
+}


### PR DESCRIPTION
## Summary

Implements Spec 3 (`dispatch-and-logs`) — the third and final spec from the DX audit. Adds `bones swarm dispatch <plan>` (manifest-emit verb that consumer skills spawn against, preserving the harness-agnostic boundary) and `bones logs --slot=<name> | --workspace` (per-slot/workspace NDJSON event log surface).

## What's in this PR

### Documentation

- **Spec 3 plan** — `docs/superpowers/plans/2026-05-01-dispatch-and-logs.md` (22 tasks, 6 phases, TDD).

### Implementation

- **`internal/dispatch/`** — added `Manifest`/`Wave`/`SlotEntry` schema, `Path`/`Write`/`Read`/`Remove`, `BuildManifest` (parses plan + creates one wave per dependency layer; v1 = single-wave), `Advance` (KV-driven wave promotion, no manifest `status` field needed), `Cancel` (closes open tasks via `ClosedReason="dispatch-canceled"`). Coexists with the pre-existing worker-spawn primitives (`Spec`/`BuildWorkerCommand`/`BuildSpec`) used by `bones tasks dispatch-parent` — no name collisions; flagged as future-cleanup to split into subpackages.
- **`internal/logwriter/`** — new package: closed `EventType` catalog (`join`/`commit`/`commit_error`/`renew`/`close`/`dispatched`/`error`), atomic O_APPEND NDJSON `Writer` with size-based rotation (10MB / 5 files default; tunable via `BONES_LOG_MAX_SIZE`/`BONES_LOG_MAX_FILES`), `OpenSlot(slotDir, slot)` helper for per-slot logs (no rotation, bounded by slot lifetime), flat JSON shape via custom `MarshalJSON`.
- **`cli/swarm_dispatch.go`** — new verb wired into existing `SwarmCmd`. Flags: `--advance`, `--cancel`, `--wave`, `--json`, `--dry-run`. `runDispatch` validates plan via existing `runValidatePlan`, guards conflicting in-flight manifests via `plan_sha256` match, creates one task per slot, emits manifest, prints next-step instruction. `runAdvance`/`runCancel` use shim closures over `tasks.Manager`.
- **`cli/logs.go`** — new top-level verb. Flags: `--slot`, `--workspace`, `--tail`/`-f`, `--since` (duration or RFC3339), `--last`, `--json`, `--full-time`. Color-coded event tags via `mattn/go-isatty` when stdout is TTY. Tail mode uses 100ms poll-and-read.
- **`internal/swarm/`** — instrumented `bones swarm join`, `commit`, `close` to emit log events to `<workspace>/.bones/swarm/<slot>/log` via shared `appendSlotEvent` helper. Failures are non-fatal (logged via `slog.Warn`).
- **`cli/swarm_status.go`** — extended to show one `Dispatch: <plan>  (wave N of M)` line at the top when a manifest is in flight.
- **`.claude/skills/orchestrator/SKILL.md`** — updated to consume `.bones/swarm/dispatch.json` instead of taking a plan path. Calls `bones swarm dispatch --advance` after each wave's subagents close. Notes that other harnesses (cursor, aider) ship their own equivalent consumer of the same schema.
- **`README.md`** — documented `bones swarm dispatch` flow + `bones logs` usage.

### Plan deviations (called out for review)

1. **Single-wave v1.** Existing plan parser emits a flat slot list — no dependency layers. All slots go in `wave=1`. Multi-wave needs new plan annotations the parser doesn't yet emit; deferred to a follow-up.
2. **Spelling:** `dispatch-canceled` (American), not `cancelled` — the project's misspell linter rejects British spelling. Exposed as `dispatch.CancelReason` const.
3. **Spec doc references the deleted `reference/CAPABILITIES.md`.** The harness-agnostic argument still holds via `docs/harness-integration.md` and ADR 0023. Spec doc cleanup is a separate follow-up PR.
4. **Plan parser logic copied** into `internal/dispatch/plan_parser.go` rather than added to `cli/validate_plan.go`'s public surface — explicit duplication, with a comment flagging future extraction to `internal/plan/`.
5. **`tasks.Manager.Close(ctx, id, reason)` doesn't exist** as a single method; `Cancel`'s `closeTask` shim uses `mgr.Update` with a mutator setting `StatusClosed + ClosedReason + ClosedAt` (mirrors existing `TasksCloseCmd` pattern).
6. **`--watch` auto-advance** stays a v2 follow-up per the spec's own Future Direction.

### Architectural boundaries preserved

- Bones binary writes a manifest and exits — does NOT spawn subagents from the binary.
- Spawning lives in the harness-specific skill (`orchestrator` for Claude Code; future cursor/aider-equivalents for those harnesses).
- Manifest schema is harness-neutral — no `claude_*` fields. Adding a new harness is a skill-only change.

## Test plan

- [x] `make check` passes locally (fmt, vet, lint, race, todo-check, full short tests)
- [x] Pre-push `ci-fast` hook passes (vet, build, short tests across all packages)
- [x] All new packages have unit test coverage (~40 new tests across `internal/dispatch/`, `internal/logwriter/`, `cli/swarm_dispatch_test.go`, `cli/swarm_log_events_test.go`, `cli/logs_test.go`, `cli/swarm_status_test.go`)
- [ ] Human review: manifest schema; orchestrator skill contract; `--advance` / `--cancel` semantics
- [ ] Manual end-to-end: write a small plan, run `bones swarm dispatch ./plan.md`, invoke `/orchestrator dispatch` in a Claude session, watch with `bones logs --slot=<name> --tail`, advance after wave completes

## Out of scope

- Multi-wave dependency analysis (deferred — needs new plan annotations)
- `bones swarm dispatch --watch` auto-advance daemon (Spec 3 v2)
- Splitting `internal/dispatch/` into `manifest/` + `worker/` subpackages (future cleanup; coexistence works for now)
- Updating Spec 3 doc to remove the deleted `reference/CAPABILITIES.md` reference (separate cleanup PR)