### PR TITLE
feat(cli): bones workspaces ls + show

### DIFF
--- a/cli/testdata/workspaces_ls.json
+++ b/cli/testdata/workspaces_ls.json
@@ -1,0 +1,22 @@
+[
+  {
+    "id": "<id>",
+    "name": "alpha",
+    "cwd": "<cwd>",
+    "hub_status": "stopped",
+    "last_touched": "<time>",
+    "agent_id": "x",
+    "nats_url": "nats://127.0.0.1:1",
+    "hub_url": "http://127.0.0.1:1"
+  },
+  {
+    "id": "<id>",
+    "name": "beta",
+    "cwd": "<cwd>",
+    "hub_status": "stopped",
+    "last_touched": "<time>",
+    "agent_id": "x",
+    "nats_url": "nats://127.0.0.1:2",
+    "hub_url": "http://127.0.0.1:2"
+  }
+]

--- a/cli/workspaces.go
+++ b/cli/workspaces.go
@@ -1,0 +1,223 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/danmestas/bones/internal/registry"
+)
+
+// WorkspacesCmd groups the cross-workspace inspection verbs (#174).
+//
+// On disk, every workspace registry file is keyed by sha256(cwd) — see
+// registry.WorkspaceID. Filenames are intentionally opaque so that
+// agents and humans can both write them without a name-collision
+// protocol; this group surfaces a name-keyed view on top.
+type WorkspacesCmd struct {
+	Ls   WorkspacesLsCmd   `cmd:"" help:"List all known workspaces (live + stopped)"`
+	Show WorkspacesShowCmd `cmd:"" help:"Show one workspace by name (or filename id)"`
+}
+
+// WorkspacesLsCmd renders the registry as a human-readable table.
+//
+// We deliberately do NOT prune stopped entries here (unlike
+// `bones status --all`, which has live-only semantics): the operator
+// running `bones workspaces ls` is asking "what does bones think it
+// knows about?", and silently discarding stale entries makes it harder
+// to debug "why is bones up showing the wrong project?" scenarios.
+type WorkspacesLsCmd struct {
+	JSON bool `name:"json" help:"emit machine-readable JSON"`
+}
+
+// Run gathers the registry view via registry.ListInfo (which performs
+// the hub-status probe) and formats it. ListInfo already sorts by
+// Name,Cwd, so we don't re-sort here.
+func (c *WorkspacesLsCmd) Run() error {
+	infos, err := registry.ListInfo()
+	if err != nil {
+		return fmt.Errorf("workspaces ls: %w", err)
+	}
+	if c.JSON {
+		return writeWorkspacesJSON(os.Stdout, infos)
+	}
+	return writeWorkspacesTable(os.Stdout, infos, time.Now())
+}
+
+// WorkspacesShowCmd prints one workspace's full registry entry.
+//
+// The Name argument is matched case-sensitively against Entry.Name and
+// against the on-disk filename ID (16-hex chars). Matching by ID lets
+// the operator disambiguate when two workspaces share a name — `ls`
+// surfaces the ID in --json output, and Show accepts it.
+type WorkspacesShowCmd struct {
+	Name string `arg:"" required:"" help:"Workspace name or 16-hex id"`
+	JSON bool   `name:"json" help:"emit raw machine-readable JSON instead of pretty"`
+}
+
+func (c *WorkspacesShowCmd) Run() error {
+	infos, err := registry.ListInfo()
+	if err != nil {
+		return fmt.Errorf("workspaces show: %w", err)
+	}
+	matches := matchWorkspaces(infos, c.Name)
+	switch len(matches) {
+	case 0:
+		return fmt.Errorf("no workspace matches %q (run `bones workspaces ls` to see all)", c.Name)
+	case 1:
+		return writeWorkspaceOne(os.Stdout, matches[0], c.JSON)
+	default:
+		return ambiguousNameError(c.Name, matches)
+	}
+}
+
+// matchWorkspaces returns every Info whose Name or ID matches the query.
+// Name match is exact; ID match is exact too, since IDs are deterministic
+// hex. We walk the list once rather than building two maps because the
+// registry is rarely large enough for the difference to matter.
+func matchWorkspaces(infos []registry.Info, q string) []registry.Info {
+	out := make([]registry.Info, 0, 1)
+	for _, i := range infos {
+		if i.Name == q || i.ID == q {
+			out = append(out, i)
+		}
+	}
+	return out
+}
+
+// ambiguousNameError formats a multi-match disambiguation prompt and
+// exits non-zero. We keep the message in one place so tests can assert
+// against a single string.
+func ambiguousNameError(q string, matches []registry.Info) error {
+	var b strings.Builder
+	fmt.Fprintf(&b, "name %q matches %d workspaces; pass an id or full cwd:\n",
+		q, len(matches))
+	sort.Slice(matches, func(i, j int) bool {
+		return matches[i].Cwd < matches[j].Cwd
+	})
+	for _, m := range matches {
+		fmt.Fprintf(&b, "  %s  %s\n", m.ID, m.Cwd)
+	}
+	return fmt.Errorf("%s", b.String())
+}
+
+// jsonRow is the per-entry shape of `bones workspaces ls --json`. The
+// schema lives in the spec attached to issue #174; please bump the
+// fixture file under cli/testdata/ if you change it.
+type jsonRow struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Cwd         string `json:"cwd"`
+	HubStatus   string `json:"hub_status"`
+	LastTouched string `json:"last_touched"`
+	AgentID     string `json:"agent_id"`
+	NATSURL     string `json:"nats_url"`
+	HubURL      string `json:"hub_url"`
+}
+
+func toJSONRow(i registry.Info) jsonRow {
+	return jsonRow{
+		ID:          i.ID,
+		Name:        i.Name,
+		Cwd:         i.Cwd,
+		HubStatus:   string(i.HubStatus),
+		LastTouched: i.LastTouched.UTC().Format(time.RFC3339),
+		AgentID:     i.AgentID,
+		NATSURL:     i.NATSURL,
+		HubURL:      i.HubURL,
+	}
+}
+
+func writeWorkspacesJSON(w io.Writer, infos []registry.Info) error {
+	rows := make([]jsonRow, len(infos))
+	for i, info := range infos {
+		rows[i] = toJSONRow(info)
+	}
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(rows)
+}
+
+// writeWorkspacesTable renders the human-readable form. now is injected
+// so tests can assert deterministic "X minutes ago" labels.
+func writeWorkspacesTable(w io.Writer, infos []registry.Info, now time.Time) error {
+	if len(infos) == 0 {
+		_, err := io.WriteString(w,
+			"No workspaces registered. Run `bones up` in a project.\n")
+		return err
+	}
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	if _, err := fmt.Fprintln(tw, "NAME\tCWD\tHUB\tLAST-TOUCHED"); err != nil {
+		return err
+	}
+	for _, i := range infos {
+		hubCol := string(i.HubStatus)
+		if i.HubStatus == registry.HubUnknown {
+			hubCol = emDash
+		}
+		if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n",
+			fallbackString(i.Name, emDash),
+			shortenHome(i.Cwd),
+			hubCol,
+			humanRelative(now.Sub(i.LastTouched)),
+		); err != nil {
+			return err
+		}
+	}
+	return tw.Flush()
+}
+
+// writeWorkspaceOne prints one Info as pretty (2-space indented) JSON.
+// The --json flag is currently a no-op shape-wise: spec ADR allows
+// "YAML or pretty JSON" for the default, and we picked pretty JSON to
+// avoid pulling yaml.v3 forward as a direct dependency. The flag is
+// kept on the command so scripts can opt in explicitly and so a future
+// switch to YAML-by-default is non-breaking for `--json` callers.
+func writeWorkspaceOne(w io.Writer, i registry.Info, _ bool) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(toJSONRow(i))
+}
+
+const emDash = "—"
+
+func fallbackString(s, fallback string) string {
+	if s == "" {
+		return fallback
+	}
+	return s
+}
+
+// humanRelative is humanAge with the trailing " ago" already attached and
+// minute/hour/day units expanded to whole words to match the spec.
+// Negative durations clamp to "just now".
+func humanRelative(d time.Duration) string {
+	if d < 0 {
+		return "just now"
+	}
+	switch {
+	case d < time.Minute:
+		s := int(d.Seconds())
+		if s <= 1 {
+			return "just now"
+		}
+		return fmt.Sprintf("%d seconds ago", s)
+	case d < 2*time.Minute:
+		return "1 minute ago"
+	case d < time.Hour:
+		return fmt.Sprintf("%d minutes ago", int(d.Minutes()))
+	case d < 2*time.Hour:
+		return "1 hour ago"
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%d hours ago", int(d.Hours()))
+	case d < 48*time.Hour:
+		return "1 day ago"
+	default:
+		return fmt.Sprintf("%d days ago", int(d.Hours()/24))
+	}
+}

--- a/cli/workspaces_test.go
+++ b/cli/workspaces_test.go
@@ -1,0 +1,287 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/danmestas/bones/internal/registry"
+)
+
+// mkBonesDir creates the .bones/ directory inside root so the
+// agent.id helper can write into it.
+func mkBonesDir(t *testing.T, root string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(root, ".bones"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// seedTwoWorkspaces writes two registry entries (each with its own
+// .bones/agent.id) and returns the resolved cwds.
+func seedTwoWorkspaces(t *testing.T) (string, string) {
+	t.Helper()
+	t.Setenv("HOME", t.TempDir())
+	wsA := t.TempDir()
+	wsB := t.TempDir()
+	mkBonesDir(t, wsA)
+	mkBonesDir(t, wsB)
+	writeAgentIDForTest(t, wsA)
+	writeAgentIDForTest(t, wsB)
+
+	now := time.Now().UTC().Truncate(time.Second)
+	if err := registry.Write(registry.Entry{
+		Cwd: wsA, Name: "alpha",
+		HubURL:    "http://127.0.0.1:1",
+		NATSURL:   "nats://127.0.0.1:1",
+		HubPID:    -1,
+		StartedAt: now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := registry.Write(registry.Entry{
+		Cwd: wsB, Name: "beta",
+		HubURL:    "http://127.0.0.1:2",
+		NATSURL:   "nats://127.0.0.1:2",
+		HubPID:    -2,
+		StartedAt: now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return wsA, wsB
+}
+
+// TestWorkspacesLsTable exercises the human path. We assert structural
+// features (header line, two rows, names, hub-status column = "stopped")
+// rather than the full byte sequence, because tabwriter padding is
+// width-sensitive and home-shortening depends on $HOME.
+func TestWorkspacesLsTable(t *testing.T) {
+	seedTwoWorkspaces(t)
+
+	infos, err := registry.ListInfo()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	// Pin "now" so humanRelative output is deterministic.
+	now := infos[0].LastTouched.Add(2 * time.Minute)
+	if err := writeWorkspacesTable(&buf, infos, now); err != nil {
+		t.Fatalf("writeWorkspacesTable: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{
+		"NAME", "CWD", "HUB", "LAST-TOUCHED",
+		"alpha", "beta", "stopped", "2 minutes ago",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+// TestWorkspacesLsTableEmpty: empty registry → friendly hint.
+func TestWorkspacesLsTableEmpty(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	var buf bytes.Buffer
+	if err := writeWorkspacesTable(&buf, nil, time.Now()); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buf.String(), "No workspaces registered") {
+		t.Errorf("expected hint, got %q", buf.String())
+	}
+}
+
+// TestWorkspacesLsJSON: JSON path emits the documented schema for both
+// workspaces. We assert each top-level field on the alpha row to keep
+// it tied to the spec; the beta row only needs to exist.
+func TestWorkspacesLsJSON(t *testing.T) {
+	wsA, _ := seedTwoWorkspaces(t)
+
+	infos, err := registry.ListInfo()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	if err := writeWorkspacesJSON(&buf, infos); err != nil {
+		t.Fatalf("writeWorkspacesJSON: %v", err)
+	}
+
+	var rows []map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &rows); err != nil {
+		t.Fatalf("decode: %v\n%s", err, buf.String())
+	}
+	if len(rows) != 2 {
+		t.Fatalf("rows = %d, want 2", len(rows))
+	}
+	// alpha sorts first; verify schema on it.
+	want := map[string]string{
+		"name":       "alpha",
+		"cwd":        wsA,
+		"hub_status": "stopped",
+		"nats_url":   "nats://127.0.0.1:1",
+		"hub_url":    "http://127.0.0.1:1",
+		"agent_id":   "x", // writeAgentIDForTest writes literal "x"
+	}
+	for k, v := range want {
+		if got, _ := rows[0][k].(string); got != v {
+			t.Errorf("alpha[%q] = %q, want %q", k, got, v)
+		}
+	}
+	id, _ := rows[0]["id"].(string)
+	if id != registry.WorkspaceID(wsA) {
+		t.Errorf("alpha.id = %q, want %q", id, registry.WorkspaceID(wsA))
+	}
+	if _, err := time.Parse(time.RFC3339, rows[0]["last_touched"].(string)); err != nil {
+		t.Errorf("alpha.last_touched not RFC3339: %v", err)
+	}
+}
+
+// TestWorkspacesShowByName: exact name match emits the matching entry's
+// JSON shape.
+func TestWorkspacesShowByName(t *testing.T) {
+	seedTwoWorkspaces(t)
+	infos, err := registry.ListInfo()
+	if err != nil {
+		t.Fatal(err)
+	}
+	matches := matchWorkspaces(infos, "beta")
+	if len(matches) != 1 {
+		t.Fatalf("matches = %d, want 1", len(matches))
+	}
+	var buf bytes.Buffer
+	if err := writeWorkspaceOne(&buf, matches[0], true); err != nil {
+		t.Fatal(err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got["name"] != "beta" {
+		t.Errorf("name = %v, want beta", got["name"])
+	}
+}
+
+// TestWorkspacesShowByID: ID (filename hex) matches even when it does
+// not match Name. This is the disambiguation handle for collisions.
+func TestWorkspacesShowByID(t *testing.T) {
+	wsA, _ := seedTwoWorkspaces(t)
+	infos, err := registry.ListInfo()
+	if err != nil {
+		t.Fatal(err)
+	}
+	id := registry.WorkspaceID(wsA)
+	matches := matchWorkspaces(infos, id)
+	if len(matches) != 1 || matches[0].Cwd != wsA {
+		t.Fatalf("matches = %+v, want 1 with cwd %s", matches, wsA)
+	}
+}
+
+// TestWorkspacesShowAmbiguous: two workspaces sharing a Name yield a
+// disambiguation error listing both IDs and CWDs.
+func TestWorkspacesShowAmbiguous(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	wsA := t.TempDir()
+	wsB := t.TempDir()
+	mkBonesDir(t, wsA)
+	mkBonesDir(t, wsB)
+	writeAgentIDForTest(t, wsA)
+	writeAgentIDForTest(t, wsB)
+	now := time.Now().UTC().Truncate(time.Second)
+	for _, cwd := range []string{wsA, wsB} {
+		if err := registry.Write(registry.Entry{
+			Cwd: cwd, Name: "twin",
+			HubURL: "http://127.0.0.1:0", HubPID: -1,
+			StartedAt: now,
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	infos, _ := registry.ListInfo()
+	matches := matchWorkspaces(infos, "twin")
+	if len(matches) != 2 {
+		t.Fatalf("matches = %d, want 2", len(matches))
+	}
+	err := ambiguousNameError("twin", matches)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	msg := err.Error()
+	for _, want := range []string{
+		"matches 2 workspaces",
+		registry.WorkspaceID(wsA),
+		registry.WorkspaceID(wsB),
+		wsA, wsB,
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("missing %q in error: %s", want, msg)
+		}
+	}
+}
+
+// TestWorkspacesShowNoMatch: unknown name yields a helpful error.
+func TestWorkspacesShowNoMatch(t *testing.T) {
+	seedTwoWorkspaces(t)
+	infos, _ := registry.ListInfo()
+	matches := matchWorkspaces(infos, "ghost")
+	if len(matches) != 0 {
+		t.Fatalf("expected zero matches, got %+v", matches)
+	}
+}
+
+// TestWorkspacesLsJSONFixture: snapshot the JSON shape against a
+// hand-curated fixture. We patch volatile field values (id, cwd,
+// last_touched) by regex before comparing so the assertion is robust
+// across hosts and clocks. Field ORDER is part of the spec — the
+// fixture is the source of truth and writeWorkspacesJSON emits via
+// a struct, so order is stable.
+func TestWorkspacesLsJSONFixture(t *testing.T) {
+	wsA, wsB := seedTwoWorkspaces(t)
+
+	infos, err := registry.ListInfo()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	if err := writeWorkspacesJSON(&buf, infos); err != nil {
+		t.Fatal(err)
+	}
+	got := scrubVolatile(buf.String(), wsA, wsB,
+		registry.WorkspaceID(wsA), registry.WorkspaceID(wsB))
+
+	fixturePath := filepath.Join("testdata", "workspaces_ls.json")
+	wantBytes, err := os.ReadFile(fixturePath)
+	if err != nil {
+		t.Fatalf("fixture: %v", err)
+	}
+	want := strings.TrimRight(string(wantBytes), "\n")
+	got = strings.TrimRight(got, "\n")
+	if got != want {
+		t.Errorf("fixture mismatch:\nwant:\n%s\ngot:\n%s", want, got)
+	}
+}
+
+// scrubVolatile rewrites the JSON output so non-deterministic fields
+// (id hash, absolute cwd, RFC3339 timestamp) are replaced with
+// placeholder strings matching the fixture.
+func scrubVolatile(s, wsA, wsB, idA, idB string) string {
+	s = strings.ReplaceAll(s, idA, "<id>")
+	s = strings.ReplaceAll(s, idB, "<id>")
+	s = strings.ReplaceAll(s, wsA, "<cwd>")
+	s = strings.ReplaceAll(s, wsB, "<cwd>")
+	// last_touched is a quoted RFC3339 string; rewrite the whole
+	// value via the field name.
+	out := make([]string, 0, 16)
+	for _, line := range strings.Split(s, "\n") {
+		if strings.Contains(line, `"last_touched":`) {
+			indent := line[:len(line)-len(strings.TrimLeft(line, " \t"))]
+			line = indent + `"last_touched": "<time>",`
+			// Last item before "agent_id" — keep trailing comma.
+		}
+		out = append(out, line)
+	}
+	return strings.Join(out, "\n")
+}

--- a/cmd/bones/cli.go
+++ b/cmd/bones/cli.go
@@ -23,6 +23,11 @@ type CLI struct {
 	Env    bonescli.EnvCmd    `cmd:"" group:"daily" help:"Emit shell exports for current workspace"`
 	Rename bonescli.RenameCmd `cmd:"" group:"daily" help:"Set workspace display name"`
 
+	// Workspaces (#174) — top-level "is bones up for project X?" view.
+	// Separated from the daily block above so gofmt does not realign
+	// the longer field name and overflow lll's 100-column limit.
+	Workspaces bonescli.WorkspacesCmd `cmd:"" group:"daily" help:"List/inspect known workspaces"`
+
 	// Repository.
 	Repo libfossilcli.RepoCmd `cmd:"" group:"repo" help:"Fossil repository operations"`
 

--- a/internal/registry/info.go
+++ b/internal/registry/info.go
@@ -1,0 +1,141 @@
+package registry
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// HubStatus is a coarse liveness label produced by ListInfo. Values:
+//
+//	HubRunning  — registry recorded a hub PID, the PID is alive on this host,
+//	              and a quick TCP/HTTP probe of HubURL returned a response.
+//	HubStopped  — registry has an entry, but the hub is not reachable
+//	              (PID dead OR HTTP probe failed).
+//	HubUnknown  — the entry has no enough info to probe (e.g. missing
+//	              HubURL/HubPID), or a probe was deliberately skipped.
+type HubStatus string
+
+const (
+	HubRunning HubStatus = "running"
+	HubStopped HubStatus = "stopped"
+	HubUnknown HubStatus = "unknown"
+)
+
+// Info is one workspace registry record enriched with the on-disk filename
+// (ID), file mtime (LastTouched), the workspace's agent.id marker (when
+// present), and a coarse hub liveness label.
+//
+// ID is the hex string used as the registry filename:
+// ~/.bones/workspaces/<ID>.json. It equals WorkspaceID(Cwd).
+type Info struct {
+	Entry
+
+	ID          string    `json:"id"`
+	AgentID     string    `json:"agent_id"`
+	HubStatus   HubStatus `json:"hub_status"`
+	LastTouched time.Time `json:"last_touched"`
+}
+
+// ListInfo enumerates every registry entry, attaching ID + mtime + agent.id +
+// hub-status. Corrupt or unreadable files are skipped (matching List). The
+// hub-status probe runs IsAlive on each entry; callers that want to skip
+// the probe (e.g. for fast paths) should use List + their own enrichment.
+//
+// Results are sorted by Name, then Cwd, for stable output across calls.
+func ListInfo() ([]Info, error) {
+	matches, err := filepath.Glob(filepath.Join(RegistryDir(), "*.json"))
+	if err != nil {
+		return nil, err
+	}
+	out := make([]Info, 0, len(matches))
+	for _, path := range matches {
+		// Skip atomic-write tmp files (".tmp.*"); only top-level *.json
+		// files are real entries.
+		if strings.Contains(filepath.Base(path), ".tmp.") {
+			continue
+		}
+		fi, err := os.Stat(path)
+		if err != nil {
+			continue
+		}
+		// Read the entry payload via the canonical Read seam so any
+		// future migrations land here too.
+		e, err := readEntryAtPath(path)
+		if err != nil {
+			continue
+		}
+		info := Info{
+			Entry:       e,
+			ID:          strings.TrimSuffix(filepath.Base(path), ".json"),
+			AgentID:     readAgentIDFile(e.Cwd),
+			HubStatus:   probeStatus(e),
+			LastTouched: fi.ModTime(),
+		}
+		out = append(out, info)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Name != out[j].Name {
+			return out[i].Name < out[j].Name
+		}
+		return out[i].Cwd < out[j].Cwd
+	})
+	return out, nil
+}
+
+// readEntryAtPath is the path-keyed sibling of Read. Read is cwd-keyed and
+// recomputes the filename via WorkspaceID; ListInfo already has the path,
+// so we read it directly to avoid the extra hash + to surface decode
+// errors at the right path.
+func readEntryAtPath(path string) (Entry, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return Entry{}, err
+	}
+	var e Entry
+	if err := json.Unmarshal(data, &e); err != nil {
+		return Entry{}, err
+	}
+	return e, nil
+}
+
+// readAgentIDFile reads <cwd>/.bones/agent.id and trims trailing whitespace,
+// or returns "" if the marker is missing or unreadable. The registry entry
+// is the source of truth for cwd, so we recompute the marker path from it.
+// Returns "" rather than an error to keep ListInfo best-effort: a workspace
+// directory that has been deleted out from under the registry should still
+// show up in `bones workspaces ls` so the operator can clean it up.
+func readAgentIDFile(cwd string) string {
+	if cwd == "" {
+		return ""
+	}
+	data, err := os.ReadFile(filepath.Join(cwd, ".bones", "agent.id"))
+	if err != nil {
+		// Fall through; cwd may have moved or .bones may have been
+		// scrubbed. Treat as unknown rather than failing the listing.
+		return ""
+	}
+	return strings.TrimSpace(string(data))
+}
+
+// probeStatus maps Entry → HubStatus using the same liveness probe that
+// `bones status --all` uses for live-only filtering. We do not parallelize
+// here: HealthTimeout caps each probe at 500ms by default, which is fast
+// enough for the ls path even with several workspaces. If that becomes a
+// problem we can promote the probe to a goroutine pool.
+//
+// Entries lacking a HubURL or HubPID are reported HubUnknown — they
+// pre-date the field or were written by a buggy hub. Either way, we
+// don't have enough signal to call them running or stopped.
+func probeStatus(e Entry) HubStatus {
+	if e.HubURL == "" || e.HubPID == 0 {
+		return HubUnknown
+	}
+	if IsAlive(e) {
+		return HubRunning
+	}
+	return HubStopped
+}

--- a/internal/registry/info_test.go
+++ b/internal/registry/info_test.go
@@ -1,0 +1,180 @@
+package registry
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestListInfoEnumerates seeds two registry files (each backed by a real
+// workspace directory with .bones/agent.id) and asserts that ListInfo
+// returns both, with ID, AgentID, LastTouched, and HubStatus populated.
+//
+// HubStatus is asserted as HubStopped: the entries reference fake PIDs
+// and unreachable URLs so IsAlive returns false. We don't assert
+// HubRunning here — that requires a live hub and is exercised by
+// `bones status --all` integration tests.
+func TestListInfoEnumerates(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	wsA := t.TempDir()
+	wsB := t.TempDir()
+	mustWriteAgentID(t, wsA, "agent-a")
+	mustWriteAgentID(t, wsB, "agent-b")
+
+	now := time.Now().UTC().Truncate(time.Second)
+	entries := []Entry{
+		{
+			Cwd: wsA, Name: "alpha",
+			HubURL:    "http://127.0.0.1:1", // unreachable
+			NATSURL:   "nats://127.0.0.1:1",
+			HubPID:    -1, // pidAlive returns false on pid<=0
+			StartedAt: now,
+		},
+		{
+			Cwd: wsB, Name: "beta",
+			HubURL:    "http://127.0.0.1:2",
+			NATSURL:   "nats://127.0.0.1:2",
+			HubPID:    -2,
+			StartedAt: now,
+		},
+	}
+	for _, e := range entries {
+		if err := Write(e); err != nil {
+			t.Fatalf("Write(%s): %v", e.Name, err)
+		}
+	}
+
+	got, err := ListInfo()
+	if err != nil {
+		t.Fatalf("ListInfo: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("ListInfo len = %d, want 2 (got %+v)", len(got), got)
+	}
+
+	// Sorted by Name: alpha < beta.
+	if got[0].Name != "alpha" || got[1].Name != "beta" {
+		t.Fatalf("sort order: got %q,%q want alpha,beta",
+			got[0].Name, got[1].Name)
+	}
+
+	for _, info := range got {
+		if info.ID == "" {
+			t.Errorf("%s: ID empty", info.Name)
+		}
+		if info.ID != WorkspaceID(info.Cwd) {
+			t.Errorf("%s: ID = %q, want %q",
+				info.Name, info.ID, WorkspaceID(info.Cwd))
+		}
+		if info.LastTouched.IsZero() {
+			t.Errorf("%s: LastTouched zero", info.Name)
+		}
+		if info.HubStatus != HubStopped {
+			t.Errorf("%s: HubStatus = %q, want %q",
+				info.Name, info.HubStatus, HubStopped)
+		}
+	}
+
+	if got[0].AgentID != "agent-a" {
+		t.Errorf("alpha agent_id = %q, want agent-a", got[0].AgentID)
+	}
+	if got[1].AgentID != "agent-b" {
+		t.Errorf("beta agent_id = %q, want agent-b", got[1].AgentID)
+	}
+}
+
+// TestListInfoEmpty: no registry directory present.
+func TestListInfoEmpty(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	got, err := ListInfo()
+	if err != nil {
+		t.Fatalf("ListInfo on empty home: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected empty, got %+v", got)
+	}
+}
+
+// TestListInfoSkipsCorrupt: a malformed JSON file in the registry dir
+// must not abort the listing — corrupt files are silently skipped.
+func TestListInfoSkipsCorrupt(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	good := t.TempDir()
+	mustWriteAgentID(t, good, "good")
+	if err := Write(Entry{
+		Cwd: good, Name: "good",
+		HubURL: "http://127.0.0.1:0", HubPID: -1,
+		StartedAt: time.Now().UTC().Truncate(time.Second),
+	}); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	bogus := filepath.Join(RegistryDir(), "deadbeefdeadbeef.json")
+	if err := os.WriteFile(bogus, []byte("not json"), 0o644); err != nil {
+		t.Fatalf("write bogus: %v", err)
+	}
+	got, err := ListInfo()
+	if err != nil {
+		t.Fatalf("ListInfo: %v", err)
+	}
+	if len(got) != 1 || got[0].Name != "good" {
+		t.Fatalf("expected just [good], got %+v", got)
+	}
+}
+
+// TestListInfoMissingAgentID: registry entry whose cwd no longer has a
+// .bones/agent.id (workspace removed underneath us) reports AgentID="".
+func TestListInfoMissingAgentID(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	gone := filepath.Join(t.TempDir(), "gone") // never created
+	if err := Write(Entry{
+		Cwd: gone, Name: "gone",
+		HubURL: "http://127.0.0.1:0", HubPID: -1,
+		StartedAt: time.Now().UTC().Truncate(time.Second),
+	}); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	got, err := ListInfo()
+	if err != nil {
+		t.Fatalf("ListInfo: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(got))
+	}
+	if got[0].AgentID != "" {
+		t.Errorf("AgentID = %q, want empty", got[0].AgentID)
+	}
+	if got[0].HubStatus != HubStopped {
+		t.Errorf("HubStatus = %q, want stopped", got[0].HubStatus)
+	}
+}
+
+// TestProbeStatusUnknown: entries lacking HubURL or HubPID = HubUnknown.
+func TestProbeStatusUnknown(t *testing.T) {
+	if got := probeStatus(Entry{}); got != HubUnknown {
+		t.Errorf("empty entry: got %q, want %q", got, HubUnknown)
+	}
+	if got := probeStatus(Entry{HubURL: "http://x"}); got != HubUnknown {
+		t.Errorf("missing pid: got %q, want %q", got, HubUnknown)
+	}
+	if got := probeStatus(Entry{HubPID: 1}); got != HubUnknown {
+		t.Errorf("missing url: got %q, want %q", got, HubUnknown)
+	}
+}
+
+func mustWriteAgentID(t *testing.T, root, id string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(root, ".bones"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(root, ".bones", "agent.id"),
+		[]byte(id+"\n"), 0o644,
+	); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
## Summary

Adds a new top-level `bones workspaces` group with `ls` and `show <name>` subverbs so operators can answer "is bones up for project X?" without `cat`-ing every JSON file under `~/.bones/workspaces/`. Implements issue #174 option (2): subcommand surface, on-disk filenames stay hash-keyed.

- `bones workspaces ls` — human-readable table (NAME, CWD, HUB, LAST-TOUCHED) with `--json` for machine-readable output (`id`, `name`, `cwd`, `hub_status`, `last_touched`, `agent_id`, `nats_url`, `hub_url`).
- `bones workspaces show <name>` — full registry entry as pretty JSON; matches by `Name` or by 16-hex filename ID. Ambiguous names list every match with its ID + cwd and exit non-zero.
- Adds `registry.ListInfo` (enriches `List` with ID + mtime + agent.id + hub-status). Hub-status probe reuses `registry.IsAlive` (PID + 500ms HTTP probe) — same signal `bones status --all` uses; entries lacking HubURL/HubPID surface as `unknown` rather than blocking on a probe.
- `ls` does NOT prune stopped entries (unlike `status --all`'s live-only semantics): operators debugging "bones up shows the wrong project" need to see what bones thinks it knows about.

## Test plan

- [x] `make check` (fmt-check, vet, lint, race, todo-check) — green
- [x] `go test -tags=otel -short ./...` — green
- [x] New unit tests: registry enumeration, JSON fixture (2-workspace setup), match-by-name, match-by-ID, ambiguous-name error, missing-`agent.id` fallback, corrupt-file skip
- [x] Smoke-tested against real `~/.bones/workspaces/` (21 entries from prior test runs visible in both table and JSON output)

Closes #174