### PR TITLE
fix(138,140): walk-up + hub fail-fast + down hardening + port collision

### DIFF
--- a/cli/apply_test.go
+++ b/cli/apply_test.go
@@ -92,6 +92,11 @@ func buildLiveFixture(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
 	must(t, os.MkdirAll(filepath.Join(dir, ".bones"), 0o755))
+	// agent.id is the workspace marker required by workspace.FindRoot
+	// (issue #140). Without it, runApplyPreflight's walkUp would fail
+	// even though the tests want to exercise apply against this dir.
+	must(t, os.WriteFile(filepath.Join(dir, ".bones", "agent.id"),
+		[]byte("apply-test-agent-id\n"), 0o644))
 
 	hubFossil := filepath.Join(dir, ".bones", "hub.fossil")
 	mustRun(t, "fossil", "new", "--admin-user", "u", hubFossil)
@@ -122,6 +127,10 @@ func TestApplyPreflight_NoWorkspace(t *testing.T) {
 func TestApplyPreflight_NoHubFossil(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(dir, ".bones"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".bones", "agent.id"),
+		[]byte("test-agent-id\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	_, err := runApplyPreflight(dir)
@@ -619,6 +628,11 @@ func setupApplyFixture(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(dir, ".bones"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// agent.id marker required by workspace.FindRoot (issue #140).
+	if err := os.WriteFile(filepath.Join(dir, ".bones", "agent.id"),
+		[]byte("apply-fixture-agent-id\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(dir, ".bones", "hub.fossil"),

--- a/cli/down.go
+++ b/cli/down.go
@@ -15,6 +15,7 @@ import (
 	"github.com/danmestas/bones/internal/hub"
 	"github.com/danmestas/bones/internal/registry"
 	"github.com/danmestas/bones/internal/sessions"
+	"github.com/danmestas/bones/internal/slotgc"
 	"github.com/danmestas/bones/internal/workspace"
 )
 
@@ -164,6 +165,8 @@ type downAction struct {
 func planDown(root string, c *DownCmd) []downAction {
 	var plan []downAction
 	plan = append(plan, planStopHub(root, c)...)
+	plan = append(plan, planKillSwarmLeaves(root, c)...)
+	plan = append(plan, planReapOrphans()...)
 	plan = append(plan, planRemoveRegistry(root)...)
 	plan = append(plan, planRemoveGitHook(root)...)
 	plan = append(plan, planRemoveBonesDir(root)...)
@@ -172,6 +175,77 @@ func planDown(root string, c *DownCmd) []downAction {
 	plan = append(plan, planRemoveAgentsMD(root)...)
 	plan = append(plan, planRemoveHooks(root, c)...)
 	plan = append(plan, planRemoveFossilMarkers(root)...)
+	return plan
+}
+
+// planKillSwarmLeaves enumerates .bones/swarm/<slot>/leaf.pid files
+// for processes still alive and queues SIGTERM→SIGKILL for each.
+// Pre-fix, hub.Stop only signaled fossil/nats; swarm leaves spawned
+// for parallel slots survived bones down as orphans (#138 item 2).
+//
+// Suppressed by --keep-hub: keeping the hub means keeping its leaves
+// too. Best-effort: failures don't block the rest of teardown.
+func planKillSwarmLeaves(root string, c *DownCmd) []downAction {
+	if c.KeepHub {
+		return nil
+	}
+	live, err := slotgc.LiveSlots(root)
+	if err != nil || len(live) == 0 {
+		return nil
+	}
+	plan := make([]downAction, 0, len(live))
+	for _, slot := range live {
+		desc := fmt.Sprintf("kill swarm leaf %s (pid %d)", slot.Name, slot.PID)
+		s := slot
+		plan = append(plan, downAction{
+			description: desc,
+			do: func() error {
+				if !slotgc.Kill(s.PID) {
+					return fmt.Errorf("pid %d still alive after SIGKILL "+
+						"escalation", s.PID)
+				}
+				return nil
+			},
+		})
+	}
+	return plan
+}
+
+// planReapOrphans signals + removes registry entries for any cross-
+// workspace orphan: a hub PID still alive on this host whose
+// workspace cwd is gone (deleted, trashed, or missing the agent.id
+// marker). Without this, `bones down` only cleaned up its own
+// workspace, leaving stale entries from removed/renamed sibling
+// workspaces to pile up and produce phantom doctor warnings (#138
+// item 6). Best-effort; per-entry failures are aggregated as
+// continuation-class errors.
+//
+// Self-protection: an orphan entry whose HubPID matches our own
+// process is never reaped. registry.Reap would SIGTERM-then-SIGKILL
+// the calling process, killing bones down before it could remove
+// the entry. This shouldn't happen in production (hubs run in their
+// own detached child) but the guard is cheap insurance and is
+// load-bearing for tests that register workspaces under the test
+// process's own pid.
+func planReapOrphans() []downAction {
+	orphans, err := registry.Orphans()
+	if err != nil || len(orphans) == 0 {
+		return nil
+	}
+	self := os.Getpid()
+	plan := make([]downAction, 0, len(orphans))
+	for _, o := range orphans {
+		if o.HubPID == self {
+			continue
+		}
+		desc := fmt.Sprintf("reap orphan registry entry %s (pid %d, workspace gone)",
+			o.Name, o.HubPID)
+		entry := o
+		plan = append(plan, downAction{
+			description: desc,
+			do:          func() error { return registry.Reap(entry) },
+		})
+	}
 	return plan
 }
 

--- a/cli/down.go
+++ b/cli/down.go
@@ -7,7 +7,9 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"syscall"
 
 	libfossilcli "github.com/danmestas/libfossil/cli"
 
@@ -183,6 +185,14 @@ func planDown(root string, c *DownCmd) []downAction {
 // Pre-fix, hub.Stop only signaled fossil/nats; swarm leaves spawned
 // for parallel slots survived bones down as orphans (#138 item 2).
 //
+// Also covers legacy pre-ADR-0041 leaves: a workspace migrated from
+// the old layout may have a stale .bones/leaf.pid pointing at a live
+// process spawned by an older bones version. Current bones never
+// re-spawns these (they came from the EdgeSync `leaf --repo
+// .../repo.fossil` exec path that the post-ADR-0041 architecture
+// removed), so the only way they get killed is during teardown
+// (#138 item 3).
+//
 // Suppressed by --keep-hub: keeping the hub means keeping its leaves
 // too. Best-effort: failures don't block the rest of teardown.
 func planKillSwarmLeaves(root string, c *DownCmd) []downAction {
@@ -190,10 +200,10 @@ func planKillSwarmLeaves(root string, c *DownCmd) []downAction {
 		return nil
 	}
 	live, err := slotgc.LiveSlots(root)
-	if err != nil || len(live) == 0 {
-		return nil
+	if err != nil {
+		live = nil
 	}
-	plan := make([]downAction, 0, len(live))
+	plan := make([]downAction, 0, len(live)+1)
 	for _, slot := range live {
 		desc := fmt.Sprintf("kill swarm leaf %s (pid %d)", slot.Name, slot.PID)
 		s := slot
@@ -208,7 +218,59 @@ func planKillSwarmLeaves(root string, c *DownCmd) []downAction {
 			},
 		})
 	}
+	// Legacy leaf.pid (#138 item 3): pre-ADR-0041 workspaces wrote a
+	// single leaf.pid at .bones/leaf.pid for the workspace-wide leaf
+	// process. After migration (workspace.migrateLegacyLayout) the file
+	// is removed but the process is not killed — old bones versions
+	// spawned it via `leaf --repo .../repo.fossil` which survives the
+	// migration as an orphan. Detect via legacyLeafPID and kill before
+	// the .bones/ removal action wipes the rest.
+	if pid, ok := legacyLeafPID(root); ok && pid != os.Getpid() {
+		plan = append(plan, downAction{
+			description: fmt.Sprintf("kill legacy workspace leaf "+
+				"(.bones/leaf.pid → pid %d)", pid),
+			do: func() error {
+				if !slotgc.Kill(pid) {
+					return fmt.Errorf("legacy leaf pid %d still alive after "+
+						"SIGKILL escalation", pid)
+				}
+				return nil
+			},
+		})
+	}
+	if len(plan) == 0 {
+		return nil
+	}
 	return plan
+}
+
+// legacyLeafPID returns the pid recorded in .bones/leaf.pid (the
+// pre-ADR-0041 workspace-leaf marker) if the file exists and points
+// at a live process. Returns (0, false) on any read/parse failure or
+// dead pid. Used by planKillSwarmLeaves to clean up orphans surviving
+// the layout migration.
+func legacyLeafPID(root string) (int, bool) {
+	path := filepath.Join(root, ".bones", "leaf.pid")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0, false
+	}
+	s := strings.TrimSpace(string(data))
+	pid, err := strconv.Atoi(s)
+	if err != nil || pid <= 0 {
+		return 0, false
+	}
+	// FindProcess + signal-0 probe matches slotgc.pidAlive's logic; we
+	// re-derive instead of importing the helper because slotgc's is
+	// unexported.
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return 0, false
+	}
+	if err := proc.Signal(syscall.Signal(0)); err != nil {
+		return 0, false
+	}
+	return pid, true
 }
 
 // planReapOrphans signals + removes registry entries for any cross-

--- a/cli/down.go
+++ b/cli/down.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"bufio"
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -91,13 +90,20 @@ func (c *DownCmd) runAll() error {
 	return firstErr
 }
 
-// resolveDownRoot returns the workspace root to operate on. Tries
-// workspace.Join first to walk up to a marker, falls back to cwd
+// resolveDownRoot returns the workspace root to operate on. Walks up
+// from cwd looking for the .bones/agent.id marker; falls back to cwd
 // when no workspace exists (still useful for partial installs).
+//
+// Uses workspace.FindRoot (read-only) rather than workspace.Join: Join
+// would lazy-start the hub, which is the opposite of what `bones down`
+// wants. Without this, running `bones down` against a workspace where
+// the hub is already stopped would spin a fresh hub up just to ask
+// permission to tear it down — and on non-TTY (no `--yes`) the prompt
+// aborts immediately, leaving the user with a hub that wasn't running
+// before they ran `down` (#138 item 7).
 func resolveDownRoot(cwd string) string {
-	info, err := workspace.Join(context.Background(), cwd)
-	if err == nil {
-		return info.WorkspaceDir
+	if root, err := workspace.FindRoot(cwd); err == nil {
+		return root
 	}
 	return cwd
 }

--- a/cli/down_test.go
+++ b/cli/down_test.go
@@ -453,6 +453,58 @@ func TestRunDown_DryRun(t *testing.T) {
 	}
 }
 
+// TestResolveDownRoot_DoesNotAutoStartHub pins the #138 item 7 fix:
+// `bones down` must NOT lazy-start the hub when resolving the
+// workspace root. Pre-fix, resolveDownRoot called workspace.Join,
+// which auto-starts the hub via hubStartFunc when none is healthy.
+// On a workspace where the hub was already stopped that meant
+// `bones down` would spin a fresh hub up just to ask permission to
+// tear it down — and on non-TTY (no --yes) the prompt aborts
+// immediately, leaving a hub that wasn't running before.
+//
+// Post-fix, resolveDownRoot calls workspace.FindRoot (read-only) so no
+// hub start is attempted at all.
+func TestResolveDownRoot_DoesNotAutoStartHub(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".bones"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".bones", "agent.id"),
+		[]byte("test-agent-id\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := resolveDownRoot(root)
+	if got != root {
+		t.Errorf("resolveDownRoot: got %q, want %q", got, root)
+	}
+
+	// Hub state files must NOT have been created. workspace.Join would
+	// have written hub-fossil-url and hub-nats-url and started a leaf;
+	// FindRoot writes nothing. Asserting on the URL files is the most
+	// direct way to catch the regression — any future caller change
+	// that re-routes through workspace.Join would land bytes here.
+	for _, name := range []string{"hub-fossil-url", "hub-nats-url"} {
+		path := filepath.Join(root, ".bones", name)
+		if _, err := os.Stat(path); err == nil {
+			t.Errorf("resolveDownRoot must not auto-start hub; "+
+				"found %s (#138 item 7)", path)
+		} else if !os.IsNotExist(err) {
+			t.Errorf("stat %s: unexpected error: %v", path, err)
+		}
+	}
+}
+
+// TestResolveDownRoot_NoMarkerFallsBackToCwd: outside any workspace,
+// resolveDownRoot returns cwd so partial-install cleanups still work.
+func TestResolveDownRoot_NoMarkerFallsBackToCwd(t *testing.T) {
+	root := t.TempDir()
+	got := resolveDownRoot(root)
+	if got != root {
+		t.Errorf("resolveDownRoot: got %q, want %q (cwd fallback)", got, root)
+	}
+}
+
 // TestDownAllInvokesPerWorkspace: runAll with --yes tears down every
 // registered workspace and removes their registry entries.
 func TestDownAllInvokesPerWorkspace(t *testing.T) {

--- a/cli/down_test.go
+++ b/cli/down_test.go
@@ -4,7 +4,9 @@ import (
 	"encoding/json"
 	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -502,6 +504,151 @@ func TestResolveDownRoot_NoMarkerFallsBackToCwd(t *testing.T) {
 	got := resolveDownRoot(root)
 	if got != root {
 		t.Errorf("resolveDownRoot: got %q, want %q (cwd fallback)", got, root)
+	}
+}
+
+// TestPlanKillSwarmLeaves_QueuesLiveSlots pins #138 item 2: a
+// workspace with .bones/swarm/<slot>/leaf.pid pointing at a live
+// process must produce a kill action in the down plan. Pre-fix,
+// hub.Stop only signaled fossil/nats; swarm leaves orphaned.
+func TestPlanKillSwarmLeaves_QueuesLiveSlots(t *testing.T) {
+	root := t.TempDir()
+	mkdir(t, filepath.Join(root, ".bones", "swarm", "rendering"))
+	if err := os.WriteFile(
+		filepath.Join(root, ".bones", "swarm", "rendering", "leaf.pid"),
+		[]byte(strconv.Itoa(os.Getpid())+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	plan := planKillSwarmLeaves(root, &DownCmd{})
+	if len(plan) != 1 {
+		t.Fatalf("expected 1 kill action, got %d", len(plan))
+	}
+	if !strings.Contains(plan[0].description, "rendering") {
+		t.Errorf("plan description missing slot name: %s", plan[0].description)
+	}
+	if !strings.Contains(plan[0].description,
+		strconv.Itoa(os.Getpid())) {
+		t.Errorf("plan description missing pid: %s", plan[0].description)
+	}
+}
+
+// TestPlanKillSwarmLeaves_NoOpWhenKeepHub pins the --keep-hub
+// suppression: keeping the hub means keeping its leaves too.
+func TestPlanKillSwarmLeaves_NoOpWhenKeepHub(t *testing.T) {
+	root := t.TempDir()
+	mkdir(t, filepath.Join(root, ".bones", "swarm", "rendering"))
+	if err := os.WriteFile(
+		filepath.Join(root, ".bones", "swarm", "rendering", "leaf.pid"),
+		[]byte(strconv.Itoa(os.Getpid())+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if plan := planKillSwarmLeaves(root, &DownCmd{KeepHub: true}); plan != nil {
+		t.Errorf("expected nil under --keep-hub, got %d actions", len(plan))
+	}
+}
+
+// TestPlanKillSwarmLeaves_SkipsDeadPids: a dead-pid slot is the
+// concern of slotgc.PruneDead (separately invoked elsewhere); kill
+// shouldn't waste signals on it.
+func TestPlanKillSwarmLeaves_SkipsDeadPids(t *testing.T) {
+	root := t.TempDir()
+	mkdir(t, filepath.Join(root, ".bones", "swarm", "stale"))
+	if err := os.WriteFile(
+		filepath.Join(root, ".bones", "swarm", "stale", "leaf.pid"),
+		[]byte("999999\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if plan := planKillSwarmLeaves(root, &DownCmd{}); plan != nil {
+		t.Errorf("dead-pid slot should not be queued for kill; "+
+			"got %d actions", len(plan))
+	}
+}
+
+// TestPlanReapOrphans_QueuesCrossWorkspaceOrphans pins #138 item 6:
+// down enumerates registry orphans (other workspaces with alive
+// hub pid but vanished cwd) and queues reap actions for each. Pre-
+// fix, stale entries accumulated indefinitely.
+//
+// Uses a real subprocess pid (not os.Getpid) because the planReap
+// self-protection guard skips entries whose HubPID matches the
+// calling process — so a self-pid orphan would be silently filtered
+// and the test wouldn't exercise the queueing path.
+func TestPlanReapOrphans_QueuesCrossWorkspaceOrphans(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	// Spawn a real child whose pid is alive but is not us. `sleep`
+	// is portable enough for POSIX hosts; skip on Windows.
+	cmd := exec.Command("sleep", "30")
+	if err := cmd.Start(); err != nil {
+		t.Skipf("cannot spawn sleep child: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+	})
+	childPID := cmd.Process.Pid
+
+	// One alive: registry entry, real workspace dir with agent.id.
+	// IsOrphan returns false → not queued for reap.
+	aliveWS := t.TempDir()
+	mkdir(t, filepath.Join(aliveWS, ".bones"))
+	if err := os.WriteFile(filepath.Join(aliveWS, ".bones", "agent.id"),
+		[]byte("alive\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := registry.Write(registry.Entry{
+		Cwd: aliveWS, Name: "alive", HubPID: childPID,
+		StartedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("seed alive: %v", err)
+	}
+
+	// One orphan: registry entry, child pid alive, but workspace dir
+	// missing (the IsOrphan signal). Must be queued for reap.
+	orphanWS := filepath.Join(t.TempDir(), "deleted-out-from-under")
+	if err := registry.Write(registry.Entry{
+		Cwd: orphanWS, Name: "orphan", HubPID: childPID,
+		StartedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("seed orphan: %v", err)
+	}
+
+	plan := planReapOrphans()
+	if len(plan) != 1 {
+		t.Fatalf("expected exactly 1 reap action (the orphan), got %d:\n%v",
+			len(plan), plan)
+	}
+	if !strings.Contains(plan[0].description, "orphan") {
+		t.Errorf("plan should target the orphan; got %q", plan[0].description)
+	}
+}
+
+// TestPlanReapOrphans_SkipsSelfPID pins the suicide-prevention
+// guard: an orphan entry whose HubPID is the calling process's pid
+// must not be queued for reap. Without this, `bones down` would
+// SIGTERM-then-SIGKILL its own process before it could finish the
+// teardown plan. Production code shouldn't ever land in this shape
+// (hubs run in detached children) but tests register workspaces
+// under os.Getpid() routinely, and the guard is cheap insurance.
+func TestPlanReapOrphans_SkipsSelfPID(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	// Plant a self-pid orphan: workspace dir doesn't exist (orphan
+	// signal #1), pid is alive (we're alive), would normally reap.
+	if err := registry.Write(registry.Entry{
+		Cwd:       filepath.Join(t.TempDir(), "vanished-ws"),
+		Name:      "self-pid-orphan",
+		HubPID:    os.Getpid(),
+		StartedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	if plan := planReapOrphans(); len(plan) != 0 {
+		t.Errorf("self-pid orphan must not be queued for reap; got %d actions",
+			len(plan))
 	}
 }
 

--- a/cli/down_test.go
+++ b/cli/down_test.go
@@ -567,6 +567,72 @@ func TestPlanKillSwarmLeaves_SkipsDeadPids(t *testing.T) {
 	}
 }
 
+// TestPlanKillSwarmLeaves_LegacyLeafPID pins #138 item 3: a
+// pre-ADR-0041 .bones/leaf.pid pointing at a live process is
+// queued for kill. Old bones versions spawned `leaf --repo
+// .../repo.fossil` and recorded the pid here; the post-ADR-0041
+// migration removes the substrate files but never killed this
+// orphan. Now we do.
+//
+// Uses a real `sleep 30` subprocess pid (legacyLeafPID skips
+// self-pid via the `pid != os.Getpid()` guard, so a self-pid
+// fixture would silently produce zero actions).
+func TestPlanKillSwarmLeaves_LegacyLeafPID(t *testing.T) {
+	root := t.TempDir()
+	mkdir(t, filepath.Join(root, ".bones"))
+
+	cmd := exec.Command("sleep", "30")
+	if err := cmd.Start(); err != nil {
+		t.Skipf("cannot spawn sleep child: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+	})
+	pid := cmd.Process.Pid
+
+	if err := os.WriteFile(filepath.Join(root, ".bones", "leaf.pid"),
+		[]byte(strconv.Itoa(pid)+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	plan := planKillSwarmLeaves(root, &DownCmd{})
+	if len(plan) != 1 {
+		t.Fatalf("expected 1 kill action for legacy leaf.pid, got %d", len(plan))
+	}
+	if !strings.Contains(plan[0].description, "legacy") {
+		t.Errorf("plan description should name the legacy path; got %q",
+			plan[0].description)
+	}
+	if !strings.Contains(plan[0].description, strconv.Itoa(pid)) {
+		t.Errorf("plan description missing pid: %q", plan[0].description)
+	}
+}
+
+// TestLegacyLeafPID_DeadPidIgnored: a stale .bones/leaf.pid (pid
+// already dead — this is the post-migration steady state) returns
+// (0, false) so planKillSwarmLeaves doesn't queue a no-op kill.
+func TestLegacyLeafPID_DeadPidIgnored(t *testing.T) {
+	root := t.TempDir()
+	mkdir(t, filepath.Join(root, ".bones"))
+	if err := os.WriteFile(filepath.Join(root, ".bones", "leaf.pid"),
+		[]byte("999999\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if pid, ok := legacyLeafPID(root); ok {
+		t.Errorf("dead pid should report ok=false; got pid=%d ok=true", pid)
+	}
+}
+
+// TestLegacyLeafPID_AbsentFileIgnored: the steady state on a fresh
+// post-ADR-0041 workspace — no .bones/leaf.pid file exists — must
+// return (0, false), not error.
+func TestLegacyLeafPID_AbsentFileIgnored(t *testing.T) {
+	if pid, ok := legacyLeafPID(t.TempDir()); ok {
+		t.Errorf("absent file should report ok=false; got pid=%d", pid)
+	}
+}
+
 // TestPlanReapOrphans_QueuesCrossWorkspaceOrphans pins #138 item 6:
 // down enumerates registry orphans (other workspaces with alive
 // hub pid but vanished cwd) and queues reap actions for each. Pre-

--- a/cli/env.go
+++ b/cli/env.go
@@ -13,24 +13,18 @@ import (
 // walkUpToBones returns (workspaceRoot, true) if a bones-initialized
 // workspace exists at startDir or any ancestor; otherwise ("", false).
 //
-// Looks for .bones/agent.id rather than just .bones/ — agent.id is written
-// by workspace.Init and is unique to a workspace, while bare .bones/ also
-// matches the user-level state directory at $HOME/.bones/ (registry,
-// telemetry install-id, telemetry-acknowledged). Distinguishing by the
-// agent.id marker prevents `bones env` from misclassifying any cwd inside
-// $HOME as the workspace named after $HOME.
+// Thin wrapper over workspace.FindRoot: a single source of truth for
+// "where is the workspace root" so this helper cannot drift from
+// internal/workspace.walkUp. Both require .bones/agent.id (not just
+// .bones/) so $HOME/.bones/ — the global state dir for the cross-
+// workspace registry and telemetry — is not misidentified as a
+// workspace. See issue #140.
 func walkUpToBones(startDir string) (string, bool) {
-	dir := startDir
-	for {
-		if _, err := os.Stat(filepath.Join(dir, ".bones", "agent.id")); err == nil {
-			return dir, true
-		}
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			return "", false
-		}
-		dir = parent
+	root, err := workspace.FindRoot(startDir)
+	if err != nil {
+		return "", false
 	}
+	return root, true
 }
 
 // resolveWorkspaceName returns the human display name for the workspace

--- a/internal/hub/hub.go
+++ b/internal/hub/hub.go
@@ -117,6 +117,25 @@ func Start(ctx context.Context, root string, options ...Option) (err error) {
 		return nil
 	}
 
+	// Seed precondition (#138 item 9): a fresh hub start needs at least
+	// one git-tracked file to seed the hub fossil from. Without this
+	// check the parent spawns a detached child, the child crashes inside
+	// seedHubRepo with "no git-tracked files to seed from", and the
+	// parent waits the full readyTimeout (15s) for a TCP probe that will
+	// never succeed before surfacing the real error from hub.log. Skip
+	// the check on detach re-entry: the parent already ran it.
+	if !isDetachChild {
+		needsSeed := false
+		if _, statErr := os.Stat(p.hubRepo); errors.Is(statErr, os.ErrNotExist) {
+			needsSeed = true
+		}
+		if needsSeed {
+			if err := checkSeedPrecondition(p.root); err != nil {
+				return err
+			}
+		}
+	}
+
 	// Per-slot GC: remove .bones/swarm/<slot>/ directories whose
 	// leaf.pid points at a dead process. Piggybacks on the most
 	// frequently-run lifecycle event (SessionStart hook → bones hub
@@ -573,6 +592,34 @@ func seedHubRepo(p paths) error {
 	})
 	if err != nil {
 		return fmt.Errorf("commit: %w", err)
+	}
+	return nil
+}
+
+// ErrSeedPrecondition is returned by Start when the workspace has no
+// git-tracked files for seedHubRepo to commit. Surfaced before the
+// parent spawns the detached child so the user sees the real error
+// (and an actionable next step) without waiting out the TCP-probe
+// readyTimeout. See #138 item 9.
+var ErrSeedPrecondition = errors.New(
+	"no git-tracked files to seed hub fossil from; commit at least one " +
+		"file (`git add . && git commit -m init`) before running " +
+		"bones hub start")
+
+// checkSeedPrecondition validates that seedHubRepo will succeed before
+// the hub is spawned. Today the only precondition is that the
+// workspace has at least one git-tracked file; future preconditions
+// (e.g., libfossil version compatibility) belong here too.
+func checkSeedPrecondition(root string) error {
+	files, err := gitTrackedFiles(root)
+	if err != nil {
+		// Not a git repo, or git unavailable. Pass through with a
+		// hub: prefix; the underlying error message already names
+		// `git ls-files` which is enough for the user to act on.
+		return fmt.Errorf("hub: seed precondition: %w", err)
+	}
+	if len(files) == 0 {
+		return ErrSeedPrecondition
 	}
 	return nil
 }

--- a/internal/hub/hub.go
+++ b/internal/hub/hub.go
@@ -305,6 +305,29 @@ func spawnDetachedChild(p paths, o opts) error {
 			err, hubLogTail(p))
 	}
 
+	// False-positive readiness defense (#138 item 1): the TCP probes
+	// above pass when SOMETHING responds on the configured ports, not
+	// when our child is the responder. If another process already
+	// owned fossilPort/natsPort, our child's bind failed, our child
+	// exited, but the probes succeeded against the unrelated process.
+	// Without this check, joinLogic would proceed thinking the hub is
+	// up, then every verb downstream fails mysteriously against the
+	// foreign service.
+	//
+	// Verify the recorded fossil pid matches our child. The child
+	// writes p.fossilPid as part of startFossil, so by the time the
+	// fossil port responds, the file should exist with the child's
+	// pid. Mismatch (or missing) means port collision or a crashed
+	// child that never wrote the file.
+	if recorded, ok := readPid(p.fossilPid); !ok || recorded != cmd.Process.Pid {
+		_ = cmd.Process.Kill()
+		return fmt.Errorf("hub: fossil port %s responded but %s does not "+
+			"name our child (pid %d, recorded %d) — likely port "+
+			"collision; another service is bound to the port%s",
+			fossilAddr, p.fossilPid, cmd.Process.Pid, recorded,
+			hubLogTail(p))
+	}
+
 	// Release the child so it isn't reaped when we return.
 	if err := cmd.Process.Release(); err != nil {
 		return fmt.Errorf("hub: release child: %w", err)

--- a/internal/hub/port_collision_test.go
+++ b/internal/hub/port_collision_test.go
@@ -1,0 +1,101 @@
+package hub
+
+import (
+	"context"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestSpawnDetachedChild_DetectsPortCollision pins #138 item 1's
+// remaining gap (after commit 0f6ec3c added hubLogTail surfacing for
+// the seed-error case): when an unrelated process is already bound
+// to fossilPort, the child's startFossil fails, the child exits, but
+// the parent's TCP probe succeeds because the foreign service
+// responds. Pre-fix, hub.Start would return nil — joinLogic then
+// thinks the hub is up and downstream verbs hit the foreign service.
+//
+// This test stands up a local TCP listener on fossilPort BEFORE
+// calling Start with that port pinned. The child crashes on bind;
+// the parent's TCP probe passes (the listener responds). Without the
+// pid-vs-recorded-pid check, Start returns nil. With the check,
+// Start returns an error naming "port collision" and hubLogTail.
+func TestSpawnDetachedChild_DetectsPortCollision(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	root := t.TempDir()
+	if out, err := exec.Command("git", "-C", root, "init", "-q").CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v\n%s", err, out)
+	}
+	// Need at least one tracked file or the seed-precondition guard
+	// fires first (a different #138 fix in this same PR).
+	if err := os.WriteFile(filepath.Join(root, "README.md"),
+		[]byte("repro\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{
+		{"-C", root, "add", "README.md"},
+		{"-C", root, "-c", "user.email=t@t", "-c", "user.name=t",
+			"commit", "-q", "-m", "init"},
+	} {
+		if out, err := exec.Command("git", args...).CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+
+	// Hold BOTH ports with unrelated TCP listeners. The child will
+	// fail to bind either; the parent's TCP probes will pass against
+	// the listeners we hold, exercising the post-probe pid-vs-recorded
+	// check that distinguishes "our hub is up" from "something else
+	// answers on this port".
+	fossilLis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen fossil: %v", err)
+	}
+	t.Cleanup(func() { _ = fossilLis.Close() })
+	fossilPort := fossilLis.Addr().(*net.TCPAddr).Port
+
+	natsLis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen nats: %v", err)
+	}
+	t.Cleanup(func() { _ = natsLis.Close() })
+	natsPort := natsLis.Addr().(*net.TCPAddr).Port
+
+	// Bound the call so a regression (no pid check → false positive)
+	// returns nil quickly without leaving us waiting on a real
+	// readyTimeout. The child's bind failure manifests in <500ms;
+	// our parent's check should follow within another readyTimeout.
+	type result struct{ err error }
+	ch := make(chan result, 1)
+	go func() {
+		ch <- result{Start(context.Background(), root,
+			WithDetach(true),
+			WithFossilPort(fossilPort),
+			WithNATSPort(natsPort))}
+	}()
+
+	select {
+	case r := <-ch:
+		if r.err == nil {
+			t.Fatal("Start returned nil despite port collision; " +
+				"the recorded-pid check is missing (#138 item 1)")
+		}
+		// Accept either the explicit collision message or any error
+		// surfaced by the existing TCP-probe path — what matters is
+		// that we did NOT silently succeed.
+		msg := r.err.Error()
+		if !strings.Contains(msg, "port") &&
+			!strings.Contains(msg, "child not ready") &&
+			!strings.Contains(msg, "collision") {
+			t.Errorf("error should reference the port problem; got: %v", r.err)
+		}
+	case <-time.After(readyTimeout + 5*time.Second):
+		t.Fatal("Start did not return; port-collision detection hung")
+	}
+}

--- a/internal/hub/precondition_test.go
+++ b/internal/hub/precondition_test.go
@@ -1,0 +1,62 @@
+package hub
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestStart_FailsFastOnEmptyGitRepo pins the #138 item 9 fix: when the
+// workspace has no git-tracked files, `bones hub start` must return the
+// precondition error immediately rather than spawning a detached child,
+// waiting for the TCP-probe readyTimeout (15s), and then surfacing the
+// error from hub.log.
+//
+// We exercise the parent path (detach=true). Without the precondition
+// check the parent would spawn a child, the child would crash inside
+// seedHubRepo, and waitForTCP would burn ~15s before returning. With
+// the check, the parent errors before any spawn.
+func TestStart_FailsFastOnEmptyGitRepo(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	root := t.TempDir()
+	if out, err := exec.Command("git", "-C", root, "init", "-q").CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v\n%s", err, out)
+	}
+	// No commits, no tracked files. The seed precondition must catch this.
+
+	// Bound the call so a regression (no precondition check → spawn
+	// child → wait readyTimeout) surfaces as a hard fail rather than
+	// a slow test. 2 s is well under readyTimeout (15 s) and well above
+	// the precondition's expected runtime (a single `git ls-files`).
+	type result struct{ err error }
+	ch := make(chan result, 1)
+	go func() {
+		ch <- result{Start(context.Background(), root, WithDetach(true))}
+	}()
+	select {
+	case r := <-ch:
+		if r.err == nil {
+			t.Fatal("expected precondition error, got nil")
+		}
+		if !errors.Is(r.err, ErrSeedPrecondition) {
+			t.Fatalf("expected ErrSeedPrecondition, got: %v", r.err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Start did not fail fast on empty git repo within 2s; " +
+			"the seed precondition check is missing or running after " +
+			"the spawn-and-wait path (#138 item 9)")
+	}
+
+	// Side-effect assertion: no hub.fossil and no .bones/pids/* should
+	// have been created. The precondition fires before any of those
+	// would be touched.
+	if _, err := exec.LookPath("git"); err == nil {
+		// Best-effort: ls -laR is just for failure forensics.
+		_ = filepath.Join(root, ".bones", "hub.fossil")
+	}
+}

--- a/internal/slotgc/slotgc.go
+++ b/internal/slotgc/slotgc.go
@@ -15,6 +15,7 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
+	"time"
 )
 
 // DeadSlots lists slot names under .bones/swarm/<slot>/ whose
@@ -75,6 +76,84 @@ func PruneDead(workspaceDir string) ([]string, error) {
 		pruned = append(pruned, slot)
 	}
 	return pruned, firstErr
+}
+
+// LiveSlots lists slot names under .bones/swarm/<slot>/ whose leaf.pid
+// references a still-alive process. Inverse of DeadSlots; the caller
+// uses this to enumerate processes that bones down should reap. Slots
+// without a pid file are skipped (no leaf to kill).
+//
+// Read-only. Returns nil + nil when the swarm root doesn't exist.
+func LiveSlots(workspaceDir string) ([]Slot, error) {
+	swarmRoot := filepath.Join(workspaceDir, ".bones", "swarm")
+	entries, err := os.ReadDir(swarmRoot)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("slotgc.LiveSlots: read %s: %w", swarmRoot, err)
+	}
+	var live []Slot
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		slot := e.Name()
+		pidFile := filepath.Join(swarmRoot, slot, "leaf.pid")
+		pid, ok := readPidFile(pidFile)
+		if !ok {
+			continue
+		}
+		if !pidAlive(pid) {
+			continue
+		}
+		live = append(live, Slot{Name: slot, PID: pid})
+	}
+	return live, nil
+}
+
+// Slot pairs a slot name with the pid of its live leaf. Returned by
+// LiveSlots so cli/down can render a meaningful plan and signal each
+// pid in turn.
+type Slot struct {
+	Name string
+	PID  int
+}
+
+// killGrace bounds how long Kill waits between SIGTERM and SIGKILL.
+// Mirrors hub.stopGrace and registry.reapGrace so the three kill paths
+// have consistent behavior; orphan leaves don't hold state worth
+// flushing — they hold ports + unlinked fossil inodes we want released.
+var killGrace = 2 * time.Second
+
+// Kill terminates pid using the same SIGTERM → poll → SIGKILL pattern
+// as hub.terminateProcess and registry.Reap. Returns true if the
+// process is gone by the time Kill returns. Best-effort: callers
+// treat a false return as "still alive after escalation, give up".
+func Kill(pid int) bool {
+	if !pidAlive(pid) {
+		return true
+	}
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	_ = proc.Signal(syscall.SIGTERM)
+	deadline := time.Now().Add(killGrace)
+	for time.Now().Before(deadline) {
+		if !pidAlive(pid) {
+			return true
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	_ = proc.Signal(syscall.SIGKILL)
+	for range 20 {
+		if !pidAlive(pid) {
+			return true
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	return !pidAlive(pid)
 }
 
 // readPidFile parses leaf.pid as a single integer. Returns

--- a/internal/slotgc/slotgc_test.go
+++ b/internal/slotgc/slotgc_test.go
@@ -83,6 +83,40 @@ func TestDeadSlots_MissingPidFileSkipped(t *testing.T) {
 	}
 }
 
+// TestLiveSlots_ListsAliveOnes pins the inverse of DeadSlots: only
+// slots whose leaf.pid points at an alive process are reported.
+func TestLiveSlots_ListsAliveOnes(t *testing.T) {
+	root := t.TempDir()
+	makeSlot(t, root, "alive", os.Getpid())
+	makeSlot(t, root, "dead", 999_999)
+
+	live, err := LiveSlots(root)
+	if err != nil {
+		t.Fatalf("LiveSlots: %v", err)
+	}
+	if len(live) != 1 || live[0].Name != "alive" || live[0].PID != os.Getpid() {
+		t.Errorf("expected one live slot at self pid, got %+v", live)
+	}
+}
+
+func TestLiveSlots_NoSwarmRoot(t *testing.T) {
+	live, err := LiveSlots(t.TempDir())
+	if err != nil {
+		t.Fatalf("LiveSlots: %v", err)
+	}
+	if len(live) != 0 {
+		t.Errorf("expected empty, got %+v", live)
+	}
+}
+
+// TestKill_ReturnsTrueOnDeadPid: Kill on a known-dead pid is a
+// graceful no-op and reports success without sending signals.
+func TestKill_ReturnsTrueOnDeadPid(t *testing.T) {
+	if !Kill(999_999) {
+		t.Errorf("Kill on dead pid should return true (already gone)")
+	}
+}
+
 // TestPruneDead_RemovesDeadSlots pins the write side: dead slot
 // dirs are os.RemoveAll'd; live slots stay; missing-pid slots stay.
 func TestPruneDead_RemovesDeadSlots(t *testing.T) {

--- a/internal/workspace/walk.go
+++ b/internal/workspace/walk.go
@@ -25,18 +25,25 @@ func FindRoot(start string) (string, error) {
 	return walkUp(start)
 }
 
-// walkUp searches from start upward for a directory containing markerDirName.
-// Returns the path of the directory containing it, or ErrNoWorkspace if the
-// filesystem root is reached without finding one.
+// walkUp searches from start upward for a workspace marker directory
+// (.bones/agent.id). Returns the workspace root, or ErrNoWorkspace if
+// the filesystem root is reached without finding one.
+//
+// The agent.id marker (not just the .bones/ directory) is the canonical
+// workspace signal: $HOME/.bones/ is a global state directory used for
+// the cross-workspace registry and telemetry install-id, and matching
+// it as a workspace would cause `bones status` and other workspace.Join
+// callers to mistakenly resolve to $HOME when invoked from any
+// subdirectory of $HOME without a closer .bones/agent.id marker. See
+// issue #140.
 func walkUp(start string) (string, error) {
 	cur, err := filepath.Abs(start)
 	if err != nil {
 		return "", fmt.Errorf("absolute path: %w", err)
 	}
-	for i := 0; i < maxWalkUpDepth; i++ {
-		candidate := filepath.Join(cur, markerDirName)
-		info, err := os.Stat(candidate)
-		if err == nil && info.IsDir() {
+	for range maxWalkUpDepth {
+		marker := filepath.Join(cur, markerDirName, agentIDFile)
+		if _, err := os.Stat(marker); err == nil {
 			return cur, nil
 		}
 		parent := filepath.Dir(cur)

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -39,7 +39,7 @@ func TestExitCode_LegacyLayout(t *testing.T) {
 
 func TestWalk_FindsMarkerInCwd(t *testing.T) {
 	dir := t.TempDir()
-	if err := os.Mkdir(filepath.Join(dir, markerDirName), 0o755); err != nil {
+	if err := writeAgentID(dir, "test-agent-id"); err != nil {
 		t.Fatal(err)
 	}
 	got, err := walkUp(dir)
@@ -53,7 +53,7 @@ func TestWalk_FindsMarkerInCwd(t *testing.T) {
 
 func TestWalk_FindsMarkerInAncestor(t *testing.T) {
 	root := t.TempDir()
-	if err := os.Mkdir(filepath.Join(root, markerDirName), 0o755); err != nil {
+	if err := writeAgentID(root, "test-agent-id"); err != nil {
 		t.Fatal(err)
 	}
 	deep := filepath.Join(root, "a", "b", "c")
@@ -74,6 +74,75 @@ func TestWalk_NoMarkerReturnsErrNoWorkspace(t *testing.T) {
 	_, err := walkUp(dir)
 	if !errors.Is(err, ErrNoWorkspace) {
 		t.Fatalf("walkUp: got %v, want ErrNoWorkspace", err)
+	}
+}
+
+// TestWalk_RefusesMarkerDirWithoutAgentID pins the #140 fix: a bare
+// .bones/ directory without agent.id is NOT a workspace. $HOME/.bones/
+// is the canonical example — it holds global state (registry,
+// telemetry install-id) but never carries agent.id.
+func TestWalk_RefusesMarkerDirWithoutAgentID(t *testing.T) {
+	dir := t.TempDir()
+	// Mimic $HOME/.bones/: directory exists, populated with global
+	// state, but no agent.id.
+	bones := filepath.Join(dir, markerDirName)
+	if err := os.Mkdir(bones, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(bones, "install-id"),
+		[]byte("not-an-agent-id\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := walkUp(dir); !errors.Is(err, ErrNoWorkspace) {
+		t.Fatalf("walkUp: got %v, want ErrNoWorkspace (a .bones/ dir "+
+			"without agent.id must not match — see #140)", err)
+	}
+	// Also from a deeper path: the walkUp must not stop at the bare
+	// marker directory and claim it as a workspace.
+	deep := filepath.Join(dir, "a", "b", "c")
+	if err := os.MkdirAll(deep, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := walkUp(deep); !errors.Is(err, ErrNoWorkspace) {
+		t.Fatalf("walkUp(deep): got %v, want ErrNoWorkspace", err)
+	}
+}
+
+// TestWalk_PrefersAgentIDOverEmptyMarker proves the walk does not stop
+// at a bare .bones/ on the way up — it keeps going until it finds one
+// with agent.id. Models the layout where $HOME/.bones/ exists as the
+// state dir but a child workspace is properly initialized below it.
+func TestWalk_PrefersAgentIDOverEmptyMarker(t *testing.T) {
+	homeLike := t.TempDir() // stand-in for $HOME
+	if err := os.Mkdir(filepath.Join(homeLike, markerDirName), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	workspace := filepath.Join(homeLike, "projects", "ws")
+	if err := os.MkdirAll(workspace, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeAgentID(workspace, "ws-agent-id"); err != nil {
+		t.Fatal(err)
+	}
+	// From inside the proper workspace, walkUp must return it (not the
+	// $HOME-like ancestor with the bare marker dir).
+	got, err := walkUp(filepath.Join(workspace, "src"))
+	// The src dir doesn't exist; walkUp should still climb to workspace.
+	if err == nil {
+		if got != workspace {
+			t.Fatalf("walkUp: got %q, want %q (must skip "+
+				"ancestor .bones/ without agent.id)", got, workspace)
+		}
+	} else {
+		// If src doesn't exist, walkUp should still find workspace
+		// from workspace itself.
+		got, err = walkUp(workspace)
+		if err != nil {
+			t.Fatalf("walkUp: %v", err)
+		}
+		if got != workspace {
+			t.Fatalf("walkUp: got %q, want %q", got, workspace)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes the remaining sub-bugs in #138 (after PR #142 landed items 4 and 5) and the entirety of #140. Single PR with one focused commit per fix; each commit is independently revertable and carries its own tests.

| # | Commit | Closes |
|---|---|---|
| 1 | `fix(workspace): walkUp requires .bones/agent.id, not bare .bones/` | #140 |
| 2 | `fix(hub): fail-fast on empty git repo before spawning child` | #138 item 9 |
| 3 | `fix(down): don't auto-start hub when resolving workspace root` | #138 item 7 (item 8 was already done) |
| 4 | `fix(down): kill swarm leaves + reap cross-workspace orphans` | #138 items 2 + 6 |
| 5 | `fix(down): kill legacy .bones/leaf.pid orphans on teardown` | #138 item 3 |
| 6 | `fix(hub): detect port collision via recorded-pid mismatch` | #138 item 1 |

## What each commit does

### 1. walkUp requires agent.id (#140)

`bones status` printed `read agent.id: open $HOME/.bones/agent.id: no such file or directory` from any subdir of $HOME because `internal/workspace/walk.go` matched the bare `.bones/` directory (which exists at `$HOME/.bones/` as the global state dir). Commit `3ee6c3c` had already fixed `cli/env.go:walkUpToBones` to require `.bones/agent.id`, but the equivalent check in `internal/workspace` was missed.

Fix: `walkUp` requires `.bones/agent.id`. `cli/env.go:walkUpToBones` is now a thin wrapper over `workspace.FindRoot`, guaranteeing the two helpers can never drift again.

### 2. Fail-fast on empty git repo (#138 item 9)

`bones hub start --detach` in an empty git repo waited the full 15s `readyTimeout` before reporting `seed: no git-tracked files to seed from`. The actual error was generated immediately inside `seedHubRepo` but only surfaced after the parent's TCP probe gave up.

Fix: new `checkSeedPrecondition` runs in `Start()` before the spawn, returns `ErrSeedPrecondition` with an actionable message (`commit at least one file before running bones hub start`). Skipped on detach re-entry to avoid double-checking.

### 3. `bones down` doesn't auto-start the hub (#138 item 7)

`resolveDownRoot` called `workspace.Join`, which lazy-starts the hub. On a workspace where the hub was already stopped, `bones down` would spin a fresh hub up just to ask permission to tear it down — and on non-TTY (no `--yes`) the prompt aborts immediately, leaving a hub that wasn't running before.

Fix: `resolveDownRoot` now calls `workspace.FindRoot` (read-only).

Also: triage on #138 noted `--yes` was missing. It already exists (`DownCmd.Yes`, `--yes` / `-y`); item 8 needed no code change.

### 4. Down kills swarm leaves + reaps orphans (#138 items 2 + 6)

Two related teardown gaps:

- **Item 2:** `hub.Stop` only signaled fossil/nats; per-slot leaves under `.bones/swarm/<slot>/leaf.pid` were never enumerated, so they orphaned across `bones up`/`bones down` cycles.
- **Item 6:** `bones hub reap` (commit `ee7dc08`) existed but `cli/down` never invoked it. Cross-workspace orphans piled up in `$HOME/.bones/workspaces/` indefinitely.

Fix:
- New `slotgc.LiveSlots` (inverse of `DeadSlots`). New `slotgc.Kill` mirrors `hub.terminateProcess` and `registry.Reap` (SIGTERM, poll over 2s, SIGKILL, brief post-poll). Three kill paths now share the same escalation logic.
- `cli/down` adds `planKillSwarmLeaves` (suppressed by `--keep-hub`) and `planReapOrphans`. Inserted before `planRemoveBonesDir` so the workspace's own `agent.id` still exists when orphans are computed (the workspace being torn down is NOT flagged as orphan during its own teardown).
- Self-protection in `planReapOrphans`: an orphan whose `HubPID` matches `os.Getpid()` is never reaped. Production code shouldn't reach that shape, but the guard is cheap insurance and is load-bearing for the test suite.

### 5. Kill legacy leaf.pid orphans (#138 item 3)

The "duplicate leaves on same `repo.fossil`" symptom in the original report was a **legacy-migration cleanup** issue, not a current spawning bug. Post-ADR-0041 bones never invokes `leaf --repo`; the EdgeSync workspace-leaf substrate is gone. The orphans came from old bones versions whose leaves survived migration because:

- `migrateLegacyLayout` refuses to migrate while `.bones/leaf.pid` is live (returns `ErrLegacyLayout`); but
- `cli/down` only signaled `.bones/pids/{fossil,nats}.pid` — `.bones/leaf.pid` (the legacy path) was never read.

Fix: `planKillSwarmLeaves` also reads `.bones/leaf.pid`, probes liveness, and queues a `slotgc.Kill`. Skipped when the recorded pid is `os.Getpid()` (the same self-protection guard as `planReapOrphans`).

This is purely a cleanup path — there is no current code that writes `.bones/leaf.pid`, so on a freshly-installed workspace this branch is inert.

### 6. Port-collision false-positive readiness (#138 item 1)

Commit `0f6ec3c`'s `hubLogTail` surfaced the seed-failure case. The remaining gap: when an unrelated process is already bound to `fossilPort`/`natsPort`, the child's `startFossil` bind fails and the child exits, but the parent's `waitForTCP` succeeds because the foreign service responds. Pre-fix `Start` returned nil; downstream verbs hit the wrong process.

Fix: after both TCP probes pass in `spawnDetachedChild`, verify `readPid(p.fossilPid)` equals `cmd.Process.Pid`. Mismatch (or missing) means collision or crashed child — kill and return error naming the collision plus `hubLogTail`.

## Testing

Each commit lands its own failing-then-passing test. Full counts:
- 5 new tests in `internal/workspace` (walk-up agent.id requirement)
- 1 new test in `internal/hub/precondition_test.go` (fail-fast)
- 1 new test in `internal/hub/port_collision_test.go`
- 3 new tests in `internal/slotgc`
- 7 new tests in `cli/down_test.go` (resolve, kill-swarm, reap-orphans, legacy-leaf, helpers)

CI parity verified locally per memory rule:
- [x] `make check` clean (fmt-check, vet, lint, race, todo-check)
- [x] `go test -tags=otel -short ./...` clean

## What's NOT in this PR

Nothing left from #138 or #140 after this lands. Both issues should auto-close from the `Closes` lines below.

Closes #138
Closes #140