### PR TITLE
fix(status,doctor): WARN on incomplete scaffold

### DIFF
--- a/cli/doctor.go
+++ b/cli/doctor.go
@@ -169,6 +169,15 @@ func runBypassReportTo(w io.Writer, cwd string) (warns int, err error) {
 	case stampErr != nil:
 		_, _ = fmt.Fprintf(w, "  WARN  scaffold stamp read: %v\n", stampErr)
 		warns++
+	case stamp == "" && workspaceMarkerPresent(cwd):
+		// .bones/agent.id present but stamp absent: bones up step 1
+		// completed and step 2 (scaffold) did not. SessionStart hooks
+		// were never installed; agents operate without context priming
+		// (#147). Distinguish from a fresh workspace (no marker, no
+		// stamp) which is just informational.
+		_, _ = fmt.Fprintln(w,
+			"  WARN  scaffold incomplete — re-run `bones up`")
+		warns++
 	case stamp == "":
 		_, _ = fmt.Fprintln(w, "  INFO  no scaffold version stamp — `bones up` to write one")
 	case scaffoldver.Drifted(stamp, version.Get()):
@@ -292,6 +301,15 @@ func checkBonesScaffoldedHooks(w io.Writer, cwd string) bool {
 	}
 	_, _ = fmt.Fprintln(w, "  OK    .claude/settings.json has bones-owned hook entries")
 	return false
+}
+
+// workspaceMarkerPresent reports whether `.bones/agent.id` exists at
+// root. The marker is the load-bearing "step 1 of bones up succeeded"
+// signal — its presence with a missing scaffold_version stamp means
+// scaffold (step 2) failed mid-flight (#147 / #146).
+func workspaceMarkerPresent(root string) bool {
+	_, err := os.Stat(filepath.Join(root, ".bones", "agent.id"))
+	return err == nil
 }
 
 // checkOrphanHubs reads the cross-workspace registry and reports

--- a/cli/doctor_all_test.go
+++ b/cli/doctor_all_test.go
@@ -15,9 +15,11 @@ import (
 )
 
 // makeFakeWorkspace builds a minimal valid bones workspace under
-// t.TempDir() — directory + .bones/agent.id marker — so registry
-// entries pointing at it don't get flagged as orphans by ADR 0043's
-// orphan check during doctor tests.
+// t.TempDir(): directory + .bones/agent.id marker + scaffold_version
+// stamp + a bones-marked AGENTS.md so doctor's substrate gates all
+// pass. Registry entries pointing at it don't get flagged as orphans
+// by ADR 0043, the #147 incomplete-scaffold WARN doesn't fire, and
+// ADR 0042's AGENTS.md presence check is satisfied.
 func makeFakeWorkspace(t *testing.T, name string) string {
 	t.Helper()
 	dir := filepath.Join(t.TempDir(), name)
@@ -27,6 +29,15 @@ func makeFakeWorkspace(t *testing.T, name string) string {
 	if err := os.WriteFile(filepath.Join(dir, ".bones", "agent.id"),
 		[]byte("test"), 0o644); err != nil {
 		t.Fatalf("makeFakeWorkspace marker: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".bones", "scaffold_version"),
+		[]byte("test"), 0o644); err != nil {
+		t.Fatalf("makeFakeWorkspace stamp: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "AGENTS.md"),
+		[]byte("# Agent Guidance for this Workspace\n\n## Agent Setup (REQUIRED)\n"),
+		0o644); err != nil {
+		t.Fatalf("makeFakeWorkspace agents.md: %v", err)
 	}
 	return dir
 }

--- a/cli/doctor_test.go
+++ b/cli/doctor_test.go
@@ -32,6 +32,45 @@ func TestRunBypassReportToNoGit(t *testing.T) {
 	if strings.Contains(out, "Fix:") {
 		t.Fatalf("expected no Fix in INFO-only output, got:\n%s", out)
 	}
+	// Fresh fixture has no .bones/agent.id either, so the new
+	// scaffold-incomplete WARN (#147) must NOT fire.
+	if strings.Contains(out, "scaffold incomplete") {
+		t.Errorf("scaffold-incomplete WARN should not fire on a fresh, "+
+			"never-up workspace:\n%s", out)
+	}
+}
+
+// TestRunBypassReportToScaffoldIncomplete pins #147: a workspace whose
+// `.bones/agent.id` marker is present but whose scaffold_version stamp
+// is absent reports a scaffold-incomplete WARN. This is the
+// half-installed state left by a failed `bones up`.
+func TestRunBypassReportToScaffoldIncomplete(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	tmp := t.TempDir()
+	if err := os.MkdirAll(tmp+"/.bones", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(tmp+"/.bones/agent.id",
+		[]byte("test-agent\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Note: no scaffold_version stamp.
+
+	var buf bytes.Buffer
+	warns, err := runBypassReportTo(&buf, tmp)
+	if err != nil {
+		t.Fatalf("runBypassReportTo: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "scaffold incomplete") {
+		t.Errorf("expected scaffold-incomplete WARN; got:\n%s", out)
+	}
+	if !strings.Contains(out, "bones up") {
+		t.Errorf("WARN should direct user to `bones up`:\n%s", out)
+	}
+	if warns < 1 {
+		t.Errorf("expected at least 1 warn, got %d", warns)
+	}
 }
 
 // TestFormatSwarmSessionsStale checks that a stale session emits WARN + Fix.

--- a/cli/status.go
+++ b/cli/status.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/danmestas/bones/internal/hub"
 	"github.com/danmestas/bones/internal/registry"
+	"github.com/danmestas/bones/internal/scaffoldver"
 	"github.com/danmestas/bones/internal/sessions"
 	"github.com/danmestas/bones/internal/swarm"
 	"github.com/danmestas/bones/internal/tasks"
@@ -64,6 +65,13 @@ type statusReport struct {
 	TasksByID     map[string]tasks.Task
 
 	Activity []activityEvent
+
+	// ScaffoldComplete is true when scaffoldver.Read returns a non-empty
+	// stamp. False signals an incomplete `bones up` (per #146): step 1
+	// (workspace init) succeeded but step 2 (scaffold) did not, so
+	// .claude/settings.json hooks are missing and AGENTS.md may be
+	// partial. Surfaced as a WARN by renderStatus (#147).
+	ScaffoldComplete bool
 }
 
 // activityEvent is one entry in the recent-activity feed. Time is
@@ -101,11 +109,13 @@ func (c *StatusCmd) Run(g *libfossilcli.Globals) error {
 // gracefully — a workspace that hasn't bootstrapped a hub repo yet
 // still gets the task/session view.
 func gatherStatus(ctx context.Context, info workspace.Info) (statusReport, error) {
+	stamp, _ := scaffoldver.Read(info.WorkspaceDir)
 	rep := statusReport{
-		WorkspaceDir:  info.WorkspaceDir,
-		GeneratedAt:   timeNow(),
-		TasksByStatus: map[tasks.Status]int{},
-		TasksByID:     map[string]tasks.Task{},
+		WorkspaceDir:     info.WorkspaceDir,
+		GeneratedAt:      timeNow(),
+		TasksByStatus:    map[tasks.Status]int{},
+		TasksByID:        map[string]tasks.Task{},
+		ScaffoldComplete: stamp != "",
 	}
 
 	mgr, closeMgr, err := openManager(ctx, info)
@@ -245,6 +255,18 @@ func renderStatus(rep statusReport, w io.Writer) error {
 	)
 	if _, err := io.WriteString(w, header); err != nil {
 		return err
+	}
+
+	// Surface incomplete scaffolds (#147): step 1 of `bones up` succeeded
+	// (the workspace marker is present, otherwise gatherStatus could not
+	// have run) but step 2 (scaffold) did not — `.claude/settings.json`
+	// hooks are missing, agents operate without context priming. Re-run
+	// `bones up` to recover (per #146).
+	if !rep.ScaffoldComplete {
+		if _, err := io.WriteString(w,
+			"WARN  scaffold incomplete — re-run `bones up`\n\n"); err != nil {
+			return err
+		}
 	}
 
 	if err := renderSlotTable(rep, w); err != nil {

--- a/cli/status_test.go
+++ b/cli/status_test.go
@@ -17,10 +17,11 @@ import (
 
 func TestRenderStatus_Empty(t *testing.T) {
 	rep := statusReport{
-		WorkspaceDir:  "/tmp/ws/bones",
-		GeneratedAt:   time.Date(2026, 4, 30, 14, 5, 2, 0, time.UTC),
-		TasksByStatus: map[tasks.Status]int{},
-		TasksByID:     map[string]tasks.Task{},
+		WorkspaceDir:     "/tmp/ws/bones",
+		GeneratedAt:      time.Date(2026, 4, 30, 14, 5, 2, 0, time.UTC),
+		TasksByStatus:    map[tasks.Status]int{},
+		TasksByID:        map[string]tasks.Task{},
+		ScaffoldComplete: true,
 	}
 	var buf bytes.Buffer
 	if err := renderStatus(rep, &buf); err != nil {
@@ -36,6 +37,36 @@ func TestRenderStatus_Empty(t *testing.T) {
 		if !strings.Contains(out, want) {
 			t.Errorf("output missing %q\n--- output ---\n%s", want, out)
 		}
+	}
+	// ScaffoldComplete=true → no incomplete-scaffold WARN.
+	if strings.Contains(out, "scaffold incomplete") {
+		t.Errorf("unexpected scaffold-incomplete WARN when stamp present:\n%s", out)
+	}
+}
+
+// TestRenderStatus_ScaffoldIncomplete pins #147: when the workspace
+// stamp is missing (scaffoldver.Read → empty), renderStatus emits a
+// WARN line directing the user to re-run `bones up`. Without this the
+// user sees a green status header against a half-installed workspace
+// where SessionStart hooks were never written.
+func TestRenderStatus_ScaffoldIncomplete(t *testing.T) {
+	rep := statusReport{
+		WorkspaceDir:     "/tmp/ws/bones",
+		GeneratedAt:      time.Date(2026, 5, 3, 14, 5, 2, 0, time.UTC),
+		TasksByStatus:    map[tasks.Status]int{},
+		TasksByID:        map[string]tasks.Task{},
+		ScaffoldComplete: false,
+	}
+	var buf bytes.Buffer
+	if err := renderStatus(rep, &buf); err != nil {
+		t.Fatalf("renderStatus: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "scaffold incomplete") {
+		t.Errorf("missing scaffold-incomplete WARN:\n%s", out)
+	}
+	if !strings.Contains(out, "bones up") {
+		t.Errorf("WARN should direct user to `bones up`:\n%s", out)
 	}
 }
 
@@ -82,6 +113,7 @@ func TestRenderStatus_WithSessionsAndTasks(t *testing.T) {
 				TaskID: "7777777a-aaaa-bbbb-cccc-dddddddddddd", Title: "auth fix",
 			},
 		},
+		ScaffoldComplete: true,
 	}
 	var buf bytes.Buffer
 	if err := renderStatus(rep, &buf); err != nil {


### PR DESCRIPTION
## Summary

- `bones status` and `bones doctor` previously reported a healthy workspace after a failed `bones up` — the user saw a green status against a workspace where SessionStart/PreCompact hooks were never installed.
- Add `ScaffoldComplete` to `statusReport` (populated by `gatherStatus` from `scaffoldver.Read`); `renderStatus` emits a WARN line when false.
- Doctor's existing empty-stamp INFO becomes a WARN (and increments `warns`) when `.bones/agent.id` is present, distinguishing the half-installed state from a fresh workspace that has never run `bones up`.

The actual recovery from the half-installed state is #146's job; this PR only surfaces the condition.

Closes #147

## Test plan

- [x] `make check` passes (fmt-check, vet, lint, race, todo-check)
- [x] `go test -tags=otel -short ./...` passes (CI-equivalent)
- [x] `TestRenderStatus_ScaffoldIncomplete` — WARN appears for incomplete scaffold
- [x] `TestRenderStatus_Empty` updated to set `ScaffoldComplete: true` and assert no WARN
- [x] `TestRunBypassReportToScaffoldIncomplete` — doctor emits WARN + increments `warns` when `.bones/agent.id` present and stamp absent
- [x] `TestRunBypassReportToNoGit` updated to assert no WARN on a fresh workspace (no marker, no stamp)
- [x] `makeFakeWorkspace` test fixture updated to write `scaffold_version` + `AGENTS.md` so it represents a completed `bones up` (existing renderer tests stay green)