### PR TITLE
fix(swarm): swarm join opens fossil checkout in slot worktree

### DIFF
--- a/internal/coord/leaf.go
+++ b/internal/coord/leaf.go
@@ -660,6 +660,44 @@ func (l *Leaf) WT() string {
 	return l.wtPath
 }
 
+// OpenWorktree creates a fossil checkout at dir using the leaf's
+// repo handle and extracts trunk's files into it. dir must already
+// exist. The Checkout handle is closed before return: bones doesn't
+// drive commits through it (Leaf.Commit writes through the repo
+// handle directly per the "one *libfossil.Repo per fossil file"
+// invariant); what downstream readers need is the on-disk `.fslckout`
+// plus the materialized files.
+//
+// On a fresh repo with no checkins this is a no-op: libfossil refuses
+// to create a checkout without a checkin, and there are no files to
+// write anyway. The next Acquire after the first slot commits will
+// populate the worktree.
+func (l *Leaf) OpenWorktree(ctx context.Context, dir string) error {
+	assert.NotNil(l, "coord.Leaf.OpenWorktree: receiver is nil")
+	tip, err := l.Tip(ctx)
+	if err != nil {
+		return fmt.Errorf("coord.Leaf.OpenWorktree: probe tip: %w", err)
+	}
+	if tip == "" {
+		return nil
+	}
+	repo := l.agent.Repo()
+	co, err := repo.CreateCheckout(dir, libfossil.CheckoutCreateOpts{})
+	if err != nil {
+		return fmt.Errorf("coord.Leaf.OpenWorktree: create checkout: %w", err)
+	}
+	tipRID, err := repo.ResolveVersion(tip)
+	if err != nil {
+		_ = co.Close()
+		return fmt.Errorf("coord.Leaf.OpenWorktree: resolve tip: %w", err)
+	}
+	if err := co.Extract(tipRID, libfossil.ExtractOpts{}); err != nil {
+		_ = co.Close()
+		return fmt.Errorf("coord.Leaf.OpenWorktree: extract trunk: %w", err)
+	}
+	return co.Close()
+}
+
 // Metadata returns the value associated with key in the harness-supplied
 // metadata map (from LeafConfig.Metadata). Returns "" if the key is
 // absent or if no metadata was provided.

--- a/internal/swarm/lease.go
+++ b/internal/swarm/lease.go
@@ -819,6 +819,10 @@ func openLeafAndClaim(
 		_ = leaf.Stop()
 		return nil, nil, fmt.Errorf("swarm.Acquire: mkdir worktree: %w", err)
 	}
+	if err := leaf.OpenWorktree(ctx, leaf.WT()); err != nil {
+		_ = leaf.Stop()
+		return nil, nil, fmt.Errorf("swarm.Acquire: open worktree: %w", err)
+	}
 	claim, err := leaf.Claim(ctx, coord.TaskID(taskID))
 	if err != nil {
 		_ = leaf.Stop()

--- a/internal/swarm/lease_test.go
+++ b/internal/swarm/lease_test.go
@@ -190,6 +190,73 @@ func openVerifySessions(t *testing.T, f *leaseFixture) *Sessions {
 	return sess
 }
 
+// TestAcquire_OpensWorktreeCheckout pins the fix for #117:
+// Acquire must leave the slot worktree as a real fossil checkout
+// containing the trunk's files, not a bare empty directory. The
+// presence of `.fslckout` proves the libfossil CreateCheckout step
+// ran inside Acquire; the readability of the seed file proves the
+// slot can read prior phases' committed artifacts off disk without
+// running a separate pull/sync verb.
+func TestAcquire_OpensWorktreeCheckout(t *testing.T) {
+	f := newLeaseFixture(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Seed the hub so it mirrors a post-`bones up` state. Slot A
+	// acquires, commits a marker file, releases — this advances the
+	// hub's trunk.
+	seedHold := filepath.Join(f.dir, "seed", "seed.txt")
+	seedTask := string(f.createTask(t, "join117-seed-task", seedHold))
+	seedLease, err := Acquire(ctx, f.info, "seed", seedTask, AcquireOpts{Hub: f.hub})
+	if err != nil {
+		t.Fatalf("seed Acquire: %v", err)
+	}
+	if err := seedLease.Release(ctx); err != nil {
+		t.Fatalf("seed Release: %v", err)
+	}
+	seedResumed, err := Resume(ctx, f.info, "seed", AcquireOpts{Hub: f.hub})
+	if err != nil {
+		t.Fatalf("seed Resume: %v", err)
+	}
+	seedFiles := []coord.File{{
+		Path:    wspath.Must(seedHold),
+		Name:    "seed.txt",
+		Content: []byte("phase1-artifact"),
+	}}
+	if _, err := seedResumed.Commit(ctx, "seed for #117 test", seedFiles); err != nil {
+		t.Fatalf("seed Commit: %v", err)
+	}
+	if err := seedResumed.Release(ctx); err != nil {
+		t.Fatalf("seed final Release: %v", err)
+	}
+
+	// Now slot B acquires against the seeded hub. The wt must contain
+	// both .fslckout and the seeded file readable from disk.
+	holdPath := filepath.Join(f.dir, "join117", "hello.txt")
+	taskID := string(f.createTask(t, "join117-task-1", holdPath))
+	lease, err := Acquire(ctx, f.info, "join117", taskID, AcquireOpts{Hub: f.hub})
+	if err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	t.Cleanup(func() { _ = lease.Release(ctx) })
+
+	wt := lease.WT()
+	if wt == "" {
+		t.Fatalf("WT: empty")
+	}
+	if _, err := os.Stat(filepath.Join(wt, ".fslckout")); err != nil {
+		t.Fatalf(".fslckout missing in worktree (Acquire did not open a checkout): %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(wt, "seed.txt"))
+	if err != nil {
+		t.Fatalf("seed.txt missing in slot B worktree: %v", err)
+	}
+	if string(got) != "phase1-artifact" {
+		t.Errorf("seed.txt content: got %q want %q", got, "phase1-artifact")
+	}
+}
+
 // TestAcquire_RefusesActiveLiveSession pins the
 // ErrSessionAlreadyLive path: a live session on the same host
 // without --force must be rejected.


### PR DESCRIPTION
## Summary
- Adds `coord.Leaf.OpenWorktree(ctx, dir)` which uses the leaf's existing repo handle to create a fossil checkout and extract trunk's files into it (preserves the "one *libfossil.Repo per fossil file" invariant)
- `swarm.Acquire` calls it after `mkdir`'ing the per-slot worktree, so `bones swarm join` produces a real fossil checkout (`.fslckout` + trunk contents) rather than an empty directory
- On a fresh hub with no checkins, OpenWorktree is a no-op — the next Acquire after the first slot commits will populate the worktree

## Test plan
- [x] New `TestAcquire_OpensWorktreeCheckout` — seeds hub via slot A's commit, asserts slot B's wt has `.fslckout` and the seeded file readable off disk
- [x] `make check` passes (fmt-check, vet, lint, race, todo-check)
- [x] `go build -tags=otel ./...` passes
- [x] `go test -tags=otel -short ./...` passes
- [x] All existing swarm + coord tests still pass (acquire on empty hub is the no-op path)

Closes #117