### PR TITLE
fix(hub,prime): surface seed errors, gitignore chat.fossil, skip empty prime

### DIFF
--- a/cli/orchestrator.go
+++ b/cli/orchestrator.go
@@ -350,6 +350,7 @@ func ensureGitignoreEntries(dir string) error {
 		".fslckout",
 		".fossil-settings/",
 		".bones/",
+		"chat.fossil",
 	}
 
 	existing := map[string]bool{}

--- a/cli/orchestrator_test.go
+++ b/cli/orchestrator_test.go
@@ -570,7 +570,7 @@ func TestEnsureGitignoreEntries_FreshFile(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, want := range []string{".fslckout", ".fossil-settings/", ".bones/"} {
+	for _, want := range []string{".fslckout", ".fossil-settings/", ".bones/", "chat.fossil"} {
 		if !strings.Contains(string(data), want) {
 			t.Errorf("missing %q\n%s", want, data)
 		}

--- a/cli/tasks_prime.go
+++ b/cli/tasks_prime.go
@@ -36,11 +36,33 @@ func (c *TasksPrimeCmd) Run(g *libfossilcli.Globals) error {
 			return err
 		}
 		if c.JSON {
+			// Skip emit when the workspace has nothing to prime —
+			// the SessionStart hook attaches whatever this command
+			// prints, and an empty payload is pure noise in the
+			// agent's context (#129). Non-JSON callers (humans
+			// running `bones tasks prime` interactively) still get
+			// the formatted output below regardless of state.
+			if isEmptyPrime(result) {
+				return nil
+			}
 			return emitJSON(os.Stdout, primeToJSON(result))
 		}
 		fmt.Print(formatPrime(result))
 		return nil
 	}))
+}
+
+// isEmptyPrime reports whether a prime result has no information
+// worth emitting via the JSON hook attachment. Empty means: zero
+// open/ready/claimed tasks, zero recent threads, and at most one
+// peer (which is the agent itself; presence-of-self isn't useful
+// to attach).
+func isEmptyPrime(r coord.PrimeResult) bool {
+	return len(r.OpenTasks) == 0 &&
+		len(r.ReadyTasks) == 0 &&
+		len(r.ClaimedTasks) == 0 &&
+		len(r.Threads) == 0 &&
+		len(r.Peers) <= 1
 }
 
 func formatPrime(r coord.PrimeResult) string {

--- a/cli/tasks_prime_test.go
+++ b/cli/tasks_prime_test.go
@@ -1,0 +1,49 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/danmestas/bones/internal/coord"
+)
+
+// TestIsEmptyPrime_AllEmpty pins the no-noise case: zero of
+// everything (no peers either) is empty.
+func TestIsEmptyPrime_AllEmpty(t *testing.T) {
+	if !isEmptyPrime(coord.PrimeResult{}) {
+		t.Errorf("zero PrimeResult should be empty")
+	}
+}
+
+// TestIsEmptyPrime_SelfOnlyPeers pins the documented edge case:
+// presence-of-self in the peers list isn't useful to attach, so
+// len(Peers) == 1 still counts as empty.
+func TestIsEmptyPrime_SelfOnlyPeers(t *testing.T) {
+	r := coord.PrimeResult{
+		Peers: make([]coord.Presence, 1),
+	}
+	if !isEmptyPrime(r) {
+		t.Errorf("self-only peers should still be empty")
+	}
+}
+
+// TestIsEmptyPrime_NonEmptyOpenTasks pins the negative case: a
+// single open task makes the result worth attaching.
+func TestIsEmptyPrime_NonEmptyOpenTasks(t *testing.T) {
+	r := coord.PrimeResult{
+		OpenTasks: make([]coord.Task, 1),
+	}
+	if isEmptyPrime(r) {
+		t.Errorf("open tasks present, should not be empty")
+	}
+}
+
+// TestIsEmptyPrime_TwoPeers pins the threshold: more than one peer
+// means at least one other agent is online — worth attaching.
+func TestIsEmptyPrime_TwoPeers(t *testing.T) {
+	r := coord.PrimeResult{
+		Peers: make([]coord.Presence, 2),
+	}
+	if isEmptyPrime(r) {
+		t.Errorf("two peers means another agent is online; not empty")
+	}
+}

--- a/internal/hub/hub.go
+++ b/internal/hub/hub.go
@@ -184,6 +184,25 @@ func runForeground(ctx context.Context, p paths, o opts) error {
 	return nil
 }
 
+// hubLogTail reads the last N lines (capped to ~2KB) of hub.log and
+// returns them prefixed with a newline + section header, ready for
+// concatenation into an error message. Returns "" when hub.log is
+// missing or empty so callers don't get an empty trailing section.
+// Used to surface in-child seed/start failures to the parent's
+// stderr, which is what SessionStart hooks actually capture.
+func hubLogTail(p paths) string {
+	const maxBytes = 2048
+	logPath := filepath.Join(p.orchDir, "hub.log")
+	data, err := os.ReadFile(logPath)
+	if err != nil || len(data) == 0 {
+		return ""
+	}
+	if len(data) > maxBytes {
+		data = data[len(data)-maxBytes:]
+	}
+	return "\n--- " + logPath + " (tail) ---\n" + string(data)
+}
+
 // spawnDetachedChild re-execs the current binary as a foreground hub
 // child, redirects its stdout/stderr to .bones/hub.log, and
 // returns once the child has bound both ports. On readiness failure,
@@ -219,16 +238,22 @@ func spawnDetachedChild(p paths, o opts) error {
 	}
 
 	// The child writes pid files itself. Probe both ports until the
-	// child reports ready.
+	// child reports ready. On failure, surface the tail of hub.log
+	// alongside the timeout — without this the SessionStart hook
+	// attaches "fossil child not ready: timeout" with no hint at the
+	// real cause (#127), which is typically a seed failure logged in
+	// hub.log only.
 	fossilAddr := fmt.Sprintf("127.0.0.1:%d", o.fossilPort)
 	natsAddr := fmt.Sprintf("127.0.0.1:%d", o.natsPort)
 	if err := waitForTCP(fossilAddr, readyTimeout); err != nil {
 		_ = cmd.Process.Kill()
-		return fmt.Errorf("hub: fossil child not ready: %w", err)
+		return fmt.Errorf("hub: fossil child not ready: %w%s",
+			err, hubLogTail(p))
 	}
 	if err := waitForTCP(natsAddr, readyTimeout); err != nil {
 		_ = cmd.Process.Kill()
-		return fmt.Errorf("hub: nats child not ready: %w", err)
+		return fmt.Errorf("hub: nats child not ready: %w%s",
+			err, hubLogTail(p))
 	}
 
 	// Release the child so it isn't reaped when we return.

--- a/internal/hub/hub_log_tail_test.go
+++ b/internal/hub/hub_log_tail_test.go
@@ -1,0 +1,74 @@
+package hub
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestHubLogTail_Empty pins the no-log case: missing hub.log yields
+// empty string so callers don't print a stray section header.
+func TestHubLogTail_Empty(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".bones"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	p, err := newPaths(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := hubLogTail(p); got != "" {
+		t.Errorf("missing hub.log should produce empty string, got: %q", got)
+	}
+}
+
+// TestHubLogTail_ContentIncluded pins the surfacing case: an existing
+// hub.log with content has its bytes embedded in the returned string,
+// prefixed with a section header so it composes into error messages.
+func TestHubLogTail_ContentIncluded(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".bones"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	logContent := "hub: seed: create repo: libfossil: disk I/O error (522)\n"
+	if err := os.WriteFile(filepath.Join(root, ".bones", "hub.log"),
+		[]byte(logContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	p, err := newPaths(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := hubLogTail(p)
+	if !strings.Contains(got, "disk I/O error (522)") {
+		t.Errorf("tail should include log content, got: %q", got)
+	}
+	if !strings.Contains(got, "hub.log") {
+		t.Errorf("tail should include section header naming the log, got: %q", got)
+	}
+}
+
+// TestHubLogTail_LargeLogTruncated pins the byte-cap: a hub.log
+// larger than the cap returns only the trailing slice. The exact
+// cap is implementation-defined; we verify "len(tail) < len(huge)."
+func TestHubLogTail_LargeLogTruncated(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".bones"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// 10 KB of "x" — well above the 2KB cap.
+	huge := strings.Repeat("x", 10_000)
+	if err := os.WriteFile(filepath.Join(root, ".bones", "hub.log"),
+		[]byte(huge), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	p, err := newPaths(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := hubLogTail(p)
+	if len(got) >= len(huge) {
+		t.Errorf("tail should truncate large log; got len=%d", len(got))
+	}
+}


### PR DESCRIPTION
## Summary
Three SessionStart-hook-adjacent fixes bundled because they share the "stop hook noise / surface failures" theme and each is too small to warrant its own PR.

- **#127** — `bones hub start --detach` silently swallowed seed failures: the parent's `waitForTCP` timeout returned generic "fossil child not ready" while the actual seed message lived only in `hub.log`. SessionStart hooks attach the parent's stderr, so the agent saw the generic error with no hint at the cause. New `hubLogTail(p)` reads up to ~2KB from `.bones/hub.log` and appends it to the not-ready error
- **#128** — `chat.fossil` (a SQLite blob, ~213 KB) materializes at the workspace root but wasn't in the gitignore set. `git add .` would silently commit it. Added to `wantEntries` in `ensureGitignoreEntries`
- **#129** — `bones tasks prime --json` emitted ~250 bytes of empty arrays + self-only peer when the workspace had no queued work. The hook attached this noise every session. The `--json` path now no-ops when the prime result is fully empty (no tasks/threads, peers ≤ 1). Non-JSON human-readable mode unchanged

## Test plan
- [x] New `TestHubLogTail_*` (3 cases: empty, content included, large-log truncated)
- [x] Updated `TestEnsureGitignoreEntries_FreshFile` to verify `chat.fossil` entry
- [x] New `TestIsEmptyPrime_*` (4 cases: all empty, self-only peers, non-empty open tasks, two peers threshold)
- [x] `make check` passes
- [x] `go build -tags=otel ./...` passes
- [x] `go test -tags=otel -short ./...` passes

Closes #127, #128, #129.

#130 stays open with triage notes posted; needs maintainer pick on fix shape (SessionEnd hook vs `bones swarm prune` verb vs start-time GC vs doctor reap).