### PR TITLE
fix(cli): suppress benign round-0 NATS no-responders ERROR on swarm commit

### DIFF
--- a/cmd/bones/log_filter.go
+++ b/cmd/bones/log_filter.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+
+	"github.com/nats-io/nats.go"
+)
+
+// suppressBenignSyncErrorHandler wraps another slog.Handler and drops
+// known-benign "sync error" records emitted by EdgeSync/leaf's
+// per-target sync loop (agent.go's `for _, target := range
+// a.syncTargets`) when the target is "nats" and the error is the
+// expected round-0 "no responders available" race.
+//
+// EdgeSync iterates each registered sync target independently and
+// logs ERROR for any that fails. NATS subject-interest hasn't
+// propagated through the leaf-node mesh on the first publish, so the
+// NATS target reports "no responders" and the HTTP target succeeds
+// in the same loop. Logging the NATS branch as ERROR creates noise
+// on every commit. The HTTP branch carries the real result.
+//
+// Other NATS errors (auth failures, dropped connections, schema
+// mismatches) still pass through. Non-"sync error" ERROR lines pass
+// through unchanged. See bones #118 and the project-code commentary
+// in internal/coord/leaf.go for the underlying mesh behavior.
+type suppressBenignSyncErrorHandler struct {
+	inner slog.Handler
+}
+
+func (h suppressBenignSyncErrorHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	return h.inner.Enabled(ctx, level)
+}
+
+func (h suppressBenignSyncErrorHandler) Handle(ctx context.Context, r slog.Record) error {
+	if isBenignNATSSyncError(r) {
+		return nil
+	}
+	return h.inner.Handle(ctx, r)
+}
+
+func (h suppressBenignSyncErrorHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return suppressBenignSyncErrorHandler{inner: h.inner.WithAttrs(attrs)}
+}
+
+func (h suppressBenignSyncErrorHandler) WithGroup(name string) slog.Handler {
+	return suppressBenignSyncErrorHandler{inner: h.inner.WithGroup(name)}
+}
+
+// isBenignNATSSyncError matches EdgeSync/leaf's `sync error` ERROR log
+// when target=nats and the error wraps nats.ErrNoResponders or its
+// rendered substring. The error attribute can be either the sentinel
+// itself or a wrapped error whose String() contains "no responders" —
+// libfossil's exchange-round error wrapping varies by call site, so
+// we accept both shapes.
+func isBenignNATSSyncError(r slog.Record) bool {
+	if r.Level != slog.LevelError || r.Message != "sync error" {
+		return false
+	}
+	var (
+		isNATS    bool
+		errSeen   error
+		errString string
+	)
+	r.Attrs(func(a slog.Attr) bool {
+		switch a.Key {
+		case "target":
+			if a.Value.String() == "nats" {
+				isNATS = true
+			}
+		case "error":
+			if e, ok := a.Value.Any().(error); ok {
+				errSeen = e
+			}
+			errString = a.Value.String()
+		}
+		return true
+	})
+	if !isNATS {
+		return false
+	}
+	if errSeen != nil && errors.Is(errSeen, nats.ErrNoResponders) {
+		return true
+	}
+	return strings.Contains(errString, "no responders")
+}

--- a/cmd/bones/log_filter_test.go
+++ b/cmd/bones/log_filter_test.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go"
+)
+
+// TestSuppressBenignNATSSyncError pins the fix for #118: a "sync error"
+// log emitted by EdgeSync/leaf's per-target sync loop, when the target
+// is "nats" and the error wraps nats.ErrNoResponders, must be dropped
+// before reaching the underlying handler. The HTTP sync target
+// succeeds independently in the same loop, so the NATS branch is
+// known-benign noise on the round-0 race.
+func TestSuppressBenignNATSSyncError(t *testing.T) {
+	cases := []struct {
+		name      string
+		level     slog.Level
+		msg       string
+		attrs     []slog.Attr
+		wantDrop  bool
+		shouldSee string // substring expected when not dropped
+	}{
+		{
+			name:  "drops nats no-responders sync error",
+			level: slog.LevelError,
+			msg:   "sync error",
+			attrs: []slog.Attr{
+				slog.String("target", "nats"),
+				slog.Any("error", nats.ErrNoResponders),
+			},
+			wantDrop: true,
+		},
+		{
+			name:  "drops wrapped nats no-responders sync error",
+			level: slog.LevelError,
+			msg:   "sync error",
+			attrs: []slog.Attr{
+				slog.String("target", "nats"),
+				slog.Any("error", errors.New(
+					"libfossil: sync: exchange round 0: nats: no responders available")),
+			},
+			wantDrop: true,
+		},
+		{
+			name:  "passes non-nats sync error",
+			level: slog.LevelError,
+			msg:   "sync error",
+			attrs: []slog.Attr{
+				slog.String("target", "http"),
+				slog.Any("error", nats.ErrNoResponders),
+			},
+			wantDrop:  false,
+			shouldSee: "http",
+		},
+		{
+			name:  "passes nats sync error with different cause",
+			level: slog.LevelError,
+			msg:   "sync error",
+			attrs: []slog.Attr{
+				slog.String("target", "nats"),
+				slog.Any("error", errors.New("authentication failed")),
+			},
+			wantDrop:  false,
+			shouldSee: "authentication failed",
+		},
+		{
+			name:  "passes unrelated error",
+			level: slog.LevelError,
+			msg:   "agent stop error",
+			attrs: []slog.Attr{
+				slog.Any("error", errors.New("boom")),
+			},
+			wantDrop:  false,
+			shouldSee: "agent stop error",
+		},
+		{
+			name:  "passes info-level sync message",
+			level: slog.LevelInfo,
+			msg:   "sync details",
+			attrs: []slog.Attr{
+				slog.String("target", "nats"),
+			},
+			wantDrop:  false,
+			shouldSee: "sync details",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			inner := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+			h := suppressBenignSyncErrorHandler{inner: inner}
+
+			r := slog.NewRecord(time.Time{}, tc.level, tc.msg, 0)
+			r.AddAttrs(tc.attrs...)
+
+			if err := h.Handle(context.Background(), r); err != nil {
+				t.Fatalf("Handle: %v", err)
+			}
+
+			out := buf.String()
+			gotDrop := out == ""
+			if gotDrop != tc.wantDrop {
+				t.Fatalf("drop: got %v want %v (output=%q)", gotDrop, tc.wantDrop, out)
+			}
+			if !tc.wantDrop && tc.shouldSee != "" && !strings.Contains(out, tc.shouldSee) {
+				t.Errorf("expected %q in output, got %q", tc.shouldSee, out)
+			}
+		})
+	}
+}

--- a/cmd/bones/main.go
+++ b/cmd/bones/main.go
@@ -80,9 +80,20 @@ func main() {
 	// to Debug so non-`-v` invocations stay quiet. `-v` (libfossilcli
 	// Globals.Verbose) reinstalls a Debug-level handler so the same
 	// sites are visible when troubleshooting.
+	//
+	// Either branch wraps in suppressBenignSyncErrorHandler so the
+	// round-0 NATS "no responders" ERROR emitted by EdgeSync/leaf's
+	// per-target sync loop (#118) is dropped while the HTTP target
+	// still carries the real result.
 	if c.Verbose {
-		slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr,
-			&slog.HandlerOptions{Level: slog.LevelDebug})))
+		slog.SetDefault(slog.New(suppressBenignSyncErrorHandler{
+			inner: slog.NewTextHandler(os.Stderr,
+				&slog.HandlerOptions{Level: slog.LevelDebug}),
+		}))
+	} else {
+		slog.SetDefault(slog.New(suppressBenignSyncErrorHandler{
+			inner: slog.Default().Handler(),
+		}))
 	}
 
 	if err := ctx.Run(&c.Globals); err != nil {


### PR DESCRIPTION
## Summary
- Adds `suppressBenignSyncErrorHandler` — a `slog.Handler` wrapper that drops the specific "sync error" record EdgeSync/leaf emits when `target=nats` and the error wraps `nats.ErrNoResponders` (or contains "no responders" in its message)
- Wired into `cmd/bones/main.go` for both verbose and non-verbose runs so every entry to the CLI gets the filter
- Other NATS errors (auth failures, dropped connections, schema mismatches) and non-"sync error" lines pass through unchanged

## Why this lives in bones
EdgeSync's `Agent.runSync` iterates each registered sync target independently and emits an ERROR for any that fails. On round-0 the NATS subject-interest hasn't propagated through the leaf-node mesh yet, so the NATS target reports `no responders available` while the HTTP target succeeds independently in the same loop. The proper architectural fix is upstream — aggregate target results, log ERROR only when all fail. Filed as danmestas/EdgeSync#96; this bones-side filter is the workaround until that lands.

## Test plan
- [x] New `TestSuppressBenignNATSSyncError` (6 cases) — drops nats+no-responders, drops wrapped variants, passes non-nats sync errors, passes auth-failure-on-nats, passes unrelated ERROR lines, passes INFO-level sync messages
- [x] `make check` passes (fmt-check, vet, lint, race, todo-check)
- [x] `go build -tags=otel ./...` passes
- [x] `go test -tags=otel -short ./...` passes

Closes #118
Upstream: danmestas/EdgeSync#96