### PR TITLE
feat(hub): orphan-process registry + bones hub reap (closes #116, ADR 0043)

### DIFF
--- a/cli/doctor.go
+++ b/cli/doctor.go
@@ -15,6 +15,7 @@ import (
 	libfossilcli "github.com/danmestas/libfossil/cli"
 
 	"github.com/danmestas/bones/internal/githook"
+	"github.com/danmestas/bones/internal/registry"
 	"github.com/danmestas/bones/internal/scaffoldver"
 	"github.com/danmestas/bones/internal/swarm"
 	"github.com/danmestas/bones/internal/telemetry"
@@ -185,6 +186,7 @@ func runBypassReportTo(w io.Writer, cwd string) (warns int, err error) {
 	if checkBonesScaffoldedHooks(w, cwd) {
 		warns++
 	}
+	warns += checkOrphanHubs(w)
 
 	switch tip, head, drifted := fossilDrift(cwd); {
 	case tip == "" && head == "":
@@ -288,6 +290,32 @@ func checkBonesScaffoldedHooks(w io.Writer, cwd string) bool {
 	}
 	_, _ = fmt.Fprintln(w, "  OK    .claude/settings.json has bones-owned hook entries")
 	return false
+}
+
+// checkOrphanHubs reads the cross-workspace registry and reports
+// any orphan hub processes — alive PIDs whose workspace directory
+// no longer exists or has been trashed (per ADR 0043). Returns the
+// number of WARN-class findings emitted (one per orphan).
+func checkOrphanHubs(w io.Writer) int {
+	orphans, err := registry.Orphans()
+	if err != nil {
+		_, _ = fmt.Fprintf(w, "  WARN  orphan-hub registry read: %v\n", err)
+		return 1
+	}
+	if len(orphans) == 0 {
+		_, _ = fmt.Fprintln(w, "  OK    no orphan hub processes registered")
+		return 0
+	}
+	for _, e := range orphans {
+		age := "?"
+		if !e.StartedAt.IsZero() {
+			age = time.Since(e.StartedAt).Round(time.Second).String()
+		}
+		_, _ = fmt.Fprintf(w,
+			"  WARN  orphan hub: pid=%d cwd=%s age=%s — run `bones hub reap` to terminate\n",
+			e.HubPID, e.Cwd, age)
+	}
+	return len(orphans)
 }
 
 // hookCommandPresent walks hooks[event] and reports whether any

--- a/cli/doctor_all_test.go
+++ b/cli/doctor_all_test.go
@@ -6,12 +6,30 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/danmestas/bones/internal/registry"
 )
+
+// makeFakeWorkspace builds a minimal valid bones workspace under
+// t.TempDir() — directory + .bones/agent.id marker — so registry
+// entries pointing at it don't get flagged as orphans by ADR 0043's
+// orphan check during doctor tests.
+func makeFakeWorkspace(t *testing.T, name string) string {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), name)
+	if err := os.MkdirAll(filepath.Join(dir, ".bones"), 0o755); err != nil {
+		t.Fatalf("makeFakeWorkspace: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".bones", "agent.id"),
+		[]byte("test"), 0o644); err != nil {
+		t.Fatalf("makeFakeWorkspace marker: %v", err)
+	}
+	return dir
+}
 
 func TestDoctorAllRendersSummary(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
@@ -20,11 +38,16 @@ func TestDoctorAllRendersSummary(t *testing.T) {
 	}))
 	defer srv.Close()
 
+	// Build real workspace dirs with markers so the new orphan check
+	// (ADR 0043) doesn't flag them. The test cares about renderer
+	// output, not orphan-detection semantics.
+	fooDir := makeFakeWorkspace(t, "foo")
+	barDir := makeFakeWorkspace(t, "bar")
 	now := time.Now().UTC()
 	for _, e := range []registry.Entry{
-		{Cwd: "/foo", Name: "foo", HubURL: srv.URL, NATSURL: "nats://x",
+		{Cwd: fooDir, Name: "foo", HubURL: srv.URL, NATSURL: "nats://x",
 			HubPID: os.Getpid(), StartedAt: now},
-		{Cwd: "/bar", Name: "bar", HubURL: srv.URL, NATSURL: "nats://x",
+		{Cwd: barDir, Name: "bar", HubURL: srv.URL, NATSURL: "nats://x",
 			HubPID: os.Getpid(), StartedAt: now},
 	} {
 		if err := registry.Write(e); err != nil {
@@ -64,9 +87,10 @@ func TestDoctorAllVerboseShowsDetails(t *testing.T) {
 	}))
 	defer srv.Close()
 
+	wkDir := makeFakeWorkspace(t, "wk")
 	now := time.Now().UTC()
 	if err := registry.Write(registry.Entry{
-		Cwd: "/wk", Name: "wk", HubURL: srv.URL, NATSURL: "nats://x",
+		Cwd: wkDir, Name: "wk", HubURL: srv.URL, NATSURL: "nats://x",
 		HubPID: os.Getpid(), StartedAt: now,
 	}); err != nil {
 		t.Fatalf("seed: %v", err)
@@ -87,8 +111,9 @@ func TestDoctorAllJSON(t *testing.T) {
 		w.WriteHeader(200)
 	}))
 	defer srv.Close()
+	xDir := makeFakeWorkspace(t, "x")
 	if err := registry.Write(registry.Entry{
-		Cwd: "/x", Name: "x", HubURL: srv.URL, HubPID: os.Getpid(), StartedAt: time.Now().UTC(),
+		Cwd: xDir, Name: "x", HubURL: srv.URL, HubPID: os.Getpid(), StartedAt: time.Now().UTC(),
 	}); err != nil {
 		t.Fatalf("seed: %v", err)
 	}

--- a/cli/hub.go
+++ b/cli/hub.go
@@ -30,6 +30,7 @@ type HubCmd struct {
 	Start HubStartCmd `cmd:"" help:"Start the embedded Fossil hub + NATS server"`
 	Stop  HubStopCmd  `cmd:"" help:"Stop the embedded Fossil hub + NATS server"`
 	User  HubUserCmd  `cmd:"" help:"Manage fossil users in the hub repo"`
+	Reap  HubReapCmd  `cmd:"" help:"Terminate orphan hub processes (ADR 0043)"`
 }
 
 // HubStartCmd wires `bones hub start` flags to hub.Start.

--- a/cli/hub_reap.go
+++ b/cli/hub_reap.go
@@ -1,0 +1,83 @@
+package cli
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	libfossilcli "github.com/danmestas/libfossil/cli"
+
+	"github.com/danmestas/bones/internal/registry"
+)
+
+// HubReapCmd lists orphan hub processes recorded in the cross-workspace
+// registry (`~/.bones/workspaces/<id>.json`) and offers to terminate
+// them. An orphan is a registered process whose PID is alive but whose
+// workspace path no longer hosts a valid bones workspace — typically
+// because the directory was moved, trashed, or migrated without a
+// `bones down` first. See ADR 0043.
+//
+// Per orphan: SIGTERM then SIGKILL after a short grace; the registry
+// entry is removed on success. Idempotent — running with no orphans
+// is a no-op.
+type HubReapCmd struct {
+	Yes    bool `name:"yes" short:"y" help:"skip the per-orphan confirmation prompt"`
+	DryRun bool `name:"dry-run" help:"print orphans without acting"`
+}
+
+func (c *HubReapCmd) Run(g *libfossilcli.Globals) error {
+	return runHubReap(c, os.Stdin, os.Stdout)
+}
+
+// runHubReap is the testable entry point. confirmIn is the io.Reader
+// used for y/N prompts; tests pass a strings.Reader.
+func runHubReap(c *HubReapCmd, confirmIn io.Reader, out io.Writer) error {
+	orphans, err := registry.Orphans()
+	if err != nil {
+		return fmt.Errorf("list orphans: %w", err)
+	}
+	if len(orphans) == 0 {
+		_, _ = fmt.Fprintln(out, "hub reap: no orphan hub processes found")
+		return nil
+	}
+
+	_, _ = fmt.Fprintf(out, "hub reap: %d orphan hub process(es):\n", len(orphans))
+	for _, e := range orphans {
+		age := "?"
+		if !e.StartedAt.IsZero() {
+			age = time.Since(e.StartedAt).Round(time.Second).String()
+		}
+		_, _ = fmt.Fprintf(out, "  pid=%d  cwd=%s  hub=%s  age=%s\n",
+			e.HubPID, e.Cwd, e.HubURL, age)
+	}
+
+	if c.DryRun {
+		_, _ = fmt.Fprintln(out, "hub reap: --dry-run, not acting")
+		return nil
+	}
+
+	reader := bufio.NewReader(confirmIn)
+	var firstErr error
+	for _, e := range orphans {
+		if !c.Yes {
+			_, _ = fmt.Fprintf(out, "Reap pid=%d (%s)? [y/N] ", e.HubPID, e.Cwd)
+			line, _ := reader.ReadString('\n')
+			if !strings.HasPrefix(strings.ToLower(strings.TrimSpace(line)), "y") {
+				_, _ = fmt.Fprintln(out, "  skipped")
+				continue
+			}
+		}
+		if err := registry.Reap(e); err != nil {
+			_, _ = fmt.Fprintf(out, "  pid=%d: reap failed: %v\n", e.HubPID, err)
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		_, _ = fmt.Fprintf(out, "  pid=%d: reaped\n", e.HubPID)
+	}
+	return firstErr
+}

--- a/cli/hub_reap_test.go
+++ b/cli/hub_reap_test.go
@@ -1,0 +1,101 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/danmestas/bones/internal/registry"
+)
+
+// TestRunHubReap_NoOrphans is the no-op path: empty registry → exits cleanly.
+func TestRunHubReap_NoOrphans(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	var out bytes.Buffer
+	if err := runHubReap(&HubReapCmd{Yes: true}, strings.NewReader(""), &out); err != nil {
+		t.Fatalf("runHubReap: %v", err)
+	}
+	if !strings.Contains(out.String(), "no orphan") {
+		t.Errorf("expected no-orphans message, got: %q", out.String())
+	}
+}
+
+// TestRunHubReap_ReapsOrphan: spawn a real subprocess, register it
+// pointing at a vanished cwd, run reap with --yes, confirm both the
+// process is gone and the registry entry is removed.
+func TestRunHubReap_ReapsOrphan(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	cmd := exec.Command("sleep", "30")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start sleep: %v", err)
+	}
+	t.Cleanup(func() {
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+			_ = cmd.Wait()
+		}
+	})
+
+	// Register pointing at a path that doesn't exist — qualifies as orphan.
+	e := registry.Entry{
+		Cwd:       "/definitely/does/not/exist/orphan-test",
+		Name:      "orphan-test",
+		HubURL:    "http://127.0.0.1:1",
+		NATSURL:   "nats://127.0.0.1:1",
+		HubPID:    cmd.Process.Pid,
+		StartedAt: time.Now(),
+	}
+	if err := registry.Write(e); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	var out bytes.Buffer
+	if err := runHubReap(&HubReapCmd{Yes: true}, strings.NewReader(""), &out); err != nil {
+		t.Fatalf("runHubReap: %v", err)
+	}
+	_ = cmd.Wait() // reap zombie
+
+	got := out.String()
+	if !strings.Contains(got, "reaped") {
+		t.Errorf("expected reaped message, got: %q", got)
+	}
+	if _, err := registry.Read(e.Cwd); err == nil {
+		t.Errorf("registry entry still present after reap")
+	}
+}
+
+// TestRunHubReap_DryRun lists orphans without acting.
+func TestRunHubReap_DryRun(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	// Register a fake orphan whose PID is alive (use os.Getpid()) and
+	// whose cwd doesn't exist. We'll only do a dry-run, so no reaping.
+	e := registry.Entry{
+		Cwd:       "/definitely/does/not/exist/dryrun-test",
+		Name:      "dryrun-test",
+		HubURL:    "http://127.0.0.1:1",
+		HubPID:    os.Getpid(), // self — alive
+		StartedAt: time.Now(),
+	}
+	if err := registry.Write(e); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	var out bytes.Buffer
+	if err := runHubReap(&HubReapCmd{DryRun: true}, strings.NewReader(""), &out); err != nil {
+		t.Fatalf("runHubReap: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "--dry-run") {
+		t.Errorf("expected dry-run notice, got: %q", got)
+	}
+	// Entry must still be there.
+	if _, err := registry.Read(e.Cwd); err != nil {
+		t.Errorf("registry entry should be intact after dry-run: %v", err)
+	}
+}

--- a/docs/adr/0043-orphan-process-registry.md
+++ b/docs/adr/0043-orphan-process-registry.md
@@ -1,0 +1,55 @@
+# ADR 0043: Cross-workspace process registry for orphan detection and reaping
+
+## Context
+
+A `bones hub start` process retains its cwd and open file descriptors when the workspace directory is moved or trashed (Finder → `~/.Trash`, manual `mv`, or migrated from `.orchestrator/` → `.bones/` per ADR 0041). The process keeps running, holding ports and unlinked fossil inodes, while the next `bones hub start` in any workspace at the original path sees an empty `.bones/pids/` and proceeds as if no hub were live. The check in `runForeground` reads `${WORKSPACE}/.bones/pids/fossil.pid` to call `pidIsLive`; with the pid file gone, it returns "not live" — even though the previous hub is still running. `bones down` walks the same `.bones/` path to find pid files, so it also can't reach the orphan. The orphan can sit for hours holding workspace-scoped resources.
+
+Field reports correlate the orphan leak with intermittent `seed: reopen … no such file or directory` and `disk I/O error (522)` failures during fresh hub starts at related paths. 522 decodes to `SQLITE_IOERR_SHORT_READ` — SQLite reading fewer bytes than expected from a file. The plausible mechanism is the orphan's mmap'd `hub.fossil-shm` (SQLite's WAL shared-memory) colliding with a fresh `libfossil.Create` whose `hub.fossil-shm` ends up at a related inode; SQLite's SHM is keyed on inode/path and stale mappings can produce short reads on a freshly-created database. The mechanism is a working hypothesis — synthetic repros of the orphan leak have not deterministically triggered 522, and the field correlation is "kill orphans, seed succeeds." Even if the 522 path turns out to be unrelated, the orphan leak is its own bug: ports and fossil inodes held indefinitely are observable harm.
+
+The `internal/registry` package already maintains per-workspace records at `~/.bones/workspaces/<id>.json` with `HubPID`, `IsAlive(e)`, plus write/list/remove. It exists for `bones down --all` and cross-workspace doctor. What it lacks: a notion of "orphan," a reaper, and integration with the lifecycle events that produce orphans.
+
+## Decision
+
+The registry under `~/.bones/workspaces/` is the canonical source of truth for "what bones processes exist on this machine, against which workspace path." Every `bones hub start` writes its entry; every `bones down` removes it; orphans are the residue of crashes, moves, or trashes that bypassed the normal teardown.
+
+### Orphan predicate
+
+An entry is an orphan when its `HubPID` is alive (per `IsAlive`) and its `Cwd` is no longer a valid workspace at the recorded path. "No longer a valid workspace" is determined by:
+
+- `os.Stat(Cwd)` returns `ErrNotExist`, or
+- `os.Stat(filepath.Join(Cwd, ".bones", "agent.id"))` returns `ErrNotExist` — the workspace marker is gone, regardless of whether the directory itself remains, or
+- `Cwd` resolves into the user's `~/.Trash` (macOS) or `$XDG_DATA_HOME/Trash` (Linux) — the directory was trashed but the process retained its old `Cwd` value
+
+Living-PID-but-not-orphan is the normal case (workspace exists, process is healthy). Dead-PID is pruned by the existing `IsAlive` path. Orphan is the new third state.
+
+### Reaper
+
+A new verb — `bones reap` — lists orphans and offers to terminate them with confirmation. Default behavior is interactive (`y/N` per orphan); `--yes` skips the prompt; `--dry-run` prints the plan without acting. Termination is `SIGTERM` followed by `SIGKILL` after a short grace period. Successful termination removes the registry entry; a failed termination leaves the entry so the next `bones reap` can retry.
+
+The reaper is the same primitive whether triggered manually, by the migrator, or by `bones doctor`.
+
+### Migrator integration
+
+When `bones up`'s migration path detects an `.orchestrator/`-to-`.bones/` move (per ADR 0041's migration semantics), it queries the registry for entries whose `Cwd` matches the workspace being migrated and whose `HubPID` is alive. Those are reaped before the new `bones up` writes its own registry entry, so the new hub never starts adjacent to a stale one. A migration that finds no orphans is a no-op.
+
+### Doctor integration
+
+`bones doctor` reads the registry, identifies orphans, and reports them with the workspace path, PID, age, and held ports. The output suggests `bones reap` rather than reaping inline — doctor stays read-only.
+
+### What stays out of scope
+
+Per-slot `bones swarm` leaves (the per-slot leaf processes spawned by `bones swarm join`) are NOT registered. Their lifecycle is bounded by `bones swarm close`; orphans there are a swarm-cleanup concern (covered by `bones swarm close result=fail` retaining wt for forensics, plus the slot KV record persistence) rather than a workspace-process concern. If swarm-leaf orphans turn out to be a recurring issue, a follow-up ADR can extend the registry to per-slot entries — the API shape generalizes cleanly.
+
+The 522 root cause is also out of scope. The reaper addresses the orphan leak directly; if 522 incidents disappear after deployment, the working hypothesis is retroactively confirmed. If they persist, that's a separate investigation with synthetic stress against `libfossil.Create` under adversarial SHM conditions.
+
+## Consequences
+
+bones gains a single source of truth for cross-workspace process state. Orphan detection works regardless of whether the original workspace's `.bones/pids/` is reachable, since the registry lives in `~/.bones/`, not the workspace. Three trigger paths — manual reap, migrator-driven reap, doctor surfacing — share one primitive.
+
+The registry can theoretically drift if a process crashes between writing the entry and the `bones down` that would remove it. The `IsAlive` predicate already handles dead-PID entries (they're pruned on read), so drift converges automatically; the orphan-vs-dead distinction is "PID still alive" vs "PID gone."
+
+Trash detection is heuristic. A user who legitimately runs `bones hub start` from inside `~/.Trash` would be flagged as an orphan. This is an acceptable edge case — the reaper requires confirmation by default, and the user can `--keep` such an entry if they actually wanted it. The cwd-no-longer-exists check is the primary signal; trash-path is a tiebreaker for the "moved to Trash but parent still exists" case.
+
+Multi-workspace concurrency works as it does today; nothing about the registry changes the per-workspace lifecycle. The new burden is one registry write at hub start (already happens) and one read at `bones reap` / `bones doctor` time. List-all is O(n) workspaces — fine for human-scale n.
+
+The 522-error correlation either resolves with this fix (validating the SHM-collision hypothesis) or persists (motivating a deeper libfossil/SQLite investigation). Either outcome is a clean signal — shipping the reaper costs little and gives us a binary answer on the larger question.

--- a/internal/registry/orphan.go
+++ b/internal/registry/orphan.go
@@ -1,0 +1,125 @@
+package registry
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"syscall"
+	"time"
+)
+
+// reapGrace is how long Reap waits between SIGTERM and SIGKILL.
+// Short by design — orphan hubs aren't holding state we want to flush;
+// they're holding ports + unlinked fossil inodes we want released ASAP.
+var reapGrace = 2 * time.Second
+
+// IsOrphan reports whether e represents a process that is alive on
+// this host but whose workspace is no longer reachable. Three signals
+// qualify a workspace as gone:
+//
+//  1. e.Cwd does not exist on disk (ENOENT)
+//  2. e.Cwd exists but its workspace marker (.bones/agent.id) does not
+//  3. e.Cwd resolves into the user's Trash (~/.Trash on macOS, the
+//     XDG-Trash equivalent on Linux)
+//
+// The PID-alive check is the same one IsAlive uses; an entry whose
+// PID is dead is not an orphan (it's a stale entry awaiting prune)
+// and will be reported by IsAlive returning false.
+func IsOrphan(e Entry) bool {
+	if !pidAlive(e.HubPID) {
+		return false
+	}
+	if _, err := os.Stat(e.Cwd); os.IsNotExist(err) {
+		return true
+	}
+	marker := filepath.Join(e.Cwd, ".bones", "agent.id")
+	if _, err := os.Stat(marker); os.IsNotExist(err) {
+		return true
+	}
+	if isTrashed(e.Cwd) {
+		return true
+	}
+	return false
+}
+
+// isTrashed reports whether path is inside the user's Trash. macOS
+// uses ~/.Trash; Linux uses ~/.local/share/Trash by default. The
+// check is path-prefix only — if a process legitimately runs from
+// inside Trash (rare), it is treated as orphan; the reaper requires
+// confirmation by default so this edge case is recoverable.
+func isTrashed(path string) bool {
+	home := os.Getenv("HOME")
+	if home == "" {
+		return false
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return false
+	}
+	candidates := []string{filepath.Join(home, ".Trash")}
+	if runtime.GOOS == "linux" {
+		candidates = append(candidates,
+			filepath.Join(home, ".local", "share", "Trash"))
+	}
+	for _, c := range candidates {
+		if strings.HasPrefix(abs, c+string(filepath.Separator)) || abs == c {
+			return true
+		}
+	}
+	return false
+}
+
+// Orphans returns all registry entries whose process is alive but
+// whose workspace is gone. Read-only; the caller decides what to do.
+func Orphans() ([]Entry, error) {
+	all, err := List()
+	if err != nil {
+		return nil, err
+	}
+	var out []Entry
+	for _, e := range all {
+		if IsOrphan(e) {
+			out = append(out, e)
+		}
+	}
+	return out, nil
+}
+
+// Reap terminates the process for e and removes its registry entry.
+// SIGTERM first; if the PID is still alive after reapGrace, SIGKILL.
+// Returns nil on success (process gone, entry removed) or an error
+// describing which step failed. The entry is removed even after
+// SIGKILL — leaving it would create a permanent registry record for
+// a process that, by definition, isn't going to come back.
+func Reap(e Entry) error {
+	if !pidAlive(e.HubPID) {
+		return Remove(e.Cwd)
+	}
+	proc, err := os.FindProcess(e.HubPID)
+	if err != nil {
+		return fmt.Errorf("registry.Reap: find pid %d: %w", e.HubPID, err)
+	}
+	if err := proc.Signal(syscall.SIGTERM); err != nil {
+		return fmt.Errorf("registry.Reap: SIGTERM pid %d: %w", e.HubPID, err)
+	}
+	deadline := time.Now().Add(reapGrace)
+	for time.Now().Before(deadline) {
+		if !pidAlive(e.HubPID) {
+			return Remove(e.Cwd)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if err := proc.Signal(syscall.SIGKILL); err != nil {
+		return fmt.Errorf("registry.Reap: SIGKILL pid %d: %w", e.HubPID, err)
+	}
+	// Best-effort wait for SIGKILL to take effect; remove entry regardless.
+	for i := 0; i < 20; i++ {
+		if !pidAlive(e.HubPID) {
+			break
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	return Remove(e.Cwd)
+}

--- a/internal/registry/orphan_test.go
+++ b/internal/registry/orphan_test.go
@@ -1,0 +1,185 @@
+package registry
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestIsOrphan_LiveProcessVanishedCwd pins the primary signal: an
+// alive PID whose recorded Cwd no longer exists is an orphan.
+func TestIsOrphan_LiveProcessVanishedCwd(t *testing.T) {
+	e := Entry{
+		Cwd:    "/definitely/does/not/exist/anywhere-12345",
+		HubPID: os.Getpid(), // self — definitely alive
+		HubURL: "http://127.0.0.1:1",
+	}
+	if !IsOrphan(e) {
+		t.Errorf("expected orphan when Cwd does not exist")
+	}
+}
+
+// TestIsOrphan_LiveProcessMissingMarker pins that an existing
+// directory without the workspace marker (.bones/agent.id) is also
+// orphan-grade — the workspace was wiped but the process kept running.
+func TestIsOrphan_LiveProcessMissingMarker(t *testing.T) {
+	dir := t.TempDir()
+	e := Entry{
+		Cwd:    dir,
+		HubPID: os.Getpid(),
+		HubURL: "http://127.0.0.1:1",
+	}
+	if !IsOrphan(e) {
+		t.Errorf("expected orphan when .bones/agent.id is missing in Cwd")
+	}
+}
+
+// TestIsOrphan_LiveProcessHealthyWorkspace pins the negative case:
+// alive PID with a real workspace marker is NOT an orphan.
+func TestIsOrphan_LiveProcessHealthyWorkspace(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".bones"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".bones", "agent.id"),
+		[]byte("test"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	e := Entry{
+		Cwd:    dir,
+		HubPID: os.Getpid(),
+		HubURL: "http://127.0.0.1:1",
+	}
+	if IsOrphan(e) {
+		t.Errorf("healthy workspace should not be orphan")
+	}
+}
+
+// TestIsOrphan_DeadPidNotOrphan pins the asymmetry: a dead PID is
+// stale, not orphan. The IsAlive path handles dead-PID pruning.
+func TestIsOrphan_DeadPidNotOrphan(t *testing.T) {
+	e := Entry{
+		Cwd:    "/definitely/does/not/exist",
+		HubPID: 1, // PID 1 is reserved (init/launchd) — Signal(0) succeeds
+		HubURL: "http://127.0.0.1:1",
+	}
+	// Use an obviously-dead PID instead. Pick a high PID that's
+	// unlikely to be in use; if FindProcess+Signal(0) returns nil,
+	// the test is meaningless on this host so we skip.
+	dead := 999_999
+	for proc, err := os.FindProcess(dead); err == nil; proc, err = os.FindProcess(dead) {
+		if proc.Signal(nilSig{}) != nil {
+			break
+		}
+		dead++
+		if dead > 1_000_100 {
+			t.Skip("could not find a dead PID on this host")
+		}
+	}
+	e.HubPID = dead
+	if IsOrphan(e) {
+		t.Errorf("dead PID with vanished Cwd should NOT be orphan (it's stale)")
+	}
+}
+
+// nilSig is a syscall.Signal-shaped no-op for the dead-PID probe.
+type nilSig struct{}
+
+func (nilSig) String() string { return "nil" }
+func (nilSig) Signal()        {}
+
+// TestIsTrashed pins macOS Trash detection: a path under ~/.Trash
+// is reported as trashed.
+func TestIsTrashed(t *testing.T) {
+	home := os.Getenv("HOME")
+	if home == "" {
+		t.Skip("HOME unset")
+	}
+	cases := []struct {
+		path string
+		want bool
+	}{
+		{filepath.Join(home, ".Trash", "some-workspace"), true},
+		{filepath.Join(home, ".Trash"), true},
+		{filepath.Join(home, "projects", "my-app"), false},
+		{"/tmp/whatever", false},
+	}
+	for _, c := range cases {
+		if got := isTrashed(c.path); got != c.want {
+			t.Errorf("isTrashed(%q) = %v, want %v", c.path, got, c.want)
+		}
+	}
+}
+
+// TestReap_SIGTERMCleansEntry verifies the reaper end-to-end:
+// spawn a real subprocess, register it, reap it, confirm both the
+// process is gone and the registry entry is removed.
+func TestReap_SIGTERMCleansEntry(t *testing.T) {
+	t.Setenv("HOME", t.TempDir()) // isolate ~/.bones/workspaces
+	cwd := t.TempDir()
+
+	// Spawn `sleep 30` — a child that exits on SIGTERM, doesn't matter
+	// what it does as long as it stays alive long enough for us to
+	// register and reap it.
+	cmd := exec.Command("sleep", "30")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start sleep: %v", err)
+	}
+	t.Cleanup(func() {
+		// Belt-and-suspenders: ensure we don't leak the child if Reap fails.
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+			_ = cmd.Wait()
+		}
+	})
+
+	e := Entry{
+		Cwd:       cwd,
+		Name:      "test-reap",
+		HubURL:    "http://127.0.0.1:1",
+		NATSURL:   "nats://127.0.0.1:1",
+		HubPID:    cmd.Process.Pid,
+		StartedAt: time.Now(),
+	}
+	if err := Write(e); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	if err := Reap(e); err != nil {
+		t.Fatalf("Reap: %v", err)
+	}
+	// Wait reaps the zombie so pidAlive() reflects post-exit reality
+	// rather than "process exited but parent hasn't called Wait yet."
+	_ = cmd.Wait()
+
+	if pidAlive(cmd.Process.Pid) {
+		t.Errorf("process still alive after Reap+Wait")
+	}
+	if _, err := Read(cwd); err == nil {
+		t.Errorf("registry entry still present after Reap")
+	}
+}
+
+// TestReap_DeadPidJustRemovesEntry pins idempotency: if the PID is
+// already dead, Reap is just an entry-remove.
+func TestReap_DeadPidJustRemovesEntry(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	cwd := t.TempDir()
+	e := Entry{
+		Cwd:    cwd,
+		Name:   "test-dead",
+		HubURL: "http://127.0.0.1:1",
+		HubPID: 999_999, // assumed-dead
+	}
+	if err := Write(e); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if err := Reap(e); err != nil {
+		t.Fatalf("Reap on dead PID: %v", err)
+	}
+	if _, err := Read(cwd); err == nil {
+		t.Errorf("entry should be removed after Reap on dead PID")
+	}
+}


### PR DESCRIPTION
## Summary
- ADR 0042-style: this PR carries both the architecture decision (ADR 0043) and the implementation
- Extends the existing `internal/registry` package with `IsOrphan(e)`, `Orphans()`, and `Reap(e)` — the registry under `~/.bones/workspaces/<id>.json` becomes the canonical source of truth for "what bones processes are running where"
- New `bones hub reap` CLI verb lists orphans with PID + cwd + age and offers per-orphan termination (SIGTERM with grace, then SIGKILL)
- `bones doctor` reports orphans as WARN-class findings with a hint to run `bones hub reap`
- Per-slot swarm leaves remain out of scope (their lifecycle is `bones swarm close`'s concern); legacy `.orchestrator/`-era orphans predate the registry and rely on the existing migrator path

## Phase 1 investigation findings (recap)
- Orphan leak: confirmed empirically. Process retains cwd + open fds (hub.fossil + WAL/SHM) after `mv`; pid file in any new workspace at the original path is empty so `pidIsLive` doesn't notice
- 522 (`SQLITE_IOERR_SHORT_READ`): plausibly caused by the orphan's mmap'd hub.fossil-shm colliding with a fresh `libfossil.Create`, but not deterministically reproducible. The reaper addresses the orphan leak directly; if 522 incidents stop after deployment, the hypothesis is retroactively confirmed

## Test plan
- [x] `internal/registry/orphan_test.go`: `IsOrphan` cases (vanished cwd, missing marker, healthy workspace, dead PID); `Reap` end-to-end (real subprocess SIGTERM/SIGKILL); `isTrashed` path matching
- [x] `cli/hub_reap_test.go`: no-orphans no-op, dry-run preserves entries, end-to-end orphan reap removes both process and registry entry
- [x] Updated `cli/doctor_all_test.go` to use real workspace fixtures (the new orphan check would otherwise flag `/foo` `/bar` placeholder paths)
- [x] `make check` passes (fmt-check, vet, lint, race, todo-check)
- [x] `go build -tags=otel ./...` passes
- [x] `go test -tags=otel -short ./...` passes
- [x] Smoke test: `bones hub reap --dry-run` on a clean machine reports "no orphan hub processes found"

Implements ADR 0043. Closes #116.