### PR TITLE
feat(up): reflect hub state in bones up output

### DIFF
--- a/cli/up.go
+++ b/cli/up.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
 
 	"github.com/danmestas/bones/internal/githook"
+	"github.com/danmestas/bones/internal/hub"
 	"github.com/danmestas/bones/internal/telemetry"
 	"github.com/danmestas/bones/internal/workspace"
 )
@@ -66,7 +68,41 @@ func runUp(cwd string, verbose bool) (err error) {
 	} else {
 		fmt.Printf("up: ready at %s\n", wsDir)
 	}
+	printHubStatus(os.Stdout, wsDir)
 	return nil
+}
+
+// printHubStatus reflects the workspace's current hub state to w
+// without spawning anything. Per ADR 0041 the hub starts lazily on
+// the first verb that needs it, so a fresh `bones up` lands with no
+// hub running and the operator otherwise has no signal that the
+// scaffold actually completed (#138 item 11).
+//
+// Three shapes:
+//
+//	hub: running at <fossil-url> / <nats-url> (pid=N)
+//	hub: previously recorded at <fossil-url> / <nats-url> — will
+//	    restart on next verb
+//	hub: not yet started — will start on next session (SessionStart
+//	    hook) or first verb that needs it
+//
+// Read-only: no pid signaling, no spawning. Safe to call from any
+// command that has just touched workspace state.
+func printHubStatus(w io.Writer, root string) {
+	fossilURL := hub.FossilURL(root)
+	natsURL := hub.NATSURL(root)
+	if fossilURL == "" || natsURL == "" {
+		_, _ = fmt.Fprintln(w, "up: hub: not yet started — will start on "+
+			"next session (SessionStart hook) or first verb that needs it")
+		return
+	}
+	if pid, ok := hub.IsRunning(root); ok {
+		_, _ = fmt.Fprintf(w, "up: hub: running at %s / %s (pid=%d)\n",
+			fossilURL, natsURL, pid)
+		return
+	}
+	_, _ = fmt.Fprintf(w, "up: hub: previously recorded at %s / %s — "+
+		"will restart on next verb\n", fossilURL, natsURL)
 }
 
 // initOrJoinWorkspace returns workspace.Info for cwd, creating the

--- a/cli/up_test.go
+++ b/cli/up_test.go
@@ -1,0 +1,117 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// TestPrintHubStatus_FreshScaffold pins shape A: a fresh `bones up`
+// has no hub-fossil-url or hub-nats-url file yet. printHubStatus
+// must announce the lazy-start expectation, not pretend silence.
+func TestPrintHubStatus_FreshScaffold(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".bones"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	printHubStatus(&buf, root)
+
+	got := buf.String()
+	if !strings.Contains(got, "not yet started") {
+		t.Errorf("fresh scaffold should announce lazy start; got: %q", got)
+	}
+	if !strings.Contains(got, "SessionStart") {
+		t.Errorf("fresh scaffold should name the lifecycle hook; got: %q", got)
+	}
+}
+
+// TestPrintHubStatus_HubRunning pins shape B: URL files exist and
+// both pids point at live processes (we use os.Getpid() as the
+// canonical live pid). printHubStatus must echo the URLs and pid so
+// the operator has a concrete handle.
+func TestPrintHubStatus_HubRunning(t *testing.T) {
+	root := t.TempDir()
+	bones := filepath.Join(root, ".bones")
+	if err := os.MkdirAll(filepath.Join(bones, "pids"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(bones, "hub-fossil-url"),
+		[]byte("http://127.0.0.1:51234\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(bones, "hub-nats-url"),
+		[]byte("nats://127.0.0.1:51235\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	live := strconv.Itoa(os.Getpid())
+	for _, name := range []string{"fossil.pid", "nats.pid"} {
+		if err := os.WriteFile(filepath.Join(bones, "pids", name),
+			[]byte(live+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	var buf bytes.Buffer
+	printHubStatus(&buf, root)
+
+	got := buf.String()
+	if !strings.Contains(got, "http://127.0.0.1:51234") {
+		t.Errorf("running shape must echo fossil URL; got: %q", got)
+	}
+	if !strings.Contains(got, "nats://127.0.0.1:51235") {
+		t.Errorf("running shape must echo nats URL; got: %q", got)
+	}
+	if !strings.Contains(got, "pid="+live) {
+		t.Errorf("running shape must echo pid; got: %q", got)
+	}
+	if strings.Contains(got, "not yet started") {
+		t.Errorf("running shape must NOT announce lazy start; got: %q", got)
+	}
+}
+
+// TestPrintHubStatus_StaleURLs pins shape C: URL files exist but
+// the recorded pid is dead (the hub was once running, has since
+// stopped, but URLs remain). printHubStatus must signal "stale" so
+// the operator doesn't think the URLs are usable right now.
+func TestPrintHubStatus_StaleURLs(t *testing.T) {
+	root := t.TempDir()
+	bones := filepath.Join(root, ".bones")
+	if err := os.MkdirAll(filepath.Join(bones, "pids"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(bones, "hub-fossil-url"),
+		[]byte("http://127.0.0.1:51234\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(bones, "hub-nats-url"),
+		[]byte("nats://127.0.0.1:51235\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// 999999 is a high pid that will not be in use on a normal host.
+	for _, name := range []string{"fossil.pid", "nats.pid"} {
+		if err := os.WriteFile(filepath.Join(bones, "pids", name),
+			[]byte("999999\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	var buf bytes.Buffer
+	printHubStatus(&buf, root)
+
+	got := buf.String()
+	if !strings.Contains(got, "previously recorded") {
+		t.Errorf("stale URL shape must say 'previously recorded'; got: %q", got)
+	}
+	if !strings.Contains(got, "restart on next verb") {
+		t.Errorf("stale URL shape must explain next-verb restart; got: %q", got)
+	}
+	if strings.Contains(got, "(pid=") {
+		t.Errorf("stale URL shape must NOT echo a pid (the recorded one "+
+			"is dead); got: %q", got)
+	}
+}

--- a/internal/hub/hub.go
+++ b/internal/hub/hub.go
@@ -439,6 +439,28 @@ func HubFossilPath(root string) string {
 	return filepath.Join(root, markerDirName, "hub.fossil")
 }
 
+// IsRunning reports whether a hub for the workspace at root is
+// currently running. Returns (pid, true) when both fossil.pid and
+// nats.pid exist and name live processes; (0, false) otherwise.
+//
+// Read-only. Used by cli/up to print accurate post-scaffold status
+// without spawning anything (per ADR 0041 the hub is started lazily
+// on first verb, not by `bones up`).
+func IsRunning(root string) (int, bool) {
+	p, err := newPaths(root)
+	if err != nil {
+		return 0, false
+	}
+	pid, ok := readPid(p.fossilPid)
+	if !ok || !pidIntIsLive(pid) {
+		return 0, false
+	}
+	if !pidIsLive(p.natsPid) {
+		return 0, false
+	}
+	return pid, true
+}
+
 // newPaths derives the hub layout from the workspace root. The root must
 // exist; the .bones subdirs are created lazily by Start.
 func newPaths(root string) (paths, error) {


### PR DESCRIPTION
## Summary

Closes the last remaining sub-bug from #138's umbrella (item 11): `bones up` printed only `up: ready at /path` and gave operators no signal about whether anything was actually serving. ADR 0041 deferred hub startup to first verb (lazy), but the output stayed silent about it — leaving users guessing whether scaffold succeeded, whether a hub already existed, or whether one would start later.

This PR adds **reflective** status output to `bones up`. It does not spawn anything; it reads `.bones/hub-{fossil,nats}-url` and the pid files to report current state in one of three shapes.

ADR 0041 is preserved verbatim. The new helper is read-only — no signaling, no spawning, no file mutation.

## Three shapes

```
up: hub: not yet started — will start on next session
    (SessionStart hook) or first verb that needs it
```

```
up: hub: running at http://127.0.0.1:N / nats://127.0.0.1:M (pid=N)
```

```
up: hub: previously recorded at http://127.0.0.1:N /
    nats://127.0.0.1:M — will restart on next verb
```

The third shape covers the hub-was-running-then-died case (pid file exists but the process is gone): pre-fix an operator might copy a stale URL from `.bones/hub-fossil-url` and then wonder why connections fail.

## Implementation

- `internal/hub`: new exported `IsRunning(root) (pid, ok)`. Reads `fossil.pid` and `nats.pid`, returns `(pid, true)` only when both name live processes.
- `cli/up.go`: new `printHubStatus(w, root)` called from `runUp` after the existing `up: ready at ...` line. Takes `io.Writer` so tests can capture without mocking stdout.

## Tests

- `TestPrintHubStatus_FreshScaffold` — no URL files → lazy-start message; asserts the `SessionStart` hook is named so operators recognize where it'll start.
- `TestPrintHubStatus_HubRunning` — URL files + live pids → both URLs echoed verbatim, pid printed; asserts the lazy-start message is NOT present (catches a regression that always prints it).
- `TestPrintHubStatus_StaleURLs` — URL files + dead pids → "previously recorded" + "restart on next verb"; asserts NO `(pid=` substring (the recorded one is dead, must not be echoed as if live).

## CI parity

- [x] `make check` clean (fmt-check, vet, lint, race, todo-check)
- [x] `go test -tags=otel -short ./...` clean

Refs #138 item 11.