### PR TITLE
fix(up): resume scaffold from half-install state

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,4 +283,4 @@ frontend  t-c44a    laptop  0      stale   120s ago
 
 ## License
 
-Apache-2.0. See `[LICENSE](LICENSE)`.
+Apache-2.0. See [LICENSE](LICENSE).

--- a/cli/up.go
+++ b/cli/up.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/danmestas/bones/internal/githook"
 	"github.com/danmestas/bones/internal/hub"
+	"github.com/danmestas/bones/internal/scaffoldver"
 	"github.com/danmestas/bones/internal/telemetry"
 	"github.com/danmestas/bones/internal/workspace"
 )
@@ -25,6 +26,13 @@ import (
 // Per ADR 0041 the hub is no longer started here. Any verb that needs the
 // hub auto-starts it lazily via workspace.Join.
 //
+// Per ADR 0046 (#146), `bones up` is also the recovery path for a
+// half-installed workspace: when step 1 has previously succeeded but
+// step 2 did not (`.bones/agent.id` present, `.bones/scaffold_version`
+// absent), runUp announces the recovery on stderr and re-runs scaffold
+// idempotently. Each scaffold step is safe to call against partial
+// state.
+//
 // Default output is a single confirmation line. With verbose=true, prints
 // per-step status lines. WARN lines from drift / missing-git checks
 // always print because they describe real issues operators must see.
@@ -34,6 +42,12 @@ func runUp(cwd string, verbose bool) (err error) {
 	)
 	defer func() { end(err) }()
 
+	// Detect recovery state BEFORE init: agent.id present from a prior
+	// run + missing stamp = step 2 failed last time. The announcement
+	// lands once on stderr per #146 — silent recovery would leave the
+	// user wondering why a re-run worked after the previous error.
+	recovery := isIncompleteScaffold(cwd)
+
 	info, err := initOrJoinWorkspace(ctx, cwd)
 	if err != nil {
 		return fmt.Errorf("workspace: %w", err)
@@ -41,6 +55,11 @@ func runUp(cwd string, verbose bool) (err error) {
 	wsDir := info.WorkspaceDir
 	if verbose {
 		fmt.Printf("up: workspace at %s\n", wsDir)
+	}
+
+	if recovery {
+		fmt.Fprintln(os.Stderr,
+			"bones: scaffold incomplete from prior run — re-running scaffold")
 	}
 
 	if err := scaffoldOrchestrator(wsDir); err != nil {
@@ -103,6 +122,25 @@ func printHubStatus(w io.Writer, root string) {
 	}
 	_, _ = fmt.Fprintf(w, "up: hub: previously recorded at %s / %s — "+
 		"will restart on next verb\n", fossilURL, natsURL)
+}
+
+// isIncompleteScaffold reports whether cwd lives inside a workspace
+// whose `.bones/agent.id` marker exists but whose
+// `.bones/scaffold_version` stamp is missing. This is the signature of
+// a `bones up` that completed step 1 (workspace init) but failed step
+// 2 (orchestrator scaffold), per #146 / ADR 0046.
+//
+// Returns false for fresh workspaces (no marker — nothing to recover
+// from), for fully-scaffolded workspaces (stamp present), and when
+// FindRoot fails. Used by runUp to decide whether to print the
+// recovery-announcement line.
+func isIncompleteScaffold(cwd string) bool {
+	root, err := workspace.FindRoot(cwd)
+	if err != nil {
+		return false
+	}
+	stamp, _ := scaffoldver.Read(root)
+	return stamp == ""
 }
 
 // initOrJoinWorkspace returns workspace.Info for cwd, creating the

--- a/cli/up_test.go
+++ b/cli/up_test.go
@@ -115,3 +115,129 @@ func TestPrintHubStatus_StaleURLs(t *testing.T) {
 			"is dead); got: %q", got)
 	}
 }
+
+// TestIsIncompleteScaffold_Fresh pins that a directory with no
+// `.bones/` is not flagged for recovery. (Per #146 / ADR 0046.)
+func TestIsIncompleteScaffold_Fresh(t *testing.T) {
+	dir := t.TempDir()
+	if isIncompleteScaffold(dir) {
+		t.Errorf("fresh dir should not be flagged for recovery")
+	}
+}
+
+// TestIsIncompleteScaffold_FullyScaffolded pins that a workspace with
+// both agent.id AND scaffold_version is not flagged for recovery.
+func TestIsIncompleteScaffold_FullyScaffolded(t *testing.T) {
+	dir := t.TempDir()
+	bones := filepath.Join(dir, ".bones")
+	if err := os.MkdirAll(bones, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(bones, "agent.id"),
+		[]byte("test-agent"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(bones, "scaffold_version"),
+		[]byte("test"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if isIncompleteScaffold(dir) {
+		t.Errorf("fully-scaffolded workspace should not be flagged for recovery")
+	}
+}
+
+// TestIsIncompleteScaffold_HalfInstalled pins #146's load-bearing
+// detection: a workspace whose agent.id exists but whose stamp is
+// missing IS flagged for recovery. This is the state left by a
+// `bones up` that aborted in step 2 (orchestrator scaffold).
+func TestIsIncompleteScaffold_HalfInstalled(t *testing.T) {
+	dir := t.TempDir()
+	bones := filepath.Join(dir, ".bones")
+	if err := os.MkdirAll(bones, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(bones, "agent.id"),
+		[]byte("test-agent"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Note: no scaffold_version stamp.
+	if !isIncompleteScaffold(dir) {
+		t.Errorf("workspace with agent.id but no stamp should be flagged " +
+			"for recovery")
+	}
+}
+
+// TestScaffoldOrchestrator_RecoversFromHalfInstall pins the contract
+// that scaffoldOrchestrator can be re-run safely against a half-
+// installed workspace and converges on the same state as a fresh run.
+// Per #146 / ADR 0046, every step inside scaffoldOrchestrator is
+// idempotent against partial prior state — there is no separate
+// "preflight" pass; the redo IS the recovery.
+//
+// Fixture: agent.id present, .claude/settings.json containing only
+// some bones hooks (simulating a settings-stage failure where
+// mergeSettings ran but a later step did not), no scaffold_version
+// stamp. Run scaffoldOrchestrator. Assert: stamp written, AGENTS.md
+// present, settings.json has full hook set.
+func TestScaffoldOrchestrator_RecoversFromHalfInstall(t *testing.T) {
+	dir := t.TempDir()
+	bones := filepath.Join(dir, ".bones")
+	if err := os.MkdirAll(bones, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(bones, "agent.id"),
+		[]byte("test-agent"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Simulate a half-merged settings.json: bones SessionStart hook is
+	// in but PreCompact is not.
+	settingsDir := filepath.Join(dir, ".claude")
+	if err := os.MkdirAll(settingsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	partial := `{"hooks":{"SessionStart":[{"matcher":"","hooks":[` +
+		`{"command":"bones tasks prime --json","type":"command","timeout":10}` +
+		`]}]}}`
+	if err := os.WriteFile(filepath.Join(settingsDir, "settings.json"),
+		[]byte(partial), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := scaffoldOrchestrator(dir); err != nil {
+		t.Fatalf("scaffoldOrchestrator on half-installed workspace: %v", err)
+	}
+
+	// Stamp written → recovery succeeded.
+	if _, err := os.Stat(filepath.Join(bones, "scaffold_version")); err != nil {
+		t.Errorf("scaffold_version stamp not written after recovery: %v", err)
+	}
+	// AGENTS.md present.
+	if _, err := os.Stat(filepath.Join(dir, "AGENTS.md")); err != nil {
+		t.Errorf("AGENTS.md not written after recovery: %v", err)
+	}
+	// settings.json now has the full hook set.
+	data, err := os.ReadFile(filepath.Join(settingsDir, "settings.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := string(data)
+	for _, want := range []string{
+		"bones tasks prime --json", // present in partial
+		"bones hub start",          // added by recovery
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("settings.json missing %q after recovery:\n%s", want, body)
+		}
+	}
+
+	// Idempotent: a third run produces a byte-identical settings.json.
+	first := body
+	if err := scaffoldOrchestrator(dir); err != nil {
+		t.Fatalf("second scaffold: %v", err)
+	}
+	data2, _ := os.ReadFile(filepath.Join(settingsDir, "settings.json"))
+	if string(data2) != first {
+		t.Errorf("settings.json not idempotent across recovery + re-run:\n"+
+			"first:\n%s\nsecond:\n%s", first, data2)
+	}
+}

--- a/cmd/bones/integration/up_recovery_test.go
+++ b/cmd/bones/integration/up_recovery_test.go
@@ -1,0 +1,96 @@
+package integration_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestCLI_UpRecoversFromHalfInstall pins #146 / ADR 0046 end-to-end:
+// when a workspace is left half-installed (`.bones/agent.id` present
+// but `.bones/scaffold_version` absent) — the state a failed `bones up`
+// leaves behind — a subsequent `bones up` announces recovery on
+// stderr, re-runs scaffold idempotently, and writes the stamp.
+func TestCLI_UpRecoversFromHalfInstall(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip in -short: integration test")
+	}
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available; skipping up recovery integration")
+	}
+	dir := newWorkspace(t)
+	gitInit(t, dir)
+
+	// Stop the auto-started hub so the down/up cycle below isn't fighting
+	// a live process. Tear down everything via `bones down --yes` to get
+	// to a known-clean state, then synthesize the half-install:
+	// agent.id present, no stamp, no settings hooks.
+	if _, _, code := runCmd(t, bonesBin, dir, "down", "--yes"); code != 0 {
+		t.Fatalf("down --yes failed before recovery setup")
+	}
+
+	bones := filepath.Join(dir, ".bones")
+	if err := os.MkdirAll(bones, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(bones, "agent.id"),
+		[]byte("test-agent\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Note: no scaffold_version stamp — this is the half-install signal.
+
+	stdout, stderr, code := runCmd(t, bonesBin, dir, "up")
+	if code != 0 {
+		t.Fatalf("bones up after half-install: code=%d stderr=%s", code, stderr)
+	}
+	t.Cleanup(func() { _, _, _ = runCmd(t, bonesBin, dir, "down", "--yes") })
+
+	// Recovery announcement must land on stderr.
+	if !strings.Contains(stderr, "scaffold incomplete from prior run") {
+		t.Errorf("recovery announcement missing from stderr:\n%s\n--- stdout ---\n%s",
+			stderr, stdout)
+	}
+
+	// Stamp must be written.
+	if _, err := os.Stat(filepath.Join(bones, "scaffold_version")); err != nil {
+		t.Errorf("scaffold_version stamp not written by recovery: %v", err)
+	}
+	// Settings hooks must be installed.
+	settingsData, err := os.ReadFile(filepath.Join(dir, ".claude", "settings.json"))
+	if err != nil {
+		t.Fatalf("read settings.json: %v", err)
+	}
+	body := string(settingsData)
+	for _, want := range []string{"bones tasks prime --json", "bones hub start"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("settings.json missing %q after recovery:\n%s", want, body)
+		}
+	}
+}
+
+// TestCLI_UpFreshNoRecoveryAnnouncement pins that a clean fresh
+// `bones up` (no prior agent.id, no prior stamp) does NOT print the
+// recovery line — it would be confusing on a brand-new workspace.
+func TestCLI_UpFreshNoRecoveryAnnouncement(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip in -short: integration test")
+	}
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available; skipping up integration")
+	}
+	dir := t.TempDir()
+	gitInit(t, dir)
+	t.Cleanup(func() { _, _, _ = runCmd(t, bonesBin, dir, "down", "--yes") })
+
+	_, stderr, code := runCmd(t, bonesBin, dir, "up")
+	if code != 0 {
+		t.Fatalf("bones up on fresh workspace: code=%d stderr=%s", code, stderr)
+	}
+
+	if strings.Contains(stderr, "scaffold incomplete from prior run") {
+		t.Errorf("fresh workspace should not print recovery announcement:\n%s",
+			stderr)
+	}
+}

--- a/docs/adr/0046-bones-up-resume-recovery.md
+++ b/docs/adr/0046-bones-up-resume-recovery.md
@@ -1,0 +1,66 @@
+# ADR 0046: `bones up` is the recovery verb for incomplete scaffolds
+
+## Context
+
+`bones up` runs in two sequential side-effect chains with no transaction boundary:
+
+1. **Workspace init.** Writes `.bones/agent.id` and triggers `workspace.Join`, which lazy-auto-starts the hub (per ADR 0041).
+2. **Orchestrator scaffold.** Runs `removeLegacyBonesSkills` → `writeAgentsMD` → `linkClaudeMD` → `mergeSettings` → `ensureGitignoreEntries` → `scaffoldver.Write` in fixed order, with no preflight pass.
+
+Any failure mid-step-2 leaves the workspace half-installed. The marker, the hub, and `AGENTS.md` may all be present while `.claude/settings.json` is empty (no SessionStart/PreCompact hooks) and `.bones/scaffold_version` is absent. On a subsequent `bones up`, the same code path runs — but `initOrJoinWorkspace` short-circuits to "already joined" and the same scaffold failure (or a different one) repeats with no signal that we are recovering from a prior incomplete state.
+
+Two coherent fix shapes were considered:
+
+- **Transactional `bones up`.** All-or-nothing: any scaffold failure rolls back filesystem state and stops the hub. Requires a preflight validate-all pass, a rollback handler, and either a `JoinNoAutoStart` variant of `workspace.Join` or a refactor that pulls hub auto-start out of `Join`. Each of those is a substantive change that touches ADR 0041's contract.
+- **Explicit partial-state with resume.** `bones up` accepts that failures happen mid-flight, but the half-state is *known* and `up` can resume from it. No rollback. Hub auto-start ordering is unchanged. Each scaffold step is verified to be idempotent against partial prior state; the redo IS the recovery.
+
+## Decision
+
+Adopt the resume model. `bones up` is the recovery verb.
+
+### Detection rule
+
+Recovery state is detected at the start of `runUp`, before `initOrJoinWorkspace`:
+
+- `.bones/agent.id` exists at the workspace root (step 1 succeeded in some prior run), AND
+- `scaffoldver.Read` returns the empty stamp (step 2 did not complete in any prior run).
+
+Both conditions must hold. A workspace with neither marker nor stamp is fresh. A workspace with both is fully scaffolded.
+
+### Behavior
+
+When recovery state is detected, `runUp` prints exactly one line to stderr before scaffold runs:
+
+```
+bones: scaffold incomplete from prior run — re-running scaffold
+```
+
+It then proceeds normally. Each step inside `scaffoldOrchestrator` converges on the same final state regardless of what subset of artifacts is already present:
+
+- `removeLegacyBonesSkills` skips missing dirs.
+- `writeAgentsMD` and `linkClaudeMD` are idempotent across the four shapes recognized by ADR 0042 + ADR 0045 (absent / bones-owned / user-authored regular file with managed block / user-authored without).
+- `mergeSettings` reads existing settings and re-merges; its `addHook` helper skips entries already present, and the prune helpers tolerate either the legacy or current shape. Starting from empty, partial bones hooks, or user hooks alongside partial bones hooks all produce identical final settings.
+- `ensureGitignoreEntries` whole-line-matches before appending.
+- `scaffoldver.Write` is the final step; its presence is the "scaffold complete" signal.
+
+### Hub auto-start ordering is unchanged
+
+`workspace.Join`'s lazy hub auto-start (per ADR 0041) stays where it is. The recovery path does not stop, restart, or reorder the hub. `hub.Start` is already idempotent; if the hub is healthy when recovery runs, the auto-start is a no-op.
+
+### No rollback handler
+
+`bones up` does not undo writes on failure. The half-installed state is the user's tradeoff for not paying for transactional semantics; recovery is a single re-run away.
+
+## Consequences
+
+A user who has hit a `bones up` failure (most commonly the issue #145 case before that fix landed, but generally any mid-scaffold error) can recover by running `bones up` again. The recovery announcement makes it obvious that something happened, so silent recovery doesn't leave the user wondering why a re-run worked after the previous error.
+
+`bones status` and `bones doctor` (per #147) also surface the half-installed state with WARN lines — so a user who doesn't immediately re-run sees the condition before swarm work resumes against an unconfigured workspace.
+
+The cost is small: a few-line detection helper, one stderr line, and a documented requirement that every scaffold step stay idempotent. No new package, no new flag, no ADR-0041 churn, no rollback handler.
+
+The main tradeoff is that a workspace can sit in the half-installed state indefinitely if the user ignores the warnings. The mitigation is that all three surface paths (`bones up`, `bones status`, `bones doctor`) flag it, and the resume path is the same verb the user would naturally re-run after seeing the prior failure.
+
+`bones down` already handles half-installed workspaces correctly: it removes `.bones/` (covering both `agent.id` and any incomplete state) and either strips bones-managed sections from user-authored CLAUDE.md / AGENTS.md or removes the bones-owned files outright. No special-case code is needed for the half-install case.
+
+A future preflight validate-all pass remains an option for polish, but is explicitly out of scope for this ADR. The redo loop is the primary mitigation; preflight would be optimization.


### PR DESCRIPTION
## Summary

- `bones up` is now the recovery verb for half-installed workspaces (per #146 / ADR 0046).
- `isIncompleteScaffold(cwd)` detects the recovery state (`.bones/agent.id` present + `.bones/scaffold_version` absent) before `initOrJoinWorkspace`.
- When recovery is detected, `runUp` prints one stderr line — `bones: scaffold incomplete from prior run — re-running scaffold` — then runs `scaffoldOrchestrator` normally. Every step inside is already idempotent against partial prior state.
- Hub auto-start ordering (ADR 0041) is unchanged. No rollback handler. No `JoinNoAutoStart` variant.
- ADR 0046 records the resume model and the rejected transactional alternative.
- Bonus fix: README's license link was wrapped in backticks, rendering as literal text instead of a clickable link.

Closes #146

## Test plan

- [x] `make check` passes (fmt-check, vet, lint, race, todo-check)
- [x] `go test -tags=otel -short ./...` passes (CI-equivalent)
- [x] `TestIsIncompleteScaffold_Fresh` — fresh dir not flagged
- [x] `TestIsIncompleteScaffold_FullyScaffolded` — agent.id + stamp not flagged
- [x] `TestIsIncompleteScaffold_HalfInstalled` — agent.id without stamp IS flagged
- [x] `TestScaffoldOrchestrator_RecoversFromHalfInstall` — scaffold against partial settings (only one of two bones hooks present) converges; second run is byte-identical (idempotency under partial state)
- [x] `TestCLI_UpRecoversFromHalfInstall` (integration) — synthesized half-install, `bones up` prints recovery announcement on stderr, writes stamp, completes hooks
- [x] `TestCLI_UpFreshNoRecoveryAnnouncement` (integration) — fresh workspace does NOT print recovery line
- [x] README license link verified to render correctly