### PR TITLE
fix(coord): move chat.fossil under .bones/, auto-recreate, better error

### DIFF
--- a/cli/orchestrator.go
+++ b/cli/orchestrator.go
@@ -580,7 +580,6 @@ func ensureGitignoreEntries(dir string) error {
 		".fslckout",
 		".fossil-settings/",
 		".bones/",
-		"chat.fossil",
 	}
 
 	existing := map[string]bool{}

--- a/cli/orchestrator_test.go
+++ b/cli/orchestrator_test.go
@@ -572,7 +572,7 @@ func TestEnsureGitignoreEntries_FreshFile(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, want := range []string{".fslckout", ".fossil-settings/", ".bones/", "chat.fossil"} {
+	for _, want := range []string{".fslckout", ".fossil-settings/", ".bones/"} {
 		if !strings.Contains(string(data), want) {
 			t.Errorf("missing %q\n%s", want, data)
 		}
@@ -581,6 +581,13 @@ func TestEnsureGitignoreEntries_FreshFile(t *testing.T) {
 	// included in the gitignore entry list.
 	if strings.Contains(string(data), ".orchestrator/") {
 		t.Errorf(".orchestrator/ should not be in gitignore post-ADR-0041\n%s", data)
+	}
+	// chat.fossil moved under .bones/ (issues #167, #168). The standalone
+	// gitignore entry is no longer needed since `.bones/` covers it; an
+	// orphaned `chat.fossil` entry would imply chat.fossil is still at
+	// the workspace root.
+	if strings.Contains(string(data), "\nchat.fossil\n") {
+		t.Errorf("standalone chat.fossil entry should be gone post #167/#168\n%s", data)
 	}
 }
 

--- a/cli/tasks_list.go
+++ b/cli/tasks_list.go
@@ -218,11 +218,18 @@ func liveAgentSet(peers []coord.Presence) map[string]struct{} {
 // newCoordConfig builds a coord.Config from workspace defaults. Lifted
 // from tasks_ready.go into tasks_list.go when the ready verb folded into
 // 'tasks list --ready'.
+//
+// chat.fossil lives under <WorkspaceDir>/.bones/ — the bones-managed
+// runtime tree — so operators don't see it as a stray file at the
+// project root and don't accidentally delete it. Per ADRs 0023 and 0041
+// the workspace already has `.bones/` as the runtime-state directory;
+// gitignoring `.bones/` covers chat.fossil transitively. Issues #167,
+// #168.
 func newCoordConfig(info workspace.Info) coord.Config {
 	return coord.Config{
 		AgentID:            info.AgentID,
 		NATSURL:            info.NATSURL,
-		ChatFossilRepoPath: filepath.Join(info.WorkspaceDir, "chat.fossil"),
+		ChatFossilRepoPath: filepath.Join(info.WorkspaceDir, ".bones", "chat.fossil"),
 		CheckoutRoot:       info.WorkspaceDir,
 	}
 }

--- a/internal/coord/coord.go
+++ b/internal/coord/coord.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -165,19 +167,9 @@ func openSubstrate(
 		s.close()
 		return nil, fmt.Errorf("coord.Open: archive tasks: %w", err)
 	}
-	chatProject := cfg.ProjectPrefix
-	if chatProject == "" {
-		chatProject = projectPrefix(cfg.AgentID)
-	}
-	if s.chat, err = chat.Open(ctx, chat.Config{
-		AgentID:        cfg.AgentID,
-		ProjectPrefix:  chatProject,
-		Nats:           nc,
-		FossilRepoPath: cfg.ChatFossilRepoPath,
-		MaxSubscribers: cfg.Tuning.MaxSubscribers,
-	}); err != nil {
+	if s.chat, err = openChat(ctx, cfg, nc); err != nil {
 		s.close()
-		return nil, fmt.Errorf("coord.Open: chat: %w", err)
+		return nil, err
 	}
 	if s.presence, err = presence.Open(ctx, presence.Config{
 		AgentID:           cfg.AgentID,
@@ -194,6 +186,43 @@ func openSubstrate(
 		return nil, fmt.Errorf("coord.Open: swarm sessions: %w", err)
 	}
 	return s, nil
+}
+
+// openChat opens the chat manager for cfg, ensuring the
+// ChatFossilRepoPath parent directory exists first (so a freshly-init
+// workspace doesn't fail on a missing `.bones/`) and re-wrapping the
+// failure with a friendly, path-naming, remediation-hinting message
+// so operators who deleted chat.fossil aren't told "no bones workspace
+// found". Issues #167, #168.
+func openChat(
+	ctx context.Context, cfg Config, nc *nats.Conn,
+) (*chat.Manager, error) {
+	if parent := filepath.Dir(cfg.ChatFossilRepoPath); parent != "" {
+		if err := os.MkdirAll(parent, 0o755); err != nil {
+			return nil, fmt.Errorf(
+				"coord.Open: chat.fossil parent dir %q: %w", parent, err,
+			)
+		}
+	}
+	chatProject := cfg.ProjectPrefix
+	if chatProject == "" {
+		chatProject = projectPrefix(cfg.AgentID)
+	}
+	m, err := chat.Open(ctx, chat.Config{
+		AgentID:        cfg.AgentID,
+		ProjectPrefix:  chatProject,
+		Nats:           nc,
+		FossilRepoPath: cfg.ChatFossilRepoPath,
+		MaxSubscribers: cfg.Tuning.MaxSubscribers,
+	})
+	if err != nil {
+		return nil, fmt.Errorf(
+			"coord: chat.fossil at %s is missing or unreadable; "+
+				"run 'bones up' to recreate or 'bones doctor' to diagnose: %w",
+			cfg.ChatFossilRepoPath, err,
+		)
+	}
+	return m, nil
 }
 
 // provisionSwarmSessionsBucket ensures the bones-swarm-sessions KV

--- a/internal/coord/coord_test.go
+++ b/internal/coord/coord_test.go
@@ -3,6 +3,7 @@ package coord
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -243,4 +244,104 @@ func TestAsk_InvariantPanics(t *testing.T) {
 			_, _ = c.Ask(context.Background(), "peer", "")
 		}, "question is empty")
 	})
+}
+
+// TestOpen_AutoCreatesChatFossilParentDir covers issue #167: callers
+// pass a ChatFossilRepoPath whose parent directory may not yet exist
+// (e.g., `<workspace>/.bones/chat.fossil` on a fresh init). Open is
+// responsible for ensuring the parent dir exists so the underlying
+// libfossil.Create can land the file.
+func TestOpen_AutoCreatesChatFossilParentDir(t *testing.T) {
+	nc, _ := natstest.NewJetStreamServer(t)
+	cfg := validConfigWithURL(t, nc.ConnectedUrl())
+
+	// Point ChatFossilRepoPath at a path whose parent does NOT exist
+	// yet — the typical "fresh workspace" shape with `.bones/`
+	// half-initialized.
+	parent := filepath.Join(t.TempDir(), "missing-parent")
+	cfg.ChatFossilRepoPath = filepath.Join(parent, "chat.fossil")
+
+	c, err := Open(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("Open: unexpected error: %v", err)
+	}
+	t.Cleanup(func() { _ = c.Close() })
+
+	if _, err := os.Stat(cfg.ChatFossilRepoPath); err != nil {
+		t.Fatalf("chat.fossil not created at %q: %v", cfg.ChatFossilRepoPath, err)
+	}
+}
+
+// TestOpen_RecreatesMissingChatFossil covers issue #167: an operator
+// who has deleted `<workspace>/.bones/chat.fossil` should not see a
+// permanent breakage. Re-opening the same config must idempotently
+// re-init the fossil DB.
+func TestOpen_RecreatesMissingChatFossil(t *testing.T) {
+	nc, _ := natstest.NewJetStreamServer(t)
+	cfg := validConfigWithURL(t, nc.ConnectedUrl())
+
+	// First Open creates the file.
+	c1, err := Open(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("first Open: %v", err)
+	}
+	if err := c1.Close(); err != nil {
+		t.Fatalf("first Close: %v", err)
+	}
+	if _, err := os.Stat(cfg.ChatFossilRepoPath); err != nil {
+		t.Fatalf("chat.fossil missing after first Open: %v", err)
+	}
+
+	// Operator deletes chat.fossil.
+	if err := os.Remove(cfg.ChatFossilRepoPath); err != nil {
+		t.Fatalf("rm chat.fossil: %v", err)
+	}
+
+	// Second Open should idempotently recreate it.
+	c2, err := Open(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("second Open after rm chat.fossil: %v", err)
+	}
+	t.Cleanup(func() { _ = c2.Close() })
+
+	if _, err := os.Stat(cfg.ChatFossilRepoPath); err != nil {
+		t.Fatalf("chat.fossil not recreated after second Open: %v", err)
+	}
+}
+
+// TestOpen_ChatFossilUnreadableErrorIncludesPath covers issue #167's
+// "better error message" requirement. When the chat.fossil path is
+// genuinely unrecoverable (here: the path points at a directory rather
+// than a fossil file), the returned error must name the path and hint
+// at remediation.
+func TestOpen_ChatFossilUnreadableErrorIncludesPath(t *testing.T) {
+	nc, _ := natstest.NewJetStreamServer(t)
+	cfg := validConfigWithURL(t, nc.ConnectedUrl())
+
+	// Force an unrecoverable shape: ChatFossilRepoPath points at a
+	// directory. libfossil.Open will fail and the wrap should mention
+	// both the path and the remediation hint.
+	dirPath := filepath.Join(t.TempDir(), "chat.fossil")
+	if err := os.MkdirAll(dirPath, 0o755); err != nil {
+		t.Fatalf("mkdir bogus chat.fossil dir: %v", err)
+	}
+	cfg.ChatFossilRepoPath = dirPath
+
+	_, err := Open(context.Background(), cfg)
+	if err == nil {
+		t.Fatalf("Open: expected error when chat.fossil path is a directory")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, dirPath) {
+		t.Errorf("error must name path %q; got %v", dirPath, err)
+	}
+	if !strings.Contains(msg, "missing or unreadable") {
+		t.Errorf("error must say 'missing or unreadable'; got %v", err)
+	}
+	if !strings.Contains(msg, "bones up") {
+		t.Errorf("error must hint at 'bones up'; got %v", err)
+	}
+	if !strings.Contains(msg, "bones doctor") {
+		t.Errorf("error must hint at 'bones doctor'; got %v", err)
+	}
 }


### PR DESCRIPTION
## Summary

Three fixes for the chat.fossil footgun reported in #167 (P0) and #168 (P1).

1. **Path moved.** `chat.fossil` now lives at `<workspace>/.bones/chat.fossil` instead of the project root. It's bones-managed runtime state and belongs in the `.bones/` tree alongside `agent.id` (ADR 0041). The standalone `chat.fossil` line in the gitignore template is dropped — `.bones/` already covers it.

2. **Idempotent re-init.** `coord.Open` now `MkdirAll`s the parent dir before opening chat. The chat layer already creates the fossil DB on absence (`libfossil.Create`), but did not create the parent dir. With the new path the parent is normally present, but the explicit ensure makes the "operator deleted chat.fossil" recovery path safe.

3. **Better error message.** `coord.Open` wraps chat-open failures with a path-naming, remediation-hinting message. New shape:

   ```
   coord: chat.fossil at <path> is missing or unreadable;
   run 'bones up' to recreate or 'bones doctor' to diagnose: <cause>
   ```

## Migration note

Existing workspaces have `chat.fossil` at the project root. After this PR, bones writes and reads `<workspace>/.bones/chat.fossil` and ignores the old file. There is **no automatic migration**: the old root-level `chat.fossil` becomes an orphan. Operators can `rm` it safely; bones never reads or rewrites it. The starter chat history is empty after the move — chat history was always rebuilt from JetStream-backed live streams, so this is functionally a no-op for in-progress threads.

## Test plan

- [x] `make check` (fmt-check, vet, lint, race, todo-check) — green
- [x] `go test -tags=otel -short ./...` — green (CI-equivalent)
- [x] `TestEnsureGitignoreEntries_FreshFile` updated for 3 entries; asserts standalone `chat.fossil` is absent
- [x] `TestOpen_AutoCreatesChatFossilParentDir` — fresh dir-doesn't-exist case
- [x] `TestOpen_RecreatesMissingChatFossil` — operator-deleted-it case
- [x] `TestOpen_ChatFossilUnreadableErrorIncludesPath` — error names path + remediation hints

## Files

- `cli/tasks_list.go` — `newCoordConfig` builds the new `.bones/chat.fossil` path
- `cli/orchestrator.go` — `ensureGitignoreEntries` drops standalone `chat.fossil`
- `cli/orchestrator_test.go` — assert 3 entries, no orphan `chat.fossil` line
- `internal/coord/coord.go` — extracted `openChat` helper that MkdirAlls and re-wraps the failure
- `internal/coord/coord_test.go` — three new regression tests

Closes #167
Closes #168