### PR TITLE
fix(tasks): emit JSON envelope when zero tasks

### DIFF
--- a/cli/tasks_prime.go
+++ b/cli/tasks_prime.go
@@ -36,33 +36,17 @@ func (c *TasksPrimeCmd) Run(g *libfossilcli.Globals) error {
 			return err
 		}
 		if c.JSON {
-			// Skip emit when the workspace has nothing to prime —
-			// the SessionStart hook attaches whatever this command
-			// prints, and an empty payload is pure noise in the
-			// agent's context (#129). Non-JSON callers (humans
-			// running `bones tasks prime` interactively) still get
-			// the formatted output below regardless of state.
-			if isEmptyPrime(result) {
-				return nil
-			}
+			// Always emit the envelope, even when the workspace
+			// has zero tasks/threads/peers. The SessionStart hook
+			// attaches stdout into agent context: an empty payload
+			// gives the agent zero signal that bones is active,
+			// while an empty-but-present envelope is the "bones is
+			// here, nothing claimed yet" signal (#170).
 			return emitJSON(os.Stdout, primeToJSON(result))
 		}
 		fmt.Print(formatPrime(result))
 		return nil
 	}))
-}
-
-// isEmptyPrime reports whether a prime result has no information
-// worth emitting via the JSON hook attachment. Empty means: zero
-// open/ready/claimed tasks, zero recent threads, and at most one
-// peer (which is the agent itself; presence-of-self isn't useful
-// to attach).
-func isEmptyPrime(r coord.PrimeResult) bool {
-	return len(r.OpenTasks) == 0 &&
-		len(r.ReadyTasks) == 0 &&
-		len(r.ClaimedTasks) == 0 &&
-		len(r.Threads) == 0 &&
-		len(r.Peers) <= 1
 }
 
 func formatPrime(r coord.PrimeResult) string {

--- a/cli/tasks_prime_test.go
+++ b/cli/tasks_prime_test.go
@@ -1,49 +1,67 @@
 package cli
 
 import (
+	"bytes"
+	"encoding/json"
 	"testing"
 
 	"github.com/danmestas/bones/internal/coord"
 )
 
-// TestIsEmptyPrime_AllEmpty pins the no-noise case: zero of
-// everything (no peers either) is empty.
-func TestIsEmptyPrime_AllEmpty(t *testing.T) {
-	if !isEmptyPrime(coord.PrimeResult{}) {
-		t.Errorf("zero PrimeResult should be empty")
+// TestPrimeJSON_ZeroTasksEnvelope pins #170: when the workspace has
+// zero tasks, zero threads, and zero peers, `bones tasks prime --json`
+// must still emit a non-empty envelope so the SessionStart hook
+// injects a "bones is active here" signal into agent context.
+//
+// The envelope must round-trip with the documented top-level keys
+// — open_tasks, ready_tasks, claimed_tasks, threads, peers — and
+// each list must be a present empty array (not omitted, not null).
+func TestPrimeJSON_ZeroTasksEnvelope(t *testing.T) {
+	var buf bytes.Buffer
+	if err := emitJSON(&buf, primeToJSON(coord.PrimeResult{})); err != nil {
+		t.Fatalf("emitJSON: %v", err)
+	}
+
+	if buf.Len() == 0 {
+		t.Fatalf("zero-tasks prime emitted empty stdout; want envelope")
+	}
+
+	var got map[string]json.RawMessage
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal envelope: %v\npayload=%q", err, buf.String())
+	}
+
+	for _, key := range []string{
+		"open_tasks", "ready_tasks", "claimed_tasks", "threads", "peers",
+	} {
+		raw, ok := got[key]
+		if !ok {
+			t.Errorf("envelope missing key %q; got=%q", key, buf.String())
+			continue
+		}
+		// Each list must serialize as an array (not null) so a
+		// downstream consumer can `.length` without a guard.
+		if string(raw) != "[]" {
+			t.Errorf("envelope key %q = %s, want []", key, raw)
+		}
 	}
 }
 
-// TestIsEmptyPrime_SelfOnlyPeers pins the documented edge case:
-// presence-of-self in the peers list isn't useful to attach, so
-// len(Peers) == 1 still counts as empty.
-func TestIsEmptyPrime_SelfOnlyPeers(t *testing.T) {
-	r := coord.PrimeResult{
-		Peers: make([]coord.Presence, 1),
-	}
-	if !isEmptyPrime(r) {
-		t.Errorf("self-only peers should still be empty")
-	}
-}
-
-// TestIsEmptyPrime_NonEmptyOpenTasks pins the negative case: a
-// single open task makes the result worth attaching.
-func TestIsEmptyPrime_NonEmptyOpenTasks(t *testing.T) {
+// TestPrimeJSON_PopulatedEnvelope guards the populated case so a
+// future refactor of primeToJSON keeps the documented keys.
+func TestPrimeJSON_PopulatedEnvelope(t *testing.T) {
+	var buf bytes.Buffer
 	r := coord.PrimeResult{
 		OpenTasks: make([]coord.Task, 1),
 	}
-	if isEmptyPrime(r) {
-		t.Errorf("open tasks present, should not be empty")
+	if err := emitJSON(&buf, primeToJSON(r)); err != nil {
+		t.Fatalf("emitJSON: %v", err)
 	}
-}
-
-// TestIsEmptyPrime_TwoPeers pins the threshold: more than one peer
-// means at least one other agent is online — worth attaching.
-func TestIsEmptyPrime_TwoPeers(t *testing.T) {
-	r := coord.PrimeResult{
-		Peers: make([]coord.Presence, 2),
+	var got map[string]json.RawMessage
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal envelope: %v", err)
 	}
-	if isEmptyPrime(r) {
-		t.Errorf("two peers means another agent is online; not empty")
+	if _, ok := got["open_tasks"]; !ok {
+		t.Errorf("populated envelope missing open_tasks; got=%q", buf.String())
 	}
 }

--- a/cmd/bones/integration/integration_test.go
+++ b/cmd/bones/integration/integration_test.go
@@ -741,6 +741,27 @@ func TestCLI_Prime(t *testing.T) {
 	}
 	dir := newWorkspace(t)
 
+	t.Run("json_zero_tasks_envelope", func(t *testing.T) {
+		// #170: even with zero tasks, the envelope must be present
+		// so the SessionStart hook injects a "bones is active"
+		// signal into agent context.
+		stdout, stderr, code := runCmd(t, bonesBin, dir, "tasks", "prime", "--json")
+		if code != 0 {
+			t.Fatalf("prime --json exit=%d stderr=%s", code, stderr)
+		}
+		if len(strings.TrimSpace(stdout)) == 0 {
+			t.Fatalf("zero-tasks prime emitted empty stdout; want envelope")
+		}
+		for _, key := range []string{
+			`"open_tasks"`, `"ready_tasks"`, `"claimed_tasks"`,
+			`"threads"`, `"peers"`,
+		} {
+			if !strings.Contains(stdout, key) {
+				t.Errorf("envelope missing %s; got=%q", key, stdout)
+			}
+		}
+	})
+
 	out, _, code := runCmd(t, bonesBin, dir, "tasks", "create", "prime task")
 	if code != 0 {
 		t.Fatalf("seed create failed code=%d", code)


### PR DESCRIPTION
## Summary

- `bones tasks prime --json` is wired to the Claude Code SessionStart hook (and PreCompact). When the workspace had zero tasks/threads/peers, the command exited 0 with empty stdout, so the hook injected nothing and the agent had no signal bones was active.
- Drops the `isEmptyPrime` short-circuit in `cli/tasks_prime.go` so the JSON path always emits the documented envelope: `open_tasks`, `ready_tasks`, `claimed_tasks`, `threads`, `peers`. Empty lists travel as `[]`, never `null`.
- Schema note: existing populated envelope already uses `open_tasks` / `ready_tasks` / `claimed_tasks` / `threads` / `peers` — kept that schema rather than the issue's example (`workspace`, `trunk`, `tasks{open,claimed,closed}`, `recent_activity`) so the fix is purely additive for hook consumers and TestCLI_Prime stays intact.

## Test plan

- [x] New unit test `TestPrimeJSON_ZeroTasksEnvelope` pins the round-trip: zero `coord.PrimeResult` produces a non-empty envelope with all five keys present as `[]`.
- [x] New integration sub-test `TestCLI_Prime/json_zero_tasks_envelope` runs `bones tasks prime --json` against a fresh empty workspace and asserts the envelope keys are present.
- [x] `make check` green.
- [x] `go test -tags=otel -short ./...` green (matches GitHub CI).

Closes #170