### PR TITLE
fix(swarm): swarm close removes per-slot worktree on success

### DIFF
--- a/cli/swarm_close.go
+++ b/cli/swarm_close.go
@@ -31,6 +31,7 @@ type SwarmCloseCmd struct {
 	Rev        string `name:"rev" help:"only with --result=fork: rev"`
 	HubURL     string `name:"hub-url" help:"override hub fossil HTTP URL"`
 	NoArtifact string `name:"no-artifact" help:"reason for closing success without a commit"`
+	KeepWT     bool   `name:"keep-wt" help:"retain wt dir on success (default: remove)"`
 }
 
 func (c *SwarmCloseCmd) Run(g *libfossilcli.Globals) error {
@@ -65,6 +66,7 @@ func (c *SwarmCloseCmd) Run(g *libfossilcli.Globals) error {
 	closeOpts := swarm.CloseOpts{
 		CloseTaskOnSuccess: c.Result == string(dispatch.ResultSuccess),
 		NoArtifact:         c.NoArtifact,
+		KeepWT:             c.KeepWT,
 	}
 	if err := lease.Close(ctx, closeOpts); err != nil {
 		return fmt.Errorf("swarm close: %w", err)

--- a/internal/swarm/lease.go
+++ b/internal/swarm/lease.go
@@ -196,6 +196,15 @@ type CloseOpts struct {
 	// operator-driven close ("subagent reported done"). No effect
 	// on the cleanup mechanics.
 	Reaped bool
+
+	// KeepWT, when true, retains the per-slot worktree directory
+	// even on a successful close. Default behavior (KeepWT=false
+	// + CloseTaskOnSuccess=true) removes the wt so it does not
+	// accumulate across cycles. Failed and forked closes
+	// (CloseTaskOnSuccess=false) always retain wt regardless of
+	// this flag — the operator may need to inspect what the slot
+	// left behind.
+	KeepWT bool
 }
 
 // leaseBase holds the fields shared by FreshLease and ResumedLease.
@@ -662,6 +671,13 @@ func (l *ResumedLease) Close(ctx context.Context, opts CloseOpts) error {
 		return err
 	}
 	l.teardown()
+	if opts.CloseTaskOnSuccess && !opts.KeepWT {
+		// Best-effort idempotent removal: missing wt is fine. A
+		// permission-style error would propagate via os.RemoveAll's
+		// own retry semantics; in practice the slot's leaf is the
+		// only writer and it is stopped by teardown above.
+		_ = os.RemoveAll(SlotWorktree(l.info.WorkspaceDir, l.slot))
+	}
 	result := "fail"
 	if opts.CloseTaskOnSuccess {
 		result = "success"

--- a/internal/swarm/lease_test.go
+++ b/internal/swarm/lease_test.go
@@ -506,6 +506,150 @@ func TestClose_RefusesSuccessWithoutCommit(t *testing.T) {
 	}
 }
 
+// TestClose_RemovesWTOnSuccess pins the fix for #120: a successful
+// close must remove the per-slot worktree directory so it does not
+// accumulate across cycles. KV record + pid file removal are
+// covered by TestClose_DeletesRecordAndPidFile; this test is
+// scoped to the wt path.
+func TestClose_RemovesWTOnSuccess(t *testing.T) {
+	f := newLeaseFixture(t)
+	holdPath := filepath.Join(f.dir, "wtremove", "hello.txt")
+	taskID := string(f.createTask(t, "wtremove-task-1", holdPath))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	first, err := Acquire(ctx, f.info, "wtremove", taskID, AcquireOpts{Hub: f.hub})
+	if err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	wt := SlotWorktree(f.dir, "wtremove")
+	if _, err := os.Stat(wt); err != nil {
+		t.Fatalf("pre-Close wt missing: %v", err)
+	}
+	if err := first.Release(ctx); err != nil {
+		t.Fatalf("Release after Acquire: %v", err)
+	}
+
+	resumed, err := Resume(ctx, f.info, "wtremove", AcquireOpts{Hub: f.hub})
+	if err != nil {
+		t.Fatalf("Resume: %v", err)
+	}
+	if err := resumed.Close(ctx, CloseOpts{
+		CloseTaskOnSuccess: true,
+		NoArtifact:         "test: covers wt-removal path",
+	}); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if _, err := os.Stat(wt); !os.IsNotExist(err) {
+		t.Errorf("wt should be gone after success Close: stat err=%v", err)
+	}
+}
+
+// TestClose_RetainsWTOnFail pins the asymmetry: a failed close must
+// leave the per-slot worktree on disk so the operator can inspect
+// what the slot left behind. fork results follow the same retention
+// rule by virtue of CloseTaskOnSuccess=false.
+func TestClose_RetainsWTOnFail(t *testing.T) {
+	f := newLeaseFixture(t)
+	holdPath := filepath.Join(f.dir, "wtfail", "hello.txt")
+	taskID := string(f.createTask(t, "wtfail-task-1", holdPath))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	first, err := Acquire(ctx, f.info, "wtfail", taskID, AcquireOpts{Hub: f.hub})
+	if err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	if err := first.Release(ctx); err != nil {
+		t.Fatalf("Release: %v", err)
+	}
+	resumed, err := Resume(ctx, f.info, "wtfail", AcquireOpts{Hub: f.hub})
+	if err != nil {
+		t.Fatalf("Resume: %v", err)
+	}
+	if err := resumed.Close(ctx, CloseOpts{CloseTaskOnSuccess: false}); err != nil {
+		t.Fatalf("Close fail: %v", err)
+	}
+	wt := SlotWorktree(f.dir, "wtfail")
+	if _, err := os.Stat(wt); err != nil {
+		t.Errorf("wt should be retained after fail Close: %v", err)
+	}
+}
+
+// TestClose_KeepWTOnSuccess pins the forensics opt-out: a successful
+// close with CloseOpts.KeepWT=true must retain the worktree even
+// when CloseTaskOnSuccess=true.
+func TestClose_KeepWTOnSuccess(t *testing.T) {
+	f := newLeaseFixture(t)
+	holdPath := filepath.Join(f.dir, "wtkeep", "hello.txt")
+	taskID := string(f.createTask(t, "wtkeep-task-1", holdPath))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	first, err := Acquire(ctx, f.info, "wtkeep", taskID, AcquireOpts{Hub: f.hub})
+	if err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	if err := first.Release(ctx); err != nil {
+		t.Fatalf("Release: %v", err)
+	}
+	resumed, err := Resume(ctx, f.info, "wtkeep", AcquireOpts{Hub: f.hub})
+	if err != nil {
+		t.Fatalf("Resume: %v", err)
+	}
+	if err := resumed.Close(ctx, CloseOpts{
+		CloseTaskOnSuccess: true,
+		NoArtifact:         "test: covers keep-wt path",
+		KeepWT:             true,
+	}); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	wt := SlotWorktree(f.dir, "wtkeep")
+	if _, err := os.Stat(wt); err != nil {
+		t.Errorf("wt should be retained when KeepWT=true: %v", err)
+	}
+}
+
+// TestClose_IdempotentMissingWT pins the close-converges contract
+// for the wt-removal step: a close on a slot whose wt was already
+// removed (e.g. by a crashed prior close, or manual cleanup) must
+// still succeed without error.
+func TestClose_IdempotentMissingWT(t *testing.T) {
+	f := newLeaseFixture(t)
+	holdPath := filepath.Join(f.dir, "wtmissing", "hello.txt")
+	taskID := string(f.createTask(t, "wtmissing-task-1", holdPath))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	first, err := Acquire(ctx, f.info, "wtmissing", taskID, AcquireOpts{Hub: f.hub})
+	if err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	if err := first.Release(ctx); err != nil {
+		t.Fatalf("Release: %v", err)
+	}
+	// Pre-remove the wt so Close must converge through a missing-dir
+	// state rather than treating it as an error.
+	wt := SlotWorktree(f.dir, "wtmissing")
+	if err := os.RemoveAll(wt); err != nil {
+		t.Fatalf("pre-remove wt: %v", err)
+	}
+	resumed, err := Resume(ctx, f.info, "wtmissing", AcquireOpts{Hub: f.hub})
+	if err != nil {
+		t.Fatalf("Resume: %v", err)
+	}
+	if err := resumed.Close(ctx, CloseOpts{
+		CloseTaskOnSuccess: true,
+		NoArtifact:         "test: covers idempotent missing-wt",
+	}); err != nil {
+		t.Fatalf("Close (wt already missing): %v", err)
+	}
+}
+
 // TestClose_AllowsFailWithoutCommit covers the asymmetry: the
 // precondition gates only --result=success. A failed or forked
 // close has no artifact contract — the slot didn't claim to have


### PR DESCRIPTION
## Summary
- `ResumedLease.Close` removes the per-slot wt directory after teardown when `CloseTaskOnSuccess && !KeepWT`. Best-effort idempotent — a missing wt is not an error.
- Failed and forked closes (`CloseTaskOnSuccess=false`) always retain wt for forensic inspection — those carry no artifact contract and the operator may need to inspect what the slot left behind.
- Adds `CloseOpts.KeepWT` and a `--keep-wt` CLI flag on `bones swarm close` for the same forensic opt-out on the success path.
- KV session record, leaf process, and pid file cleanups continue to work as before.

## Test plan
- [x] New `TestClose_RemovesWTOnSuccess` — success close removes wt
- [x] New `TestClose_RetainsWTOnFail` — fail close retains wt
- [x] New `TestClose_KeepWTOnSuccess` — `KeepWT=true` retains wt on success
- [x] New `TestClose_IdempotentMissingWT` — pre-removed wt does not error during close
- [x] Existing `TestClose_DeletesRecordAndPidFile`, `TestClose_RefusesSuccessWithoutCommit`, `TestClose_AllowsFailWithoutCommit` still pass
- [x] `make check` passes (fmt-check, vet, lint, race, todo-check)
- [x] `go build -tags=otel ./...` passes
- [x] `go test -tags=otel -short ./...` passes

Closes #120