### PR TITLE
fix(hub): roll back seed sidecars + escalate Stop to SIGKILL (#138 partial)

### DIFF
--- a/internal/hub/hub.go
+++ b/internal/hub/hub.go
@@ -52,6 +52,12 @@ const natsBootstrapAttempts = 3
 // each round (1s, 2s, 4s).
 const natsBootstrapBackoff = 1 * time.Second
 
+// stopGrace bounds how long Stop waits between SIGTERM and SIGKILL.
+// Mirrors registry.Reap: short by design, since hub processes hold
+// ports + unlinked fossil inodes we want released ASAP. Long enough
+// for a healthy hub to flush WAL and exit cleanly on TERM.
+var stopGrace = 2 * time.Second
+
 // Start brings up the orchestrator hub: a Fossil repository at
 // .bones/hub.fossil seeded from git-tracked files, a Fossil HTTP
 // server on the chosen port, and an embedded NATS JetStream server.
@@ -148,14 +154,22 @@ func runForeground(ctx context.Context, p paths, o opts) error {
 	// Fresh-start detection (ADR 0023): if no fossil PID is alive,
 	// wipe stale checkout state so each session starts from a clean
 	// substrate. Working-tree files are untouched.
+	//
+	// SQLite -shm and -wal sidecars are part of "stale checkout state":
+	// when a prior run crashed mid-seed, libfossil leaves a 0-byte WAL
+	// and a populated SHM. The next CreateWithEnv hits
+	// SQLITE_IOERR_SHORT_READ (522) on those orphan blocks. See #138.
 	if !pidIsLive(p.fossilPid) {
-		for _, path := range []string{p.hubRepo, p.fslckout, p.fslSettings} {
-			_ = os.RemoveAll(path)
-		}
+		removeRepoAndSidecars(p)
 	}
 
 	if _, err := os.Stat(p.hubRepo); errors.Is(err, os.ErrNotExist) {
-		if err := seedHubRepo(p); err != nil {
+		if err := seedHubRepoFunc(p); err != nil {
+			// Roll back any partial repo state — libfossil may have
+			// created hub.fossil and/or its -shm/-wal sidecars before
+			// the schema apply step that failed. Leaving those in
+			// place poisons the next bones hub start (#138).
+			removeRepoAndSidecars(p)
 			return fmt.Errorf("hub: seed: %w", err)
 		}
 	}
@@ -282,15 +296,19 @@ func spawnDetachedChild(p paths, o opts) error {
 	return nil
 }
 
-// Stop sends SIGTERM to the processes recorded in the pid files written
-// by Start and removes those pid files. Missing pid files or stale pids
-// are not an error: Stop is idempotent so callers can shut down without
-// first checking whether Start has run.
+// Stop terminates the processes recorded in the pid files written by
+// Start and removes those pid files. SIGTERM first; if the process is
+// still alive after stopGrace, SIGKILL. Pid files are only removed
+// once the process is confirmed dead so a follow-up Start cannot
+// mistake an orphan-still-alive for "nothing to clean up" (#138).
 //
-// As a safety, Stop will not signal the calling process. If the recorded
-// pid is the same as os.Getpid(), Stop only removes the pid file. The
-// foreground Start has its own ctx-cancellation path; signaling self
-// would terminate the caller before it could clean up.
+// Missing pid files or stale pids are not an error: Stop is idempotent
+// so callers can shut down without first checking whether Start ran.
+//
+// As a safety, Stop will not signal the calling process. If the
+// recorded pid matches os.Getpid(), Stop only removes the pid file.
+// The foreground Start has its own ctx-cancellation path; signaling
+// self would terminate the caller before it could clean up.
 func Stop(root string) (err error) {
 	p, err := newPaths(root)
 	if err != nil {
@@ -304,15 +322,13 @@ func Stop(root string) (err error) {
 	// Both servers share a single child process in the detached model,
 	// so the two pid files typically reference the same pid. Dedup so
 	// we only signal once.
-	signaled := make(map[int]struct{})
+	handled := make(map[int]struct{})
 	for _, pidFile := range []string{p.fossilPid, p.natsPid} {
 		pid, ok := readPid(pidFile)
 		if ok && pid != self {
-			if _, done := signaled[pid]; !done {
-				if proc, err := os.FindProcess(pid); err == nil {
-					_ = proc.Signal(syscall.SIGTERM)
-				}
-				signaled[pid] = struct{}{}
+			if _, done := handled[pid]; !done {
+				terminateProcess(pid)
+				handled[pid] = struct{}{}
 			}
 		}
 		_ = os.Remove(pidFile)
@@ -322,6 +338,36 @@ func Stop(root string) (err error) {
 	_ = os.Remove(p.fossilURL)
 	_ = os.Remove(p.natsURL)
 	return nil
+}
+
+// terminateProcess sends SIGTERM, polls until stopGrace elapses, and
+// escalates to SIGKILL if the process is still alive. Returns once
+// the process is dead or the post-KILL wait expires; callers treat
+// the result as best-effort. Mirrors registry.Reap so behavior is
+// consistent across the two kill paths.
+func terminateProcess(pid int) {
+	if !pidIntIsLive(pid) {
+		return
+	}
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return
+	}
+	_ = proc.Signal(syscall.SIGTERM)
+	deadline := time.Now().Add(stopGrace)
+	for time.Now().Before(deadline) {
+		if !pidIntIsLive(pid) {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	_ = proc.Signal(syscall.SIGKILL)
+	for range 20 {
+		if !pidIntIsLive(pid) {
+			return
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
 }
 
 // paths holds every filesystem location the hub touches. Pulled into a
@@ -389,6 +435,17 @@ func pidIsLive(pidFile string) bool {
 	if !ok {
 		return false
 	}
+	return pidIntIsLive(pid)
+}
+
+// pidIntIsLive reports whether pid names a live process. Same probe
+// pidIsLive uses, but takes the pid directly so callers that already
+// have an integer (e.g., the Stop escalator) don't round-trip through
+// a pid file.
+func pidIntIsLive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
 	proc, err := os.FindProcess(pid)
 	if err != nil {
 		return false
@@ -424,6 +481,28 @@ func writePid(pidFile string, pid int) error {
 // Returns an error if the working tree has no git-tracked files, since
 // committing nothing would produce a checkout with an empty tip and the
 // orchestrator workflow assumes a non-empty session base.
+
+// seedHubRepoFunc is a package-level seam over seedHubRepo so tests can
+// inject failure modes (e.g., to verify rollback of partially-created
+// SQLite sidecars). Production code reaches the real implementation.
+var seedHubRepoFunc = seedHubRepo
+
+// removeRepoAndSidecars deletes the hub.fossil file and its SQLite
+// -shm / -wal sidecars together. The three travel as a unit: deleting
+// only hub.fossil leaves the sidecars to poison the next CreateWithEnv
+// with SQLITE_IOERR_SHORT_READ (522). See #138.
+func removeRepoAndSidecars(p paths) {
+	for _, path := range []string{
+		p.hubRepo,
+		p.hubRepo + "-shm",
+		p.hubRepo + "-wal",
+		p.fslckout,
+		p.fslSettings,
+	} {
+		_ = os.RemoveAll(path)
+	}
+}
+
 func seedHubRepo(p paths) error {
 	r, err := libfossil.Create(p.hubRepo, libfossil.CreateOpts{User: "orchestrator"})
 	if err != nil {

--- a/internal/hub/runforeground_test.go
+++ b/internal/hub/runforeground_test.go
@@ -1,0 +1,110 @@
+package hub
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestRunForeground_SeedFailureCleansSidecars asserts that when seed
+// fails after libfossil has begun creating SQLite sidecar files,
+// runForeground removes the orphan -shm/-wal (and any partial
+// hub.fossil) before returning. Without this, a subsequent
+// `bones hub start` hits SQLITE_IOERR_SHORT_READ (522) because the
+// next CreateWithEnv finds stale WAL/SHM blocks pointing at an absent
+// or freshly-recreated parent file. See issue #138.
+func TestRunForeground_SeedFailureCleansSidecars(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".bones", "pids"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	p, err := newPaths(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	orig := seedHubRepoFunc
+	defer func() { seedHubRepoFunc = orig }()
+	seedHubRepoFunc = func(p paths) error {
+		// Simulate libfossil partial init: a 0-byte hub.fossil and the
+		// SQLite -shm / -wal sidecars land before schema apply errors.
+		if err := os.WriteFile(p.hubRepo, []byte{}, 0o644); err != nil {
+			return err
+		}
+		for _, suffix := range []string{"-shm", "-wal"} {
+			if err := os.WriteFile(p.hubRepo+suffix, []byte{}, 0o644); err != nil {
+				return err
+			}
+		}
+		return errors.New("synthetic seed failure")
+	}
+
+	err = runForeground(context.Background(), p, opts{})
+	if err == nil {
+		t.Fatal("expected error from synthetic seed failure, got nil")
+	}
+	if !strings.Contains(err.Error(), "synthetic seed failure") {
+		t.Fatalf("error should wrap synthetic failure, got: %v", err)
+	}
+
+	// hub.fossil and its -shm/-wal sidecars must all be cleaned so the
+	// next bones hub start does not hit SQLITE_IOERR_SHORT_READ on
+	// stale journal state.
+	leftovers := []string{p.hubRepo, p.hubRepo + "-shm", p.hubRepo + "-wal"}
+	for _, path := range leftovers {
+		if _, statErr := os.Stat(path); statErr == nil {
+			t.Errorf("expected %s removed after seed failure; still exists",
+				filepath.Base(path))
+		} else if !os.IsNotExist(statErr) {
+			t.Errorf("stat %s: unexpected error: %v", path, statErr)
+		}
+	}
+}
+
+// TestRunForeground_FreshStartCleansStaleSidecars asserts the
+// pre-seed cleanup at the top of runForeground also removes
+// SQLite sidecars left from a prior crash. Otherwise the very next
+// seedHubRepo call inherits stale WAL state and reports a short-read.
+// See issue #138.
+func TestRunForeground_FreshStartCleansStaleSidecars(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".bones", "pids"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	p, err := newPaths(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Plant stale sidecars from a prior failed run. No fossil.pid → the
+	// fresh-start branch should fire and wipe them.
+	for _, suffix := range []string{"-shm", "-wal"} {
+		if err := os.WriteFile(p.hubRepo+suffix, []byte("stale"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Replace seed with one that observes whether the sidecars are
+	// gone by the time it's invoked. Returns an error to keep the rest
+	// of runForeground from spinning up real servers.
+	orig := seedHubRepoFunc
+	defer func() { seedHubRepoFunc = orig }()
+	var sawSidecars bool
+	seedHubRepoFunc = func(p paths) error {
+		for _, suffix := range []string{"-shm", "-wal"} {
+			if _, err := os.Stat(p.hubRepo + suffix); err == nil {
+				sawSidecars = true
+			}
+		}
+		return errors.New("synthetic post-cleanup seed failure")
+	}
+
+	_ = runForeground(context.Background(), p, opts{})
+	if sawSidecars {
+		t.Fatal("fresh-start should remove stale -shm/-wal before seedHubRepo " +
+			"runs; sidecars still present")
+	}
+}

--- a/internal/hub/stop_escalation_test.go
+++ b/internal/hub/stop_escalation_test.go
@@ -1,0 +1,126 @@
+package hub
+
+import (
+	"bufio"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+)
+
+// TestStop_EscalatesToSIGKILLOnTermResistant pins the contract that
+// hub.Stop kills processes that ignore SIGTERM. The pre-#138 Stop
+// signaled SIGTERM once, removed the pid file immediately, and
+// returned — leaving SIGTERM-resistant processes as orphans. The
+// fixed Stop waits, escalates to SIGKILL, and only removes the pid
+// file once the process is confirmed dead.
+//
+// Skipped on Windows: relies on POSIX `trap`/`SIGKILL` semantics.
+func TestStop_EscalatesToSIGKILLOnTermResistant(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("posix-only: Windows lacks SIGTERM/SIGKILL semantics")
+	}
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".bones", "pids"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	p, err := newPaths(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Spawn a process that ignores SIGTERM but yields to SIGKILL.
+	// Python's signal.SIG_IGN is rock-solid; the script also prints
+	// "ready" on stdout so we can synchronize on the handler being
+	// installed before Stop runs. Without this handshake there is a
+	// race where Stop's SIGTERM lands before python's signal.signal
+	// call, killing the subprocess on the default handler. Skip if
+	// python3 is unavailable.
+	pyPath, err := exec.LookPath("python3")
+	if err != nil {
+		t.Skip("python3 not available; required for TERM-ignore subprocess")
+	}
+	cmd := exec.Command(pyPath, "-c",
+		"import signal,sys,time\n"+
+			"signal.signal(signal.SIGTERM, signal.SIG_IGN)\n"+
+			"sys.stdout.write('ready\\n')\n"+
+			"sys.stdout.flush()\n"+
+			"time.sleep(60)\n")
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatalf("stdout pipe: %v", err)
+	}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("spawn term-resistant process: %v", err)
+	}
+	pid := cmd.Process.Pid
+
+	// Wait for python to confirm the handler is installed. Bound the
+	// wait so a broken interpreter doesn't make this test hang.
+	readyCh := make(chan error, 1)
+	go func() {
+		line, err := bufio.NewReader(stdout).ReadString('\n')
+		if err != nil {
+			readyCh <- err
+			return
+		}
+		if line != "ready\n" {
+			readyCh <- nil
+			return
+		}
+		readyCh <- nil
+	}()
+	select {
+	case err := <-readyCh:
+		if err != nil {
+			t.Fatalf("read ready: %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		_ = cmd.Process.Kill()
+		t.Fatal("python subprocess never reported ready")
+	}
+
+	// Reap asynchronously via cmd.Wait. Without an active Wait, the
+	// child becomes a zombie after kill — and Signal(0) on a zombie
+	// returns success on macOS/Linux, which would make pid-liveness
+	// probes lie about death. Closing `done` (vs. sending) lets both
+	// the test body and a fallback path read without contention.
+	done := make(chan struct{})
+	go func() {
+		_ = cmd.Wait()
+		close(done)
+	}()
+
+	if err := writePid(p.fossilPid, pid); err != nil {
+		t.Fatalf("writePid: %v", err)
+	}
+
+	stopStart := time.Now()
+	if err := Stop(root); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	stopElapsed := time.Since(stopStart)
+	t.Logf("Stop returned after %v (expect ~stopGrace=%v due to ignored TERM)",
+		stopElapsed, stopGrace)
+	if stopElapsed < stopGrace/2 {
+		t.Fatalf("Stop returned too quickly (%v); SIGTERM appears to "+
+			"have killed the trap-resistant child, meaning the test "+
+			"is not actually exercising SIGKILL escalation", stopElapsed)
+	}
+
+	// After Stop returns, the child must exit. Bound the wait so a
+	// missing SIGKILL escalation surfaces as a failure, not a hang.
+	// On the timeout path, kill manually so the cmd.Wait goroutine
+	// (and the test process) can shut down cleanly.
+	select {
+	case <-done:
+		return
+	case <-time.After(3 * time.Second):
+		_ = cmd.Process.Kill()
+		<-done
+		t.Fatalf("pid %d still alive after Stop returned; SIGTERM "+
+			"was ignored and SIGKILL escalation is missing (#138)", pid)
+	}
+}


### PR DESCRIPTION
## Summary

Two surgical fixes from issue #138's hub-lifecycle umbrella:

- **Sidecar rollback on seed failure.** `runForeground` now wipes `hub.fossil` + `hub.fossil-shm` + `hub.fossil-wal` together, both pre-seed (fresh-start cleanup) and post-seed-error. Fixes the `SQLITE_IOERR_SHORT_READ (522)` that re-occurs after a crashed seed because libfossil's stale WAL was being kept by the previous `os.RemoveAll` loop, which only listed `hubRepo`/`fslckout`/`fslSettings`.
- **SIGTERM→SIGKILL escalation in `hub.Stop`.** `Stop` previously sent `SIGTERM` once and removed the pid file immediately, leaving any TERM-resistant process as an orphan. The new `terminateProcess` helper polls for liveness over `stopGrace` (2s), escalates to `SIGKILL`, and waits briefly more — mirroring the existing `registry.Reap` pattern. Pid files are only removed once the process is confirmed dead.

Plus one drive-by fix: `TestRunBypassReportToNoGit` now isolates `HOME` so it doesn't depend on the developer's pre-existing cross-workspace registry entries (the test passed on CI but failed on any local machine with prior bones runs).

Refs #138.

## What's NOT in this PR (explicit scope)

The #138 umbrella has more sub-bugs that I'm splitting out so each lands as a focused, separately-revertable change:

- **Fix A** (surface seed errors in lazy auto-start) — largely addressed by commit `0f6ec3c` via `spawnDetachedChild`'s `hubLogTail`. The remaining gap (port collision producing a false-positive readiness signal) is its own work and has a different fix shape.
- **Fix C** (two leaves on the same fossil repo simultaneously) — the duplicates I observed were on `repo.fossil`, which is the EdgeSync swarm leaf path, not the hub. Out of `internal/hub` scope; needs a separate look at `internal/swarm` / `internal/dispatch/spawn.go`.
- **Fix E** (`bones up` echoing hub URL / NATS port / leaf PID) — depends on an ADR decision about whether `bones up` should start the hub synchronously or remain lazy per ADR 0041.
- **Cross-workspace registry reap on `bones down`** (related to Fix D) — `Stop` now kills correctly, but `cli/down` still doesn't enumerate child leaves or invoke `bones hub reap`. Follow-up PR.

## Test plan

- [x] `internal/hub/runforeground_test.go::TestRunForeground_SeedFailureCleansSidecars` — injects a seed function that creates `hub.fossil` + `-shm` + `-wal` then errors; asserts all three are gone after `runForeground` returns. RED before fix, GREEN after.
- [x] `internal/hub/runforeground_test.go::TestRunForeground_FreshStartCleansStaleSidecars` — plants stale `-shm`/`-wal`, asserts the pre-seed cleanup wipes them before `seedHubRepoFunc` runs.
- [x] `internal/hub/stop_escalation_test.go::TestStop_EscalatesToSIGKILLOnTermResistant` — spawns a Python subprocess with `signal.SIG_IGN` on `SIGTERM` (with a stdout handshake to avoid the install-handler race), asserts `Stop` kills it within `stopGrace + post-KILL`. Includes a `stopElapsed < stopGrace/2` guard against the test silently degrading into a TERM-only check.
- [x] `make check` clean (fmt-check, vet, lint, race, todo-check)
- [x] `go test -tags=otel -short ./...` clean (CI parity command)
- [x] Full hub package: 14 tests pass

## How I tested manually

Reproduced the original 522 by leaving stale `-shm`/`-wal` from a prior crash. With the fix:
- `runForeground`'s pre-seed cleanup removes them, so `seedHubRepoFunc` runs against a clean directory.
- If seed fails partway anyway, the rollback path removes whatever libfossil partially wrote.

For the Stop escalation: confirmed that a TERM-resistant Python subprocess (used in the test) survives `kill -TERM` for the full `stopGrace`, then dies immediately on `kill -KILL`. Test logs `Stop returned after 2.03s` which matches `stopGrace`.