### PR TITLE
fix(scaffold): nested-aware managed-block parser

### DIFF
--- a/cli/orchestrator.go
+++ b/cli/orchestrator.go
@@ -138,6 +138,47 @@ func writeAgentsMD(root string) error {
 	return upsertManagedBlock(path, string(agentsMDTemplate))
 }
 
+// findManagedBlock locates the outer bones-managed section in s using
+// nested-aware parsing: BEGIN/END marker pairs occurring inside the
+// body (e.g. when the bones AGENTS.md template documents the marker
+// syntax in a fenced code block) are counted as nested and do not
+// terminate the outer block.
+//
+// Returns (begin, end, true, nil) where begin is the index of the
+// outer BEGIN marker and end is the index just past the outer END
+// marker, suitable for s[:begin] / s[end:] slicing.
+// Returns (-1, -1, false, nil) when no BEGIN marker is present.
+// Returns a non-nil error when a BEGIN marker is present without a
+// matching END (counting nesting); the caller must surface the error
+// rather than silently corrupting user content (issue #150).
+func findManagedBlock(s string) (begin, end int, ok bool, err error) {
+	begin = strings.Index(s, bonesBlockBegin)
+	if begin == -1 {
+		return -1, -1, false, nil
+	}
+	cursor := begin + len(bonesBlockBegin)
+	depth := 1
+	for {
+		nextBegin := strings.Index(s[cursor:], bonesBlockBegin)
+		nextEnd := strings.Index(s[cursor:], bonesBlockEnd)
+		if nextEnd == -1 {
+			return -1, -1, false, fmt.Errorf("malformed managed block: "+
+				"%s present without matching %s",
+				bonesBlockBegin, bonesBlockEnd)
+		}
+		if nextBegin != -1 && nextBegin < nextEnd {
+			depth++
+			cursor += nextBegin + len(bonesBlockBegin)
+			continue
+		}
+		depth--
+		cursor += nextEnd + len(bonesBlockEnd)
+		if depth == 0 {
+			return begin, cursor, true, nil
+		}
+	}
+}
+
 // upsertManagedBlock writes (or refreshes) a bones-managed section
 // delimited by bonesBlockBegin / bonesBlockEnd inside the file at
 // path. User content outside the markers is preserved byte-for-byte.
@@ -148,10 +189,10 @@ func writeAgentsMD(root string) error {
 // content and the BEGIN marker; one trailing newline after the END
 // marker. If the file is empty, no leading blank line is added.
 //
-// If the file is missing it is created with just the block. If a
-// bonesBlockBegin marker is present without a matching bonesBlockEnd
-// marker, the block is treated as malformed and an error is returned
-// so we never silently corrupt user content.
+// If the file is missing it is created with just the block. Nested
+// marker pairs in the body (per findManagedBlock) are tolerated. A
+// BEGIN marker without a matching END (after counting nesting) is
+// treated as malformed and surfaces an error.
 func upsertManagedBlock(path, body string) error {
 	data, err := os.ReadFile(path)
 	if err != nil && !os.IsNotExist(err) {
@@ -159,11 +200,15 @@ func upsertManagedBlock(path, body string) error {
 	}
 	s := string(data)
 
-	beginIdx := strings.Index(s, bonesBlockBegin)
 	newBlock := bonesBlockBegin + "\n" + body + "\n" + bonesBlockEnd
 
+	begin, end, ok, err := findManagedBlock(s)
+	if err != nil {
+		return fmt.Errorf("%s: %w", path, err)
+	}
+
 	var out string
-	if beginIdx == -1 {
+	if !ok {
 		// Append a fresh block. Normalize trailing newline on user
 		// content and add a single blank line separator.
 		prefix := s
@@ -175,14 +220,7 @@ func upsertManagedBlock(path, body string) error {
 		}
 		out = prefix + newBlock + "\n"
 	} else {
-		endRel := strings.Index(s[beginIdx:], bonesBlockEnd)
-		if endRel == -1 {
-			return fmt.Errorf("malformed managed block in %s: "+
-				"%s present without matching %s",
-				path, bonesBlockBegin, bonesBlockEnd)
-		}
-		endAbs := beginIdx + endRel + len(bonesBlockEnd)
-		out = s[:beginIdx] + newBlock + s[endAbs:]
+		out = s[:begin] + newBlock + s[end:]
 	}
 
 	if err := os.WriteFile(path, []byte(out), 0o644); err != nil {
@@ -198,6 +236,10 @@ func upsertManagedBlock(path, body string) error {
 // is collapsed back to a single trailing newline so a strip-then-
 // upsert cycle round-trips cleanly.
 //
+// Nested marker pairs in the body are handled by findManagedBlock —
+// only the outer block is removed, even when the body itself contains
+// literal marker strings (issue #150).
+//
 // No-op if the file is absent or contains no managed block. If
 // stripping leaves the file empty, the file is removed entirely so
 // `bones down` doesn't leave behind a 0-byte CLAUDE.md / AGENTS.md.
@@ -210,25 +252,21 @@ func stripManagedBlock(path string) error {
 		return fmt.Errorf("read %s: %w", path, err)
 	}
 	s := string(data)
-	beginIdx := strings.Index(s, bonesBlockBegin)
-	if beginIdx == -1 {
+	begin, end, ok, err := findManagedBlock(s)
+	if err != nil {
+		return fmt.Errorf("%s: %w", path, err)
+	}
+	if !ok {
 		return nil
 	}
-	endRel := strings.Index(s[beginIdx:], bonesBlockEnd)
-	if endRel == -1 {
-		return fmt.Errorf("malformed managed block in %s: "+
-			"%s present without matching %s",
-			path, bonesBlockBegin, bonesBlockEnd)
-	}
-	endAbs := beginIdx + endRel + len(bonesBlockEnd)
-	if endAbs < len(s) && s[endAbs] == '\n' {
-		endAbs++
+	if end < len(s) && s[end] == '\n' {
+		end++
 	}
 
 	// Collapse trailing newlines on the prefix (including the blank
 	// separator we added on upsert) so we restore exactly one trailing
 	// newline — matching the user's original "ends with \n" shape.
-	trimEnd := beginIdx
+	trimEnd := begin
 	for trimEnd > 0 && s[trimEnd-1] == '\n' {
 		trimEnd--
 	}
@@ -236,7 +274,7 @@ func stripManagedBlock(path string) error {
 	if prefix != "" {
 		prefix += "\n"
 	}
-	out := prefix + s[endAbs:]
+	out := prefix + s[end:]
 
 	if out == "" {
 		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
@@ -250,11 +288,19 @@ func stripManagedBlock(path string) error {
 	return nil
 }
 
-// hasManagedBlock reports whether content contains a bones-managed
-// section. Used by `bones down` to decide whether to strip a block out
-// of a user-authored file vs leave it alone.
+// hasManagedBlock reports whether content contains a real outer
+// bones-managed section, not merely the marker substrings. A file
+// that mentions the markers in user prose without actually opening a
+// block (e.g. BEGIN-only, or end-only) returns false so `bones down`
+// does not attempt to strip something that isn't there (issue #150).
+//
+// Malformed blocks (BEGIN with no matching END, counting nesting) are
+// treated as "no block present" rather than surfacing an error: the
+// strip path will re-detect and error if it tries to act, but mere
+// detection should not be a failure mode.
 func hasManagedBlock(content []byte) bool {
-	return strings.Contains(string(content), bonesBlockBegin)
+	_, _, ok, err := findManagedBlock(string(content))
+	return ok && err == nil
 }
 
 // bonesOwnedAgentsMD reports whether the given AGENTS.md content was

--- a/cli/orchestrator_test.go
+++ b/cli/orchestrator_test.go
@@ -1093,3 +1093,121 @@ func TestStripManagedBlock_NoBlockNoOp(t *testing.T) {
 		t.Errorf("file modified by no-op strip:\nwant %q\ngot  %q", user, got)
 	}
 }
+
+// nestedMarkerBody is a body that itself contains the literal
+// bones-block markers. The bones AGENTS.md template body is exactly
+// this shape: it documents the marker syntax in a fenced code block.
+// All managed-section helpers must treat these as nested content of
+// the outer block, not as outer-block boundaries (issue #150).
+var nestedMarkerBody = "real body line\n\n" +
+	"```\n" +
+	bonesBlockBegin + "\n" +
+	"…example…\n" +
+	bonesBlockEnd + "\n" +
+	"```\n\n" +
+	"trailing body line"
+
+// TestUpsertManagedBlock_NestedMarkersInBody pins issue #150: the
+// outer block must be located using nested-aware parsing, not first-
+// END-after-BEGIN. Re-upserting the same body produces a byte-
+// identical file, even when the body contains the literal marker
+// strings.
+func TestUpsertManagedBlock_NestedMarkersInBody(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "F.md")
+	user := "# User\n"
+	if err := os.WriteFile(path, []byte(user), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := upsertManagedBlock(path, nestedMarkerBody); err != nil {
+		t.Fatalf("first upsert: %v", err)
+	}
+	first, _ := os.ReadFile(path)
+	if !strings.HasPrefix(string(first), user) {
+		t.Errorf("user prefix lost: %q", first)
+	}
+	if !strings.Contains(string(first), "trailing body line") {
+		t.Errorf("body trailing content missing: %q", first)
+	}
+	if err := upsertManagedBlock(path, nestedMarkerBody); err != nil {
+		t.Fatalf("second upsert: %v", err)
+	}
+	second, _ := os.ReadFile(path)
+	if string(first) != string(second) {
+		t.Errorf("re-upsert with nested markers not idempotent:\nfirst:\n%s\nsecond:\n%s",
+			first, second)
+	}
+}
+
+// TestStripManagedBlock_NestedMarkersInBody pins that strip removes
+// the outer block in full and leaves the user's content intact, even
+// when the body content contains literal marker strings (issue #150).
+func TestStripManagedBlock_NestedMarkersInBody(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "F.md")
+	user := "# User\n\nUser content.\n"
+	if err := os.WriteFile(path, []byte(user), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := upsertManagedBlock(path, nestedMarkerBody); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	if err := stripManagedBlock(path); err != nil {
+		t.Fatalf("strip: %v", err)
+	}
+	got, _ := os.ReadFile(path)
+	if string(got) != user {
+		t.Errorf("user content not restored after nested-body strip:\nwant %q\ngot  %q",
+			user, got)
+	}
+}
+
+// TestStripManagedBlock_PreservesContentAfterBlock pins that user
+// content following the outer END marker is not consumed by strip,
+// even when the body content above it contains literal markers.
+func TestStripManagedBlock_PreservesContentAfterBlock(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "F.md")
+	user := "# User\n"
+	if err := os.WriteFile(path, []byte(user), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := upsertManagedBlock(path, nestedMarkerBody); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	// Manually append user content after the END marker.
+	current, _ := os.ReadFile(path)
+	withTail := string(current) + "\n## After bones\n\nMore user prose.\n"
+	if err := os.WriteFile(path, []byte(withTail), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := stripManagedBlock(path); err != nil {
+		t.Fatalf("strip: %v", err)
+	}
+	got, _ := os.ReadFile(path)
+	want := "# User\n\n## After bones\n\nMore user prose.\n"
+	if string(got) != want {
+		t.Errorf("post-block content not preserved:\nwant %q\ngot  %q", want, got)
+	}
+}
+
+// TestHasManagedBlock_RejectsBareSubstring pins that hasManagedBlock
+// returns true only for files that contain a real outer block — a
+// file that mentions the marker strings in user prose (no actual
+// block) must not trigger a strip on `bones down` (issue #150).
+func TestHasManagedBlock_RejectsBareSubstring(t *testing.T) {
+	// Begin-only, no end: not a real block.
+	beginOnly := "# Doc\n\nMy file mentions " + bonesBlockBegin + " but never closes it.\n"
+	if hasManagedBlock([]byte(beginOnly)) {
+		t.Errorf("hasManagedBlock should be false for BEGIN without END:\n%s", beginOnly)
+	}
+	// No markers at all.
+	if hasManagedBlock([]byte("# Doc\n\nBoring content.\n")) {
+		t.Errorf("hasManagedBlock should be false for marker-free content")
+	}
+	// Real block: should be true.
+	real := "# Doc\n\n" + bonesBlockBegin + "\nbody\n" + bonesBlockEnd + "\n"
+	if !hasManagedBlock([]byte(real)) {
+		t.Errorf("hasManagedBlock should be true for a real block:\n%s", real)
+	}
+}


### PR DESCRIPTION
## Summary

- `upsertManagedBlock`, `stripManagedBlock`, and `hasManagedBlock` previously used `strings.Index` to locate the END marker, which returns the first match. The bones AGENTS.md template body documents the marker syntax in a fenced code block — meaning the body itself contains literal `<!-- BONES:BEGIN -->` / `<!-- BONES:END -->` strings. Upsert/strip would mis-locate the outer END at an inner marker, corrupting the file.
- Add `findManagedBlock`, a depth-counting parser that treats nested marker pairs as body content. All three helpers route through it.
- `hasManagedBlock` now correctly returns `false` for files that mention the marker strings in prose without actually opening a real outer block.
- End-to-end verified against the bones repo's own user-authored `AGENTS.md` + `CLAUDE.md`: `bones up` → `bones up` (idempotent) → `bones down` restores both files byte-for-byte.

Closes #150

## Test plan

- [x] `make check` passes (fmt-check, vet, lint, race, todo-check)
- [x] `go test -tags=otel -short ./...` passes (CI-equivalent)
- [x] Repro from #150: `bones up` against a user-authored AGENTS.md (where the appended template body contains marker strings) is idempotent on re-run (`TestUpsertManagedBlock_NestedMarkersInBody`)
- [x] `bones down` against the same file restores user content byte-for-byte (`TestStripManagedBlock_NestedMarkersInBody`)
- [x] User content following the outer END marker is preserved by strip even when body content above contains nested markers (`TestStripManagedBlock_PreservesContentAfterBlock`)
- [x] `hasManagedBlock` returns false for BEGIN-only files and marker-free content; true only for real outer blocks (`TestHasManagedBlock_RejectsBareSubstring`)
- [x] Existing #145 tests still pass (no regression on the simple-body path)
- [x] Real-world end-to-end: built local binary, ran `bones up` then `bones down` against the bones repo, verified `shasum` of CLAUDE.md and AGENTS.md returns to original