### PR TITLE
fix: unbreak v0.6.0 — Kong panics on env --shell enum and doctor --verbose collision

### DIFF
--- a/cli/doctor.go
+++ b/cli/doctor.go
@@ -34,10 +34,10 @@ var osHostname = os.Hostname
 // participate in Kong parsing.
 type DoctorCmd struct {
 	edgecli.DoctorCmd
-	All     bool `name:"all" help:"check all registered workspaces on this user/host"`
-	Quiet   bool `name:"quiet" short:"q" help:"only show workspaces with issues (with --all)"`
-	Verbose bool `name:"verbose" help:"show all checks including OK rows (with --all)"`
-	JSON    bool `name:"json" help:"emit machine-readable JSON"`
+	All    bool `name:"all" help:"check all registered workspaces on this user/host"`
+	Quiet  bool `name:"quiet" short:"q" help:"only show workspaces with issues (with --all)"`
+	ShowOK bool `name:"show-ok" help:"include OK workspaces in --all output (verbose mode)"`
+	JSON   bool `name:"json" help:"emit machine-readable JSON"`
 }
 
 // Run invokes the EdgeSync doctor first; on completion (regardless
@@ -82,8 +82,8 @@ func (c *DoctorCmd) runAll(_ *libfossilcli.Globals) error {
 		exitCode = renderDoctorAllJSON(os.Stdout)
 	} else {
 		exitCode = renderDoctorAll(os.Stdout, doctorAllOpts{
-			Quiet:   c.Quiet,
-			Verbose: c.Verbose,
+			Quiet:  c.Quiet,
+			ShowOK: c.ShowOK,
 		})
 	}
 	if exitCode != 0 {

--- a/cli/doctor_all.go
+++ b/cli/doctor_all.go
@@ -14,8 +14,8 @@ import (
 )
 
 type doctorAllOpts struct {
-	Quiet   bool
-	Verbose bool
+	Quiet  bool
+	ShowOK bool
 }
 
 // workspaceResult holds the per-workspace doctor outcome from --all.
@@ -55,7 +55,7 @@ func renderDoctorAll(w io.Writer, opts doctorAllOpts) int {
 	_ = tw.Flush()
 
 	// Per-workspace details. By default and with --quiet, only show
-	// workspaces that have issues. With --verbose, show every workspace
+	// workspaces that have issues. With --show-ok, show every workspace
 	// (including OK rows). --quiet additionally suppresses the per-row
 	// header in favor of a one-line tally when nothing's wrong.
 	anyIssue := false
@@ -63,7 +63,7 @@ func renderDoctorAll(w io.Writer, opts doctorAllOpts) int {
 		if r.Issues > 0 {
 			anyIssue = true
 		}
-		if r.Issues == 0 && !opts.Verbose {
+		if r.Issues == 0 && !opts.ShowOK {
 			continue
 		}
 		_, _ = fmt.Fprintf(w, "\n=== %s (%s) ===\n", r.Entry.Name, r.Entry.Cwd)

--- a/cli/doctor_all_test.go
+++ b/cli/doctor_all_test.go
@@ -73,7 +73,7 @@ func TestDoctorAllVerboseShowsDetails(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	renderDoctorAll(&buf, doctorAllOpts{Verbose: true})
+	renderDoctorAll(&buf, doctorAllOpts{ShowOK: true})
 	out := buf.String()
 	// Verbose mode shows per-workspace section even for OK workspaces.
 	if !strings.Contains(out, "=== wk") {

--- a/cli/env.go
+++ b/cli/env.go
@@ -37,7 +37,7 @@ func resolveWorkspaceName(root string) string {
 }
 
 type EnvCmd struct {
-	Shell string `name:"shell" help:"shell: bash|zsh|fish (default: auto)" enum:"bash,zsh,fish,"`
+	Shell string `name:"shell" help:"shell: bash|zsh|fish (default: auto-detect from $SHELL)"`
 }
 
 func (c *EnvCmd) Run() error { return c.run(os.Stdout) }
@@ -46,6 +46,11 @@ func (c *EnvCmd) run(w io.Writer) error {
 	shell := c.Shell
 	if shell == "" {
 		shell = detectShell()
+	}
+	switch shell {
+	case "bash", "zsh", "fish":
+	default:
+		return fmt.Errorf("--shell: unknown shell %q (want bash, zsh, or fish)", shell)
 	}
 	cwd, err := os.Getwd()
 	if err != nil {


### PR DESCRIPTION
## Urgent — v0.6.0 binary panics on every invocation

Two Kong tag bugs slipped through `make ci` and shipped in v0.6.0. The released binary panics on `bones --help` and any subcommand `--help`:

```
$ bones --help
panic: EnvCmd.Shell: enum value is only valid if it is either required or has a valid default value

$ bones --help  # after fix attempt 1
panic: DoctorCmd.Verbose: duplicate flag --verbose
```

Repro: `brew install danmestas/tap/bones && bones --help`.

## Fixes

1. **`cli/env.go` — drop the bad enum.** `enum:"bash,zsh,fish,"` (trailing comma to allow empty default) was rejected by Kong v1.15. Removed the enum tag entirely; do explicit shell validation in `run()` instead.

2. **`cli/doctor.go` — rename `Verbose` → `ShowOK`.** Conflicted with embedded `edgecli.DoctorCmd`'s `--verbose` flag. The new name (`--show-ok`) describes the actual behavior in `--all` mode (include OK workspaces in output) more precisely than "verbose" did.

## Why `make ci` missed it

The CI pipeline runs `go vet`, `go build`, and `go test`. None of those exercise `Kong.Parse` on the root CLI struct. Only running the binary surfaces these tag-validation panics. Follow-up should add a smoke test that runs `bones --help` and asserts exit 0 — for now this PR is the urgent patch.

## Verification

- [x] `bones --help`, `bones doctor --help`, `bones env --help`, `bones swarm dispatch --help` all work
- [x] `go test ./cli/` passes
- [x] `make ci-fast` clean
- [x] Smoke-tested all daily-group verbs

## Recommended cadence

Merge ASAP and cut `v0.6.1` immediately so the brew formula picks it up. Anyone who installed v0.6.0 in the last hour gets a non-functional binary.