### PR TITLE
fix(hub): bound NATS/Fossil drain on shutdown (#158)

### DIFF
--- a/cli/hub.go
+++ b/cli/hub.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	libfossilcli "github.com/danmestas/libfossil/cli"
 
@@ -48,6 +49,9 @@ type HubStartCmd struct {
 	// Pass an explicit non-zero port to pin.
 	FossilPort int `name:"fossil-port" default:"0" help:"Fossil HTTP port (0 = per-ws)"`
 	NATSPort   int `name:"nats-port" default:"0" help:"NATS client port (0 = per-ws)"`
+	// DrainTimeout bounds NATS/Fossil drain on shutdown before
+	// runForeground returns errDrainTimeout (non-zero exit). See #158.
+	DrainTimeout time.Duration `name:"drain-timeout" default:"30s" help:"max drain wait"` //nolint:lll
 }
 
 func (c *HubStartCmd) Run(g *libfossilcli.Globals) error {
@@ -66,6 +70,7 @@ func (c *HubStartCmd) Run(g *libfossilcli.Globals) error {
 		hub.WithFossilPort(c.FossilPort),
 		hub.WithNATSPort(c.NATSPort),
 		hub.WithDetach(c.Detach),
+		hub.WithDrainTimeout(c.DrainTimeout),
 	)
 }
 

--- a/internal/hub/hub.go
+++ b/internal/hub/hub.go
@@ -58,6 +58,20 @@ const natsBootstrapBackoff = 1 * time.Second
 // for a healthy hub to flush WAL and exit cleanly on TERM.
 var stopGrace = 2 * time.Second
 
+// defaultDrainTimeout bounds the in-process NATS shutdown wait and the
+// Fossil drain wait when ctx is canceled. Without a bound, a stuck
+// leaf or fossil checkpoint can keep the hub process alive
+// indefinitely — natsserver.Server.WaitForShutdown has no timeout
+// (#158). 30s is generous for a healthy shutdown and short enough
+// that operators do not wait minutes for force-kill escalation.
+const defaultDrainTimeout = 30 * time.Second
+
+// errDrainTimeout is returned from runForeground when the NATS or
+// Fossil drain blocks past the configured drain timeout. Surfaces a
+// non-zero exit code at the CLI so the parent can distinguish a clean
+// shutdown from a forced one.
+var errDrainTimeout = errors.New("hub: drain timeout exceeded")
+
 // Start brings up the orchestrator hub: a Fossil repository at
 // .bones/hub.fossil seeded from git-tracked files, a Fossil HTTP
 // server on the chosen port, and an embedded NATS JetStream server.
@@ -226,11 +240,59 @@ func runForeground(ctx context.Context, p paths, o opts) error {
 	<-ctx.Done()
 	fossilCancel()
 	natsSrv.Shutdown()
-	natsSrv.WaitForShutdown()
-	<-fossilDone
+
+	// Bound both drain waits so a stuck NATS connection (no leaf to
+	// disconnect) or a wedged Fossil checkpoint cannot keep this
+	// process alive forever (#158). On timeout, abandon the wait,
+	// log the forced exit, and propagate errDrainTimeout so the CLI
+	// exits non-zero.
+	natsDone := make(chan struct{})
+	go func() {
+		natsSrv.WaitForShutdown()
+		close(natsDone)
+	}()
+
+	var drainErr error
+	if err := waitOrTimeout(natsDone, o.drainTimeout); err != nil {
+		fmt.Fprintf(os.Stderr,
+			"hub: nats shutdown exceeded %s; forcing exit (#158)\n",
+			effectiveDrainTimeout(o.drainTimeout))
+		drainErr = err
+	}
+	if err := waitOrTimeout(fossilDone, o.drainTimeout); err != nil {
+		fmt.Fprintf(os.Stderr,
+			"hub: fossil drain exceeded %s; forcing exit (#158)\n",
+			effectiveDrainTimeout(o.drainTimeout))
+		drainErr = err
+	}
+
 	_ = os.Remove(p.fossilPid)
 	_ = os.Remove(p.natsPid)
-	return nil
+	return drainErr
+}
+
+// effectiveDrainTimeout returns d when positive, otherwise the package
+// default. Used so both runForeground's stderr lines and the actual
+// wait honor the same fallback.
+func effectiveDrainTimeout(d time.Duration) time.Duration {
+	if d <= 0 {
+		return defaultDrainTimeout
+	}
+	return d
+}
+
+// waitOrTimeout blocks until done is closed or timeout elapses. Returns
+// nil on close, errDrainTimeout on timeout. A zero or negative timeout
+// falls back to defaultDrainTimeout. Used to bound the NATS shutdown
+// wait and the Fossil drain so a stuck server cannot hang the hub
+// process forever (#158).
+func waitOrTimeout(done <-chan struct{}, timeout time.Duration) error {
+	select {
+	case <-done:
+		return nil
+	case <-time.After(effectiveDrainTimeout(timeout)):
+		return errDrainTimeout
+	}
 }
 
 // hubLogTail reads the last N lines (capped to ~2KB) of hub.log and
@@ -273,6 +335,7 @@ func spawnDetachedChild(p paths, o opts) error {
 	cmd := exec.Command(exe, "hub", "start",
 		"--fossil-port", strconv.Itoa(o.fossilPort),
 		"--nats-port", strconv.Itoa(o.natsPort),
+		"--drain-timeout", effectiveDrainTimeout(o.drainTimeout).String(),
 	)
 	cmd.Dir = p.root
 	cmd.Stdout = hubLog

--- a/internal/hub/options.go
+++ b/internal/hub/options.go
@@ -16,15 +16,18 @@
 //	  pid files. Idempotent: missing or stale pid files are not an error.
 package hub
 
+import "time"
+
 // Option configures Start.
 type Option func(*opts)
 
 // opts holds tunable behavior for Start. The exported Option constructors
 // are the only way to mutate this struct from outside the package.
 type opts struct {
-	fossilPort int
-	natsPort   int
-	detach     bool
+	fossilPort   int
+	natsPort     int
+	detach       bool
+	drainTimeout time.Duration
 }
 
 // defaults returns the production defaults: ports left zero so
@@ -33,7 +36,11 @@ type opts struct {
 // or pick a free port"; passing WithFossilPort(N) or WithNATSPort(N)
 // pins to N.
 func defaults() opts {
-	return opts{fossilPort: 0, natsPort: 0}
+	return opts{
+		fossilPort:   0,
+		natsPort:     0,
+		drainTimeout: defaultDrainTimeout,
+	}
 }
 
 // WithFossilPort pins the Fossil HTTP port. Zero means "let the hub
@@ -50,3 +57,14 @@ func WithNATSPort(p int) Option { return func(o *opts) { o.natsPort = p } }
 // (the default), Start blocks on ctx.Done() and shuts both servers down
 // cleanly when ctx is canceled.
 func WithDetach(d bool) Option { return func(o *opts) { o.detach = d } }
+
+// WithDrainTimeout bounds how long runForeground waits for the embedded
+// NATS server and the Fossil child to drain after ctx is canceled.
+// Without a bound, a stuck leaf or fossil checkpoint can keep the hub
+// process alive indefinitely (#158). On timeout the wait is abandoned,
+// a stderr log line records the forced exit, and Start returns a
+// non-nil error so the parent CLI exits non-zero. A zero or negative
+// value falls back to defaultDrainTimeout.
+func WithDrainTimeout(d time.Duration) Option {
+	return func(o *opts) { o.drainTimeout = d }
+}

--- a/internal/hub/runforeground_test.go
+++ b/internal/hub/runforeground_test.go
@@ -7,7 +7,61 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
+
+// TestWaitOrTimeout_DoneClosed asserts the bounded-wait helper returns
+// nil when its done channel closes before the timeout expires. This is
+// the happy path for runForeground's drain wait — NATS shutdown completes
+// in time and the hub exits cleanly.
+func TestWaitOrTimeout_DoneClosed(t *testing.T) {
+	done := make(chan struct{})
+	close(done)
+	if err := waitOrTimeout(done, 5*time.Second); err != nil {
+		t.Fatalf("waitOrTimeout(closed done): got err %v, want nil", err)
+	}
+}
+
+// TestWaitOrTimeout_Timeout asserts the helper returns errDrainTimeout
+// when its done channel never closes. This is the core mechanism that
+// prevents natsserver.WaitForShutdown from hanging the hub forever (#158).
+func TestWaitOrTimeout_Timeout(t *testing.T) {
+	never := make(chan struct{})
+	start := time.Now()
+	err := waitOrTimeout(never, 50*time.Millisecond)
+	elapsed := time.Since(start)
+	if !errors.Is(err, errDrainTimeout) {
+		t.Fatalf("waitOrTimeout(never): got err %v, want errDrainTimeout", err)
+	}
+	// Bound the lower edge so we know the timer actually fired (not a
+	// fast-path nil), and the upper edge so a regression that swaps in a
+	// 30s default timeout fails fast instead of running for half a minute.
+	if elapsed < 50*time.Millisecond {
+		t.Fatalf("waitOrTimeout: returned in %v, want >= 50ms", elapsed)
+	}
+	if elapsed > time.Second {
+		t.Fatalf("waitOrTimeout: returned in %v, want < 1s", elapsed)
+	}
+}
+
+// TestWaitOrTimeout_ZeroFallsBackToDefault asserts that a zero/negative
+// timeout uses defaultDrainTimeout rather than firing immediately. The
+// happy-path closure still returns nil because the channel closes well
+// before the default expires.
+func TestWaitOrTimeout_ZeroFallsBackToDefault(t *testing.T) {
+	done := make(chan struct{})
+	close(done)
+	if err := waitOrTimeout(done, 0); err != nil {
+		t.Fatalf("waitOrTimeout(zero, closed done): got err %v, want nil", err)
+	}
+	if err := waitOrTimeout(done, -5*time.Second); err != nil {
+		t.Fatalf("waitOrTimeout(negative, closed done): got err %v, want nil", err)
+	}
+	if defaultDrainTimeout != 30*time.Second {
+		t.Errorf("defaultDrainTimeout: got %v, want 30s — brief documents 30s",
+			defaultDrainTimeout)
+	}
+}
 
 // TestRunForeground_SeedFailureCleansSidecars asserts that when seed
 // fails after libfossil has begun creating SQLite sidecar files,


### PR DESCRIPTION
## Summary

- `runForeground`'s `natsSrv.WaitForShutdown()` is unbounded; a stuck leaf or wedged checkpoint pins the hub process indefinitely (observed at etime 25:10 in the wild on `bones hub start`).
- Wrap both drain waits in a `select` against `o.drainTimeout` (default 30s). On timeout, abandon the wait, log to stderr, and propagate `errDrainTimeout` so the CLI exits non-zero.
- Adds `--drain-timeout` to `bones hub start`, `WithDrainTimeout` Go option, and forwards the flag to the spawned detached child.

## Mechanics

- New helper `waitOrTimeout(done, timeout) error` returns `errDrainTimeout` when `done` does not close before `timeout`. Falls back to `defaultDrainTimeout = 30s` on zero/negative input.
- `runForeground` runs `natsSrv.WaitForShutdown` in a goroutine, races it against `o.drainTimeout`, and does the same for `fossilDone`. PID files are removed regardless of drain outcome so the next `bones hub start` sees clean state.
- `spawnDetachedChild` forwards `--drain-timeout` to the child so the running hub honors the operator's configured bound across the detach boundary.

## Test plan

- [x] `make check` (fmt-check, vet, lint, race, todo-check) — pass
- [x] `go test -race -short ./...` — pass
- [x] `go test -tags=otel -short ./...` — pass (replicates CI otel lane)
- [x] New unit tests in `internal/hub/runforeground_test.go`:
  - `TestWaitOrTimeout_DoneClosed` — happy path
  - `TestWaitOrTimeout_Timeout` — never-closes channel returns `errDrainTimeout` within bounded wall-clock
  - `TestWaitOrTimeout_ZeroFallsBackToDefault` — zero/negative timeout uses `defaultDrainTimeout`
- [ ] Manual: `bones hub start --drain-timeout=5s` followed by SIGTERM with a stuck leaf (deferred — would require integration harness with a stub leaf that ignores disconnect)

## Out of scope

- `bones hub start`'s "active-but-unresponsive prior process" cleanup is deferred. The drain bound here ensures the hub actually exits, so PID files get removed and the next `start` sees clean state. A live-but-unresponsive scenario (TCP probe failing on a live PID) is a separate detection problem.
- The active-slot refusal in `bones hub stop` belongs to #157, not here.

Closes #158