### PR TITLE
feat(plan): bones plan finalize materializes hub trunk artifacts to host tree

### DIFF
--- a/cli/plan.go
+++ b/cli/plan.go
@@ -1,0 +1,9 @@
+package cli
+
+// PlanCmd is the umbrella command for plan-workflow operations
+// beyond validation. Today's surface: `bones plan finalize`. Validate
+// stays at the top level (`bones validate-plan`) for now — it predates
+// this group and changing the verb shape is a separate concern.
+type PlanCmd struct {
+	Finalize PlanFinalizeCmd `cmd:"" help:"Materialize hub artifacts to the host tree (ADR 0044)"`
+}

--- a/cli/plan_finalize.go
+++ b/cli/plan_finalize.go
@@ -1,0 +1,197 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	libfossil "github.com/danmestas/libfossil"
+	libfossilcli "github.com/danmestas/libfossil/cli"
+
+	"github.com/danmestas/bones/internal/dispatch"
+	"github.com/danmestas/bones/internal/workspace"
+)
+
+// PlanFinalizeCmd materializes files committed by each slot to hub
+// trunk back into the host tree, closing the loop on the swarm
+// workflow. The slot's `[slot: name]` annotation in the plan is the
+// manifest — files listed in the dispatch manifest's per-slot
+// `Files` are the materialization set. See ADR 0044.
+type PlanFinalizeCmd struct {
+	Plan  string `name:"plan" help:"plan path (default: read .bones/swarm/dispatch.json)"`
+	Force bool   `name:"force" help:"overwrite host-tree files that differ from hub trunk"`
+	Stage bool   `name:"stage" help:"git add the materialized files after writing"`
+}
+
+// finalizeResult holds the per-file outcomes of a finalize pass.
+// Categories are mutually exclusive; sum equals total files visited.
+type finalizeResult struct {
+	Written    []string
+	Matched    []string
+	Conflicted []string
+	Missing    []string // file in dispatch manifest but not on hub trunk
+}
+
+func (c *PlanFinalizeCmd) Run(g *libfossilcli.Globals) error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("plan finalize: cwd: %w", err)
+	}
+	info, err := workspace.Join(context.Background(), cwd)
+	if err != nil {
+		return fmt.Errorf("plan finalize: %w", err)
+	}
+	return runPlanFinalize(c, info.WorkspaceDir, os.Stdout)
+}
+
+// runPlanFinalize is the testable entry point. workspaceDir is the
+// resolved bones workspace root; out is where the summary prints.
+func runPlanFinalize(c *PlanFinalizeCmd, workspaceDir string, out io.Writer) error {
+	manifest, planSource, err := resolvePlanManifest(c.Plan, workspaceDir)
+	if err != nil {
+		return err
+	}
+	_, _ = fmt.Fprintf(out, "plan finalize: %s\n", planSource)
+
+	hubRepoPath := filepath.Join(workspaceDir, ".bones", "hub.fossil")
+	repo, err := libfossil.Open(hubRepoPath)
+	if err != nil {
+		return fmt.Errorf("plan finalize: open hub: %w", err)
+	}
+	defer func() { _ = repo.Close() }()
+
+	res := materializeManifest(repo, manifest, workspaceDir, c.Force)
+	printFinalizeSummary(out, res)
+
+	if len(res.Conflicted) > 0 && !c.Force {
+		return fmt.Errorf("plan finalize: %d file(s) conflict with host tree; "+
+			"resolve manually or re-run with --force", len(res.Conflicted))
+	}
+	if c.Stage && len(res.Written) > 0 {
+		if err := stageFiles(workspaceDir, res.Written); err != nil {
+			return fmt.Errorf("plan finalize: --stage: %w", err)
+		}
+		_, _ = fmt.Fprintf(out, "plan finalize: staged %d file(s)\n", len(res.Written))
+	}
+	return nil
+}
+
+// resolvePlanManifest implements the ordering from ADR 0044: explicit
+// --plan first, then .bones/swarm/dispatch.json, else error. Returns
+// the manifest plus a one-line source description for the summary.
+func resolvePlanManifest(planFlag, workspaceDir string) (
+	*dispatch.Manifest, string, error,
+) {
+	if planFlag != "" {
+		m, err := dispatch.BuildManifest(dispatch.BuildOptions{PlanPath: planFlag})
+		if err != nil {
+			return nil, "", fmt.Errorf("plan finalize: parse plan %s: %w", planFlag, err)
+		}
+		return &m, "plan=" + planFlag + " (--plan)", nil
+	}
+	m, err := dispatch.Read(workspaceDir)
+	if err != nil {
+		if errors.Is(err, dispatch.ErrNoManifest) {
+			return nil, "", errors.New("plan finalize: no active dispatch found; " +
+				"pass --plan=<path> to finalize a specific plan")
+		}
+		return nil, "", fmt.Errorf("plan finalize: read dispatch.json: %w", err)
+	}
+	return &m, "plan=" + m.PlanPath + " (active dispatch)", nil
+}
+
+// materializeManifest walks every (wave, slot, file) in the manifest,
+// reads the file from hub trunk, and writes it to the host tree under
+// the same relative path. Conflicts are listed without writing unless
+// force is set; matched files (host == trunk) are reported and skipped.
+func materializeManifest(
+	repo *libfossil.Repo, m *dispatch.Manifest, workspaceDir string, force bool,
+) finalizeResult {
+	var res finalizeResult
+	seen := map[string]bool{}
+	for _, wave := range m.Waves {
+		for _, slot := range wave.Slots {
+			for _, file := range slot.Files {
+				if seen[file] {
+					continue
+				}
+				seen[file] = true
+				trunk, err := repo.ReadFileAt("trunk", file)
+				if err != nil {
+					res.Missing = append(res.Missing, file)
+					continue
+				}
+				hostPath := filepath.Join(workspaceDir, file)
+				if existing, err := os.ReadFile(hostPath); err == nil {
+					if bytes.Equal(existing, trunk) {
+						res.Matched = append(res.Matched, file)
+						continue
+					}
+					if !force {
+						res.Conflicted = append(res.Conflicted, file)
+						continue
+					}
+				}
+				if err := os.MkdirAll(filepath.Dir(hostPath), 0o755); err != nil {
+					res.Conflicted = append(res.Conflicted, file)
+					continue
+				}
+				if err := os.WriteFile(hostPath, trunk, 0o644); err != nil {
+					res.Conflicted = append(res.Conflicted, file)
+					continue
+				}
+				res.Written = append(res.Written, file)
+			}
+		}
+	}
+	sort.Strings(res.Written)
+	sort.Strings(res.Matched)
+	sort.Strings(res.Conflicted)
+	sort.Strings(res.Missing)
+	return res
+}
+
+// printFinalizeSummary emits a per-category section so the operator
+// sees what happened at a glance. Empty categories are still labeled
+// (with "(none)") so the output shape is stable across runs.
+func printFinalizeSummary(out io.Writer, res finalizeResult) {
+	section := func(label string, files []string) {
+		_, _ = fmt.Fprintf(out, "  %s (%d):\n", label, len(files))
+		if len(files) == 0 {
+			_, _ = fmt.Fprintln(out, "    (none)")
+			return
+		}
+		for _, f := range files {
+			_, _ = fmt.Fprintln(out, "    - "+f)
+		}
+	}
+	section("written", res.Written)
+	section("matched", res.Matched)
+	section("conflicted", res.Conflicted)
+	if len(res.Missing) > 0 {
+		section("missing on trunk", res.Missing)
+	}
+}
+
+// stageFiles runs `git add --` on every materialized file. Paths are
+// joined explicitly to avoid shell-quoting hazards. A failure on any
+// file aborts the stage; the operator can re-run after diagnosing.
+func stageFiles(workspaceDir string, files []string) error {
+	if len(files) == 0 {
+		return nil
+	}
+	args := append([]string{"add", "--"}, files...)
+	cmd := exec.Command("git", args...)
+	cmd.Dir = workspaceDir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("git add: %w (output: %s)", err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}

--- a/cli/plan_finalize_test.go
+++ b/cli/plan_finalize_test.go
@@ -1,0 +1,241 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	libfossil "github.com/danmestas/libfossil"
+	_ "github.com/danmestas/libfossil/db/driver/modernc"
+
+	"github.com/danmestas/bones/internal/dispatch"
+)
+
+// TestResolvePlanManifest_NoSourceErrors pins the no-source case:
+// without --plan and without dispatch.json, the verb errors with
+// the explicit message ADR 0044 mandates.
+func TestResolvePlanManifest_NoSourceErrors(t *testing.T) {
+	dir := t.TempDir()
+	_, _, err := resolvePlanManifest("", dir)
+	if err == nil {
+		t.Fatal("expected error when no plan source")
+	}
+	if !strings.Contains(err.Error(), "no active dispatch found") {
+		t.Errorf("error missing required phrase, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "--plan=") {
+		t.Errorf("error missing --plan hint, got: %v", err)
+	}
+}
+
+// TestMaterializeManifest_WritesMatchesConflicts exercises the four
+// outcome categories of the materialization pass against a real
+// libfossil-backed hub trunk.
+func TestMaterializeManifest_WritesMatchesConflicts(t *testing.T) {
+	workspaceDir := t.TempDir()
+	bonesDir := filepath.Join(workspaceDir, ".bones")
+	if err := os.MkdirAll(bonesDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	hubRepoPath := filepath.Join(bonesDir, "hub.fossil")
+	repo, err := libfossil.Create(hubRepoPath, libfossil.CreateOpts{User: "hub"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	t.Cleanup(func() { _ = repo.Close() })
+
+	// Seed hub trunk with three files: one will be "written" (no host
+	// counterpart), one "matched" (host already equals trunk), and one
+	// "conflicted" (host differs from trunk).
+	files := []libfossil.FileToCommit{
+		{Name: "docs/research/rendering/REPORT.md", Content: []byte("rendering report\n")},
+		{Name: "docs/research/physics/REPORT.md", Content: []byte("physics report\n")},
+		{Name: "docs/research/ui/REPORT.md", Content: []byte("ui report v2\n")},
+	}
+	if _, _, err := repo.Commit(libfossil.CommitOpts{
+		Files:   files,
+		Comment: "seed",
+		User:    "hub",
+		Time:    time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+
+	// Pre-populate host tree:
+	//   - rendering: nothing yet → expect "written"
+	//   - physics: same content as trunk → expect "matched"
+	//   - ui: different content → expect "conflicted" (no force)
+	mustWrite(t, workspaceDir, "docs/research/physics/REPORT.md", "physics report\n")
+	mustWrite(t, workspaceDir, "docs/research/ui/REPORT.md", "ui report OLD\n")
+
+	manifest := &dispatch.Manifest{
+		Waves: []dispatch.Wave{
+			{
+				Wave: 1,
+				Slots: []dispatch.SlotEntry{
+					{Slot: "rendering", Files: []string{
+						"docs/research/rendering/REPORT.md",
+					}},
+					{Slot: "physics", Files: []string{
+						"docs/research/physics/REPORT.md",
+					}},
+					{Slot: "ui", Files: []string{
+						"docs/research/ui/REPORT.md",
+					}},
+				},
+			},
+		},
+	}
+
+	res := materializeManifest(repo, manifest, workspaceDir, false)
+
+	if !equalSorted(res.Written, []string{"docs/research/rendering/REPORT.md"}) {
+		t.Errorf("Written: got %v", res.Written)
+	}
+	if !equalSorted(res.Matched, []string{"docs/research/physics/REPORT.md"}) {
+		t.Errorf("Matched: got %v", res.Matched)
+	}
+	if !equalSorted(res.Conflicted, []string{"docs/research/ui/REPORT.md"}) {
+		t.Errorf("Conflicted: got %v", res.Conflicted)
+	}
+
+	// Conflicted file's host content must NOT have been overwritten.
+	got, _ := os.ReadFile(filepath.Join(workspaceDir, "docs/research/ui/REPORT.md"))
+	if string(got) != "ui report OLD\n" {
+		t.Errorf("conflicted file overwritten without --force: %q", got)
+	}
+
+	// Written file's content must match trunk.
+	got, _ = os.ReadFile(filepath.Join(workspaceDir, "docs/research/rendering/REPORT.md"))
+	if string(got) != "rendering report\n" {
+		t.Errorf("written file content: %q", got)
+	}
+}
+
+// TestMaterializeManifest_ForceOverridesConflicts pins --force: the
+// conflicting host file is overwritten with trunk content.
+func TestMaterializeManifest_ForceOverridesConflicts(t *testing.T) {
+	workspaceDir := t.TempDir()
+	hubRepoPath := filepath.Join(workspaceDir, ".bones", "hub.fossil")
+	if err := os.MkdirAll(filepath.Dir(hubRepoPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	repo, err := libfossil.Create(hubRepoPath, libfossil.CreateOpts{User: "hub"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	t.Cleanup(func() { _ = repo.Close() })
+
+	if _, _, err := repo.Commit(libfossil.CommitOpts{
+		Files: []libfossil.FileToCommit{
+			{Name: "out.md", Content: []byte("trunk version\n")},
+		},
+		Comment: "seed", User: "hub", Time: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+
+	mustWrite(t, workspaceDir, "out.md", "host version (older)\n")
+
+	manifest := &dispatch.Manifest{Waves: []dispatch.Wave{{
+		Wave: 1, Slots: []dispatch.SlotEntry{
+			{Slot: "alpha", Files: []string{"out.md"}},
+		},
+	}}}
+	res := materializeManifest(repo, manifest, workspaceDir, true)
+
+	if len(res.Conflicted) != 0 {
+		t.Errorf("expected no conflicts under --force, got %v", res.Conflicted)
+	}
+	if !equalSorted(res.Written, []string{"out.md"}) {
+		t.Errorf("Written: got %v", res.Written)
+	}
+	got, _ := os.ReadFile(filepath.Join(workspaceDir, "out.md"))
+	if string(got) != "trunk version\n" {
+		t.Errorf("force did not overwrite: %q", got)
+	}
+}
+
+// TestMaterializeManifest_MissingOnTrunk pins the recovery path: a
+// dispatch manifest references a file that wasn't actually committed
+// to trunk. The file is reported as missing, not as a hard error.
+func TestMaterializeManifest_MissingOnTrunk(t *testing.T) {
+	workspaceDir := t.TempDir()
+	hubRepoPath := filepath.Join(workspaceDir, ".bones", "hub.fossil")
+	if err := os.MkdirAll(filepath.Dir(hubRepoPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	repo, err := libfossil.Create(hubRepoPath, libfossil.CreateOpts{User: "hub"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	t.Cleanup(func() { _ = repo.Close() })
+
+	// Empty repo — no commits. The "expected file" is not on trunk.
+	manifest := &dispatch.Manifest{Waves: []dispatch.Wave{{
+		Wave: 1, Slots: []dispatch.SlotEntry{
+			{Slot: "ghost", Files: []string{"never-committed.md"}},
+		},
+	}}}
+	res := materializeManifest(repo, manifest, workspaceDir, false)
+
+	if !equalSorted(res.Missing, []string{"never-committed.md"}) {
+		t.Errorf("Missing: got %v", res.Missing)
+	}
+	if len(res.Written)+len(res.Matched)+len(res.Conflicted) != 0 {
+		t.Errorf("non-missing categories should be empty, got %+v", res)
+	}
+}
+
+// TestPrintFinalizeSummary_StableShape pins the per-category section
+// labels even when categories are empty — keeps the output shape
+// stable for operators scanning logs.
+func TestPrintFinalizeSummary_StableShape(t *testing.T) {
+	var buf bytes.Buffer
+	res := finalizeResult{
+		Written:    []string{"a"},
+		Matched:    nil,
+		Conflicted: []string{"b"},
+	}
+	printFinalizeSummary(&buf, res)
+	out := buf.String()
+	for _, want := range []string{
+		"written (1):", "  - a",
+		"matched (0):", "    (none)",
+		"conflicted (1):", "  - b",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+// mustWrite is a tmpdir helper: create the parent directory and write
+// content. Failures fail the test immediately.
+func mustWrite(t *testing.T, root, rel, content string) {
+	t.Helper()
+	p := filepath.Join(root, rel)
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// equalSorted reports element-wise equality after sort. Both slices
+// are mutated in place; callers don't need the original ordering.
+func equalSorted(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/cmd/bones/cli.go
+++ b/cmd/bones/cli.go
@@ -34,6 +34,7 @@ type CLI struct {
 
 	// Tooling — used by humans authoring plans/skills.
 	ValidatePlan bonescli.ValidatePlanCmd `cmd:"" group:"tooling" help:"Validate plan"`
+	Plan         bonescli.PlanCmd         `cmd:"" group:"tooling" help:"Plan workflow operations"`
 	Peek         bonescli.PeekCmd         `cmd:"" group:"tooling" help:"Browse hub via fossil ui"`
 	Telemetry    bonescli.TelemetryCmd    `cmd:"" group:"tooling" help:"Manage usage telemetry"`
 

--- a/docs/adr/0044-plan-finalize.md
+++ b/docs/adr/0044-plan-finalize.md
@@ -1,0 +1,55 @@
+# ADR 0044: `bones plan finalize` materializes hub trunk artifacts to the host tree
+
+## Context
+
+The end-of-plan workflow is three steps: each slot commits its artifact to hub trunk, the operator copies/extracts those artifacts into the host git tree (typically via `bones repo cat <path>@<rev> > <path>`), and the operator stages the result for review. Step 2 is fiddly and easy to abandon mid-way — in the field, plans have completed with all slot artifacts on hub trunk but nothing in the host tree, invisible to plain `git status`.
+
+`bones swarm dispatch` already records the plan path in `.bones/swarm/dispatch.json` while a dispatch is in flight. The plan validator already extracts the slot→slot-dir mapping from `[slot: name]` annotations. The subagent rules already enforce that each slot only writes files inside `$(bones swarm cwd --slot=<name>)`, which corresponds 1:1 to the slot-dir derived from the plan. The pieces are in place; what's missing is the verb that ties them together.
+
+The shape of the manifest — how `finalize` knows which files to write where — has four obvious candidates: a markdown `## Artifacts` block authored per plan, a YAML frontmatter list, a sibling JSON manifest, or the existing `[slot: name]` convention extended ("walk hub trunk for files under each slot-dir, materialize them"). The first three each require plan authors to maintain a list that duplicates information already encoded by the slot annotation; the fourth needs no per-plan authoring and respects the rules slots already follow.
+
+## Decision
+
+`bones plan finalize` reads hub trunk, materializes the files committed under each slot-dir to the corresponding host-tree paths, and prints a summary. The plan's `[slot: name]` annotations are the manifest. No second source of truth.
+
+### Plan-path resolution
+
+The verb resolves the plan path in this order:
+
+1. `--plan=<path>` flag if supplied
+2. `.bones/swarm/dispatch.json`'s recorded plan path if the file exists and is readable
+3. Error: "no active dispatch found; pass `--plan=<path>` to finalize a specific plan"
+
+The fallback to dispatch.json is the hot path — finalize is run immediately after a swarm completes, and dispatch.json is still on disk at that moment. Older plans, or plans that were never dispatched, are addressed via `--plan` explicitly. There is no heuristic "newest plan in `docs/`" lookup; heuristics for stateful operations confuse more than they help.
+
+### Slot-dir extraction
+
+The verb invokes the same plan-validator logic that powers `bones validate-plan --list-slots`, producing the slot→slot-dir mapping. Phase-2 synthesis slots (e.g. `[slot: integration]`) appear in the same list and are materialized identically — there is no special-case for synthesis.
+
+### Materialization
+
+For each slot-dir, the verb walks hub trunk for files under that path (`fossil.ListFiles(trunkRID)` filtered by prefix), reads each file's content from the trunk version, and writes it to the host tree at the same relative path. Files committed by `bones swarm commit` are the only files in the slot-dir on hub trunk — slots commit deliberately and the substrate doesn't pick up arbitrary `wt/` contents — so there is no "everything under artifacts/" ambiguity.
+
+### Conflict handling
+
+Before writing each file, the verb compares the trunk content to the host-tree content. If the host-tree file exists and matches, it's reported as `matched` and skipped. If it differs, `finalize` refuses by default with a list of conflicting paths and exits non-zero. `--force` overwrites all conflicts. There is no three-way merge; the host-tree file is either bit-exact-the-same or different, no merge resolution beyond that.
+
+### `--stage` (optional)
+
+When `--stage` is passed, after successful write the verb runs `git add` on every materialized file. Default behavior is "write only, leave uncommitted" so the operator can still review with `git diff` before staging. Stage is opt-in to keep `finalize` from surprising operators with a populated git index.
+
+### Summary output
+
+`finalize` prints a per-slot section listing files in three categories: `written` (host file did not exist or was overwritten via `--force`), `matched` (host file equals trunk; no write performed), and `conflicted` (host file differs and `--force` not set). The conflict-list is printed even on success so the operator sees what was skipped.
+
+## Consequences
+
+The `finalize` verb closes the loop on the swarm workflow: dispatch creates work, slots commit, finalize materializes. The "we did the work and then forgot to ship it" failure mode is prevented because finalize is a single-arg command that the operator runs once at the end.
+
+The decision to reuse the slot-dir convention rather than introduce a manifest format keeps plan markdown free of bookkeeping. Plan authors think in terms of slots and tasks; bookkeeping is the substrate's job. If a future use case emerges that genuinely needs a per-plan manifest (e.g. artifacts that belong to multiple slots, or output paths that don't match input paths), a follow-up ADR can introduce a `## Artifacts` section without unwinding this decision — the existing slot-dir behavior becomes the default and the manifest becomes an override.
+
+`finalize` cannot fix a planner error retroactively — if a slot was annotated `[slot: rendering]` but its files were committed under `src/physics/`, finalize won't materialize them under either path correctly. The subagent rules ("don't edit outside `$(bones swarm cwd --slot=<name>)`") already prevent this; finalize's "files under slot-dir" walk respects the same boundary. Files committed by mistake outside the slot-dir are invisible to finalize, which is the correct behavior — they're substrate-rule violations and should be addressed at the slot level, not papered over here.
+
+The `--force` flag is a deliberate friction point for the conflict case. When the host tree has divergent content, the user is being asked: "are you sure you want to clobber this?" Defaulting to refuse-with-list rather than overwrite-with-backup keeps the operator's git working tree predictable; backup files would be a new artifact category to manage, and the operator can always `git stash` first if they want pre-finalize state preserved.
+
+`finalize` is read-only against hub fossil and write-only against the host tree. It does not touch dispatch.json, the registry, or any swarm session state. The verb is idempotent: running it twice in a row reports everything `matched` on the second run.


### PR DESCRIPTION
## Summary
- New verb `bones plan finalize` closes the loop on the swarm workflow: dispatch creates work, slots commit, finalize materializes
- The dispatch manifest's per-slot `Files` list is the materialization set — no separate manifest format required, the slot's `[slot: name]` annotation already encodes what gets shipped (per ADR 0044)
- Plan source resolution: `--plan` flag → `.bones/swarm/dispatch.json` → error with `--plan=<path>` hint. Hot path is zero-arg right after a swarm completes
- Per-file outcomes bucketed into `written` / `matched` / `conflicted` / `missing on trunk`. Conflict-on-divergence refuses with the list by default; `--force` overwrites; `--stage` runs `git add`
- Idempotent: re-running on an already-finalized plan reports everything `matched`, no writes
- Net: +503 lines including the ADR

## Why this design
`dispatch.SlotEntry.Files` already exists; reusing it means zero per-plan authoring (vs a markdown `## Artifacts` block, frontmatter `artifacts:`, or sibling JSON, all of which would duplicate information already encoded by the slot annotation). The risk people raise about "convention" — "does every file under artifacts/ get committed?" — doesn't apply here because slots only commit files they explicitly pass to `swarm commit` (no accidental ephemera).

## Test plan
- [x] `TestResolvePlanManifest_NoSourceErrors` — error message contains required phrase + `--plan=` hint
- [x] `TestMaterializeManifest_WritesMatchesConflicts` — three-way category exercise against a real libfossil-backed hub
- [x] `TestMaterializeManifest_ForceOverridesConflicts` — `--force` overwrites
- [x] `TestMaterializeManifest_MissingOnTrunk` — manifest references uncommitted file → `missing` not error
- [x] `TestPrintFinalizeSummary_StableShape` — empty categories still labeled with `(none)`
- [x] `make check` passes (fmt-check, vet, lint, race, todo-check)
- [x] `go build -tags=otel ./...` passes
- [x] `go test -tags=otel -short ./...` passes
- [x] Smoke test: `bones plan finalize --help` shows the flag set; `bones plan` lists `finalize`

Implements ADR 0044. Closes #121.