### PR TITLE
docs(readme): point hub-contents inspection at bones repo, not raw fossil ls

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,18 @@ The hub fossil holds durable state (commits, tasks, presence, chat). Tasks live 
 
 Add `-v` to any command for DEBUG-level slog output. Default is silent.
 
+### Inspecting hub contents
+
+To list or read files in `.bones/hub.fossil`, use `bones repo` — not raw `fossil`:
+
+```bash
+bones repo ls -R .bones/hub.fossil          # list files at trunk tip
+bones repo ls -R .bones/hub.fossil <rev>    # list files at a specific rev
+bones repo cat -R .bones/hub.fossil <path>  # read a file's content at tip
+```
+
+`fossil ls -R .bones/hub.fossil -r tip` may return empty silently against a bones-managed hub even when the artifact is verifiably present. `bones repo` routes through libfossil — the same code path the hub uses to write commits — so it always sees the contents. Reach for `bones repo` first; it's the supported inspection surface.
+
 ## Telemetry
 
 Release binaries (Homebrew + GitHub releases) ship anonymous usage telemetry **on by default** — boolean outcomes, durations, and a 12-char `workspace_hash` go to a private Axiom dataset so the maintainer can see real-world failure modes. Source builds (`go install`) are zero-egress.


### PR DESCRIPTION
## Summary
- Adds an "Inspecting hub contents" subsection under Commands in README
- Recommends `bones repo ls/cat -R .bones/hub.fossil` for hub-side inspection
- Warns that raw `fossil ls -R hub.fossil -r tip` may silently return empty even when the artifact is verifiably present
- 12-line addition; no other changes

## Why
`bones repo` routes through libfossil — the same code path the hub uses to write commits — so it always sees the contents. Raw `fossil` CLI may not find the same artifacts because of how libfossil-managed repos populate (or don't populate) the standard fossil event/checkin tables that `fossil ls` consults.

## Test plan
- [x] `make check` passes
- [x] Reproduced both behaviors locally on a fresh `bones up` workspace: `bones repo ls -R .bones/hub.fossil` works; `fossil ls -R .bones/hub.fossil -r tip` is sometimes empty (per the original report's situation)

Closes #119