### PR TITLE
feat(dispatch): add SubstrateError/SubstrateFault to ResultMessage (#159)

### DIFF
--- a/cli/swarm_close.go
+++ b/cli/swarm_close.go
@@ -24,14 +24,22 @@ import (
 // record (already closed) is not an error so re-running close
 // after a crash converges.
 type SwarmCloseCmd struct {
-	Slot       string `name:"slot" help:"slot (defaults to single active slot on host)"`
-	Result     string `name:"result" default:"success" help:"success|fail|fork"`
-	Summary    string `name:"summary" default:"swarm close" help:"final summary"`
-	Branch     string `name:"branch" help:"only with --result=fork: branch name"`
-	Rev        string `name:"rev" help:"only with --result=fork: rev"`
-	HubURL     string `name:"hub-url" help:"override hub fossil HTTP URL"`
-	NoArtifact string `name:"no-artifact" help:"reason for closing success without a commit"`
-	KeepWT     bool   `name:"keep-wt" help:"retain wt dir on success (default: remove)"`
+	Slot    string `name:"slot" help:"slot (defaults to single active slot on host)"`
+	Result  string `name:"result" default:"success" help:"success|fail|fork"`
+	Summary string `name:"summary" default:"swarm close" help:"final summary"`
+	Branch  string `name:"branch" help:"only with --result=fork: branch name"`
+	Rev     string `name:"rev" help:"only with --result=fork: rev"`
+	HubURL  string `name:"hub-url" help:"override hub fossil HTTP URL"`
+	// SubstrateError / SubstrateFault expose the dispatch.ResultMessage
+	// substrate fields added in #159 so a wrapper or orchestrator can
+	// signal explicitly that bones (not the agent) hit a failure on
+	// the close path. The flags are separate from --summary because
+	// --summary is the agent's intent and must reach darken verbatim;
+	// these markers are bones-side observations.
+	SubstrateError string `name:"substrate-error" help:"free-text substrate failure (#159)"`
+	SubstrateFault string `name:"substrate-fault" help:"substrate fault category (#159)"`
+	NoArtifact     string `name:"no-artifact" help:"reason for closing success without a commit"`
+	KeepWT         bool   `name:"keep-wt" help:"retain wt dir on success (default: remove)"`
 }
 
 func (c *SwarmCloseCmd) Run(g *libfossilcli.Globals) error {
@@ -124,10 +132,12 @@ func (c *SwarmCloseCmd) postResult(
 	}
 	defer func() { _ = co.Close() }()
 	msg := dispatch.ResultMessage{
-		Kind:    dispatch.ResultKind(c.Result),
-		Summary: c.Summary,
-		Branch:  c.Branch,
-		Rev:     c.Rev,
+		Kind:           dispatch.ResultKind(c.Result),
+		Summary:        c.Summary,
+		Branch:         c.Branch,
+		Rev:            c.Rev,
+		SubstrateError: c.SubstrateError,
+		SubstrateFault: c.SubstrateFault,
 	}
 	if err := co.Post(ctx, taskID, []byte(dispatch.FormatResult(msg))); err != nil {
 		return fmt.Errorf("post result: %w", err)

--- a/internal/dispatch/result.go
+++ b/internal/dispatch/result.go
@@ -10,24 +10,60 @@ const (
 	ResultFail    ResultKind = "fail"
 )
 
+// ResultMessage is the dispatch payload posted on the task thread when
+// a swarm slot closes. Kind + Summary are agent intent; Branch + Rev
+// describe a fork outcome. SubstrateError and SubstrateFault are
+// substrate-level signals — populated when bones (not the agent)
+// observed a failure on the close path, so a downstream orchestrator
+// can distinguish "agent didn't accomplish X" from "the substrate
+// blocked the agent from accomplishing X" (#159).
+//
+// SubstrateError is a free-text message (e.g. "swarm commit failed:
+// nats: no responders"). SubstrateFault is a short category tag
+// (e.g. "commit-failed", "hub-unreachable") for orchestrator-side
+// branching without parsing free text.
 type ResultMessage struct {
-	Kind    ResultKind
-	Summary string
-	Branch  string
-	Rev     string
+	Kind           ResultKind
+	Summary        string
+	Branch         string
+	Rev            string
+	SubstrateError string
+	SubstrateFault string
 }
 
+// FormatResult serializes msg as a pipe-delimited dispatch payload.
+// The wire format is positional — index 0 is the literal
+// "dispatch-result" tag, 1 is kind, 2 is summary, 3 is branch, 4 is
+// rev, 5 is substrate_error, 6 is substrate_fault. To preserve
+// position when an early field is empty but a later one is set,
+// empty-string placeholders fill the gaps. Trailing empty fields
+// are elided so format output for messages without substrate data
+// is unchanged from the pre-#159 schema.
 func FormatResult(msg ResultMessage) string {
 	parts := []string{"dispatch-result", string(msg.Kind), msg.Summary}
-	if msg.Branch != "" {
-		parts = append(parts, msg.Branch)
+
+	optional := []string{
+		msg.Branch,
+		msg.Rev,
+		msg.SubstrateError,
+		msg.SubstrateFault,
 	}
-	if msg.Rev != "" {
-		parts = append(parts, msg.Rev)
+	highest := -1
+	for i, v := range optional {
+		if v != "" {
+			highest = i
+		}
+	}
+	for i := 0; i <= highest; i++ {
+		parts = append(parts, optional[i])
 	}
 	return strings.Join(parts, "|")
 }
 
+// ParseResult deserializes a pipe-delimited dispatch payload. Missing
+// trailing fields are treated as empty strings so consumers reading
+// the older 3/4/5-field format continue to work. Unknown Kind values
+// are rejected.
 func ParseResult(body string) (ResultMessage, bool) {
 	parts := strings.Split(body, "|")
 	if len(parts) < 3 || parts[0] != "dispatch-result" {
@@ -42,6 +78,12 @@ func ParseResult(body string) (ResultMessage, bool) {
 	}
 	if len(parts) > 4 {
 		msg.Rev = parts[4]
+	}
+	if len(parts) > 5 {
+		msg.SubstrateError = parts[5]
+	}
+	if len(parts) > 6 {
+		msg.SubstrateFault = parts[6]
 	}
 	switch msg.Kind {
 	case ResultSuccess, ResultFork, ResultFail:

--- a/internal/dispatch/result_test.go
+++ b/internal/dispatch/result_test.go
@@ -37,3 +37,106 @@ func TestParseResult_RejectsUnknownMessage(t *testing.T) {
 		t.Fatal("expected non-result message to be rejected")
 	}
 }
+
+// TestFormatAndParseResult_WithSubstrateError exercises the additive
+// schema fields introduced for #159: when SubstrateError is set,
+// FormatResult emits empty placeholders for branch and rev so the
+// substrate field lands at the documented index 5. ParseResult must
+// recover the field from that index.
+func TestFormatAndParseResult_WithSubstrateError(t *testing.T) {
+	msg := FormatResult(ResultMessage{
+		Kind:           ResultSuccess,
+		Summary:        "design + plan written to slot worktree on disk",
+		SubstrateError: "swarm commit failed: nats: no responders",
+	})
+	got, ok := ParseResult(msg)
+	if !ok {
+		t.Fatalf("ParseResult(%q): ok=false", msg)
+	}
+	if got.Summary != "design + plan written to slot worktree on disk" {
+		t.Errorf("Summary not preserved verbatim: %q", got.Summary)
+	}
+	if got.SubstrateError != "swarm commit failed: nats: no responders" {
+		t.Errorf("SubstrateError = %q", got.SubstrateError)
+	}
+	if got.Branch != "" || got.Rev != "" {
+		t.Errorf("expected empty branch/rev, got branch=%q rev=%q",
+			got.Branch, got.Rev)
+	}
+}
+
+// TestFormatAndParseResult_WithSubstrateFault asserts the
+// orchestrator-friendly category tag round-trips at index 6. Branch
+// and rev are unset; the placeholder behavior must keep the fault
+// at the right position.
+func TestFormatAndParseResult_WithSubstrateFault(t *testing.T) {
+	msg := FormatResult(ResultMessage{
+		Kind:           ResultFail,
+		Summary:        "could not commit",
+		SubstrateFault: "hub-unreachable",
+	})
+	got, ok := ParseResult(msg)
+	if !ok {
+		t.Fatalf("ParseResult(%q): ok=false", msg)
+	}
+	if got.SubstrateFault != "hub-unreachable" {
+		t.Errorf("SubstrateFault = %q", got.SubstrateFault)
+	}
+	if got.SubstrateError != "" {
+		t.Errorf("SubstrateError should be empty, got %q", got.SubstrateError)
+	}
+}
+
+// TestFormatAndParseResult_AllFields covers the full 7-field
+// positional payload to lock the wire format end-to-end.
+func TestFormatAndParseResult_AllFields(t *testing.T) {
+	in := ResultMessage{
+		Kind:           ResultFork,
+		Summary:        "needs merge",
+		Branch:         "fork-branch",
+		Rev:            "abc123",
+		SubstrateError: "race against parent",
+		SubstrateFault: "fork-required",
+	}
+	wire := FormatResult(in)
+	got, ok := ParseResult(wire)
+	if !ok {
+		t.Fatalf("ParseResult(%q): ok=false", wire)
+	}
+	if got != in {
+		t.Errorf("round-trip differs:\n got = %+v\nwant = %+v", got, in)
+	}
+}
+
+// TestFormatResult_ElidesTrailingEmpty asserts that messages without
+// any optional fields keep the pre-#159 wire footprint — three
+// pipe-delimited segments, no trailing empty placeholders. Old
+// consumers reading by index continue to work unchanged.
+func TestFormatResult_ElidesTrailingEmpty(t *testing.T) {
+	wire := FormatResult(ResultMessage{Kind: ResultSuccess, Summary: "done"})
+	if wire != "dispatch-result|success|done" {
+		t.Errorf("wire = %q, want %q", wire, "dispatch-result|success|done")
+	}
+}
+
+// TestParseResult_AcceptsLegacyShortPayload asserts that payloads
+// from pre-#159 producers (3 to 5 fields) parse correctly with
+// SubstrateError and SubstrateFault defaulting to empty strings.
+func TestParseResult_AcceptsLegacyShortPayload(t *testing.T) {
+	cases := []string{
+		"dispatch-result|success|done",
+		"dispatch-result|fork|merge|fork-branch",
+		"dispatch-result|fork|merge|fork-branch|abc123",
+	}
+	for _, c := range cases {
+		got, ok := ParseResult(c)
+		if !ok {
+			t.Errorf("ParseResult(%q): ok=false", c)
+			continue
+		}
+		if got.SubstrateError != "" || got.SubstrateFault != "" {
+			t.Errorf("ParseResult(%q): substrate fields should default empty, got %+v",
+				c, got)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

The pipe-delimited dispatch payload had no schema slot to distinguish agent-supplied summary from substrate-failure markers. A downstream orchestrator (darken) couldn't tell "the agent's intent" apart from "what bones observed went wrong on the way out", so a substrate-induced close surfaced as a false deviation/fabrication signal against honest subagents.

This PR ships **option A** from the triage: extend `dispatch.ResultMessage` additively with two new positional fields. No wire-format break for existing consumers.

## Mechanics

- New fields: `SubstrateError` (free-text, e.g. `swarm commit failed: nats: no responders`) and `SubstrateFault` (category tag, e.g. `commit-failed`, `hub-unreachable`) at wire indices 5 and 6.
- `FormatResult` fills empty placeholders for branch/rev when a substrate field is set so positions stay aligned. Trailing-empty fields are elided, so a payload with no substrate data keeps the pre-#159 wire footprint and old index-based consumers continue to work.
- `ParseResult` reads the new indices and treats missing trailing fields as empty strings (forward + backward compatible).
- `bones swarm close --substrate-error="..." --substrate-fault="..."` exposes the new fields so an orchestrator wrapper can populate markers when bones observes a close-path failure that wasn't the agent's doing.

## Test plan

- [x] `make lint vet fmt-check todo-check` — pass
- [x] `go test -race -short ./...` — pass
- [x] `go test -tags=otel -short ./...` — pass (CI otel lane)
- [x] New tests in `internal/dispatch/result_test.go`:
  - `TestFormatAndParseResult_WithSubstrateError` — round-trip with only error set, branch/rev placeholders
  - `TestFormatAndParseResult_WithSubstrateFault` — round-trip with only fault set
  - `TestFormatAndParseResult_AllFields` — full 7-field positional payload
  - `TestFormatResult_ElidesTrailingEmpty` — no-substrate payload keeps the 3-field shape (backward compat)
  - `TestParseResult_AcceptsLegacyShortPayload` — pre-#159 producers (3/4/5-field) parse with empty substrate fields

## Out of scope

- Auto-population of substrate fields from inside bones when commit fails — left as a follow-up. The schema lands now; orchestrators (or a future bones close path) can populate later without another wire change.
- Switching the wire format to JSON (option B from triage) — viable long-term but requires darken-side coordination; we land schema slots additively now and revisit format choice if the position-based approach proves limiting.

Closes #159