### PR TITLE
feat(hub,doctor): start-time GC of dead-pid slot dirs + doctor surfacing

### DIFF
--- a/cli/doctor.go
+++ b/cli/doctor.go
@@ -17,6 +17,7 @@ import (
 	"github.com/danmestas/bones/internal/githook"
 	"github.com/danmestas/bones/internal/registry"
 	"github.com/danmestas/bones/internal/scaffoldver"
+	"github.com/danmestas/bones/internal/slotgc"
 	"github.com/danmestas/bones/internal/swarm"
 	"github.com/danmestas/bones/internal/telemetry"
 	"github.com/danmestas/bones/internal/version"
@@ -187,6 +188,7 @@ func runBypassReportTo(w io.Writer, cwd string) (warns int, err error) {
 		warns++
 	}
 	warns += checkOrphanHubs(w)
+	warns += checkStaleSlotDirs(w, cwd)
 
 	switch tip, head, drifted := fossilDrift(cwd); {
 	case tip == "" && head == "":
@@ -316,6 +318,28 @@ func checkOrphanHubs(w io.Writer) int {
 			e.HubPID, e.Cwd, age)
 	}
 	return len(orphans)
+}
+
+// checkStaleSlotDirs reports per-slot directories under
+// .bones/swarm/<slot>/ whose leaf.pid points at a dead process.
+// Read-only; the operator can clear them by running `bones hub
+// start` (which triggers a GC pass) or by `rm -rf` on the named
+// directories. Returns the number of WARN findings emitted.
+func checkStaleSlotDirs(w io.Writer, cwd string) int {
+	dead, err := slotgc.DeadSlots(cwd)
+	if err != nil {
+		_, _ = fmt.Fprintf(w, "  WARN  slot dir scan: %v\n", err)
+		return 1
+	}
+	if len(dead) == 0 {
+		return 0
+	}
+	for _, slot := range dead {
+		_, _ = fmt.Fprintf(w,
+			"  WARN  stale slot dir .bones/swarm/%s — run `bones hub start` to GC\n",
+			slot)
+	}
+	return len(dead)
 }
 
 // hookCommandPresent walks hooks[event] and reports whether any

--- a/internal/hub/hub.go
+++ b/internal/hub/hub.go
@@ -18,6 +18,7 @@ import (
 	natsserver "github.com/nats-io/nats-server/v2/server"
 
 	"github.com/danmestas/bones/internal/registry"
+	"github.com/danmestas/bones/internal/slotgc"
 	"github.com/danmestas/bones/internal/telemetry"
 )
 
@@ -108,6 +109,21 @@ func Start(ctx context.Context, root string, options ...Option) (err error) {
 	// Idempotency: if both pid files point at live processes, we're done.
 	if pidIsLive(p.fossilPid) && pidIsLive(p.natsPid) {
 		return nil
+	}
+
+	// Per-slot GC: remove .bones/swarm/<slot>/ directories whose
+	// leaf.pid points at a dead process. Piggybacks on the most
+	// frequently-run lifecycle event (SessionStart hook → bones hub
+	// start) so stale slot dirs don't accumulate across sessions
+	// (#130). Best-effort: a permission failure on one slot doesn't
+	// block hub start for the rest.
+	if pruned, err := slotgc.PruneDead(p.root); err != nil {
+		fmt.Fprintf(os.Stderr,
+			"hub: swarm gc warning (non-fatal): %v\n", err)
+	} else if len(pruned) > 0 {
+		fmt.Fprintf(os.Stderr,
+			"hub: pruned %d stale slot dir(s): %s\n",
+			len(pruned), strings.Join(pruned, ", "))
 	}
 
 	// Resolve any zero-valued port to the workspace's recorded port

--- a/internal/slotgc/slotgc.go
+++ b/internal/slotgc/slotgc.go
@@ -1,0 +1,107 @@
+// Package slotgc detects and removes per-slot directories under
+// .bones/swarm/<slot>/ whose leaf process is no longer alive.
+//
+// The package lives outside both internal/swarm (to avoid an import
+// cycle: hub → swarm → workspace → hub) and internal/hub (so cli's
+// doctor can read without importing the hub start path). It depends
+// only on the standard library and the path convention
+// .bones/swarm/<slot>/leaf.pid that swarm.SlotDir/SlotPidFile encode.
+package slotgc
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+// DeadSlots lists slot names under .bones/swarm/<slot>/ whose
+// leaf.pid file points at a process that no longer exists. Slots
+// without a pid file (mid-creation, or already partially cleaned)
+// are skipped — only "had a leaf, leaf is gone" qualifies.
+//
+// Read-only. Returns nil + nil when the swarm root doesn't exist
+// (workspace never used swarm verbs).
+func DeadSlots(workspaceDir string) ([]string, error) {
+	swarmRoot := filepath.Join(workspaceDir, ".bones", "swarm")
+	entries, err := os.ReadDir(swarmRoot)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("slotgc.DeadSlots: read %s: %w", swarmRoot, err)
+	}
+	var dead []string
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		slot := e.Name()
+		pidFile := filepath.Join(swarmRoot, slot, "leaf.pid")
+		pid, ok := readPidFile(pidFile)
+		if !ok {
+			continue
+		}
+		if pidAlive(pid) {
+			continue
+		}
+		dead = append(dead, slot)
+	}
+	return dead, nil
+}
+
+// PruneDead removes per-slot directories whose leaf.pid file points
+// at a dead PID. Returns the list of slot names actually removed.
+// Errors on individual slot removals are aggregated; the pass
+// continues so a permission-denied on one slot doesn't block cleanup
+// of the rest.
+func PruneDead(workspaceDir string) ([]string, error) {
+	dead, err := DeadSlots(workspaceDir)
+	if err != nil {
+		return nil, err
+	}
+	swarmRoot := filepath.Join(workspaceDir, ".bones", "swarm")
+	pruned := make([]string, 0, len(dead))
+	var firstErr error
+	for _, slot := range dead {
+		if err := os.RemoveAll(filepath.Join(swarmRoot, slot)); err != nil {
+			if firstErr == nil {
+				firstErr = fmt.Errorf("slotgc.PruneDead: remove %s: %w", slot, err)
+			}
+			continue
+		}
+		pruned = append(pruned, slot)
+	}
+	return pruned, firstErr
+}
+
+// readPidFile parses leaf.pid as a single integer. Returns
+// (0, false) on missing file, parse error, or empty content.
+func readPidFile(path string) (int, bool) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0, false
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil {
+		return 0, false
+	}
+	return pid, pid > 0
+}
+
+// pidAlive reports whether pid names a process visible to this host.
+// Mirrors internal/registry.pidAlive and internal/hub.pidIsLive
+// rather than depending on either; the implementation is six lines
+// and the cross-package coupling isn't worth a shared helper.
+func pidAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	return proc.Signal(syscall.Signal(0)) == nil
+}

--- a/internal/slotgc/slotgc_test.go
+++ b/internal/slotgc/slotgc_test.go
@@ -1,0 +1,111 @@
+package slotgc
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// makeSlot scaffolds a per-slot directory under
+// <root>/.bones/swarm/<slot>/ with a leaf.pid file containing pid.
+// Helper for table-driven test setup.
+func makeSlot(t *testing.T, root, slot string, pid int) {
+	t.Helper()
+	dir := filepath.Join(root, ".bones", "swarm", slot)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	pidFile := filepath.Join(dir, "leaf.pid")
+	if err := os.WriteFile(pidFile, fmt.Appendf(nil, "%d\n", pid), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestDeadSlots_NoSwarmRoot pins the no-op case: a workspace that
+// never touched swarm verbs has no .bones/swarm/, so DeadSlots
+// returns nil + nil.
+func TestDeadSlots_NoSwarmRoot(t *testing.T) {
+	dead, err := DeadSlots(t.TempDir())
+	if err != nil {
+		t.Fatalf("DeadSlots: %v", err)
+	}
+	if len(dead) != 0 {
+		t.Errorf("expected empty dead list, got %v", dead)
+	}
+}
+
+// TestDeadSlots_DeadPidDetected pins the primary signal: a slot
+// dir with leaf.pid pointing at a guaranteed-dead PID is reported.
+func TestDeadSlots_DeadPidDetected(t *testing.T) {
+	root := t.TempDir()
+	makeSlot(t, root, "rendering", 999_999) // assumed-dead PID
+
+	dead, err := DeadSlots(root)
+	if err != nil {
+		t.Fatalf("DeadSlots: %v", err)
+	}
+	if len(dead) != 1 || dead[0] != "rendering" {
+		t.Errorf("expected [rendering], got %v", dead)
+	}
+}
+
+// TestDeadSlots_LivePidSkipped pins the negative case: a slot with
+// an alive PID (use os.Getpid() — self) is NOT reported.
+func TestDeadSlots_LivePidSkipped(t *testing.T) {
+	root := t.TempDir()
+	makeSlot(t, root, "physics", os.Getpid())
+
+	dead, err := DeadSlots(root)
+	if err != nil {
+		t.Fatalf("DeadSlots: %v", err)
+	}
+	if len(dead) != 0 {
+		t.Errorf("expected empty (PID alive), got %v", dead)
+	}
+}
+
+// TestDeadSlots_MissingPidFileSkipped pins the mid-creation guard:
+// a slot dir without a leaf.pid is left alone (could be a slot
+// being created, or partially cleaned up by hand).
+func TestDeadSlots_MissingPidFileSkipped(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, ".bones", "swarm", "halfbuilt")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	dead, err := DeadSlots(root)
+	if err != nil {
+		t.Fatalf("DeadSlots: %v", err)
+	}
+	if len(dead) != 0 {
+		t.Errorf("expected empty (no pid file), got %v", dead)
+	}
+}
+
+// TestPruneDead_RemovesDeadSlots pins the write side: dead slot
+// dirs are os.RemoveAll'd; live slots stay; missing-pid slots stay.
+func TestPruneDead_RemovesDeadSlots(t *testing.T) {
+	root := t.TempDir()
+	makeSlot(t, root, "dead-1", 999_999)
+	makeSlot(t, root, "alive-1", os.Getpid())
+	makeSlot(t, root, "dead-2", 999_998)
+
+	pruned, err := PruneDead(root)
+	if err != nil {
+		t.Fatalf("PruneDead: %v", err)
+	}
+	if len(pruned) != 2 {
+		t.Errorf("expected 2 pruned, got %v", pruned)
+	}
+	// Dead slot dirs gone:
+	for _, slot := range []string{"dead-1", "dead-2"} {
+		if _, err := os.Stat(filepath.Join(root, ".bones", "swarm", slot)); err == nil {
+			t.Errorf("slot %s should be removed", slot)
+		}
+	}
+	// Live slot dir kept:
+	if _, err := os.Stat(filepath.Join(root, ".bones", "swarm", "alive-1")); err != nil {
+		t.Errorf("alive slot should be preserved: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- New `internal/slotgc` package detects and removes per-slot directories under `.bones/swarm/<slot>/` whose `leaf.pid` points at a dead process. Slots with missing pid files (mid-creation, partial cleanup) or live PIDs are skipped — only "had a leaf, leaf is gone" qualifies
- `bones hub start` calls `slotgc.PruneDead` at the head of `runForeground`. Piggybacks on the most-frequently-run lifecycle event (every SessionStart hook fires `bones hub start`), so stale slot dirs vanish on the next session start
- `bones doctor` reads via `slotgc.DeadSlots` and emits one WARN per stale slot with a hint to run `bones hub start`. Stays read-only

## Why this design (per the triage notes on #130)
- **(a) SessionEnd hook** — skipped. ADR 0038 explicitly rejected SessionEnd hub-teardown because concurrent sessions could share state; the same logic plausibly applies to slot dirs
- **(b) `bones swarm prune` verb** — skipped. Redundant with (d); `bones hub start` already triggers the GC primitive
- **(c) Start-time GC** — done. Auto-cleanup on the most frequent lifecycle event
- **(d) Doctor surfacing** — done. Read-only with reap-hint, mirrors the orphan-hub pattern from PR #134

## Why a new `internal/slotgc` package
Avoids a cycle: `hub → swarm → workspace → hub`. Putting the GC logic in `internal/swarm` would require `internal/hub` to import `internal/swarm`, which is forbidden. `slotgc` only needs the path convention (`.bones/swarm/<slot>/leaf.pid`) and pure stdlib pid-alive check — no `swarm` or `workspace` imports, so both `hub` and `cli/doctor` can use it freely.

## Deferred (orthogonal)
- `swarm-events.jsonl` rotation. The slot-dir accumulation is the immediate pain; the event log is append-only journaling that can be addressed in a separate issue if it becomes a problem

## Test plan
- [x] `internal/slotgc` tests cover: no-swarm-root no-op, dead PID detected, live PID skipped, missing pid file skipped, prune removes dead + preserves live
- [x] `make check` passes (fmt-check, vet, lint, race, todo-check)
- [x] `go build -tags=otel ./...` passes
- [x] `go test -tags=otel -short ./...` passes

Closes #130.