### PR TITLE
fix(hub): refuse stop on active slots, preserve URL across restart (#157)

### DIFF
--- a/cli/down.go
+++ b/cli/down.go
@@ -341,7 +341,10 @@ func planStopHub(root string, c *DownCmd) []downAction {
 		description: "stop hub (.bones/pids/{fossil,nats}.pid)",
 		do: func() error {
 			// Best-effort: an already-stopped hub must not fail down.
-			_ = hub.Stop(root)
+			// WithForce so the active-slot guard (#157) doesn't block
+			// down — bones down is an explicit destructive teardown
+			// the operator already confirmed.
+			_ = hub.Stop(root, hub.WithForce(true))
 			return nil
 		},
 	}}

--- a/cli/hub.go
+++ b/cli/hub.go
@@ -86,12 +86,19 @@ func warnScaffoldDrift(cwd string) {
 }
 
 // HubStopCmd wires `bones hub stop` to hub.Stop. Idempotent.
-type HubStopCmd struct{}
+//
+// --force overrides the active-slot safety check (#157). Without it,
+// stop refuses when any .bones/swarm/<slot>/leaf.pid points at a live
+// process, since restarting the hub on a different port would silently
+// break those leaves' cached NATS URLs.
+type HubStopCmd struct {
+	Force bool `name:"force" help:"stop even when swarm slots are active (#157)"`
+}
 
 func (c *HubStopCmd) Run(g *libfossilcli.Globals) error {
 	cwd, err := os.Getwd()
 	if err != nil {
 		return fmt.Errorf("cwd: %w", err)
 	}
-	return hub.Stop(cwd)
+	return hub.Stop(cwd, hub.WithForce(c.Force))
 }

--- a/internal/hub/hub.go
+++ b/internal/hub/hub.go
@@ -344,6 +344,30 @@ func spawnDetachedChild(p paths, o opts) error {
 	return nil
 }
 
+// StopOption configures Stop. Passed variadically so existing callers
+// using Stop(root) continue to compile without change.
+type StopOption func(*stopOpts)
+
+type stopOpts struct {
+	force bool
+}
+
+// WithForce overrides Stop's safety check that refuses a teardown
+// while any swarm slot has a live leaf process (#157). With
+// force=true, Stop proceeds regardless and the operator owns any
+// active leaves that lose their cached NATS URL when the hub
+// restarts on a different port. bones down passes WithForce(true)
+// since it is an explicit destructive teardown that has already
+// confirmed with the operator.
+func WithForce(force bool) StopOption {
+	return func(o *stopOpts) { o.force = force }
+}
+
+// ErrActiveSlots is returned by Stop when one or more swarm slots
+// have live leaf processes that would be silently disconnected by
+// tearing the hub down (#157). Use WithForce to override.
+var ErrActiveSlots = errors.New("hub: active swarm slots present")
+
 // Stop terminates the processes recorded in the pid files written by
 // Start and removes those pid files. SIGTERM first; if the process is
 // still alive after stopGrace, SIGKILL. Pid files are only removed
@@ -357,7 +381,24 @@ func spawnDetachedChild(p paths, o opts) error {
 // recorded pid matches os.Getpid(), Stop only removes the pid file.
 // The foreground Start has its own ctx-cancellation path; signaling
 // self would terminate the caller before it could clean up.
-func Stop(root string) (err error) {
+//
+// Active-slot guard (#157): without WithForce, Stop refuses if any
+// .bones/swarm/<slot>/leaf.pid points at a live process. That guard
+// surfaces ErrActiveSlots wrapped with the slot names so the operator
+// can close them first or pass --force.
+//
+// URL files (.bones/hub-{fossil,nats}-url) are preserved across Stop
+// so the next Start re-reads the previously-bound port via
+// resolvePorts. When the port is still free, the new hub binds the
+// same port and active leaves' cached NATS URLs keep working. Full
+// teardown (bones down) clears the URL files separately by removing
+// the entire .bones directory.
+func Stop(root string, options ...StopOption) (err error) {
+	so := stopOpts{}
+	for _, fn := range options {
+		fn(&so)
+	}
+
 	p, err := newPaths(root)
 	if err != nil {
 		return err
@@ -365,6 +406,19 @@ func Stop(root string) (err error) {
 
 	_, end := telemetry.RecordCommand(context.Background(), "hub.stop")
 	defer func() { end(err) }()
+
+	if !so.force {
+		if names, listErr := activeSlotNames(root); listErr != nil {
+			// Best-effort: a missing or unreadable swarm dir must not
+			// block stop. Log and proceed as if no slots were active.
+			fmt.Fprintf(os.Stderr,
+				"hub: warning: could not enumerate active slots: %v\n", listErr)
+		} else if len(names) > 0 {
+			return fmt.Errorf(
+				"%w: %s — close them first or pass --force",
+				ErrActiveSlots, strings.Join(names, ", "))
+		}
+	}
 
 	self := os.Getpid()
 	// Both servers share a single child process in the detached model,
@@ -381,11 +435,23 @@ func Stop(root string) (err error) {
 		}
 		_ = os.Remove(pidFile)
 	}
-	// Clear the recorded URL files so subsequent FossilURL/NATSURL
-	// callers see the hub as down.
-	_ = os.Remove(p.fossilURL)
-	_ = os.Remove(p.natsURL)
 	return nil
+}
+
+// activeSlotNames returns the names of swarm slots whose leaf.pid
+// points at a still-alive process. Wraps slotgc.LiveSlots so Stop's
+// active-slot check shares a single source of truth with bones down's
+// orphan reaping (#157).
+func activeSlotNames(root string) ([]string, error) {
+	live, err := slotgc.LiveSlots(root)
+	if err != nil {
+		return nil, fmt.Errorf("list active slots: %w", err)
+	}
+	names := make([]string, 0, len(live))
+	for _, s := range live {
+		names = append(names, s.Name)
+	}
+	return names, nil
 }
 
 // terminateProcess sends SIGTERM, polls until stopGrace elapses, and

--- a/internal/hub/stop_active_slot_test.go
+++ b/internal/hub/stop_active_slot_test.go
@@ -1,0 +1,151 @@
+package hub
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestStop_RefusesWithActiveSlots asserts the active-slot safety guard
+// in #157. Stop without WithForce must return ErrActiveSlots when any
+// .bones/swarm/<slot>/leaf.pid points at a live process, naming the
+// offending slot(s) and the --force escape hatch in the error string.
+func TestStop_RefusesWithActiveSlots(t *testing.T) {
+	root := t.TempDir()
+
+	// Plant a live "leaf" — sleep is portable and harmless.
+	pidPath, sleepCmd := plantLiveSlot(t, root, "test-slot")
+	defer cleanupCmd(sleepCmd)
+
+	err := Stop(root)
+	if !errors.Is(err, ErrActiveSlots) {
+		t.Fatalf("Stop with active slot: got err %v, want ErrActiveSlots", err)
+	}
+	if !strings.Contains(err.Error(), "test-slot") {
+		t.Errorf("error should name the active slot; got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "--force") {
+		t.Errorf("error should mention --force escape hatch; got: %v", err)
+	}
+
+	// Pid file must still exist — Stop refused, no destructive side-effect.
+	if _, statErr := os.Stat(pidPath); statErr != nil {
+		t.Errorf("leaf.pid should be preserved when Stop refuses: %v", statErr)
+	}
+}
+
+// TestStop_WithForceOverrides asserts that Stop(root, WithForce(true))
+// proceeds despite active slots. No leaf process is killed by Stop —
+// the guard is a CLI-level safety, not a leaf-reaper. Stop just stops
+// declining to teardown the hub processes.
+func TestStop_WithForceOverrides(t *testing.T) {
+	root := t.TempDir()
+	_, sleepCmd := plantLiveSlot(t, root, "force-slot")
+	defer cleanupCmd(sleepCmd)
+
+	// No hub pid files exist, so Stop's signal loop is a no-op. The
+	// only thing this asserts is that the active-slot check does not
+	// reject the call when WithForce(true) is passed.
+	if err := Stop(root, WithForce(true)); err != nil {
+		t.Fatalf("Stop --force with active slot: got err %v, want nil", err)
+	}
+}
+
+// TestStop_PreservesURLFiles asserts the port-preservation contract
+// (#157): Stop must NOT remove .bones/hub-{fossil,nats}-url so the
+// next Start re-reads the recorded port via resolvePorts. When the
+// port is still free, the new hub binds the same port and active
+// leaves' cached NATS URLs keep working across the restart.
+//
+// bones down is the channel for full URL clearing — it removes the
+// entire .bones/ directory (planRemoveBonesDir).
+func TestStop_PreservesURLFiles(t *testing.T) {
+	root := t.TempDir()
+	p, err := newPaths(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(p.orchDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Plant URL files as if a Start had bound real ports.
+	if err := os.WriteFile(p.fossilURL, []byte("http://127.0.0.1:60778\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p.natsURL, []byte("nats://127.0.0.1:60779\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Stop(root); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+
+	// Both URL files must survive so resolvePorts reuses the recorded
+	// port on next Start.
+	for _, urlFile := range []string{p.fossilURL, p.natsURL} {
+		if _, statErr := os.Stat(urlFile); statErr != nil {
+			t.Errorf("%s should be preserved across Stop: %v",
+				filepath.Base(urlFile), statErr)
+		}
+	}
+}
+
+// TestActiveSlotNames_NoSwarmDir asserts activeSlotNames returns
+// (nil, nil) when .bones/swarm doesn't exist, so Stop on a fresh
+// workspace doesn't trip on a missing directory.
+func TestActiveSlotNames_NoSwarmDir(t *testing.T) {
+	root := t.TempDir()
+	names, err := activeSlotNames(root)
+	if err != nil {
+		t.Fatalf("activeSlotNames(empty workspace): err %v", err)
+	}
+	if len(names) != 0 {
+		t.Errorf("activeSlotNames(empty): got %v, want empty", names)
+	}
+}
+
+// plantLiveSlot creates .bones/swarm/<slot>/leaf.pid pointing at a
+// live `sleep 30` subprocess. Returns the pid file path and the
+// command so the test can clean up. The sleep duration is long enough
+// that it stays alive for any reasonable test runtime, short enough
+// that an aborted test doesn't leave a long-running orphan.
+func plantLiveSlot(t *testing.T, root, slot string) (string, *exec.Cmd) {
+	t.Helper()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("plantLiveSlot relies on `sleep`; skipping on windows")
+	}
+	cmd := exec.Command("sleep", "30")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("spawn sleep: %v", err)
+	}
+
+	slotDir := filepath.Join(root, ".bones", "swarm", slot)
+	if err := os.MkdirAll(slotDir, 0o755); err != nil {
+		_ = cmd.Process.Kill()
+		t.Fatalf("mkdir slot dir: %v", err)
+	}
+	pidPath := filepath.Join(slotDir, "leaf.pid")
+	if err := os.WriteFile(pidPath, []byte(strconv.Itoa(cmd.Process.Pid)+"\n"), 0o644); err != nil {
+		_ = cmd.Process.Kill()
+		t.Fatalf("write leaf.pid: %v", err)
+	}
+
+	// Brief settle so the process is observable in /proc / kill -0.
+	time.Sleep(20 * time.Millisecond)
+	return pidPath, cmd
+}
+
+func cleanupCmd(cmd *exec.Cmd) {
+	if cmd != nil && cmd.Process != nil {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	}
+}

--- a/internal/hub/url_test.go
+++ b/internal/hub/url_test.go
@@ -143,10 +143,18 @@ func TestFossilURL_RoundTrip(t *testing.T) {
 	}
 }
 
-// TestStartStopWritesAndRemovesURLFiles is a thin assert layered on the
-// existing round-trip: after Start binds, the URL files exist; after
-// Stop, they're gone.
-func TestStartStopWritesAndRemovesURLFiles(t *testing.T) {
+// TestStartWritesURLFilesStopPreserves layers a thin assert on the
+// existing round-trip: resolvePorts writes the URL files, FossilURL
+// reads them back, and Stop preserves them so the next Start can
+// re-read the recorded port (#157 port preservation across stop/start).
+//
+// Pre-#157 contract was that Stop removed the URL files. The active-
+// leaf desync surfaced in #157 forced the swap: leaves that cached a
+// NATS URL at workspace.Join time must keep working across a hub
+// restart when the port is still free, which only works if the
+// recorded URL survives Stop. Full teardown (bones down) clears them
+// separately by removing the entire .bones/ directory.
+func TestStartWritesURLFilesStopPreserves(t *testing.T) {
 	root := t.TempDir()
 	p, err := newPaths(root)
 	if err != nil {
@@ -169,13 +177,14 @@ func TestStartStopWritesAndRemovesURLFiles(t *testing.T) {
 	if got := FossilURL(root); got != want {
 		t.Errorf("FossilURL = %q, want %q", got, want)
 	}
-	// Stop removes URL files.
+	// Stop preserves URL files (#157).
 	if err := Stop(root); err != nil {
 		t.Fatal(err)
 	}
 	for _, path := range []string{p.fossilURL, p.natsURL} {
-		if _, err := os.Stat(path); !os.IsNotExist(err) {
-			t.Errorf("URL file %s still present after Stop", filepath.Base(path))
+		if _, err := os.Stat(path); err != nil {
+			t.Errorf("URL file %s should be preserved across Stop (#157): %v",
+				filepath.Base(path), err)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- `hub.Stop` tore down without checking active swarm leaves AND removed `.bones/hub-{fossil,nats}-url`, so a restart bound a fresh ephemeral port and every active leaf's cached NATS URL pointed at a defunct port (surfacing later as the AnnounceHolds errors in #155).
- Two coupled changes:
  1. **Active-slot guard**: `Stop` now refuses by default when any `.bones/swarm/<slot>/leaf.pid` is live, returns `ErrActiveSlots` with the slot names. `bones hub stop --force` overrides.
  2. **Port preservation**: `Stop` no longer removes URL files. `resolvePorts` already prefers the recorded URL when port=0, so the next `Start` re-binds the previously-bound port if it's still free, and active leaves' cached URLs keep working.

## Mechanics

- New `StopOption` functional-options type; existing `Stop(root)` callers compile unchanged via the variadic API.
- `WithForce(bool)` — override the active-slot guard.
- `activeSlotNames(root)` wraps `slotgc.LiveSlots` so the active-slot check shares one source of truth with `bones down`'s leaf reaping.
- `bones down` passes `WithForce(true)` because it's an explicit destructive teardown the operator already confirmed; `planRemoveBonesDir` then nukes the URL files along with the rest of `.bones/`.

## Test plan

- [x] `make lint vet fmt-check todo-check` — pass
- [x] `go test -race -short ./...` — pass
- [x] `go test -tags=otel -short ./...` — pass (CI otel lane)
- [x] New tests in `internal/hub/stop_active_slot_test.go`:
  - `TestStop_RefusesWithActiveSlots` — error wraps `ErrActiveSlots`, names the slot, mentions `--force`
  - `TestStop_WithForceOverrides` — `WithForce(true)` proceeds despite live leaf
  - `TestStop_PreservesURLFiles` — URL files survive `Stop`
  - `TestActiveSlotNames_NoSwarmDir` — empty workspace returns `(nil, nil)`
- [x] Updated `TestStartStopWritesAndRemovesURLFiles` → `TestStartWritesURLFilesStopPreserves` to match the new contract.

## Out of scope

- **Migrate-active-slots-on-restart** is the deferred follow-up for #157. This PR ships "refuse + record port" only — leaves are not auto-reconnected, but their cached URL keeps working when the port is free.
- The leaf-side reconnect logic for port drift (issue #155).
- The drain timeout (#158, in #160).

Closes #157