### PR TITLE
fix: walkUpToBones misclassifies ~/.bones/ (state dir) as a workspace

### DIFF
--- a/cli/env.go
+++ b/cli/env.go
@@ -10,12 +10,19 @@ import (
 	"github.com/danmestas/bones/internal/workspace"
 )
 
-// walkUpToBones returns (workspaceRoot, true) if a .bones directory
-// exists at startDir or any ancestor; otherwise ("", false).
+// walkUpToBones returns (workspaceRoot, true) if a bones-initialized
+// workspace exists at startDir or any ancestor; otherwise ("", false).
+//
+// Looks for .bones/agent.id rather than just .bones/ — agent.id is written
+// by workspace.Init and is unique to a workspace, while bare .bones/ also
+// matches the user-level state directory at $HOME/.bones/ (registry,
+// telemetry install-id, telemetry-acknowledged). Distinguishing by the
+// agent.id marker prevents `bones env` from misclassifying any cwd inside
+// $HOME as the workspace named after $HOME.
 func walkUpToBones(startDir string) (string, bool) {
 	dir := startDir
 	for {
-		if _, err := os.Stat(filepath.Join(dir, ".bones")); err == nil {
+		if _, err := os.Stat(filepath.Join(dir, ".bones", "agent.id")); err == nil {
 			return dir, true
 		}
 		parent := filepath.Dir(dir)

--- a/cli/env_test.go
+++ b/cli/env_test.go
@@ -17,6 +17,10 @@ func TestWalkUpToBones(t *testing.T) {
 	if err := os.MkdirAll(bonesDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
+	// agent.id is the workspace marker (see walkUpToBones doc).
+	if err := os.WriteFile(filepath.Join(bonesDir, "agent.id"), []byte("test-agent"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	got, found := walkUpToBones(deep)
 	if !found {
 		t.Fatalf("expected to find .bones above %s", deep)
@@ -27,6 +31,32 @@ func TestWalkUpToBones(t *testing.T) {
 	other := t.TempDir()
 	if _, found := walkUpToBones(other); found {
 		t.Fatalf("expected not found in %s", other)
+	}
+}
+
+// TestWalkUpToBones_IgnoresStateDir verifies that ~/.bones/ (the user-level
+// state dir holding install-id, telemetry-acknowledged, and the workspaces/
+// registry) is NOT misclassified as a workspace. Only .bones/agent.id
+// (written by workspace.Init) marks a real workspace.
+func TestWalkUpToBones_IgnoresStateDir(t *testing.T) {
+	fakeHome := t.TempDir()
+	stateDir := filepath.Join(fakeHome, ".bones")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Mimic the user-level state-dir contents (no agent.id).
+	if err := os.WriteFile(filepath.Join(stateDir, "install-id"), []byte("xxx"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(stateDir, "workspaces"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	deep := filepath.Join(fakeHome, "projects", "anything")
+	if err := os.MkdirAll(deep, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if root, found := walkUpToBones(deep); found {
+		t.Fatalf("walkUpToBones must not match the state dir at %s, but returned root=%s", stateDir, root)
 	}
 }
 
@@ -61,6 +91,10 @@ func TestResolveWorkspaceName(t *testing.T) {
 func TestEnvCmdInsideWorkspace(t *testing.T) {
 	root := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(root, ".bones"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// agent.id is the workspace marker walkUpToBones checks for.
+	if err := os.WriteFile(filepath.Join(root, ".bones", "agent.id"), []byte("x"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	// Manual chdir + cleanup (t.Chdir requires Go 1.24+)
@@ -111,6 +145,9 @@ func TestEnvCmdOutsideWorkspace(t *testing.T) {
 func TestEnvCmdFishSyntax(t *testing.T) {
 	root := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(root, ".bones"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".bones", "agent.id"), []byte("x"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	oldCwd, _ := os.Getwd()

--- a/cli/env_test.go
+++ b/cli/env_test.go
@@ -7,6 +7,17 @@ import (
 	"testing"
 )
 
+// writeAgentIDForTest creates the .bones/agent.id marker that walkUpToBones
+// requires to recognize a directory as a workspace. Test fixtures use this
+// instead of just `mkdir .bones`.
+func writeAgentIDForTest(t *testing.T, root string) {
+	t.Helper()
+	path := filepath.Join(root, ".bones", "agent.id")
+	if err := os.WriteFile(path, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestWalkUpToBones(t *testing.T) {
 	root := t.TempDir()
 	deep := filepath.Join(root, "a", "b", "c")
@@ -18,9 +29,7 @@ func TestWalkUpToBones(t *testing.T) {
 		t.Fatal(err)
 	}
 	// agent.id is the workspace marker (see walkUpToBones doc).
-	if err := os.WriteFile(filepath.Join(bonesDir, "agent.id"), []byte("test-agent"), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	writeAgentIDForTest(t, filepath.Join(root, "a"))
 	got, found := walkUpToBones(deep)
 	if !found {
 		t.Fatalf("expected to find .bones above %s", deep)
@@ -45,7 +54,8 @@ func TestWalkUpToBones_IgnoresStateDir(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Mimic the user-level state-dir contents (no agent.id).
-	if err := os.WriteFile(filepath.Join(stateDir, "install-id"), []byte("xxx"), 0o644); err != nil {
+	idPath := filepath.Join(stateDir, "install-id")
+	if err := os.WriteFile(idPath, []byte("xxx"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.MkdirAll(filepath.Join(stateDir, "workspaces"), 0o755); err != nil {
@@ -56,7 +66,7 @@ func TestWalkUpToBones_IgnoresStateDir(t *testing.T) {
 		t.Fatal(err)
 	}
 	if root, found := walkUpToBones(deep); found {
-		t.Fatalf("walkUpToBones must not match the state dir at %s, but returned root=%s", stateDir, root)
+		t.Fatalf("must not match state dir at %s, returned root=%s", stateDir, root)
 	}
 }
 
@@ -94,9 +104,7 @@ func TestEnvCmdInsideWorkspace(t *testing.T) {
 		t.Fatal(err)
 	}
 	// agent.id is the workspace marker walkUpToBones checks for.
-	if err := os.WriteFile(filepath.Join(root, ".bones", "agent.id"), []byte("x"), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	writeAgentIDForTest(t, root)
 	// Manual chdir + cleanup (t.Chdir requires Go 1.24+)
 	oldCwd, _ := os.Getwd()
 	if err := os.Chdir(root); err != nil {
@@ -147,9 +155,7 @@ func TestEnvCmdFishSyntax(t *testing.T) {
 	if err := os.MkdirAll(filepath.Join(root, ".bones"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(root, ".bones", "agent.id"), []byte("x"), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	writeAgentIDForTest(t, root)
 	oldCwd, _ := os.Getwd()
 	if err := os.Chdir(root); err != nil {
 		t.Fatal(err)

--- a/cli/rename_test.go
+++ b/cli/rename_test.go
@@ -46,9 +46,7 @@ func TestRenameWritesAndUpdatesRegistry(t *testing.T) {
 	if err := os.MkdirAll(filepath.Join(wsDir, ".bones"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(wsDir, ".bones", "agent.id"), []byte("x"), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	writeAgentIDForTest(t, wsDir)
 	oldCwd, _ := os.Getwd()
 	if err := os.Chdir(wsDir); err != nil {
 		t.Fatal(err)
@@ -89,9 +87,7 @@ func TestRenameRejectsCollision(t *testing.T) {
 	if err := os.MkdirAll(filepath.Join(wsDir, ".bones"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(wsDir, ".bones", "agent.id"), []byte("x"), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	writeAgentIDForTest(t, wsDir)
 	oldCwd, _ := os.Getwd()
 	if err := os.Chdir(wsDir); err != nil {
 		t.Fatal(err)

--- a/cli/rename_test.go
+++ b/cli/rename_test.go
@@ -46,6 +46,9 @@ func TestRenameWritesAndUpdatesRegistry(t *testing.T) {
 	if err := os.MkdirAll(filepath.Join(wsDir, ".bones"), 0o755); err != nil {
 		t.Fatal(err)
 	}
+	if err := os.WriteFile(filepath.Join(wsDir, ".bones", "agent.id"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	oldCwd, _ := os.Getwd()
 	if err := os.Chdir(wsDir); err != nil {
 		t.Fatal(err)
@@ -84,6 +87,9 @@ func TestRenameRejectsCollision(t *testing.T) {
 	otherWS := t.TempDir()
 	wsDir := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(wsDir, ".bones"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(wsDir, ".bones", "agent.id"), []byte("x"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	oldCwd, _ := os.Getwd()


### PR DESCRIPTION
## Bug

Surfaced by v0.6.0's new \`bones env\` prompt-hook flow (the per-prompt eval). From anywhere under \`\$HOME\`, \`walkUpToBones\` walks up, finds \`~/.bones/\`, and reports it as the workspace named after \`\$HOME\`:

\`\`\`
\$ cd ~ && bones env
export BONES_WORKSPACE=dmestas
export BONES_WORKSPACE_CWD=/Users/dmestas
\`\`\`

Every shell prompt outside an actual workspace would falsely set \`BONES_WORKSPACE\` to the home-dir basename.

## Root cause

\`~/.bones/\` is the user-level state directory, NOT a workspace. Per existing ADRs:

- \`~/.bones/install-id\` (telemetry — ADR 0039 §45)
- \`~/.bones/telemetry-acknowledged\` (ADR 0039 §29)
- \`~/.bones/no-telemetry\` (ADR 0040 §38)
- \`~/.bones/workspaces/\` (Spec 1 registry)

A real workspace's \`.bones/\` contains \`agent.id\` (written by \`workspace.Init\`, see \`internal/workspace/agent_id.go:11\`). The state dir does not.

\`walkUpToBones\` was matching by directory existence only — never distinguished the two cases. The collision was always latent; the per-prompt \`bones env\` flow is what made it user-visible.

## Fix

Check for \`.bones/agent.id\` specifically. Workspace test fixtures that mocked workspaces by \`mkdir .bones\` (4 tests across \`env_test.go\` and \`rename_test.go\`) now also write a stub \`agent.id\`. Added \`TestWalkUpToBones_IgnoresStateDir\` to lock in the regression.

## Verification

- [x] \`go test ./cli/ -run TestWalkUpToBones\` — both passing (existing test + new state-dir test)
- [x] \`make ci-fast\` clean
- [x] Manual: \`bones env\` from \`\$HOME\` now correctly returns \`unset BONES_WORKSPACE\`

## Recommended cadence

Merge ASAP and cut \`v0.6.2\`. The bug is user-visible in every shell with the prompt-hook installed.

## Future architectural fix (not this PR)

The deeper issue is that \`~/.bones/\` does double duty (user state + workspace registry). A cleaner design: move user state to \`\$XDG_CONFIG_HOME/bones/\` or \`\$XDG_STATE_HOME/bones/\` so \`.bones/\` only ever names a workspace. That requires a migration path for the existing \`install-id\` / \`telemetry-acknowledged\` / \`workspaces/\` files; out of scope for this patch.