### PR TITLE
fix(scaffold): coexist with user-authored CLAUDE.md/AGENTS.md

### DIFF
--- a/cli/down.go
+++ b/cli/down.go
@@ -404,39 +404,56 @@ func planRemoveSkills(root string, c *DownCmd) []downAction {
 	return plan
 }
 
-// planRemoveAgentsMD removes the bones-managed AGENTS.md and the
-// CLAUDE.md symlink (or its file fallback). Per ADR 0042 these are
-// the harness-agnostic guidance channel; they pair with the hook
-// entries removed by planRemoveHooks. AGENTS.md is removed only if
-// it was bones-managed (first line matches the bones marker) — a
-// user-authored AGENTS.md is left in place so we don't clobber
-// project-specific guidance.
+// planRemoveAgentsMD removes (or strips bones content from) the
+// CLAUDE.md and AGENTS.md files at the workspace root. Per ADR 0042
+// these are the harness-agnostic guidance channel; they pair with the
+// hook entries removed by planRemoveHooks.
+//
+// Three cases per file:
+//   - Bones-owned outright (AGENTS.md template, or a CLAUDE.md symlink
+//     to AGENTS.md, or the regular-file fallback carrying the bones
+//     marker) — file is removed entirely.
+//   - User-authored with a bones managed block (per the issue #145
+//     model) — block is stripped in place, user content preserved.
+//   - User-authored with no bones content — left alone.
 func planRemoveAgentsMD(root string) []downAction {
 	var plan []downAction
+
 	agentsPath := filepath.Join(root, "AGENTS.md")
-	if data, err := os.ReadFile(agentsPath); err == nil && bonesOwnedAgentsMD(data) {
-		plan = append(plan, downAction{
-			description: "remove " + agentsPath,
-			do:          func() error { return os.Remove(agentsPath) },
-		})
+	if data, err := os.ReadFile(agentsPath); err == nil {
+		switch {
+		case bonesOwnedAgentsMD(data):
+			plan = append(plan, downAction{
+				description: "remove " + agentsPath,
+				do:          func() error { return os.Remove(agentsPath) },
+			})
+		case hasManagedBlock(data):
+			plan = append(plan, downAction{
+				description: "strip bones block from " + agentsPath,
+				do:          func() error { return stripManagedBlock(agentsPath) },
+			})
+		}
 	}
-	// CLAUDE.md is unconditionally bones-managed when AGENTS.md is —
-	// it's a symlink we wrote pointing at AGENTS.md (or a file fallback
-	// with the same content on platforms that don't support symlinks).
-	// Remove it only if it points at AGENTS.md or contains the bones
-	// marker; an unrelated CLAUDE.md (user-authored, e.g. an older
-	// project convention) is preserved.
+
 	claudePath := filepath.Join(root, "CLAUDE.md")
 	if target, err := os.Readlink(claudePath); err == nil && target == "AGENTS.md" {
 		plan = append(plan, downAction{
 			description: "remove " + claudePath,
 			do:          func() error { return os.Remove(claudePath) },
 		})
-	} else if data, err := os.ReadFile(claudePath); err == nil && bonesOwnedAgentsMD(data) {
-		plan = append(plan, downAction{
-			description: "remove " + claudePath,
-			do:          func() error { return os.Remove(claudePath) },
-		})
+	} else if data, err := os.ReadFile(claudePath); err == nil {
+		switch {
+		case bonesOwnedAgentsMD(data):
+			plan = append(plan, downAction{
+				description: "remove " + claudePath,
+				do:          func() error { return os.Remove(claudePath) },
+			})
+		case hasManagedBlock(data):
+			plan = append(plan, downAction{
+				description: "strip bones block from " + claudePath,
+				do:          func() error { return stripManagedBlock(claudePath) },
+			})
+		}
 	}
 	return plan
 }

--- a/cli/down_test.go
+++ b/cli/down_test.go
@@ -364,8 +364,9 @@ func TestPlanDown_FullInstall(t *testing.T) {
 }
 
 // TestPlanRemoveAgentsMD_PreservesUserAuthored pins that an
-// AGENTS.md without the bones marker is left in place — bones down
-// only removes its own scaffolded copy.
+// AGENTS.md without the bones marker AND without a managed block is
+// left out of the removal plan entirely — bones down does not touch
+// untouched user files.
 func TestPlanRemoveAgentsMD_PreservesUserAuthored(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, filepath.Join(dir, "AGENTS.md"),
@@ -375,6 +376,78 @@ func TestPlanRemoveAgentsMD_PreservesUserAuthored(t *testing.T) {
 		if strings.Contains(a.description, "AGENTS.md") {
 			t.Errorf("user-authored AGENTS.md should not be in removal plan: %q", a.description)
 		}
+	}
+}
+
+// TestPlanRemoveAgentsMD_StripsBlockFromUserAuthored pins the
+// managed-section teardown contract for AGENTS.md (issue #145):
+// when the user-authored file contains a bones block, down strips the
+// block in place and leaves the user content otherwise intact.
+func TestPlanRemoveAgentsMD_StripsBlockFromUserAuthoredAGENTS(t *testing.T) {
+	dir := t.TempDir()
+	agentsPath := filepath.Join(dir, "AGENTS.md")
+	user := "# My Project\n\nUser content.\n"
+	writeFile(t, agentsPath, user)
+	if err := upsertManagedBlock(agentsPath, "bones contract body"); err != nil {
+		t.Fatalf("seed managed block: %v", err)
+	}
+
+	plan := planRemoveAgentsMD(dir)
+	stripFound := false
+	for _, a := range plan {
+		if strings.Contains(a.description, "AGENTS.md") &&
+			strings.Contains(a.description, "strip") {
+			stripFound = true
+			if err := a.do(); err != nil {
+				t.Fatalf("strip action returned error: %v", err)
+			}
+		}
+		if strings.Contains(a.description, "AGENTS.md") &&
+			strings.Contains(a.description, "remove") {
+			t.Errorf("user-authored AGENTS.md should be stripped, not removed: %q", a.description)
+		}
+	}
+	if !stripFound {
+		t.Fatalf("expected strip action for user-authored AGENTS.md; plan=%v", plan)
+	}
+	got, _ := os.ReadFile(agentsPath)
+	if string(got) != user {
+		t.Errorf("user AGENTS.md not restored after strip:\nwant %q\ngot  %q", user, got)
+	}
+}
+
+// TestPlanRemoveAgentsMD_StripsBlockFromUserAuthoredCLAUDE pins the
+// same contract for CLAUDE.md.
+func TestPlanRemoveAgentsMD_StripsBlockFromUserAuthoredCLAUDE(t *testing.T) {
+	dir := t.TempDir()
+	claudePath := filepath.Join(dir, "CLAUDE.md")
+	user := "# My rules\n\nKeep me.\n"
+	writeFile(t, claudePath, user)
+	if err := upsertManagedBlock(claudePath, "bones pointer body"); err != nil {
+		t.Fatalf("seed managed block: %v", err)
+	}
+
+	plan := planRemoveAgentsMD(dir)
+	stripFound := false
+	for _, a := range plan {
+		if strings.Contains(a.description, "CLAUDE.md") &&
+			strings.Contains(a.description, "strip") {
+			stripFound = true
+			if err := a.do(); err != nil {
+				t.Fatalf("strip action returned error: %v", err)
+			}
+		}
+		if strings.Contains(a.description, "CLAUDE.md") &&
+			strings.Contains(a.description, "remove") {
+			t.Errorf("user-authored CLAUDE.md should be stripped, not removed: %q", a.description)
+		}
+	}
+	if !stripFound {
+		t.Fatalf("expected strip action for user-authored CLAUDE.md; plan=%v", plan)
+	}
+	got, _ := os.ReadFile(claudePath)
+	if string(got) != user {
+		t.Errorf("user CLAUDE.md not restored after strip:\nwant %q\ngot  %q", user, got)
 	}
 }
 

--- a/cli/orchestrator.go
+++ b/cli/orchestrator.go
@@ -19,8 +19,28 @@ var agentsMDTemplate []byte
 // agentsMDMarker is the first line of the bones-managed AGENTS.md
 // template. scaffoldOrchestrator uses it to tell whether an existing
 // AGENTS.md is bones-owned (safe to overwrite) or user-authored
-// (refuse and surface a merge instruction).
+// (upsert a managed block instead).
 const agentsMDMarker = "# Agent Guidance for this Workspace"
+
+// bonesBlockBegin and bonesBlockEnd delimit the bones-managed section
+// inserted into a user-authored CLAUDE.md or AGENTS.md. HTML comments
+// keep the markers invisible to most renderers and unique enough to
+// detect by substring without false positives in normal markdown
+// content. See ADR 0042's managed-section addendum.
+const (
+	bonesBlockBegin = "<!-- BONES:BEGIN -->"
+	bonesBlockEnd   = "<!-- BONES:END -->"
+)
+
+// claudeManagedBody is the body of the bones-managed block inserted
+// into a user-authored CLAUDE.md. CLAUDE.md is a pointer file; the
+// agent contract itself lives in AGENTS.md. Kept short on purpose: the
+// user already has their own CLAUDE.md content and we want our
+// addition to be unobtrusive.
+const claudeManagedBody = "Bones is active in this workspace. " +
+	"The full agent contract is in AGENTS.md.\n\n" +
+	"On `bones down` the agent removes this entire block " +
+	"(markers and all) from CLAUDE.md and deletes AGENTS.md."
 
 // legacyBonesSkills are the per-skill directories `bones up` used to
 // scaffold under .claude/skills/ before ADR 0042. They are wiped on
@@ -90,22 +110,151 @@ func removeLegacyBonesSkills(root string) error {
 	return nil
 }
 
-// writeAgentsMD writes the bones-managed AGENTS.md template to the
-// workspace root. If an AGENTS.md already exists and starts with the
-// bones marker, it is overwritten (idempotent re-scaffold). If it
-// exists without the marker, the file is user-authored and we refuse
-// with a message that points at the merge path.
+// writeAgentsMD installs the bones-managed AGENTS.md content at the
+// workspace root. Three shapes are recognized:
+//
+//  1. AGENTS.md is absent — the bones template is written as the
+//     entire file (the workspace is now a "bones-owned AGENTS.md"
+//     workspace).
+//  2. AGENTS.md exists and starts with the bones marker — bones owns
+//     the whole file; the template is rewritten in place
+//     (idempotent re-scaffold).
+//  3. AGENTS.md exists without the marker — the file is user-authored.
+//     The bones template is upserted into a marker-delimited block at
+//     the end of the file. User content is preserved byte-for-byte;
+//     re-scaffold replaces only the block contents.
+//
+// The user-authored case (added per issue #145) replaces an earlier
+// guard that refused user content outright.
 func writeAgentsMD(root string) error {
 	path := filepath.Join(root, "AGENTS.md")
-	if existing, err := os.ReadFile(path); err == nil {
-		if !bonesOwnedAgentsMD(existing) {
-			return fmt.Errorf("AGENTS.md exists and is not bones-managed; "+
-				"merge bones content manually or remove %s and re-run", path)
-		}
-	} else if !os.IsNotExist(err) {
+	existing, err := os.ReadFile(path)
+	if err != nil && !os.IsNotExist(err) {
 		return err
 	}
-	return os.WriteFile(path, agentsMDTemplate, 0o644)
+	if os.IsNotExist(err) || bonesOwnedAgentsMD(existing) {
+		return os.WriteFile(path, agentsMDTemplate, 0o644)
+	}
+	return upsertManagedBlock(path, string(agentsMDTemplate))
+}
+
+// upsertManagedBlock writes (or refreshes) a bones-managed section
+// delimited by bonesBlockBegin / bonesBlockEnd inside the file at
+// path. User content outside the markers is preserved byte-for-byte.
+// Idempotent: running the function twice with the same body yields a
+// byte-identical file.
+//
+// Layout: a single blank line separator between any pre-existing user
+// content and the BEGIN marker; one trailing newline after the END
+// marker. If the file is empty, no leading blank line is added.
+//
+// If the file is missing it is created with just the block. If a
+// bonesBlockBegin marker is present without a matching bonesBlockEnd
+// marker, the block is treated as malformed and an error is returned
+// so we never silently corrupt user content.
+func upsertManagedBlock(path, body string) error {
+	data, err := os.ReadFile(path)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("read %s: %w", path, err)
+	}
+	s := string(data)
+
+	beginIdx := strings.Index(s, bonesBlockBegin)
+	newBlock := bonesBlockBegin + "\n" + body + "\n" + bonesBlockEnd
+
+	var out string
+	if beginIdx == -1 {
+		// Append a fresh block. Normalize trailing newline on user
+		// content and add a single blank line separator.
+		prefix := s
+		if prefix != "" && !strings.HasSuffix(prefix, "\n") {
+			prefix += "\n"
+		}
+		if prefix != "" {
+			prefix += "\n"
+		}
+		out = prefix + newBlock + "\n"
+	} else {
+		endRel := strings.Index(s[beginIdx:], bonesBlockEnd)
+		if endRel == -1 {
+			return fmt.Errorf("malformed managed block in %s: "+
+				"%s present without matching %s",
+				path, bonesBlockBegin, bonesBlockEnd)
+		}
+		endAbs := beginIdx + endRel + len(bonesBlockEnd)
+		out = s[:beginIdx] + newBlock + s[endAbs:]
+	}
+
+	if err := os.WriteFile(path, []byte(out), 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	return nil
+}
+
+// stripManagedBlock removes the bones-managed section (markers and
+// body) from the file at path. User content outside the markers is
+// preserved byte-for-byte. The blank-line separator that
+// upsertManagedBlock added between user content and the BEGIN marker
+// is collapsed back to a single trailing newline so a strip-then-
+// upsert cycle round-trips cleanly.
+//
+// No-op if the file is absent or contains no managed block. If
+// stripping leaves the file empty, the file is removed entirely so
+// `bones down` doesn't leave behind a 0-byte CLAUDE.md / AGENTS.md.
+func stripManagedBlock(path string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("read %s: %w", path, err)
+	}
+	s := string(data)
+	beginIdx := strings.Index(s, bonesBlockBegin)
+	if beginIdx == -1 {
+		return nil
+	}
+	endRel := strings.Index(s[beginIdx:], bonesBlockEnd)
+	if endRel == -1 {
+		return fmt.Errorf("malformed managed block in %s: "+
+			"%s present without matching %s",
+			path, bonesBlockBegin, bonesBlockEnd)
+	}
+	endAbs := beginIdx + endRel + len(bonesBlockEnd)
+	if endAbs < len(s) && s[endAbs] == '\n' {
+		endAbs++
+	}
+
+	// Collapse trailing newlines on the prefix (including the blank
+	// separator we added on upsert) so we restore exactly one trailing
+	// newline — matching the user's original "ends with \n" shape.
+	trimEnd := beginIdx
+	for trimEnd > 0 && s[trimEnd-1] == '\n' {
+		trimEnd--
+	}
+	prefix := s[:trimEnd]
+	if prefix != "" {
+		prefix += "\n"
+	}
+	out := prefix + s[endAbs:]
+
+	if out == "" {
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("remove %s: %w", path, err)
+		}
+		return nil
+	}
+	if err := os.WriteFile(path, []byte(out), 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	return nil
+}
+
+// hasManagedBlock reports whether content contains a bones-managed
+// section. Used by `bones down` to decide whether to strip a block out
+// of a user-authored file vs leave it alone.
+func hasManagedBlock(content []byte) bool {
+	return strings.Contains(string(content), bonesBlockBegin)
 }
 
 // bonesOwnedAgentsMD reports whether the given AGENTS.md content was
@@ -122,62 +271,64 @@ func bonesOwnedAgentsMD(content []byte) bool {
 	return false
 }
 
-// linkClaudeMD creates CLAUDE.md as a symbolic link to AGENTS.md per
-// the agents.md spec migration recipe. Mirrors writeAgentsMD's safety
-// gate: pre-existing user content is refused, never silently destroyed
-// (issue #139). Bones-managed shapes — a symlink to AGENTS.md, or a
-// regular-file fallback carrying the bones marker — are recognized and
-// replaced idempotently. Workspaces on platforms without symlink
-// support land on the regular-file fallback with the AGENTS.md content.
+// linkClaudeMD installs the bones-side CLAUDE.md content at the
+// workspace root. Four shapes are recognized:
+//
+//  1. CLAUDE.md is absent — bones writes a symlink to AGENTS.md (or,
+//     on filesystems without symlink support, a regular file fallback
+//     carrying the AGENTS.md content).
+//  2. CLAUDE.md is a symlink to AGENTS.md — bones-owned, no-op.
+//  3. CLAUDE.md is a regular file whose first lines carry the bones
+//     marker — the bones-owned fallback shape; rewritten in place
+//     (idempotent re-scaffold).
+//  4. CLAUDE.md is a regular file without the marker — user-authored.
+//     A short bones-managed block (markers + claudeManagedBody) is
+//     upserted at the end of the file. User content is preserved
+//     byte-for-byte; re-scaffold replaces only the block contents.
+//
+// CLAUDE.md as a symlink to anything other than AGENTS.md is refused:
+// following arbitrary symlinks could write outside the workspace, and
+// the brief explicitly scopes the new model to regular files.
+//
+// The user-authored regular-file case (added per issue #145) replaces
+// the earlier guard from issue #139 that refused user content
+// outright.
 func linkClaudeMD(root string) error {
 	target := "AGENTS.md"
 	link := filepath.Join(root, "CLAUDE.md")
 
-	if err := requireBonesOwnedClaudeMD(link, target); err != nil {
-		return err
-	}
-	if cur, err := os.Readlink(link); err == nil && cur == target {
-		return nil
-	}
-	if err := os.Remove(link); err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("remove existing CLAUDE.md: %w", err)
-	}
-	if err := os.Symlink(target, link); err == nil {
-		return nil
-	}
-	// Fallback: write a regular file with the same content. Less ideal
-	// (drifts on AGENTS.md edits), but symlinks are unsupported on some
-	// filesystems (e.g. older Windows volumes without developer mode).
-	return os.WriteFile(link, agentsMDTemplate, 0o644)
-}
-
-// requireBonesOwnedClaudeMD returns an error if CLAUDE.md exists in a
-// shape bones did not produce. The four bones-recognized shapes are:
-// (1) absent, (2) symlink whose target is AGENTS.md, (3) regular file
-// whose first lines carry the bones marker (the fallback path on
-// symlink-unsupported filesystems). Any other shape — symlink to a
-// different target, regular file without the marker — is treated as
-// user content and refused.
-func requireBonesOwnedClaudeMD(link, target string) error {
 	if cur, err := os.Readlink(link); err == nil {
 		if cur == target {
 			return nil
 		}
-		return fmt.Errorf("CLAUDE.md is a symlink to %q, not bones-managed; "+
-			"merge bones content manually or remove %s and re-run", cur, link)
+		return fmt.Errorf("CLAUDE.md is a symlink to %q, which bones cannot "+
+			"safely modify; remove %s or replace it with a regular file "+
+			"(bones will preserve its content) and re-run", cur, link)
 	}
+
 	data, err := os.ReadFile(link)
-	if os.IsNotExist(err) {
-		return nil
-	}
-	if err != nil {
+	if err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("read CLAUDE.md: %w", err)
 	}
-	if bonesOwnedAgentsMD(data) {
-		return nil
+
+	if os.IsNotExist(err) {
+		if err := os.Symlink(target, link); err == nil {
+			return nil
+		}
+		// Fallback: write a regular file with the same content. Less
+		// ideal (drifts on AGENTS.md edits), but symlinks are
+		// unsupported on some filesystems (e.g. older Windows volumes
+		// without developer mode).
+		return os.WriteFile(link, agentsMDTemplate, 0o644)
 	}
-	return fmt.Errorf("CLAUDE.md exists and is not bones-managed; "+
-		"merge bones content into AGENTS.md or remove %s and re-run", link)
+
+	if bonesOwnedAgentsMD(data) {
+		// Bones-owned fallback shape: rewrite in place to converge on
+		// the current template.
+		return os.WriteFile(link, agentsMDTemplate, 0o644)
+	}
+
+	return upsertManagedBlock(link, claudeManagedBody)
 }
 
 // mergeSettings idempotently installs the SessionStart + PreCompact

--- a/cli/orchestrator_test.go
+++ b/cli/orchestrator_test.go
@@ -127,27 +127,29 @@ func TestScaffoldOrchestrator_PreservesUserAuthoredSkills(t *testing.T) {
 	}
 }
 
-// TestScaffoldOrchestrator_RefusesUserAuthoredAgentsMD pins the safety
-// against clobbering: if AGENTS.md exists without the bones marker,
-// scaffold returns an error rather than overwriting.
-func TestScaffoldOrchestrator_RefusesUserAuthoredAgentsMD(t *testing.T) {
+// TestScaffoldOrchestrator_AppendsBlockToUserAuthoredAGENTS pins the
+// new managed-section behavior: if AGENTS.md exists without the bones
+// marker, scaffold succeeds and appends a bones-managed block at the
+// end of the file. User content above the block is preserved
+// byte-for-byte.
+func TestScaffoldOrchestrator_AppendsBlockToUserAuthoredAGENTS(t *testing.T) {
 	dir := t.TempDir()
 	usersAgents := "# My Project\n\nProject-specific agent guidance.\n"
 	agentsPath := filepath.Join(dir, "AGENTS.md")
 	if err := os.WriteFile(agentsPath, []byte(usersAgents), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	err := scaffoldOrchestrator(dir)
-	if err == nil {
-		t.Fatal("expected error when AGENTS.md is user-authored")
+	if err := scaffoldOrchestrator(dir); err != nil {
+		t.Fatalf("scaffoldOrchestrator on user-authored AGENTS.md: %v", err)
 	}
-	if !strings.Contains(err.Error(), "not bones-managed") {
-		t.Errorf("error should mention bones-managed; got: %v", err)
+	got, _ := os.ReadFile(agentsPath)
+	if !strings.HasPrefix(string(got), usersAgents) {
+		t.Errorf("user AGENTS.md prefix lost:\nwant prefix %q\ngot %q",
+			usersAgents, got)
 	}
-	// User's AGENTS.md content is intact.
-	got, _ := os.ReadFile(filepath.Join(dir, "AGENTS.md"))
-	if string(got) != usersAgents {
-		t.Errorf("user AGENTS.md modified: %q", got)
+	if !strings.Contains(string(got), bonesBlockBegin) ||
+		!strings.Contains(string(got), bonesBlockEnd) {
+		t.Errorf("managed block missing from AGENTS.md:\n%s", got)
 	}
 }
 
@@ -791,34 +793,99 @@ func TestScaffoldOrchestrator_MigratesLegacyBootstrap(t *testing.T) {
 	}
 }
 
-// TestLinkClaudeMD_RefusesUserAuthoredFile pins the safety against
-// clobbering a pre-existing user-authored CLAUDE.md (issue #139).
-// Mirrors the existing AGENTS.md guard in writeAgentsMD: the marker
-// is the ownership signal; absence means the file is the user's.
-func TestLinkClaudeMD_RefusesUserAuthoredFile(t *testing.T) {
+// TestLinkClaudeMD_AppendsBlockToUserAuthoredFile pins the
+// managed-section behavior (issue #145): a user-authored CLAUDE.md is
+// preserved byte-for-byte at the top of the file and a bones-managed
+// block delimited by bonesBlockBegin / bonesBlockEnd is appended at
+// the end. The user-rules-protection contract from #139 (never
+// silently destroy user content) is preserved by requiring the prefix
+// to match exactly.
+func TestLinkClaudeMD_AppendsBlockToUserAuthoredFile(t *testing.T) {
 	dir := t.TempDir()
 	usersClaude := "# My project rules\n\nNever do X. Always do Y.\n"
 	claudePath := filepath.Join(dir, "CLAUDE.md")
 	if err := os.WriteFile(claudePath, []byte(usersClaude), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	err := linkClaudeMD(dir)
-	if err == nil {
-		t.Fatal("expected error when CLAUDE.md is user-authored")
-	}
-	if !strings.Contains(err.Error(), "not bones-managed") {
-		t.Errorf("error should mention bones-managed; got: %v", err)
+	if err := linkClaudeMD(dir); err != nil {
+		t.Fatalf("linkClaudeMD on user-authored CLAUDE.md: %v", err)
 	}
 	got, _ := os.ReadFile(claudePath)
-	if string(got) != usersClaude {
-		t.Errorf("user CLAUDE.md content modified:\nwant %q\ngot  %q", usersClaude, got)
+	if !strings.HasPrefix(string(got), usersClaude) {
+		t.Errorf("user CLAUDE.md prefix lost:\nwant prefix %q\ngot %q",
+			usersClaude, got)
+	}
+	if !strings.Contains(string(got), bonesBlockBegin) ||
+		!strings.Contains(string(got), bonesBlockEnd) {
+		t.Errorf("managed block missing from CLAUDE.md:\n%s", got)
+	}
+	// File still a regular file, not a symlink.
+	if _, err := os.Readlink(claudePath); err == nil {
+		t.Errorf("CLAUDE.md should remain a regular file, not be replaced with a symlink")
+	}
+}
+
+// TestLinkClaudeMD_IdempotentUserAuthored pins idempotency for the
+// managed-section path: re-running over a workspace where the block
+// already exists produces a byte-identical file.
+func TestLinkClaudeMD_IdempotentUserAuthored(t *testing.T) {
+	dir := t.TempDir()
+	usersClaude := "# My project rules\n\nKeep this prose.\n"
+	claudePath := filepath.Join(dir, "CLAUDE.md")
+	if err := os.WriteFile(claudePath, []byte(usersClaude), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := linkClaudeMD(dir); err != nil {
+		t.Fatalf("first linkClaudeMD: %v", err)
+	}
+	first, _ := os.ReadFile(claudePath)
+	if err := linkClaudeMD(dir); err != nil {
+		t.Fatalf("second linkClaudeMD: %v", err)
+	}
+	second, _ := os.ReadFile(claudePath)
+	if string(first) != string(second) {
+		t.Errorf("re-render not idempotent:\nfirst:\n%s\nsecond:\n%s", first, second)
+	}
+}
+
+// TestLinkClaudeMD_PreservesUserEditsAboveBlock pins the contract that
+// user edits made above the managed block survive a re-run. Only the
+// content between the markers belongs to bones; everything else is the
+// user's.
+func TestLinkClaudeMD_PreservesUserEditsAboveBlock(t *testing.T) {
+	dir := t.TempDir()
+	claudePath := filepath.Join(dir, "CLAUDE.md")
+	if err := os.WriteFile(claudePath, []byte("# Original\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := linkClaudeMD(dir); err != nil {
+		t.Fatalf("first linkClaudeMD: %v", err)
+	}
+	// User edits above the block — adds a new line of prose.
+	current, _ := os.ReadFile(claudePath)
+	edited := strings.Replace(string(current), "# Original\n",
+		"# Original\n\nA new user-written line.\n", 1)
+	if err := os.WriteFile(claudePath, []byte(edited), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := linkClaudeMD(dir); err != nil {
+		t.Fatalf("second linkClaudeMD: %v", err)
+	}
+	got, _ := os.ReadFile(claudePath)
+	if !strings.Contains(string(got), "A new user-written line.") {
+		t.Errorf("user edit above the block was clobbered:\n%s", got)
+	}
+	if !strings.Contains(string(got), bonesBlockBegin) {
+		t.Errorf("managed block missing after re-render:\n%s", got)
 	}
 }
 
 // TestLinkClaudeMD_RefusesUnrelatedSymlink pins that a CLAUDE.md
-// symlinked to something other than AGENTS.md is treated as user
-// content. Users do create deliberate symlinks (e.g. CLAUDE.md ->
-// docs/agent-rules.md); silently retargeting them is data loss.
+// symlinked to something other than AGENTS.md is refused (the
+// managed-section model only handles regular files; following arbitrary
+// symlinks could write outside the workspace). Users with deliberate
+// symlinks (e.g. CLAUDE.md -> docs/agent-rules.md) get a clear error
+// directing them to replace the symlink with a regular file.
 func TestLinkClaudeMD_RefusesUnrelatedSymlink(t *testing.T) {
 	dir := t.TempDir()
 	otherTarget := filepath.Join(dir, "elsewhere.md")
@@ -832,9 +899,6 @@ func TestLinkClaudeMD_RefusesUnrelatedSymlink(t *testing.T) {
 	err := linkClaudeMD(dir)
 	if err == nil {
 		t.Fatal("expected error when CLAUDE.md is a symlink to a non-AGENTS.md target")
-	}
-	if !strings.Contains(err.Error(), "not bones-managed") {
-		t.Errorf("error should mention bones-managed; got: %v", err)
 	}
 	target, rerr := os.Readlink(claudePath)
 	if rerr != nil {
@@ -861,25 +925,27 @@ func TestLinkClaudeMD_AcceptsBonesOwnedFallback(t *testing.T) {
 	}
 }
 
-// TestScaffoldOrchestrator_RefusesUserAuthoredCLAUDE is the full-path
-// integration: scaffoldOrchestrator must refuse when CLAUDE.md is
-// user-authored, and the user's content is left intact. Without this,
-// `bones up` silently destroys user instructions on first install.
-func TestScaffoldOrchestrator_RefusesUserAuthoredCLAUDE(t *testing.T) {
+// TestScaffoldOrchestrator_AppendsBlockToUserAuthoredCLAUDE is the
+// full-path integration for issue #145: `bones up` against a workspace
+// with a user-authored CLAUDE.md must succeed, preserve the user's
+// content, and append the bones-managed block.
+func TestScaffoldOrchestrator_AppendsBlockToUserAuthoredCLAUDE(t *testing.T) {
 	dir := t.TempDir()
 	usersClaude := "When the user corrects you, stop and re-read their message.\n"
 	claudePath := filepath.Join(dir, "CLAUDE.md")
 	if err := os.WriteFile(claudePath, []byte(usersClaude), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	err := scaffoldOrchestrator(dir)
-	if err == nil {
-		t.Fatal("expected error when CLAUDE.md is user-authored")
+	if err := scaffoldOrchestrator(dir); err != nil {
+		t.Fatalf("scaffoldOrchestrator on user-authored CLAUDE.md: %v", err)
 	}
 	got, _ := os.ReadFile(claudePath)
-	if string(got) != usersClaude {
-		t.Errorf("user CLAUDE.md content modified by scaffold:\nwant %q\ngot  %q",
+	if !strings.HasPrefix(string(got), usersClaude) {
+		t.Errorf("user CLAUDE.md prefix lost:\nwant prefix %q\ngot %q",
 			usersClaude, got)
+	}
+	if !strings.Contains(string(got), bonesBlockBegin) {
+		t.Errorf("managed block missing from CLAUDE.md after scaffold:\n%s", got)
 	}
 }
 
@@ -899,5 +965,131 @@ func TestScaffoldOrchestrator_AGENTSNonEmpty(t *testing.T) {
 	}
 	if info.Size() == 0 {
 		t.Fatal("AGENTS.md is empty after scaffold")
+	}
+}
+
+// TestUpsertManagedBlock_AppendsAndReplaces verifies the helper's two
+// codepaths: append a block when none exists, and replace the block in
+// place when one does. User content above the block is preserved
+// byte-for-byte across both runs.
+func TestUpsertManagedBlock_AppendsAndReplaces(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "F.md")
+	user := "# User\n\nUser line.\n"
+	if err := os.WriteFile(path, []byte(user), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := upsertManagedBlock(path, "first body"); err != nil {
+		t.Fatalf("first upsert: %v", err)
+	}
+	first, _ := os.ReadFile(path)
+	if !strings.HasPrefix(string(first), user) {
+		t.Errorf("user prefix lost: %q", first)
+	}
+	if !strings.Contains(string(first), "first body") {
+		t.Errorf("body missing: %q", first)
+	}
+	if err := upsertManagedBlock(path, "second body"); err != nil {
+		t.Fatalf("second upsert: %v", err)
+	}
+	second, _ := os.ReadFile(path)
+	if !strings.HasPrefix(string(second), user) {
+		t.Errorf("user prefix lost on replace: %q", second)
+	}
+	if strings.Contains(string(second), "first body") {
+		t.Errorf("old body not replaced: %q", second)
+	}
+	if !strings.Contains(string(second), "second body") {
+		t.Errorf("new body missing: %q", second)
+	}
+	// Exactly one block: counts of begin/end markers stay at one.
+	if got := strings.Count(string(second), bonesBlockBegin); got != 1 {
+		t.Errorf("begin marker count: got %d want 1", got)
+	}
+	if got := strings.Count(string(second), bonesBlockEnd); got != 1 {
+		t.Errorf("end marker count: got %d want 1", got)
+	}
+}
+
+// TestUpsertManagedBlock_IdempotentSameBody checks that re-running with
+// the same body yields a byte-identical file. This is what carries the
+// "no diff on re-scaffold" property up to writeAgentsMD / linkClaudeMD.
+func TestUpsertManagedBlock_IdempotentSameBody(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "F.md")
+	if err := os.WriteFile(path, []byte("# User\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := upsertManagedBlock(path, "body"); err != nil {
+		t.Fatalf("first: %v", err)
+	}
+	first, _ := os.ReadFile(path)
+	if err := upsertManagedBlock(path, "body"); err != nil {
+		t.Fatalf("second: %v", err)
+	}
+	second, _ := os.ReadFile(path)
+	if string(first) != string(second) {
+		t.Errorf("not idempotent:\nfirst:\n%s\nsecond:\n%s", first, second)
+	}
+}
+
+// TestStripManagedBlock_RestoresUserContent verifies that strip removes
+// the markers and the block contents, leaving the user's original
+// content intact (modulo a normalized trailing newline).
+func TestStripManagedBlock_RestoresUserContent(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "F.md")
+	user := "# User\n\nLine.\n"
+	if err := os.WriteFile(path, []byte(user), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := upsertManagedBlock(path, "body"); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	if err := stripManagedBlock(path); err != nil {
+		t.Fatalf("strip: %v", err)
+	}
+	got, _ := os.ReadFile(path)
+	if string(got) != user {
+		t.Errorf("user content not restored:\nwant %q\ngot  %q", user, got)
+	}
+}
+
+// TestStripManagedBlock_RemovesEmptyResultFile checks that stripping a
+// file whose only content is the managed block leaves no empty file
+// behind — the file is removed entirely.
+func TestStripManagedBlock_RemovesEmptyResultFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "F.md")
+	if err := os.WriteFile(path, []byte(""), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := upsertManagedBlock(path, "body"); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	if err := stripManagedBlock(path); err != nil {
+		t.Fatalf("strip: %v", err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("file should be removed when strip leaves it empty; got err=%v", err)
+	}
+}
+
+// TestStripManagedBlock_NoBlockNoOp pins that strip is a no-op when the
+// file has no managed block — used by `bones down` against files that
+// were never bones-touched.
+func TestStripManagedBlock_NoBlockNoOp(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "F.md")
+	user := "# User\n"
+	if err := os.WriteFile(path, []byte(user), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := stripManagedBlock(path); err != nil {
+		t.Fatalf("strip: %v", err)
+	}
+	got, _ := os.ReadFile(path)
+	if string(got) != user {
+		t.Errorf("file modified by no-op strip:\nwant %q\ngot  %q", user, got)
 	}
 }

--- a/cli/templates/orchestrator/AGENTS.md
+++ b/cli/templates/orchestrator/AGENTS.md
@@ -151,13 +151,23 @@ When the user explicitly asks to remove bones from this project, prefer:
 bones down              # confirms before removing
 ```
 
-`bones down` is the supported uninstaller. It stops the hub, removes `.bones/`, removes this AGENTS.md and the CLAUDE.md symlink, removes the bones-owned hook entries from `.claude/settings.json` (leaving unrelated hooks intact), and removes the Fossil checkout markers (`.fslckout`, `.fossil-settings/`).
+`bones down` is the supported uninstaller. It stops the hub, removes `.bones/`, removes the bones-owned files (this AGENTS.md and the CLAUDE.md symlink/fallback), removes the bones-owned hook entries from `.claude/settings.json` (leaving unrelated hooks intact), and removes the Fossil checkout markers (`.fslckout`, `.fossil-settings/`).
+
+If the workspace had a user-authored CLAUDE.md or AGENTS.md when `bones up` ran, bones did not overwrite it — instead a marker-delimited block was appended:
+
+```
+<!-- BONES:BEGIN -->
+…bones content…
+<!-- BONES:END -->
+```
+
+`bones down` strips that block and leaves the user's content otherwise byte-for-byte unchanged.
 
 Manual fallback (only if `bones down` fails or the user wants to inspect each step):
 
 1. `bones hub stop` — idempotent
 2. `rm -rf .bones/` — workspace state
-3. `rm -f AGENTS.md CLAUDE.md` — this file and its symlink
+3. For each of `AGENTS.md` and `CLAUDE.md`: if the file is bones-owned (whole file, or a CLAUDE.md symlink to AGENTS.md), `rm -f` it; otherwise delete the `<!-- BONES:BEGIN --> … <!-- BONES:END -->` block (markers and all) and leave the rest
 4. Edit `.claude/settings.json` to remove the bones-owned hook entries (the ones whose `command` is `bones hub start` or `bones tasks prime --json`); leave unrelated hooks alone
 5. `rm -rf .fslckout .fossil-settings/` — Fossil checkout (working files are not stored here)
 6. Optionally remove `.fslckout`, `.fossil-settings/`, `.bones/` lines from `.gitignore`

--- a/docs/adr/0045-managed-section-claude-md.md
+++ b/docs/adr/0045-managed-section-claude-md.md
@@ -1,0 +1,54 @@
+# ADR 0045: Managed-section model for user-authored CLAUDE.md / AGENTS.md
+
+## Context
+
+ADR 0042 made AGENTS.md the universal channel and CLAUDE.md a symlink to it. The migration strategy was "wipe and rewrite": `bones up` owns these two files outright. To prevent silent destruction of user content, the scaffold gate refuses to proceed when CLAUDE.md or AGENTS.md exists in any shape it did not produce — the only accepted shapes are (a) absent, (b) bones-owned outright (a CLAUDE.md symlink to AGENTS.md, a regular-file fallback whose first lines carry the bones marker, or an AGENTS.md whose first line carries the marker).
+
+Both files are common conventions a project may already use for its own purposes. CLAUDE.md in particular is widely adopted across Claude Code projects independent of bones. Refusing to scaffold against any pre-existing user-authored CLAUDE.md or AGENTS.md blocks adoption in essentially every project a Claude Code user already cares about. The user's only remediation is to delete or merge their file, then re-run — and `bones down` cannot help because the precondition was never satisfied.
+
+## Decision
+
+`bones up` owns a marker-delimited section, not the whole file. The section is delimited by HTML comments:
+
+```
+<!-- BONES:BEGIN -->
+… bones content …
+<!-- BONES:END -->
+```
+
+Detection is a substring match on `<!-- BONES:BEGIN -->`. Comments are invisible to most markdown renderers and unique enough to avoid false positives in normal prose.
+
+### Four shapes per file
+
+For each of CLAUDE.md and AGENTS.md, four shapes are recognized at scaffold time:
+
+1. **Absent.** Bones writes the file outright (CLAUDE.md as a symlink to AGENTS.md, with regular-file fallback on filesystems without symlink support). Bones now owns the whole file.
+2. **Bones-owned outright.** A symlink-to-AGENTS.md, a regular file whose first lines carry the bones marker, or an AGENTS.md template. The whole file is rewritten in place; the workspace stays in the bones-owns-the-whole-file mode established by ADR 0042.
+3. **User-authored regular file.** A managed block is upserted at the end of the file. User content above the block is preserved byte-for-byte. Idempotent: re-running with the same body produces a byte-identical file.
+4. **CLAUDE.md as a symlink to anything other than AGENTS.md.** Refused. The managed-section model is scoped to regular files; following arbitrary symlinks could write outside the workspace and that is not a tradeoff bones makes silently. The user's recourse is to replace the symlink with a regular file, which bones will then preserve.
+
+### Block bodies
+
+For CLAUDE.md the block body is a short pointer ("Bones is active in this workspace; the agent contract is in AGENTS.md; on `bones down` the agent removes this entire block from CLAUDE.md and deletes AGENTS.md"). CLAUDE.md is a pointer file — the agent contract itself lives in AGENTS.md.
+
+For user-authored AGENTS.md the block body is the full bones AGENTS.md template. AGENTS.md *is* the agent contract; if the user has their own AGENTS.md, the bones contract sits inside the marker-delimited block alongside the user's content. There is no separate file for the bones contract.
+
+### Teardown
+
+`bones down` strips the managed block in place when the file is user-authored, and removes the file outright when bones owns it. The strip preserves user content byte-for-byte (modulo collapsing the blank-line separator added on upsert). If stripping leaves the file empty, the file is removed entirely so down does not leave behind a 0-byte CLAUDE.md or AGENTS.md.
+
+The AGENTS.md template documents the strip step in its Uninstall section so an in-loop agent can perform the manual fallback if `bones down` fails.
+
+## Consequences
+
+`bones up` no longer blocks adoption against pre-existing CLAUDE.md or AGENTS.md. The repro from issue #145 (`echo rules > CLAUDE.md && bones up`) succeeds without manual intervention. The contract from issue #139 (never silently destroy user content) is preserved by upserting only between markers.
+
+Idempotency holds across the new shape: a workspace re-running `bones up` over a managed block produces the same file bytes; a workspace re-running over user edits above the block keeps those edits and re-renders only the block contents.
+
+The bones-owned outright shape from ADR 0042 is unchanged. Workspaces scaffolded before this ADR continue to work as bones-owned files; there is no migration. The new model only kicks in when bones detects pre-existing user content, which by definition was not there in earlier installs.
+
+The cost is one new helper pair (`upsertManagedBlock`, `stripManagedBlock`) and one extra branch in `linkClaudeMD` / `writeAgentsMD` / `planRemoveAgentsMD`. The shape detection is local to those three sites; no new file, no new package, no new flag.
+
+The refused case (CLAUDE.md as a symlink to a non-AGENTS.md target) is a deliberate scope cut, not an oversight. Following arbitrary symlinks turns "modify a workspace file" into "modify any file the symlink resolves to," which can be outside the workspace, in a parent directory, or in a system path. The error message directs the user to replace the symlink with a regular file; bones will then preserve its content.
+
+The block-body asymmetry between CLAUDE.md (short pointer) and AGENTS.md (full template) reflects what each file is *for*. CLAUDE.md is a Claude Code convention; AGENTS.md is the agent-contract spec. The agent contract belongs in AGENTS.md regardless of which file the user authored, so AGENTS.md carries the full body and CLAUDE.md just points at it.


### PR DESCRIPTION
## Summary

- `bones up` no longer refuses to scaffold against a pre-existing user-authored `CLAUDE.md` or `AGENTS.md`. Instead a marker-delimited block (`<!-- BONES:BEGIN --> ... <!-- BONES:END -->`) is upserted at the end of the file; user content above the block is preserved byte-for-byte and re-scaffold is idempotent.
- `bones down` strips the block in place when the file is user-authored, removes the file outright when bones owns it, and removes the file entirely if stripping leaves it empty.
- Symlinks to non-`AGENTS.md` targets are still refused with a clearer error directing the user to replace the symlink with a regular file (out of scope to follow arbitrary symlinks).
- `cli/templates/orchestrator/AGENTS.md` Uninstall section documents the strip-block step for the manual-fallback path.
- ADR 0045 documents the four-shape detection model and consequences.

The bones-owned-outright shape from ADR 0042 is unchanged — workspaces scaffolded before this PR continue to operate as bones-owned files.

Closes #145

## Test plan

- [x] `make check` passes (fmt-check, vet, lint, race, todo-check)
- [x] `go test -tags=otel -short ./...` passes (CI-equivalent)
- [x] Issue #145 repro: `mkdir /tmp/repro && cd /tmp/repro && git init && echo 'rules' > CLAUDE.md && bones up` succeeds and the user's CLAUDE.md content is preserved with a managed block appended (covered by `TestScaffoldOrchestrator_AppendsBlockToUserAuthoredCLAUDE`)
- [x] Same for AGENTS.md (`TestScaffoldOrchestrator_AppendsBlockToUserAuthoredAGENTS`)
- [x] Idempotent re-render: second `bones up` yields byte-identical file (`TestLinkClaudeMD_IdempotentUserAuthored`, `TestUpsertManagedBlock_IdempotentSameBody`)
- [x] User edits above the block survive re-scaffold (`TestLinkClaudeMD_PreservesUserEditsAboveBlock`)
- [x] `bones down` strips the block from a user-authored file and leaves user content intact (`TestPlanRemoveAgentsMD_StripsBlockFromUserAuthoredAGENTS`, `TestPlanRemoveAgentsMD_StripsBlockFromUserAuthoredCLAUDE`)
- [x] Symlink to non-`AGENTS.md` target still refused (`TestLinkClaudeMD_RefusesUnrelatedSymlink`)
- [x] Bones-owned shapes still recognized (`TestLinkClaudeMD_AcceptsBonesOwnedFallback`, existing idempotency tests)