### PR TITLE
fix(swarm): preserve wt/ to recovery dir before success-close (#156)

### DIFF
--- a/docs/adr/0028-bones-swarm-verbs.md
+++ b/docs/adr/0028-bones-swarm-verbs.md
@@ -192,6 +192,15 @@ fail/fork, releases the claim only — task stays open for human
 inspection. `wt/` and `leaf.fossil` stay for forensics until
 explicit `bones swarm prune <slot>`.
 
+**Success-close salvage trail.** Before destroying `wt/` on
+success-close (without `--keep-wt`), bones copies any files in the
+worktree to `.bones/recovery/<slot>-<unix-ts>/`. The recovery dir is
+not auto-pruned — the operator decides when to clean it. The "success
+cleans" contract still holds: `wt/` is unconditionally removed; the
+recovery dir is the salvage trail for cases where files were left
+behind (commit failed earlier, files written after the last commit,
+etc.) so the destroy doesn't silently lose work.
+
 **`swarm status` / `swarm cwd` / `swarm tasks`** — read-only.
 `status` iterates `bones-swarm-sessions` and combines KV
 `last_renewed` with a local PID probe (when `host` matches). `cwd`

--- a/internal/swarm/lease.go
+++ b/internal/swarm/lease.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -672,6 +673,24 @@ func (l *ResumedLease) Close(ctx context.Context, opts CloseOpts) error {
 	}
 	l.teardown()
 	if opts.CloseTaskOnSuccess && !opts.KeepWT {
+		// #156 safety net: copy wt/ contents into
+		// .bones/recovery/<slot>-<unix-ts>/ before destroying so a
+		// successful close that nonetheless leaves uncommitted files
+		// behind (commit failed earlier, agent wrote files post-commit,
+		// etc.) doesn't silently lose them. ADR 0028's "success cleans"
+		// contract still holds — wt is removed unconditionally below;
+		// the recovery dir is the salvage trail, not a replacement
+		// worktree.
+		if path, count, err := preserveWorktree(
+			l.info.WorkspaceDir, l.slot, l.now(),
+		); err != nil {
+			fmt.Fprintf(os.Stderr,
+				"swarm.ResumedLease.Close: warning: preserve wt failed: %v\n", err)
+		} else if count > 0 {
+			fmt.Fprintf(os.Stderr,
+				"swarm.ResumedLease.Close: preserved %d file(s) at %s (#156)\n",
+				count, path)
+		}
 		// Best-effort idempotent removal: missing wt is fine. A
 		// permission-style error would propagate via os.RemoveAll's
 		// own retry semantics; in practice the slot's leaf is the
@@ -1085,6 +1104,123 @@ func writePidFile(workspaceDir, slot string) error {
 	}
 	if err := os.WriteFile(pidPath, []byte(strconv.Itoa(os.Getpid())+"\n"), 0o644); err != nil {
 		return fmt.Errorf("write pid file: %w", err)
+	}
+	return nil
+}
+
+// preserveWorktree copies the slot's wt/ contents into
+// .bones/recovery/<slot>-<unix-ts>/ before a success-close destroys
+// the worktree (#156). Returns the destination path and the count of
+// files copied; ("", 0, nil) when wt is missing or has no files
+// (callers branch on count > 0 to decide whether to print the
+// operator-visible "preserved N files" notice).
+//
+// Best-effort intent: an error here must not block the close. The
+// caller logs and proceeds — the alternative (refusing to close, or
+// destroying without preserving) is worse than partial salvage.
+//
+// Recovery dirs are not auto-pruned; the operator decides when to
+// clean .bones/recovery/. This is the safety-net contract: if bones
+// destroyed work, a copy is on disk until the operator says otherwise.
+func preserveWorktree(workspaceDir, slot string, now time.Time) (string, int, error) {
+	wt := SlotWorktree(workspaceDir, slot)
+	info, err := os.Stat(wt)
+	if errors.Is(err, os.ErrNotExist) {
+		return "", 0, nil
+	}
+	if err != nil {
+		return "", 0, fmt.Errorf("stat wt: %w", err)
+	}
+	if !info.IsDir() {
+		return "", 0, nil
+	}
+
+	count, err := countFiles(wt)
+	if err != nil {
+		return "", 0, fmt.Errorf("walk wt: %w", err)
+	}
+	if count == 0 {
+		return "", 0, nil
+	}
+
+	recoveryName := fmt.Sprintf("%s-%d", slot, now.Unix())
+	recoveryDir := filepath.Join(workspaceDir, ".bones", "recovery", recoveryName)
+	if err := os.MkdirAll(recoveryDir, 0o755); err != nil {
+		return "", 0, fmt.Errorf("mkdir recovery: %w", err)
+	}
+
+	if err := copyTree(wt, recoveryDir); err != nil {
+		return recoveryDir, 0, fmt.Errorf("copy wt: %w", err)
+	}
+	return recoveryDir, count, nil
+}
+
+// countFiles walks root and returns the number of regular files. Used
+// by preserveWorktree to decide whether the recovery copy is worth
+// doing — an empty wt has nothing to salvage.
+func countFiles(root string) (int, error) {
+	count := 0
+	err := filepath.WalkDir(root, func(_ string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if !d.IsDir() {
+			count++
+		}
+		return nil
+	})
+	return count, err
+}
+
+// copyTree mirrors src into dst, creating subdirectories and copying
+// regular files with their permission bits preserved. Symlinks and
+// other non-regular files are skipped — the slot worktree is a leaf
+// checkout that does not currently produce them, and silently
+// dereferencing a symlink target into a recovery copy could mislead
+// the operator about what was actually preserved.
+func copyTree(src, dst string) error {
+	return filepath.WalkDir(src, func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		if rel == "." {
+			return nil
+		}
+		target := filepath.Join(dst, rel)
+		if d.IsDir() {
+			return os.MkdirAll(target, 0o755)
+		}
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		if !info.Mode().IsRegular() {
+			return nil
+		}
+		return copyFile(path, target, info.Mode().Perm())
+	})
+}
+
+// copyFile is a stdlib-only file copy that preserves the source mode
+// bits. Stops short of full os.Chown / mtime preservation since the
+// recovery dir is for salvage inspection, not bit-perfect mirroring.
+func copyFile(src, dst string, perm os.FileMode) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = in.Close() }()
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, perm)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = out.Close() }()
+	if _, err := io.Copy(out, in); err != nil {
+		return err
 	}
 	return nil
 }

--- a/internal/swarm/recovery_test.go
+++ b/internal/swarm/recovery_test.go
@@ -1,0 +1,181 @@
+package swarm
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestPreserveWorktree_NoWT asserts the no-op contract: a missing
+// wt directory returns ("", 0, nil) so success-close on a slot that
+// already lost its worktree (crash, manual cleanup) doesn't trip on
+// the preservation step. Mirrors TestClose_IdempotentMissingWT for
+// the bare helper.
+func TestPreserveWorktree_NoWT(t *testing.T) {
+	root := t.TempDir()
+	path, count, err := preserveWorktree(root, "missing", time.Now())
+	if err != nil {
+		t.Fatalf("preserveWorktree(missing wt): err %v", err)
+	}
+	if path != "" || count != 0 {
+		t.Errorf("missing wt: got (%q, %d), want (\"\", 0)", path, count)
+	}
+}
+
+// TestPreserveWorktree_EmptyWT asserts that a wt directory with no
+// files (no subdirs with files either) skips the recovery copy. The
+// safety net only fires when there's something to salvage.
+func TestPreserveWorktree_EmptyWT(t *testing.T) {
+	root := t.TempDir()
+	wt := SlotWorktree(root, "empty")
+	if err := os.MkdirAll(wt, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path, count, err := preserveWorktree(root, "empty", time.Now())
+	if err != nil {
+		t.Fatalf("preserveWorktree(empty wt): err %v", err)
+	}
+	if path != "" || count != 0 {
+		t.Errorf("empty wt: got (%q, %d), want (\"\", 0)", path, count)
+	}
+	// Recovery dir must NOT have been created — the helper's contract
+	// is that the operator only sees recovery/ when there's a salvage.
+	recoveryRoot := filepath.Join(root, ".bones", "recovery")
+	if _, err := os.Stat(recoveryRoot); !os.IsNotExist(err) {
+		t.Errorf("recovery/ should not exist for empty wt: stat err=%v", err)
+	}
+}
+
+// TestPreserveWorktree_CopiesFlatTree exercises the salvage path: a
+// wt with files (no subdirs) gets copied to .bones/recovery/<slot>-<ts>
+// with file content preserved.
+func TestPreserveWorktree_CopiesFlatTree(t *testing.T) {
+	root := t.TempDir()
+	wt := SlotWorktree(root, "flat")
+	if err := os.MkdirAll(wt, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	files := map[string]string{
+		"hello.txt": "hello world\n",
+		"plan.md":   "# Plan\n\nstep 1\nstep 2\n",
+	}
+	for name, body := range files {
+		if err := os.WriteFile(filepath.Join(wt, name), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	now := time.Date(2026, 5, 3, 12, 0, 0, 0, time.UTC)
+	path, count, err := preserveWorktree(root, "flat", now)
+	if err != nil {
+		t.Fatalf("preserveWorktree: %v", err)
+	}
+	if count != len(files) {
+		t.Errorf("count = %d, want %d", count, len(files))
+	}
+	wantSuffix := filepath.Join(".bones", "recovery", "flat-"+strconv.FormatInt(now.Unix(), 10))
+	if !strings.HasSuffix(path, wantSuffix) {
+		t.Errorf("path = %q, want suffix %q", path, wantSuffix)
+	}
+	for name, want := range files {
+		got, err := os.ReadFile(filepath.Join(path, name))
+		if err != nil {
+			t.Errorf("read %s in recovery: %v", name, err)
+			continue
+		}
+		if string(got) != want {
+			t.Errorf("%s content: got %q, want %q", name, string(got), want)
+		}
+	}
+}
+
+// TestPreserveWorktree_CopiesNestedTree asserts subdirectories are
+// recreated correctly. Slots with structured docs (e.g. docs/plan.md
+// + tests/foo_test.go) must round-trip the tree shape.
+func TestPreserveWorktree_CopiesNestedTree(t *testing.T) {
+	root := t.TempDir()
+	wt := SlotWorktree(root, "nested")
+	if err := os.MkdirAll(filepath.Join(wt, "docs", "plans"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(wt, "tests"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(wt, "docs", "plans", "p.md"), []byte("plan"), 0o644,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(wt, "tests", "t.go"), []byte("package t"), 0o644,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	path, count, err := preserveWorktree(root, "nested", time.Now())
+	if err != nil {
+		t.Fatalf("preserveWorktree: %v", err)
+	}
+	if count != 2 {
+		t.Errorf("count = %d, want 2", count)
+	}
+	for _, rel := range []string{"docs/plans/p.md", "tests/t.go"} {
+		if _, err := os.Stat(filepath.Join(path, rel)); err != nil {
+			t.Errorf("missing in recovery: %s: %v", rel, err)
+		}
+	}
+}
+
+// TestPreserveWorktree_PreservesPermissionBits asserts an executable
+// file in the worktree round-trips with its mode bits intact. Recovery
+// is meant for operator inspection — losing +x on a script would
+// silently degrade what they recover.
+func TestPreserveWorktree_PreservesPermissionBits(t *testing.T) {
+	root := t.TempDir()
+	wt := SlotWorktree(root, "perms")
+	if err := os.MkdirAll(wt, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	src := filepath.Join(wt, "run.sh")
+	if err := os.WriteFile(src, []byte("#!/bin/sh\necho hi\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	path, _, err := preserveWorktree(root, "perms", time.Now())
+	if err != nil {
+		t.Fatalf("preserveWorktree: %v", err)
+	}
+	dst := filepath.Join(path, "run.sh")
+	info, err := os.Stat(dst)
+	if err != nil {
+		t.Fatalf("stat dst: %v", err)
+	}
+	if info.Mode().Perm()&0o111 == 0 {
+		t.Errorf("recovery copy should preserve +x: mode = %v", info.Mode())
+	}
+}
+
+// TestCountFiles_SkipsDirectories confirms the count returned by
+// preserveWorktree is "regular files only". This is what the operator-
+// visible "preserved N file(s)" message reflects, and it is also what
+// gates the recovery-dir creation. Counting directory entries would
+// fire recovery for empty subdirs, which is wrong.
+func TestCountFiles_SkipsDirectories(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "a", "b"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "f.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	count, err := countFiles(root)
+	if err != nil {
+		t.Fatalf("countFiles: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("count = %d, want 1 (directories should not count)", count)
+	}
+}


### PR DESCRIPTION
## Summary

`ResumedLease.Close` on success ran `os.RemoveAll(wt/)` unconditionally, so any files left behind — uncommitted changes after a commit failure, files written post-commit, agent salvage attempts on the substrate-failure path — were silently destroyed.

This PR ships **option A** from the triage: backup-before-destroy. Before removing `wt/`, copy its contents to `.bones/recovery/<slot>-<unix-ts>/`. ADR 0028's "success cleans" contract still holds — `wt/` is unconditionally removed; the recovery dir is the salvage trail, not a replacement worktree.

## Mechanics

- New helper `preserveWorktree(workspaceDir, slot, now)` returns `(path, count, error)`. Returns `("", 0, nil)` on missing-or-empty `wt/` so success-close on a slot that already lost its worktree (crash, manual cleanup) is a no-op for the safety net.
- New helpers `countFiles` (regular files only — skips directory entries) and `copyTree` / `copyFile` (stdlib walk + io.Copy, preserving permission bits).
- `Close` calls `preserveWorktree` before `os.RemoveAll(wt)` on the `CloseTaskOnSuccess && !KeepWT` path. Errors from preservation are logged to stderr but do not block the close — partial salvage is better than refusing-to-close or destroying-without-preserving.
- Operator-visible stderr: `swarm.ResumedLease.Close: preserved N file(s) at <path> (#156)` when preservation fires.
- Recovery dir is **not** auto-pruned — operator decides when to clean `.bones/recovery/`.

## ADR

- `docs/adr/0028-bones-swarm-verbs.md` updated with a "Success-close salvage trail" paragraph.

## Test plan

- [x] `make lint vet fmt-check todo-check` — pass
- [x] `go test -race -short ./...` — pass
- [x] `go test -tags=otel -short ./internal/swarm/... ./internal/dispatch/... ./cli/...` — pass
- [x] New tests in `internal/swarm/recovery_test.go`:
  - `TestPreserveWorktree_NoWT` — missing `wt/` → no-op
  - `TestPreserveWorktree_EmptyWT` — empty `wt/` → no-op, no recovery dir created
  - `TestPreserveWorktree_CopiesFlatTree` — flat tree round-trip with content + path shape
  - `TestPreserveWorktree_CopiesNestedTree` — subdirectories round-trip
  - `TestPreserveWorktree_PreservesPermissionBits` — `+x` on copied scripts
  - `TestCountFiles_SkipsDirectories` — count is regular-files-only
- [x] Existing `TestClose_RemovesWTOnSuccess` still passes — `wt/` is still gone after close (the salvage trail is independent of the destroy contract).

## Out of scope

- A real "dirty-state filter" (only preserve files not in `leaf.fossil` HEAD) — this PR over-saves (any non-empty wt → backup). Refining the filter requires libfossil checkout-status query and is a follow-up enhancement; over-saving is strictly safer in the meantime.
- Auto-pruning the recovery dir (e.g. on `bones swarm prune`, on `bones down`) — the safety-net contract is "operator owns cleanup". Adding cleanup automation is a UX follow-up.
- Symlinks in `wt/` — currently skipped by `copyTree` (slot worktree is a leaf checkout that does not produce them). Revisit if a future use case introduces them.

Closes #156