### PR TITLE
chore(deps): bump EdgeSync/leaf v0.0.5 → v0.0.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26.0
 require (
 	github.com/alecthomas/kong v1.15.0
 	github.com/danmestas/EdgeSync v0.0.8
-	github.com/danmestas/EdgeSync/leaf v0.0.5
+	github.com/danmestas/EdgeSync/leaf v0.0.6
 	github.com/danmestas/libfossil v0.4.6-rc3
 	github.com/danmestas/libfossil/db/driver/modernc v0.1.0
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -20,6 +20,8 @@ github.com/danmestas/EdgeSync/leaf v0.0.4 h1:26fkQogM6mUGtMufjyzAFZUSTPMTWWPSz7Z
 github.com/danmestas/EdgeSync/leaf v0.0.4/go.mod h1:7cGvLI5HRs7AK01E067rR6hkJkrC3pcDIRQj3pg2G60=
 github.com/danmestas/EdgeSync/leaf v0.0.5 h1:Erpzr4Yoze/EOF66dPKcl1ucEWCLPWn+hjywrYmBnbU=
 github.com/danmestas/EdgeSync/leaf v0.0.5/go.mod h1:7cGvLI5HRs7AK01E067rR6hkJkrC3pcDIRQj3pg2G60=
+github.com/danmestas/EdgeSync/leaf v0.0.6 h1:KifsL7WQ7Ay4p/y9SaWxws2RpNUH+plotK1SbNvCji8=
+github.com/danmestas/EdgeSync/leaf v0.0.6/go.mod h1:7cGvLI5HRs7AK01E067rR6hkJkrC3pcDIRQj3pg2G60=
 github.com/danmestas/go-sqlite3-opfs v0.2.0 h1:bO6iQYobgWCqTCQZ4NQ147x3yU2v+J+nn0Sq3y1b7sk=
 github.com/danmestas/go-sqlite3-opfs v0.2.0/go.mod h1:eAYxwG9hykpkB6oNMnsM8sSGB9HhHZv/NIN6yO9ZVQE=
 github.com/danmestas/libfossil v0.4.6-rc3 h1:lL4l2+cFhE8/1lrWcSczwtSdb1u/rz1f6SdhaPKlzi8=


### PR DESCRIPTION
## Summary
- Bumps `github.com/danmestas/EdgeSync/leaf` to `v0.0.6` which carries danmestas/EdgeSync#101 (closes danmestas/EdgeSync#100): a `sync.Mutex` fix in `notify.Service.Watch` that prevents `panic: send on closed channel` when ctx cancellation interleaves with NATS callback dispatch
- Eliminates a flake source that surfaced in #125's CI run (visible in `internal/coord` tests under Linux schedulers; not reliably reproducible on macOS but real)

## Why this lives in its own PR
Orthogonal to the swarm-cluster work. The notify race was unrelated to #118; merging it as part of #125 would have conflated two upstream fixes. Tagging it separately keeps the changelog clean.

## Test plan
- [x] 10× stress run on `internal/coord/...` + `internal/swarm/...` with `-tags=otel -short` — all clean
- [x] `make check` passes (fmt-check, vet, lint, race, todo-check)
- [x] `go build -tags=otel ./...` passes
- [x] `go test -tags=otel -short ./...` passes