### PR TITLE
feat(swarm): NATS-failure diagnostic on swarm verb errors (#155)

### DIFF
--- a/cli/swarm.go
+++ b/cli/swarm.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/nats-io/nats.go"
 
@@ -82,6 +83,10 @@ func bootstrapResume(
 	sess, closeSess, err := openSwarmSessions(ctx, info)
 	if err != nil {
 		stop()
+		// #155 instrumentation: openSwarmSessions wraps a
+		// nats.Connect; a failure here is the most direct symptom
+		// of URL discovery race or hub-down.
+		reportSwarmFailure(info.WorkspaceDir, info.NATSURL)
 		return nil, workspace.Info{}, nil, nil, err
 	}
 	host, _ := os.Hostname()
@@ -99,9 +104,58 @@ func bootstrapResume(
 		if errors.Is(err, swarm.ErrSessionNotFound) {
 			return nil, workspace.Info{}, nil, nil, err
 		}
+		// #155 instrumentation: Resume opens its own NATS
+		// connection; surface the same diagnostic on failure.
+		reportSwarmFailure(info.WorkspaceDir, info.NATSURL)
 		return nil, workspace.Info{}, nil, nil, fmt.Errorf("%s: %w", verbName, err)
 	}
 	return ctx, info, lease, stop, nil
+}
+
+// diagnoseSwarmFailure builds a stderr-friendly diagnostic snippet
+// for #155: when a swarm verb fails on a NATS-related error
+// (commonly "nats: no responders available"), the most likely root
+// causes are URL discovery race (the verb cached one URL but the hub
+// rebound on a different port) or hub-down (pid files name dead
+// processes). Capture both at the moment of failure so the next
+// recurrence has actionable evidence rather than a bare error.
+//
+// connectedURL is whichever URL the verb actually dialed (typically
+// info.NATSURL captured at workspace.Join time). The on-disk URL is
+// re-read here so any mid-flight drift surfaces.
+func diagnoseSwarmFailure(workspaceDir, connectedURL string) string {
+	if workspaceDir == "" {
+		return "  (no workspace context — cannot diagnose)"
+	}
+	diskURL := hub.NATSURL(workspaceDir)
+	pid, running := hub.IsRunning(workspaceDir)
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "  connected to: %s\n", connectedURL)
+	fmt.Fprintf(&b, "  on disk now : %s\n", diskURL)
+	if connectedURL != diskURL && diskURL != "" {
+		b.WriteString(
+			"  ⚠ MISMATCH: NATS URL changed since this verb captured it; the\n" +
+				"    hub likely restarted on a different port. See #155, #157.\n",
+		)
+	}
+	if running {
+		fmt.Fprintf(&b, "  hub status  : up, pid=%d\n", pid)
+	} else {
+		b.WriteString("  hub status  : DOWN (no live fossil/nats pids)\n")
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+// reportSwarmFailure is the stderr-side companion to
+// diagnoseSwarmFailure. Verbs call this on a non-nil error to
+// surface the diagnostic alongside the bare error message. Always
+// safe — workspaceDir or connectedURL may be empty when the verb
+// failed before workspace.Join completed.
+func reportSwarmFailure(workspaceDir, connectedURL string) {
+	fmt.Fprintf(os.Stderr,
+		"swarm: diagnostic (#155):\n%s\n",
+		diagnoseSwarmFailure(workspaceDir, connectedURL))
 }
 
 // resolveHubURL returns the hub fossil HTTP URL for swarm operations,

--- a/cli/swarm_close.go
+++ b/cli/swarm_close.go
@@ -69,6 +69,10 @@ func (c *SwarmCloseCmd) Run(g *libfossilcli.Globals) error {
 		KeepWT:             c.KeepWT,
 	}
 	if err := lease.Close(ctx, closeOpts); err != nil {
+		// Surface diagnostic context (#155) on close failure too —
+		// less common than commit failure but the same URL/hub
+		// state matters when it happens.
+		reportSwarmFailure(info.WorkspaceDir, info.NATSURL)
 		return fmt.Errorf("swarm close: %w", err)
 	}
 	fmt.Fprintf(os.Stderr,

--- a/cli/swarm_commit.go
+++ b/cli/swarm_commit.go
@@ -56,6 +56,10 @@ func (c *SwarmCommitCmd) Run(g *libfossilcli.Globals) error {
 			Event:     logwriter.EventCommitError,
 			Fields:    map[string]interface{}{"reason": err.Error()},
 		})
+		// Surface diagnostic context (#155): if the failure was
+		// "no responders available" or similar, the connected URL
+		// vs disk URL plus hub liveness is the actionable evidence.
+		reportSwarmFailure(info.WorkspaceDir, info.NATSURL)
 		return fmt.Errorf("swarm commit: %w", err)
 	}
 	c.emitCommitReport(lease.Slot(), lease.TaskID(), files, res, resolveHubURL(c.HubURL))

--- a/cli/swarm_diagnostic_test.go
+++ b/cli/swarm_diagnostic_test.go
@@ -1,0 +1,86 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestDiagnoseSwarmFailure_NoWorkspace asserts the helper degrades
+// gracefully when called before workspace.Join has captured a
+// workspace dir — used by callers that surface the diagnostic on
+// any swarm verb error, including those that fail before info is
+// populated.
+func TestDiagnoseSwarmFailure_NoWorkspace(t *testing.T) {
+	got := diagnoseSwarmFailure("", "nats://127.0.0.1:0")
+	if !strings.Contains(got, "no workspace context") {
+		t.Errorf("empty workspace dir: got %q, want a 'no workspace context' line", got)
+	}
+}
+
+// TestDiagnoseSwarmFailure_HubDown covers the most actionable case:
+// a swarm verb fails because the hub is gone. The diagnostic must
+// say so explicitly so the operator does not waste time on URL
+// races.
+func TestDiagnoseSwarmFailure_HubDown(t *testing.T) {
+	root := t.TempDir()
+	got := diagnoseSwarmFailure(root, "nats://127.0.0.1:55555")
+	if !strings.Contains(got, "DOWN") {
+		t.Errorf("hub down: got %q, want a 'DOWN' marker", got)
+	}
+	if !strings.Contains(got, "nats://127.0.0.1:55555") {
+		t.Errorf("got %q, want connected URL surfaced", got)
+	}
+}
+
+// TestDiagnoseSwarmFailure_URLMismatch is the smoking-gun case the
+// instrumentation was added for (#155): the connected URL diverges
+// from the URL recorded on disk. The diagnostic must call this out
+// explicitly so the operator pivots straight to the URL discovery
+// path rather than chasing JetStream readiness.
+func TestDiagnoseSwarmFailure_URLMismatch(t *testing.T) {
+	root := t.TempDir()
+	pidsDir := filepath.Join(root, ".bones", "pids")
+	if err := os.MkdirAll(pidsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(root, ".bones", "hub-nats-url"),
+		[]byte("nats://127.0.0.1:60000\n"), 0o644,
+	); err != nil {
+		t.Fatal(err)
+	}
+	got := diagnoseSwarmFailure(root, "nats://127.0.0.1:55555")
+	if !strings.Contains(got, "MISMATCH") {
+		t.Errorf("URL mismatch: got %q, want 'MISMATCH' marker", got)
+	}
+	if !strings.Contains(got, "nats://127.0.0.1:55555") {
+		t.Errorf("got %q, want connected URL %q", got, "nats://127.0.0.1:55555")
+	}
+	if !strings.Contains(got, "nats://127.0.0.1:60000") {
+		t.Errorf("got %q, want disk URL %q", got, "nats://127.0.0.1:60000")
+	}
+}
+
+// TestDiagnoseSwarmFailure_URLAgreesNoMismatch confirms the no-false-
+// alarm case: when the connected URL matches the disk URL, the
+// diagnostic must NOT print a MISMATCH marker. False positives here
+// would steer operators toward URL races for failures that are
+// actually JetStream-readiness or KV-bucket issues.
+func TestDiagnoseSwarmFailure_URLAgreesNoMismatch(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".bones"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(root, ".bones", "hub-nats-url"),
+		[]byte("nats://127.0.0.1:55555\n"), 0o644,
+	); err != nil {
+		t.Fatal(err)
+	}
+	got := diagnoseSwarmFailure(root, "nats://127.0.0.1:55555")
+	if strings.Contains(got, "MISMATCH") {
+		t.Errorf("matching URLs should not flag MISMATCH; got %q", got)
+	}
+}

--- a/cli/swarm_join.go
+++ b/cli/swarm_join.go
@@ -57,6 +57,10 @@ func (c *SwarmJoinCmd) run(ctx context.Context, info workspace.Info) error {
 		NoAutosync:    c.NoAutosync,
 	})
 	if err != nil {
+		// Surface diagnostic context (#155) so operators see the
+		// connected URL vs disk URL plus hub liveness in stderr —
+		// the actionable evidence when join fails on a NATS error.
+		reportSwarmFailure(info.WorkspaceDir, info.NATSURL)
 		// Stamp the verb name into the error so operators see which
 		// CLI command surfaced it (the swarm.* errors are package-
 		// scoped and would otherwise read as bare "swarm: ..."


### PR DESCRIPTION
## Summary

When `bones swarm commit` (and other verbs) fail with NATS errors — typically `nats: no responders available` — the bare error gave the operator no actionable evidence. Per the #155 triage, this PR ships the **instrumentation pass** so the next recurrence has enough signal to pin down which discovery path broke.

This is **informational only** — no fix attempt. The PR does not Close #155; we keep #155 open and reopen-on-recurrence semantics until the diagnostic actually fires in the wild and points at the right fix.

## Mechanics

- `diagnoseSwarmFailure(workspaceDir, connectedURL)` returns a stderr-friendly snippet with:
  - the URL the verb actually dialed (typically `info.NATSURL` captured at workspace.Join time)
  - the URL on disk RIGHT NOW (re-read from `.bones/hub-nats-url`)
  - a `⚠ MISMATCH` marker when they disagree (the smoking gun for #155 / #157 port drift)
  - hub `IsRunning` state + pid
- `reportSwarmFailure(...)` wraps the helper with a stderr write.
- Wired into:
  - `swarm join` — on `swarm.Acquire` error
  - `swarm commit` — on `lease.Commit` error
  - `swarm close` — on `lease.Close` error
  - `bootstrapResume` — on `openSwarmSessions` and `swarm.Resume` errors

## Test plan

- [x] `make lint vet fmt-check todo-check` — pass
- [x] `go test -race -short ./...` — pass
- [x] `go test -tags=otel -short ./cli/... ./internal/swarm/... ./internal/dispatch/...` — pass
- [x] New tests in `cli/swarm_diagnostic_test.go`:
  - `TestDiagnoseSwarmFailure_NoWorkspace` — graceful degradation
  - `TestDiagnoseSwarmFailure_HubDown` — DOWN marker when pid files name dead processes
  - `TestDiagnoseSwarmFailure_URLMismatch` — MISMATCH marker when connected URL diverges from disk URL
  - `TestDiagnoseSwarmFailure_URLAgreesNoMismatch` — no false positive when URLs match

## Why no Closes #155

The triage agreed: instrument first, decide on the fix when the diagnostic shows which discovery path is at fault. Three options remain on the table (fsync URL file, env-var pass-through, JetStream readiness probe) and the choice depends on what the diagnostic surfaces.

Refs #155