### PR TITLE
fix(scaffold): refuse to overwrite user-authored CLAUDE.md

### DIFF
--- a/cli/doctor_test.go
+++ b/cli/doctor_test.go
@@ -14,6 +14,10 @@ import (
 
 // TestRunBypassReportToNoGit checks that a dir without .git emits INFO (not Fix).
 func TestRunBypassReportToNoGit(t *testing.T) {
+	// Isolate from any pre-existing ~/.bones/workspaces/ registry on the
+	// dev host. checkOrphanHubs reads $HOME-rooted state; a stale entry
+	// there would emit an unrelated WARN and fail this test.
+	t.Setenv("HOME", t.TempDir())
 	var buf bytes.Buffer
 	tmp := t.TempDir()
 	warns, err := runBypassReportTo(&buf, tmp)

--- a/cli/orchestrator.go
+++ b/cli/orchestrator.go
@@ -123,15 +123,19 @@ func bonesOwnedAgentsMD(content []byte) bool {
 }
 
 // linkClaudeMD creates CLAUDE.md as a symbolic link to AGENTS.md per
-// the agents.md spec migration recipe. Idempotent: an existing symlink
-// pointing at AGENTS.md is left alone; an existing symlink pointing
-// elsewhere or a regular file there is replaced (CLAUDE.md is bones-
-// managed in this workspace once AGENTS.md is). Workspaces on platforms
-// without symlink support fall back to a regular-file copy with the
-// same content.
+// the agents.md spec migration recipe. Mirrors writeAgentsMD's safety
+// gate: pre-existing user content is refused, never silently destroyed
+// (issue #139). Bones-managed shapes — a symlink to AGENTS.md, or a
+// regular-file fallback carrying the bones marker — are recognized and
+// replaced idempotently. Workspaces on platforms without symlink
+// support land on the regular-file fallback with the AGENTS.md content.
 func linkClaudeMD(root string) error {
 	target := "AGENTS.md"
 	link := filepath.Join(root, "CLAUDE.md")
+
+	if err := requireBonesOwnedClaudeMD(link, target); err != nil {
+		return err
+	}
 	if cur, err := os.Readlink(link); err == nil && cur == target {
 		return nil
 	}
@@ -145,6 +149,35 @@ func linkClaudeMD(root string) error {
 	// (drifts on AGENTS.md edits), but symlinks are unsupported on some
 	// filesystems (e.g. older Windows volumes without developer mode).
 	return os.WriteFile(link, agentsMDTemplate, 0o644)
+}
+
+// requireBonesOwnedClaudeMD returns an error if CLAUDE.md exists in a
+// shape bones did not produce. The four bones-recognized shapes are:
+// (1) absent, (2) symlink whose target is AGENTS.md, (3) regular file
+// whose first lines carry the bones marker (the fallback path on
+// symlink-unsupported filesystems). Any other shape — symlink to a
+// different target, regular file without the marker — is treated as
+// user content and refused.
+func requireBonesOwnedClaudeMD(link, target string) error {
+	if cur, err := os.Readlink(link); err == nil {
+		if cur == target {
+			return nil
+		}
+		return fmt.Errorf("CLAUDE.md is a symlink to %q, not bones-managed; "+
+			"merge bones content manually or remove %s and re-run", cur, link)
+	}
+	data, err := os.ReadFile(link)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("read CLAUDE.md: %w", err)
+	}
+	if bonesOwnedAgentsMD(data) {
+		return nil
+	}
+	return fmt.Errorf("CLAUDE.md exists and is not bones-managed; "+
+		"merge bones content into AGENTS.md or remove %s and re-run", link)
 }
 
 // mergeSettings idempotently installs the SessionStart + PreCompact

--- a/cli/orchestrator_test.go
+++ b/cli/orchestrator_test.go
@@ -790,3 +790,114 @@ func TestScaffoldOrchestrator_MigratesLegacyBootstrap(t *testing.T) {
 		t.Errorf("bones hub start missing after migration:\n%s", body)
 	}
 }
+
+// TestLinkClaudeMD_RefusesUserAuthoredFile pins the safety against
+// clobbering a pre-existing user-authored CLAUDE.md (issue #139).
+// Mirrors the existing AGENTS.md guard in writeAgentsMD: the marker
+// is the ownership signal; absence means the file is the user's.
+func TestLinkClaudeMD_RefusesUserAuthoredFile(t *testing.T) {
+	dir := t.TempDir()
+	usersClaude := "# My project rules\n\nNever do X. Always do Y.\n"
+	claudePath := filepath.Join(dir, "CLAUDE.md")
+	if err := os.WriteFile(claudePath, []byte(usersClaude), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	err := linkClaudeMD(dir)
+	if err == nil {
+		t.Fatal("expected error when CLAUDE.md is user-authored")
+	}
+	if !strings.Contains(err.Error(), "not bones-managed") {
+		t.Errorf("error should mention bones-managed; got: %v", err)
+	}
+	got, _ := os.ReadFile(claudePath)
+	if string(got) != usersClaude {
+		t.Errorf("user CLAUDE.md content modified:\nwant %q\ngot  %q", usersClaude, got)
+	}
+}
+
+// TestLinkClaudeMD_RefusesUnrelatedSymlink pins that a CLAUDE.md
+// symlinked to something other than AGENTS.md is treated as user
+// content. Users do create deliberate symlinks (e.g. CLAUDE.md ->
+// docs/agent-rules.md); silently retargeting them is data loss.
+func TestLinkClaudeMD_RefusesUnrelatedSymlink(t *testing.T) {
+	dir := t.TempDir()
+	otherTarget := filepath.Join(dir, "elsewhere.md")
+	if err := os.WriteFile(otherTarget, []byte("user target"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	claudePath := filepath.Join(dir, "CLAUDE.md")
+	if err := os.Symlink("elsewhere.md", claudePath); err != nil {
+		t.Fatal(err)
+	}
+	err := linkClaudeMD(dir)
+	if err == nil {
+		t.Fatal("expected error when CLAUDE.md is a symlink to a non-AGENTS.md target")
+	}
+	if !strings.Contains(err.Error(), "not bones-managed") {
+		t.Errorf("error should mention bones-managed; got: %v", err)
+	}
+	target, rerr := os.Readlink(claudePath)
+	if rerr != nil {
+		t.Fatalf("symlink replaced with regular file: %v", rerr)
+	}
+	if target != "elsewhere.md" {
+		t.Errorf("symlink target changed: got %q want %q", target, "elsewhere.md")
+	}
+}
+
+// TestLinkClaudeMD_AcceptsBonesOwnedFallback covers the
+// symlink-unsupported-fs branch: linkClaudeMD writes the AGENTS.md
+// content as a regular file. A subsequent run sees that regular file
+// (carrying the bones marker) and treats it as bones-managed
+// (idempotent re-scaffold).
+func TestLinkClaudeMD_AcceptsBonesOwnedFallback(t *testing.T) {
+	dir := t.TempDir()
+	claudePath := filepath.Join(dir, "CLAUDE.md")
+	if err := os.WriteFile(claudePath, agentsMDTemplate, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := linkClaudeMD(dir); err != nil {
+		t.Errorf("linkClaudeMD on bones-owned fallback file: %v", err)
+	}
+}
+
+// TestScaffoldOrchestrator_RefusesUserAuthoredCLAUDE is the full-path
+// integration: scaffoldOrchestrator must refuse when CLAUDE.md is
+// user-authored, and the user's content is left intact. Without this,
+// `bones up` silently destroys user instructions on first install.
+func TestScaffoldOrchestrator_RefusesUserAuthoredCLAUDE(t *testing.T) {
+	dir := t.TempDir()
+	usersClaude := "When the user corrects you, stop and re-read their message.\n"
+	claudePath := filepath.Join(dir, "CLAUDE.md")
+	if err := os.WriteFile(claudePath, []byte(usersClaude), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	err := scaffoldOrchestrator(dir)
+	if err == nil {
+		t.Fatal("expected error when CLAUDE.md is user-authored")
+	}
+	got, _ := os.ReadFile(claudePath)
+	if string(got) != usersClaude {
+		t.Errorf("user CLAUDE.md content modified by scaffold:\nwant %q\ngot  %q",
+			usersClaude, got)
+	}
+}
+
+// TestScaffoldOrchestrator_AGENTSNonEmpty pins that AGENTS.md after a
+// fresh scaffold is not zero bytes. Catches the secondary
+// empty-AGENTS.md sub-bug observed in the issue #139 reproduction:
+// a workspace can end up with a 0-byte AGENTS.md and a CLAUDE.md
+// symlink to it, which silently delivers empty agent guidance.
+func TestScaffoldOrchestrator_AGENTSNonEmpty(t *testing.T) {
+	dir := t.TempDir()
+	if err := scaffoldOrchestrator(dir); err != nil {
+		t.Fatalf("scaffoldOrchestrator: %v", err)
+	}
+	info, err := os.Stat(filepath.Join(dir, "AGENTS.md"))
+	if err != nil {
+		t.Fatalf("stat AGENTS.md: %v", err)
+	}
+	if info.Size() == 0 {
+		t.Fatal("AGENTS.md is empty after scaffold")
+	}
+}


### PR DESCRIPTION
## Summary

`linkClaudeMD` silently destroyed any pre-existing `CLAUDE.md` before symlinking it at `AGENTS.md`. On first install, that meant losing user-authored project instructions; combined with `bones down`'s removal-without-restore, the install/uninstall round-trip was permanently destructive (observed in serverdom, where a 5-line user CLAUDE.md was lost across `bones up && bones down`).

The fix mirrors the safety gate `writeAgentsMD` already has for AGENTS.md: only proceed when the existing CLAUDE.md is bones-managed (absent, symlink to AGENTS.md, or regular-file fallback carrying the bones marker). Any other shape returns an error pointing at manual merge.

No backup mechanism, no migration path. Refuse-and-tell-user is consistent with the AGENTS.md handling already in place and avoids a new failure mode (silent partial restoration).

## Behavior change

| CLAUDE.md state | Before | After |
|---|---|---|
| absent | create symlink | create symlink |
| symlink → AGENTS.md | no-op (idempotent) | no-op (idempotent) |
| symlink → other target | **silently retargeted** | refuse with merge instruction |
| regular file with bones marker | replace | replace |
| regular file without bones marker | **silently destroyed** | refuse with merge instruction |

## Tests

Five new tests in `cli/orchestrator_test.go`:

- `TestLinkClaudeMD_RefusesUserAuthoredFile` — pre-existing regular file with no marker → linkClaudeMD errors; original content intact.
- `TestLinkClaudeMD_RefusesUnrelatedSymlink` — symlink to a non-AGENTS.md target → linkClaudeMD errors; symlink unchanged.
- `TestLinkClaudeMD_AcceptsBonesOwnedFallback` — regular file with bones marker (symlink-unsupported fs path) → succeeds.
- `TestScaffoldOrchestrator_RefusesUserAuthoredCLAUDE` — full scaffold path; user CLAUDE.md preserved on refusal.
- `TestScaffoldOrchestrator_AGENTSNonEmpty` — pins the secondary observation from the issue: post-scaffold AGENTS.md is non-empty.

3 of the 5 were RED on `main` (proving the bug); 2 are regression guards for already-correct behavior.

## Drive-by

`TestRunBypassReportToNoGit` was failing on `main` for any dev with stale entries in `~/.bones/workspaces/` (`checkOrphanHubs` reads `\$HOME`-rooted state). Pre-push hook blocked. Smallest possible fix: `t.Setenv("HOME", t.TempDir())` in the one affected test. Real test-isolation rework is out of scope.

## Test plan

- [x] New tests fail on `main` for the 3 destructive paths
- [x] `go test -short ./...` passes (except a pre-existing baseline now also fixed here)
- [x] `go test -tags=otel -short ./...` matches CI
- [x] `make fmt-check vet lint todo-check` all clean
- [x] `go test -race` on the touched tests
- [x] Pre-push `make ci-fast` passes (auto-run on push)

Closes #139