### PR TITLE
feat(up): structured log + expanded summary + ADR-0041 help text

### DIFF
--- a/cli/orchestrator.go
+++ b/cli/orchestrator.go
@@ -49,6 +49,41 @@ const claudeManagedBody = "Bones is active in this workspace. " +
 // names are left alone.
 var legacyBonesSkills = []string{"orchestrator", "subagent", "uninstall-bones"}
 
+// scaffoldFootprint captures what scaffoldOrchestrator did during a
+// single invocation, for surfacing in the default-mode `bones up`
+// summary (issue #173). All counts and slices are zero-value safe; a
+// re-run on a fully-scaffolded workspace yields an empty footprint.
+type scaffoldFootprint struct {
+	// FilesWritten lists workspace-relative paths that were created or
+	// rewritten as bones-owned files (e.g. AGENTS.md, CLAUDE.md when
+	// fresh-installed as a symlink, .bones/AGENT_GUIDANCE.md).
+	FilesWritten []string
+
+	// MarkerBlockTargets lists workspace-relative paths whose existing
+	// user content received an upserted bones marker block (e.g.
+	// CLAUDE.md when user-authored).
+	MarkerBlockTargets []string
+
+	// GitignoreEntriesAdded lists the entries newly appended to
+	// .gitignore. Empty when all entries already existed.
+	GitignoreEntriesAdded []string
+
+	// HooksAddedByEvent counts new hook entries added to settings.json,
+	// keyed by event name (e.g. "SessionStart": 2, "PreCompact": 1).
+	// Existing duplicates are not counted.
+	HooksAddedByEvent map[string]int
+}
+
+// hooksAdded returns the total count of new hook entries written, summed
+// across all events. Used to keep the summary line one-shot.
+func (f *scaffoldFootprint) hooksAdded() int {
+	n := 0
+	for _, c := range f.HooksAddedByEvent {
+		n += c
+	}
+	return n
+}
+
 // scaffoldOrchestrator scaffolds the AGENTS.md universal channel and
 // Claude-format hooks into the workspace at root. Per ADR 0042 the
 // pre-existing per-skill markdown trees under .claude/skills/{orchestrator,
@@ -58,26 +93,35 @@ var legacyBonesSkills = []string{"orchestrator", "subagent", "uninstall-bones"}
 //
 // Idempotent: re-running yields no diff against an already-installed
 // workspace.
-func scaffoldOrchestrator(root string) error {
+//
+// Returns a scaffoldFootprint describing the per-call file-and-hook
+// changes (used by runUp to render the default-mode summary, #173). The
+// footprint is best-effort: helpers track only the actions they actually
+// performed, so a fully-scaffolded workspace produces a zero-value
+// footprint.
+func scaffoldOrchestrator(root string) (scaffoldFootprint, error) {
+	var fp scaffoldFootprint
+	fp.HooksAddedByEvent = map[string]int{}
+
 	if err := removeLegacyBonesSkills(root); err != nil {
-		return fmt.Errorf("legacy skills cleanup: %w", err)
+		return fp, fmt.Errorf("legacy skills cleanup: %w", err)
 	}
-	if err := writeAgentsMD(root); err != nil {
-		return fmt.Errorf("agents.md: %w", err)
+	if err := writeAgentsMD(root, &fp); err != nil {
+		return fp, fmt.Errorf("agents.md: %w", err)
 	}
-	if err := linkClaudeMD(root); err != nil {
-		return fmt.Errorf("claude.md symlink: %w", err)
+	if err := linkClaudeMD(root, &fp); err != nil {
+		return fp, fmt.Errorf("claude.md symlink: %w", err)
 	}
-	if err := mergeSettings(filepath.Join(root, ".claude", "settings.json")); err != nil {
-		return fmt.Errorf("settings: %w", err)
+	if err := mergeSettings(filepath.Join(root, ".claude", "settings.json"), &fp); err != nil {
+		return fp, fmt.Errorf("settings: %w", err)
 	}
-	if err := ensureGitignoreEntries(root); err != nil {
-		return fmt.Errorf("root gitignore: %w", err)
+	if err := ensureGitignoreEntries(root, &fp); err != nil {
+		return fp, fmt.Errorf("root gitignore: %w", err)
 	}
 	if err := scaffoldver.Write(root, version.Get()); err != nil {
-		return fmt.Errorf("scaffold version stamp: %w", err)
+		return fp, fmt.Errorf("scaffold version stamp: %w", err)
 	}
-	return nil
+	return fp, nil
 }
 
 // removeLegacyBonesSkills removes the three pre-ADR-0042 bones-owned
@@ -126,16 +170,39 @@ func removeLegacyBonesSkills(root string) error {
 //
 // The user-authored case (added per issue #145) replaces an earlier
 // guard that refused user content outright.
-func writeAgentsMD(root string) error {
+func writeAgentsMD(root string, fp *scaffoldFootprint) error {
 	path := filepath.Join(root, "AGENTS.md")
 	existing, err := os.ReadFile(path)
 	if err != nil && !os.IsNotExist(err) {
 		return err
 	}
-	if os.IsNotExist(err) || bonesOwnedAgentsMD(existing) {
-		return os.WriteFile(path, agentsMDTemplate, 0o644)
+	if os.IsNotExist(err) {
+		if err := os.WriteFile(path, agentsMDTemplate, 0o644); err != nil {
+			return err
+		}
+		recordWritten(fp, "AGENTS.md")
+		return nil
 	}
-	return upsertManagedBlock(path, string(agentsMDTemplate))
+	if bonesOwnedAgentsMD(existing) {
+		// Bones-owned: rewrite in place. Only count as "written" when the
+		// content actually changed, so re-running on a converged
+		// workspace doesn't lie in the summary.
+		if string(existing) != string(agentsMDTemplate) {
+			if err := os.WriteFile(path, agentsMDTemplate, 0o644); err != nil {
+				return err
+			}
+			recordWritten(fp, "AGENTS.md")
+		}
+		return nil
+	}
+	had := hasManagedBlock(existing)
+	if err := upsertManagedBlock(path, string(agentsMDTemplate)); err != nil {
+		return err
+	}
+	if !had {
+		recordMarkerBlock(fp, "AGENTS.md")
+	}
+	return nil
 }
 
 // findManagedBlock locates the outer bones-managed section in s using
@@ -339,7 +406,7 @@ func bonesOwnedAgentsMD(content []byte) bool {
 // The user-authored regular-file case (added per issue #145) replaces
 // the earlier guard from issue #139 that refused user content
 // outright.
-func linkClaudeMD(root string) error {
+func linkClaudeMD(root string, fp *scaffoldFootprint) error {
 	target := "AGENTS.md"
 	link := filepath.Join(root, "CLAUDE.md")
 
@@ -359,22 +426,41 @@ func linkClaudeMD(root string) error {
 
 	if os.IsNotExist(err) {
 		if err := os.Symlink(target, link); err == nil {
+			recordWritten(fp, "CLAUDE.md")
 			return nil
 		}
 		// Fallback: write a regular file with the same content. Less
 		// ideal (drifts on AGENTS.md edits), but symlinks are
 		// unsupported on some filesystems (e.g. older Windows volumes
 		// without developer mode).
-		return os.WriteFile(link, agentsMDTemplate, 0o644)
+		if err := os.WriteFile(link, agentsMDTemplate, 0o644); err != nil {
+			return err
+		}
+		recordWritten(fp, "CLAUDE.md")
+		return nil
 	}
 
 	if bonesOwnedAgentsMD(data) {
 		// Bones-owned fallback shape: rewrite in place to converge on
-		// the current template.
-		return os.WriteFile(link, agentsMDTemplate, 0o644)
+		// the current template. Only record as "written" when content
+		// actually changes.
+		if string(data) != string(agentsMDTemplate) {
+			if err := os.WriteFile(link, agentsMDTemplate, 0o644); err != nil {
+				return err
+			}
+			recordWritten(fp, "CLAUDE.md")
+		}
+		return nil
 	}
 
-	return upsertManagedBlock(link, claudeManagedBody)
+	had := hasManagedBlock(data)
+	if err := upsertManagedBlock(link, claudeManagedBody); err != nil {
+		return err
+	}
+	if !had {
+		recordMarkerBlock(fp, "CLAUDE.md")
+	}
+	return nil
 }
 
 // mergeSettings idempotently installs the SessionStart + PreCompact
@@ -391,7 +477,7 @@ func linkClaudeMD(root string) error {
 // ADR 0038 the hub is workspace-scoped and `bones down` is the explicit
 // teardown; legacy hub-shutdown.sh entries under Stop or SessionEnd are
 // migrated away.
-func mergeSettings(path string) error {
+func mergeSettings(path string, fp *scaffoldFootprint) error {
 	root := map[string]any{}
 	if data, err := os.ReadFile(path); err == nil {
 		if len(data) > 0 {
@@ -427,9 +513,15 @@ func mergeSettings(path string) error {
 	// session boundaries — specs written outside `bones tasks` evaporate
 	// at the next compaction, which keeps planners filing atomic work
 	// rather than bypassing the tracker with freeform docs.
-	addHook(hooks, "SessionStart", "bones tasks prime --json")
-	addHook(hooks, "SessionStart", "bones hub start")
-	addHook(hooks, "PreCompact", "bones tasks prime --json")
+	if addHook(hooks, "SessionStart", "bones tasks prime --json") {
+		recordHook(fp, "SessionStart")
+	}
+	if addHook(hooks, "SessionStart", "bones hub start") {
+		recordHook(fp, "SessionStart")
+	}
+	if addHook(hooks, "PreCompact", "bones tasks prime --json") {
+		recordHook(fp, "PreCompact")
+	}
 
 	root["hooks"] = hooks
 
@@ -518,7 +610,10 @@ func pruneCommandFromEvent(hooks map[string]any, event, needle string) {
 	hooks[event] = keep
 }
 
-func addHook(hooks map[string]any, event, cmd string) {
+// addHook returns true when a fresh entry was appended, false when the
+// hook was already present (idempotent no-op). The boolean lets the
+// caller report a precise "merged N hooks" count in the up summary.
+func addHook(hooks map[string]any, event, cmd string) bool {
 	groups, _ := hooks[event].([]any)
 
 	grpIdx := -1
@@ -551,7 +646,7 @@ func addHook(hooks map[string]any, event, cmd string) {
 		}
 		if c, _ := em["command"].(string); c == cmd {
 			hooks[event] = groups
-			return
+			return false
 		}
 	}
 
@@ -563,6 +658,39 @@ func addHook(hooks map[string]any, event, cmd string) {
 	grp["hooks"] = entries
 	groups[grpIdx] = grp
 	hooks[event] = groups
+	return true
+}
+
+// recordWritten appends path to fp.FilesWritten when fp is non-nil. The
+// nil-check keeps every helper safe to call from tests that don't care
+// about footprint reporting.
+func recordWritten(fp *scaffoldFootprint, path string) {
+	if fp == nil {
+		return
+	}
+	fp.FilesWritten = append(fp.FilesWritten, path)
+}
+
+// recordMarkerBlock appends path to fp.MarkerBlockTargets when fp is
+// non-nil. Used when an upsert added a fresh bones-managed block to a
+// user-authored file (vs. a no-op refresh).
+func recordMarkerBlock(fp *scaffoldFootprint, path string) {
+	if fp == nil {
+		return
+	}
+	fp.MarkerBlockTargets = append(fp.MarkerBlockTargets, path)
+}
+
+// recordHook bumps the per-event hook-add counter when fp is non-nil.
+// Initializes the map on first use so callers can stay terse.
+func recordHook(fp *scaffoldFootprint, event string) {
+	if fp == nil {
+		return
+	}
+	if fp.HooksAddedByEvent == nil {
+		fp.HooksAddedByEvent = map[string]int{}
+	}
+	fp.HooksAddedByEvent[event]++
 }
 
 // ensureGitignoreEntries appends Fossil + bones runtime entries to the
@@ -574,7 +702,7 @@ func addHook(hooks map[string]any, event, cmd string) {
 //
 // Idempotent: skips entries already present (whole-line match).
 // Creates .gitignore if missing.
-func ensureGitignoreEntries(dir string) error {
+func ensureGitignoreEntries(dir string, fp *scaffoldFootprint) error {
 	path := filepath.Join(dir, ".gitignore")
 	wantEntries := []string{
 		".fslckout",
@@ -615,6 +743,9 @@ func ensureGitignoreEntries(dir string) error {
 		if _, err := f.WriteString(e + "\n"); err != nil {
 			return fmt.Errorf("write .gitignore: %w", err)
 		}
+	}
+	if fp != nil {
+		fp.GitignoreEntriesAdded = append(fp.GitignoreEntriesAdded, missing...)
 	}
 	return nil
 }

--- a/cli/orchestrator_test.go
+++ b/cli/orchestrator_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestScaffoldOrchestrator_FreshWorkspace(t *testing.T) {
 	dir := t.TempDir()
-	if err := scaffoldOrchestrator(dir); err != nil {
+	if _, err := scaffoldOrchestrator(dir); err != nil {
 		t.Fatalf("scaffoldOrchestrator: %v", err)
 	}
 	// Per ADR 0042: AGENTS.md (universal channel) + CLAUDE.md symlink
@@ -61,12 +61,12 @@ func TestScaffoldOrchestrator_FreshWorkspace(t *testing.T) {
 // content diff.
 func TestScaffoldOrchestrator_Idempotent_AGENTSandCLAUDE(t *testing.T) {
 	dir := t.TempDir()
-	if err := scaffoldOrchestrator(dir); err != nil {
+	if _, err := scaffoldOrchestrator(dir); err != nil {
 		t.Fatal(err)
 	}
 	firstAgents, _ := os.ReadFile(filepath.Join(dir, "AGENTS.md"))
 	firstClaude, _ := os.Readlink(filepath.Join(dir, "CLAUDE.md"))
-	if err := scaffoldOrchestrator(dir); err != nil {
+	if _, err := scaffoldOrchestrator(dir); err != nil {
 		t.Fatal(err)
 	}
 	secondAgents, _ := os.ReadFile(filepath.Join(dir, "AGENTS.md"))
@@ -96,7 +96,7 @@ func TestScaffoldOrchestrator_WipesLegacyBonesSkills(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	if err := scaffoldOrchestrator(dir); err != nil {
+	if _, err := scaffoldOrchestrator(dir); err != nil {
 		t.Fatalf("scaffoldOrchestrator: %v", err)
 	}
 	for _, name := range legacyBonesSkills {
@@ -119,7 +119,7 @@ func TestScaffoldOrchestrator_PreservesUserAuthoredSkills(t *testing.T) {
 	if err := os.WriteFile(skillPath, []byte("mine\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := scaffoldOrchestrator(dir); err != nil {
+	if _, err := scaffoldOrchestrator(dir); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := os.Stat(userSkill); err != nil {
@@ -139,7 +139,7 @@ func TestScaffoldOrchestrator_AppendsBlockToUserAuthoredAGENTS(t *testing.T) {
 	if err := os.WriteFile(agentsPath, []byte(usersAgents), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := scaffoldOrchestrator(dir); err != nil {
+	if _, err := scaffoldOrchestrator(dir); err != nil {
 		t.Fatalf("scaffoldOrchestrator on user-authored AGENTS.md: %v", err)
 	}
 	got, _ := os.ReadFile(agentsPath)
@@ -155,14 +155,14 @@ func TestScaffoldOrchestrator_AppendsBlockToUserAuthoredAGENTS(t *testing.T) {
 
 func TestScaffoldOrchestrator_Idempotent(t *testing.T) {
 	dir := t.TempDir()
-	if err := scaffoldOrchestrator(dir); err != nil {
+	if _, err := scaffoldOrchestrator(dir); err != nil {
 		t.Fatal(err)
 	}
 	first, err := os.ReadFile(filepath.Join(dir, ".claude", "settings.json"))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := scaffoldOrchestrator(dir); err != nil {
+	if _, err := scaffoldOrchestrator(dir); err != nil {
 		t.Fatal(err)
 	}
 	second, err := os.ReadFile(filepath.Join(dir, ".claude", "settings.json"))
@@ -189,7 +189,7 @@ func TestScaffoldOrchestrator_PreservesExistingHooks(t *testing.T) {
 	if err := os.WriteFile(settings, []byte(existing), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := scaffoldOrchestrator(dir); err != nil {
+	if _, err := scaffoldOrchestrator(dir); err != nil {
 		t.Fatal(err)
 	}
 	data, err := os.ReadFile(settings)
@@ -246,7 +246,7 @@ func TestScaffoldOrchestrator_MigrateLegacyStopHook(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := scaffoldOrchestrator(dir); err != nil {
+	if _, err := scaffoldOrchestrator(dir); err != nil {
 		t.Fatalf("scaffoldOrchestrator: %v", err)
 	}
 
@@ -296,7 +296,7 @@ func TestScaffoldOrchestrator_PreservesUnrelatedStopHook(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := scaffoldOrchestrator(dir); err != nil {
+	if _, err := scaffoldOrchestrator(dir); err != nil {
 		t.Fatalf("scaffoldOrchestrator: %v", err)
 	}
 
@@ -362,7 +362,7 @@ func countHookCommand(settings map[string]any, event, cmd string) int {
 // "tasks-as-survivor" pressure that keeps planners filing atomic work.
 func TestScaffoldOrchestrator_SessionStartIncludesPrime(t *testing.T) {
 	dir := t.TempDir()
-	if err := scaffoldOrchestrator(dir); err != nil {
+	if _, err := scaffoldOrchestrator(dir); err != nil {
 		t.Fatalf("scaffoldOrchestrator: %v", err)
 	}
 	cmds := hookCommandsFor(readSettings(t, dir), "SessionStart")
@@ -378,7 +378,7 @@ func TestScaffoldOrchestrator_SessionStartIncludesPrime(t *testing.T) {
 // alone leaves a multi-hour window where freeform context can win.
 func TestScaffoldOrchestrator_PreCompactIncludesPrime(t *testing.T) {
 	dir := t.TempDir()
-	if err := scaffoldOrchestrator(dir); err != nil {
+	if _, err := scaffoldOrchestrator(dir); err != nil {
 		t.Fatalf("scaffoldOrchestrator: %v", err)
 	}
 	cmds := hookCommandsFor(readSettings(t, dir), "PreCompact")
@@ -396,7 +396,7 @@ func TestScaffoldOrchestrator_PreCompactIncludesPrime(t *testing.T) {
 func TestScaffoldOrchestrator_PrimeHookIdempotent(t *testing.T) {
 	dir := t.TempDir()
 	for i := range 3 {
-		if err := scaffoldOrchestrator(dir); err != nil {
+		if _, err := scaffoldOrchestrator(dir); err != nil {
 			t.Fatalf("scaffold pass %d: %v", i+1, err)
 		}
 	}
@@ -472,7 +472,7 @@ func TestScaffoldOrchestrator_MigrateLegacySessionEndShutdown(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := scaffoldOrchestrator(dir); err != nil {
+	if _, err := scaffoldOrchestrator(dir); err != nil {
 		t.Fatalf("scaffoldOrchestrator: %v", err)
 	}
 
@@ -514,7 +514,7 @@ func TestScaffoldOrchestrator_PreservesUnrelatedSessionEndHook(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := scaffoldOrchestrator(dir); err != nil {
+	if _, err := scaffoldOrchestrator(dir); err != nil {
 		t.Fatalf("scaffoldOrchestrator: %v", err)
 	}
 
@@ -530,7 +530,7 @@ func TestScaffoldOrchestrator_PreservesUnrelatedSessionEndHook(t *testing.T) {
 // ADR 0023.
 func TestScaffoldOrchestrator_AgentsMDHasADR0023Completion(t *testing.T) {
 	dir := t.TempDir()
-	if err := scaffoldOrchestrator(dir); err != nil {
+	if _, err := scaffoldOrchestrator(dir); err != nil {
 		t.Fatalf("scaffoldOrchestrator: %v", err)
 	}
 	agents, err := os.ReadFile(filepath.Join(dir, "AGENTS.md"))
@@ -550,7 +550,7 @@ func TestScaffoldOrchestrator_AgentsMDHasADR0023Completion(t *testing.T) {
 // a value to compare against.
 func TestScaffoldOrchestrator_StampsScaffoldVersion(t *testing.T) {
 	dir := t.TempDir()
-	if err := scaffoldOrchestrator(dir); err != nil {
+	if _, err := scaffoldOrchestrator(dir); err != nil {
 		t.Fatalf("scaffoldOrchestrator: %v", err)
 	}
 	stamp, err := os.ReadFile(filepath.Join(dir, ".bones", "scaffold_version"))
@@ -565,7 +565,7 @@ func TestScaffoldOrchestrator_StampsScaffoldVersion(t *testing.T) {
 
 func TestEnsureGitignoreEntries_FreshFile(t *testing.T) {
 	dir := t.TempDir()
-	if err := ensureGitignoreEntries(dir); err != nil {
+	if err := ensureGitignoreEntries(dir, nil); err != nil {
 		t.Fatal(err)
 	}
 	data, err := os.ReadFile(filepath.Join(dir, ".gitignore"))
@@ -593,14 +593,14 @@ func TestEnsureGitignoreEntries_FreshFile(t *testing.T) {
 
 func TestEnsureGitignoreEntries_Idempotent(t *testing.T) {
 	dir := t.TempDir()
-	if err := ensureGitignoreEntries(dir); err != nil {
+	if err := ensureGitignoreEntries(dir, nil); err != nil {
 		t.Fatal(err)
 	}
 	first, err := os.ReadFile(filepath.Join(dir, ".gitignore"))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := ensureGitignoreEntries(dir); err != nil {
+	if err := ensureGitignoreEntries(dir, nil); err != nil {
 		t.Fatal(err)
 	}
 	second, err := os.ReadFile(filepath.Join(dir, ".gitignore"))
@@ -619,7 +619,7 @@ func TestEnsureGitignoreEntries_PreservesExisting(t *testing.T) {
 	if err := os.WriteFile(path, []byte(preexisting), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := ensureGitignoreEntries(dir); err != nil {
+	if err := ensureGitignoreEntries(dir, nil); err != nil {
 		t.Fatal(err)
 	}
 	data, err := os.ReadFile(path)
@@ -641,7 +641,7 @@ func TestEnsureGitignoreEntries_PartialOverlap(t *testing.T) {
 	if err := os.WriteFile(path, []byte(preexisting), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := ensureGitignoreEntries(dir); err != nil {
+	if err := ensureGitignoreEntries(dir, nil); err != nil {
 		t.Fatal(err)
 	}
 	data, err := os.ReadFile(path)
@@ -783,7 +783,7 @@ func TestScaffoldOrchestrator_MigratesLegacyBootstrap(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := scaffoldOrchestrator(dir); err != nil {
+	if _, err := scaffoldOrchestrator(dir); err != nil {
 		t.Fatalf("scaffoldOrchestrator: %v", err)
 	}
 
@@ -814,7 +814,7 @@ func TestLinkClaudeMD_AppendsBlockToUserAuthoredFile(t *testing.T) {
 	if err := os.WriteFile(claudePath, []byte(usersClaude), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := linkClaudeMD(dir); err != nil {
+	if err := linkClaudeMD(dir, nil); err != nil {
 		t.Fatalf("linkClaudeMD on user-authored CLAUDE.md: %v", err)
 	}
 	got, _ := os.ReadFile(claudePath)
@@ -842,11 +842,11 @@ func TestLinkClaudeMD_IdempotentUserAuthored(t *testing.T) {
 	if err := os.WriteFile(claudePath, []byte(usersClaude), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := linkClaudeMD(dir); err != nil {
+	if err := linkClaudeMD(dir, nil); err != nil {
 		t.Fatalf("first linkClaudeMD: %v", err)
 	}
 	first, _ := os.ReadFile(claudePath)
-	if err := linkClaudeMD(dir); err != nil {
+	if err := linkClaudeMD(dir, nil); err != nil {
 		t.Fatalf("second linkClaudeMD: %v", err)
 	}
 	second, _ := os.ReadFile(claudePath)
@@ -865,7 +865,7 @@ func TestLinkClaudeMD_PreservesUserEditsAboveBlock(t *testing.T) {
 	if err := os.WriteFile(claudePath, []byte("# Original\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := linkClaudeMD(dir); err != nil {
+	if err := linkClaudeMD(dir, nil); err != nil {
 		t.Fatalf("first linkClaudeMD: %v", err)
 	}
 	// User edits above the block — adds a new line of prose.
@@ -875,7 +875,7 @@ func TestLinkClaudeMD_PreservesUserEditsAboveBlock(t *testing.T) {
 	if err := os.WriteFile(claudePath, []byte(edited), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := linkClaudeMD(dir); err != nil {
+	if err := linkClaudeMD(dir, nil); err != nil {
 		t.Fatalf("second linkClaudeMD: %v", err)
 	}
 	got, _ := os.ReadFile(claudePath)
@@ -903,7 +903,7 @@ func TestLinkClaudeMD_RefusesUnrelatedSymlink(t *testing.T) {
 	if err := os.Symlink("elsewhere.md", claudePath); err != nil {
 		t.Fatal(err)
 	}
-	err := linkClaudeMD(dir)
+	err := linkClaudeMD(dir, nil)
 	if err == nil {
 		t.Fatal("expected error when CLAUDE.md is a symlink to a non-AGENTS.md target")
 	}
@@ -927,7 +927,7 @@ func TestLinkClaudeMD_AcceptsBonesOwnedFallback(t *testing.T) {
 	if err := os.WriteFile(claudePath, agentsMDTemplate, 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := linkClaudeMD(dir); err != nil {
+	if err := linkClaudeMD(dir, nil); err != nil {
 		t.Errorf("linkClaudeMD on bones-owned fallback file: %v", err)
 	}
 }
@@ -943,7 +943,7 @@ func TestScaffoldOrchestrator_AppendsBlockToUserAuthoredCLAUDE(t *testing.T) {
 	if err := os.WriteFile(claudePath, []byte(usersClaude), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := scaffoldOrchestrator(dir); err != nil {
+	if _, err := scaffoldOrchestrator(dir); err != nil {
 		t.Fatalf("scaffoldOrchestrator on user-authored CLAUDE.md: %v", err)
 	}
 	got, _ := os.ReadFile(claudePath)
@@ -963,7 +963,7 @@ func TestScaffoldOrchestrator_AppendsBlockToUserAuthoredCLAUDE(t *testing.T) {
 // symlink to it, which silently delivers empty agent guidance.
 func TestScaffoldOrchestrator_AGENTSNonEmpty(t *testing.T) {
 	dir := t.TempDir()
-	if err := scaffoldOrchestrator(dir); err != nil {
+	if _, err := scaffoldOrchestrator(dir); err != nil {
 		t.Fatalf("scaffoldOrchestrator: %v", err)
 	}
 	info, err := os.Stat(filepath.Join(dir, "AGENTS.md"))

--- a/cli/up.go
+++ b/cli/up.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
+	"strings"
 
 	"github.com/danmestas/bones/internal/githook"
 	"github.com/danmestas/bones/internal/hub"
@@ -48,47 +50,118 @@ func runUp(cwd string, verbose bool) (err error) {
 	// user wondering why a re-run worked after the previous error.
 	recovery := isIncompleteScaffold(cwd)
 
-	info, err := initOrJoinWorkspace(ctx, cwd)
-	if err != nil {
-		return fmt.Errorf("workspace: %w", err)
+	info, ierr := initOrJoinWorkspace(ctx, cwd)
+	if ierr != nil {
+		err = fmt.Errorf("workspace: %w", ierr)
+		return err
 	}
 	wsDir := info.WorkspaceDir
+
+	// Open the audit log under <wsDir>/.bones/up.log (#171). Defer Close
+	// so the exit code + duration land regardless of which step fails
+	// below. The logger is non-nil even on open failure (writes degrade
+	// to no-ops) so terminal output never depends on disk-writability.
+	logger := openUpLog(wsDir)
+	defer logger.Close(err)
+
 	if verbose {
-		fmt.Printf("up: workspace at %s\n", wsDir)
+		logger.Infof("up: workspace at %s", wsDir)
 	}
 
 	if recovery {
-		fmt.Fprintln(os.Stderr,
-			"bones: scaffold incomplete from prior run — re-running scaffold")
+		logger.Warnf("bones: scaffold incomplete from prior run — re-running scaffold")
 	}
 
-	if err := scaffoldOrchestrator(wsDir); err != nil {
-		return fmt.Errorf("orchestrator scaffold: %w", err)
+	fp, scaffErr := scaffoldOrchestrator(wsDir)
+	if scaffErr != nil {
+		err = fmt.Errorf("orchestrator scaffold: %w", scaffErr)
+		return err
 	}
 	if verbose {
-		fmt.Println("up: orchestrator skills, hooks, and gitignore installed")
+		logger.Infof("up: orchestrator skills, hooks, and gitignore installed")
 	}
 
-	if err := installGitHook(wsDir, verbose); err != nil {
-		return fmt.Errorf("git hook: %w", err)
+	if hookErr := installGitHook(wsDir, verbose, logger); hookErr != nil {
+		err = fmt.Errorf("git hook: %w", hookErr)
+		return err
 	}
 
-	if err := writeAgentGuidance(wsDir); err != nil {
-		return fmt.Errorf("agent guidance: %w", err)
+	guidanceWritten, gErr := writeAgentGuidance(wsDir)
+	if gErr != nil {
+		err = fmt.Errorf("agent guidance: %w", gErr)
+		return err
+	}
+	if guidanceWritten {
+		fp.FilesWritten = append(fp.FilesWritten,
+			filepath.Join(".bones", "AGENT_GUIDANCE.md"))
 	}
 
-	if err := checkFossilDrift(wsDir); err != nil {
-		fmt.Fprintf(os.Stderr, "up: WARN  %v\n", err)
+	if dErr := checkFossilDrift(wsDir); dErr != nil {
+		logger.Warnf("up: WARN  %v", dErr)
 	}
 
 	if verbose {
-		fmt.Println("up: workspace ready. Run any verb (e.g., `bones tasks status`) " +
+		logger.Infof("up: workspace ready. Run any verb (e.g., `bones tasks status`) " +
 			"and the hub will start automatically; or run `bones hub start` now.")
 	} else {
-		fmt.Printf("up: ready at %s\n", wsDir)
+		logger.Infof("up: ready at %s", wsDir)
+		emitFootprintSummary(logger, fp)
 	}
-	printHubStatus(os.Stdout, wsDir)
+	printHubStatus(logger.Tee(os.Stdout), wsDir)
 	return nil
+}
+
+// emitFootprintSummary surfaces per-action file/hook changes from the
+// scaffold pass into the default-mode summary (#173). Each line is
+// indented under the "up: ready at" banner so a quick scan reads as
+// "what just changed in this workspace". When the workspace was already
+// fully scaffolded (no-op re-run), the function emits a single
+// "no changes" line so the operator sees an explicit affirmation rather
+// than wondering whether they pasted the wrong cwd.
+func emitFootprintSummary(logger *upLogger, fp scaffoldFootprint) {
+	emitted := false
+
+	if len(fp.FilesWritten) > 0 {
+		emitted = true
+		logger.Infof("up:   wrote %s", strings.Join(fp.FilesWritten, ", "))
+	}
+	for _, path := range fp.MarkerBlockTargets {
+		emitted = true
+		logger.Infof("up:   appended bones marker block to %s", path)
+	}
+	if len(fp.GitignoreEntriesAdded) > 0 {
+		emitted = true
+		logger.Infof("up:   added %d entries to .gitignore (%s)",
+			len(fp.GitignoreEntriesAdded),
+			strings.Join(fp.GitignoreEntriesAdded, ", "))
+	}
+	if total := fp.hooksAdded(); total > 0 {
+		emitted = true
+		logger.Infof("up:   merged %d hooks into .claude/settings.json (%s)",
+			total, formatHookCounts(fp.HooksAddedByEvent))
+	}
+
+	if !emitted {
+		logger.Infof("up:   no changes (workspace already converged)")
+	}
+}
+
+// formatHookCounts renders the per-event hook-add counts with stable
+// ordering so summary output is reproducible across runs (the underlying
+// map is unordered).
+func formatHookCounts(byEvent map[string]int) string {
+	keys := make([]string, 0, len(byEvent))
+	for k, v := range byEvent {
+		if v > 0 {
+			keys = append(keys, k)
+		}
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, k := range keys {
+		parts = append(parts, fmt.Sprintf("%s: %d", k, byEvent[k]))
+	}
+	return strings.Join(parts, ", ")
 }
 
 // printHubStatus reflects the workspace's current hub state to w
@@ -164,17 +237,17 @@ func initOrJoinWorkspace(ctx context.Context, cwd string) (workspace.Info, error
 // The "no .git found" line prints regardless of verbose because it
 // signals a missing enforcement gate the operator should know about.
 // The success line is verbose-only.
-func installGitHook(wsDir string, verbose bool) error {
+func installGitHook(wsDir string, verbose bool, logger *upLogger) error {
 	gitDir := githook.FindGitDir(wsDir)
 	if gitDir == "" {
-		fmt.Println("up: no .git found — skipping pre-commit hook install")
+		logger.Infof("up: no .git found — skipping pre-commit hook install")
 		return nil
 	}
 	if err := githook.Install(gitDir); err != nil {
 		return err
 	}
 	if verbose {
-		fmt.Printf("up: pre-commit hook installed at %s/hooks/pre-commit\n", gitDir)
+		logger.Infof("up: pre-commit hook installed at %s/hooks/pre-commit", gitDir)
 	}
 	return nil
 }
@@ -183,15 +256,23 @@ func installGitHook(wsDir string, verbose bool) error {
 // that don't read CLAUDE.md still pick up workspace-level direction
 // to use bones rather than direct git. The SessionStart hook reads
 // this file and injects it into agent context.
-func writeAgentGuidance(wsDir string) error {
+//
+// Returns (true, nil) when the file was just created (a fresh up wrote
+// it), (false, nil) when it already existed (re-run no-op). The boolean
+// is consumed by runUp's footprint summary so default-mode output can
+// reflect whether AGENT_GUIDANCE.md is part of this run's diff.
+func writeAgentGuidance(wsDir string) (bool, error) {
 	path := filepath.Join(wsDir, ".bones", "AGENT_GUIDANCE.md")
 	if _, err := os.Stat(path); err == nil {
-		return nil
+		return false, nil
 	}
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return err
+		return false, err
 	}
-	return os.WriteFile(path, []byte(agentGuidance), 0o644)
+	if err := os.WriteFile(path, []byte(agentGuidance), 0o644); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 const agentGuidance = `# Bones is active in this workspace

--- a/cli/up_log.go
+++ b/cli/up_log.go
@@ -1,0 +1,159 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+// upLogger tees `bones up` output to a file under <wsDir>/.bones/up.log
+// while preserving the user-visible stdout/stderr stream. Writes append
+// (per #171) so a re-run of `bones up` accumulates audit trail rather
+// than truncating prior history.
+//
+// The logger is safe for concurrent use, but `bones up` is single-threaded
+// in practice so the mutex exists only to avoid interleaving when the
+// future migration plumbs scaffold helpers into a shared writer.
+//
+// Lifecycle: the caller opens the logger at the top of runUp, defers
+// Close to record exit code + duration, and uses Infof / Warnf / Tee
+// for terminal-and-disk output. A nil logger is safe — every method is a
+// no-op so non-up callers (or test fixtures) need not stand up a fake.
+type upLogger struct {
+	mu    sync.Mutex
+	file  *os.File
+	start time.Time
+	path  string
+}
+
+// openUpLog opens (or creates, append-mode) <wsDir>/.bones/up.log and
+// emits a banner line marking the start of this invocation. Returns a
+// usable logger even on open failure (the file pointer is nil and all
+// disk writes degrade to no-ops) so the caller doesn't need to branch
+// on error: a write-protected workspace must not break `bones up`.
+//
+// The parent .bones/ directory is created if missing — runUp normally
+// runs *after* workspace.Init has done so, but the logger is opened
+// before scaffolding, so a fresh clone may not have it yet.
+func openUpLog(wsDir string) *upLogger {
+	dir := filepath.Join(wsDir, ".bones")
+	_ = os.MkdirAll(dir, 0o755)
+	path := filepath.Join(dir, "up.log")
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	l := &upLogger{path: path, start: time.Now()}
+	if err == nil {
+		l.file = f
+		_, _ = fmt.Fprintf(f, "%s INFO  bones up: starting (pid=%d, cwd=%s)\n",
+			ts(l.start), os.Getpid(), wsDir)
+	}
+	return l
+}
+
+// Close records the exit code and elapsed duration, then closes the
+// underlying file. Safe to call on a nil logger or one whose file failed
+// to open. Always returns the input err so callers can `defer
+// l.Close(&err)` without rebinding.
+func (l *upLogger) Close(exitErr error) {
+	if l == nil || l.file == nil {
+		return
+	}
+	dur := time.Since(l.start)
+	code := 0
+	msg := "ok"
+	if exitErr != nil {
+		code = 1
+		msg = exitErr.Error()
+	}
+	l.mu.Lock()
+	_, _ = fmt.Fprintf(l.file, "%s INFO  bones up: finished (exit=%d, duration=%s, result=%s)\n",
+		ts(time.Now()), code, dur.Round(time.Millisecond), msg)
+	_ = l.file.Close()
+	l.file = nil
+	l.mu.Unlock()
+}
+
+// Infof writes a structured INFO line to disk and the user-visible
+// counterpart (without the timestamp/level prefix) to stdout. The
+// terminal output preserves the existing `bones up` UX; the file
+// captures the timestamped audit record (#171).
+func (l *upLogger) Infof(format string, args ...any) {
+	if l == nil {
+		fmt.Println(fmt.Sprintf(format, args...))
+		return
+	}
+	msg := fmt.Sprintf(format, args...)
+	fmt.Println(msg)
+	l.appendLine("INFO", msg)
+}
+
+// Warnf is the WARN-level peer of Infof. Terminal output goes to stderr
+// (unchanged from the pre-logger code path); disk output includes the
+// WARN level marker so post-hoc audits can grep for issues.
+func (l *upLogger) Warnf(format string, args ...any) {
+	if l == nil {
+		fmt.Fprintln(os.Stderr, fmt.Sprintf(format, args...))
+		return
+	}
+	msg := fmt.Sprintf(format, args...)
+	fmt.Fprintln(os.Stderr, msg)
+	l.appendLine("WARN", msg)
+}
+
+// Tee returns an io.Writer that fans out to dest and the log file.
+// Used by printHubStatus, which writes through an io.Writer rather than
+// fmt.Print directly.
+func (l *upLogger) Tee(dest io.Writer) io.Writer {
+	if l == nil || l.file == nil {
+		return dest
+	}
+	return &teeWriter{logger: l, dest: dest}
+}
+
+// appendLine writes one timestamped line to the log file. Caller-side
+// errors are dropped: `bones up` proceeds even if the log file goes
+// unwriteable mid-run (rare, but possible on an SD-card-mounted
+// workspace yanked during run).
+func (l *upLogger) appendLine(level, msg string) {
+	if l == nil || l.file == nil {
+		return
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	_, _ = fmt.Fprintf(l.file, "%s %-5s %s\n", ts(time.Now()), level, msg)
+}
+
+// teeWriter copies every Write into both the user-visible destination
+// and the log file. Used for printHubStatus output where the call site
+// already takes an io.Writer.
+type teeWriter struct {
+	logger *upLogger
+	dest   io.Writer
+}
+
+func (t *teeWriter) Write(p []byte) (int, error) {
+	n, err := t.dest.Write(p)
+	if t.logger != nil {
+		// Strip trailing newline so the log line is clean; appendLine
+		// adds its own. Preserve interior newlines so a multi-line
+		// printf is captured as multiple log lines.
+		text := strings.TrimRight(string(p), "\n")
+		for _, line := range strings.Split(text, "\n") {
+			if line == "" {
+				continue
+			}
+			t.logger.appendLine("INFO", line)
+		}
+	}
+	return n, err
+}
+
+// ts formats a time for log output. Local time keeps the file readable
+// for the operator; UTC would be cleaner for ingestion but bones logs
+// are operator-facing first.
+func ts(t time.Time) string {
+	return t.Format("2006-01-02T15:04:05.000")
+}

--- a/cli/up_log_test.go
+++ b/cli/up_log_test.go
@@ -1,0 +1,133 @@
+package cli
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestOpenUpLog_CreatesFileAndBanner pins #171's load-bearing
+// guarantee: opening the logger creates <wsDir>/.bones/up.log with a
+// banner line so a closed terminal still leaves an audit trail.
+func TestOpenUpLog_CreatesFileAndBanner(t *testing.T) {
+	dir := t.TempDir()
+	l := openUpLog(dir)
+	l.Close(nil)
+
+	logPath := filepath.Join(dir, ".bones", "up.log")
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("up.log not created: %v", err)
+	}
+	body := string(data)
+	if !strings.Contains(body, "starting") {
+		t.Errorf("missing start banner in:\n%s", body)
+	}
+	if !strings.Contains(body, "finished") {
+		t.Errorf("missing finished banner in:\n%s", body)
+	}
+	if !strings.Contains(body, "exit=0") {
+		t.Errorf("missing exit code in:\n%s", body)
+	}
+}
+
+// TestOpenUpLog_AppendsAcrossRuns pins #171's "idempotent on re-run"
+// requirement: a second openUpLog must append to (not truncate) the
+// existing file. Operators auditing a chain of `bones up` invocations
+// rely on the cumulative history.
+func TestOpenUpLog_AppendsAcrossRuns(t *testing.T) {
+	dir := t.TempDir()
+
+	first := openUpLog(dir)
+	first.Infof("first-run-marker")
+	first.Close(nil)
+
+	logPath := filepath.Join(dir, ".bones", "up.log")
+	beforeSize := fileSize(t, logPath)
+
+	second := openUpLog(dir)
+	second.Infof("second-run-marker")
+	second.Close(nil)
+
+	afterSize := fileSize(t, logPath)
+	if afterSize <= beforeSize {
+		t.Errorf("up.log shrank or stayed the same on re-run "+
+			"(before=%d after=%d) — append mode broken", beforeSize, afterSize)
+	}
+
+	body, _ := os.ReadFile(logPath)
+	for _, want := range []string{"first-run-marker", "second-run-marker"} {
+		if !strings.Contains(string(body), want) {
+			t.Errorf("re-run lost %q from log:\n%s", want, body)
+		}
+	}
+}
+
+// TestOpenUpLog_RecordsExitCodeOnError pins the exit-code half of
+// #171's defer contract: a failing run lands an "exit=1" line so a
+// downstream debugger can grep for failure signatures.
+func TestOpenUpLog_RecordsExitCodeOnError(t *testing.T) {
+	dir := t.TempDir()
+	l := openUpLog(dir)
+	l.Close(errors.New("simulated step failure"))
+
+	body, _ := os.ReadFile(filepath.Join(dir, ".bones", "up.log"))
+	s := string(body)
+	if !strings.Contains(s, "exit=1") {
+		t.Errorf("expected exit=1 marker in:\n%s", s)
+	}
+	if !strings.Contains(s, "simulated step failure") {
+		t.Errorf("expected error message in:\n%s", s)
+	}
+}
+
+// TestUpLogger_NilSafe pins the soft-fail design: methods on a nil
+// *upLogger fall back to plain stdout/stderr so a code path that
+// can't open a workspace logger (early errors, tests) still functions.
+func TestUpLogger_NilSafe(t *testing.T) {
+	var l *upLogger
+	l.Infof("info") // must not panic
+	l.Warnf("warn") // must not panic
+	l.Close(nil)    // must not panic
+
+	w := l.Tee(io.Discard)
+	if _, err := w.Write([]byte("ok\n")); err != nil {
+		t.Errorf("nil-logger WriteTo failed: %v", err)
+	}
+}
+
+// TestUpLogger_WriteToTees pins the printHubStatus integration: writes
+// through the returned writer reach both the user-visible destination
+// AND the log file so hub status lines are captured for audit.
+func TestUpLogger_WriteToTees(t *testing.T) {
+	dir := t.TempDir()
+	l := openUpLog(dir)
+
+	var visible bytes.Buffer
+	w := l.Tee(&visible)
+	if _, err := w.Write([]byte("up: hub: not yet started\n")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	l.Close(nil)
+
+	if !strings.Contains(visible.String(), "not yet started") {
+		t.Errorf("user-visible side missing payload: %q", visible.String())
+	}
+	body, _ := os.ReadFile(filepath.Join(dir, ".bones", "up.log"))
+	if !strings.Contains(string(body), "not yet started") {
+		t.Errorf("log file missing tee'd payload:\n%s", body)
+	}
+}
+
+func fileSize(t *testing.T, path string) int64 {
+	t.Helper()
+	st, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat %s: %v", path, err)
+	}
+	return st.Size()
+}

--- a/cli/up_test.go
+++ b/cli/up_test.go
@@ -203,7 +203,7 @@ func TestScaffoldOrchestrator_RecoversFromHalfInstall(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := scaffoldOrchestrator(dir); err != nil {
+	if _, err := scaffoldOrchestrator(dir); err != nil {
 		t.Fatalf("scaffoldOrchestrator on half-installed workspace: %v", err)
 	}
 
@@ -232,7 +232,7 @@ func TestScaffoldOrchestrator_RecoversFromHalfInstall(t *testing.T) {
 
 	// Idempotent: a third run produces a byte-identical settings.json.
 	first := body
-	if err := scaffoldOrchestrator(dir); err != nil {
+	if _, err := scaffoldOrchestrator(dir); err != nil {
 		t.Fatalf("second scaffold: %v", err)
 	}
 	data2, _ := os.ReadFile(filepath.Join(settingsDir, "settings.json"))

--- a/cmd/bones/cli.go
+++ b/cmd/bones/cli.go
@@ -13,7 +13,7 @@ type CLI struct {
 	libfossilcli.Globals
 
 	// Daily.
-	Up     bonescli.UpCmd     `cmd:"" group:"daily" help:"Bootstrap workspace, scaffold, leaf, hub"`
+	Up     bonescli.UpCmd     `cmd:"" group:"daily" help:"Bootstrap workspace, lazy hub (ADR 0041)"`
 	Down   bonescli.DownCmd   `cmd:"" group:"daily" help:"Reverse up: stop hub + clean scaffold"`
 	Status bonescli.StatusCmd `cmd:"" group:"daily" help:"Snapshot tasks, sessions, hub activity"`
 	Tasks  bonescli.TasksCmd  `cmd:"" group:"daily" help:"Inspect and mutate runtime agent tasks"`

--- a/cmd/bones/integration/up_output_test.go
+++ b/cmd/bones/integration/up_output_test.go
@@ -1,0 +1,174 @@
+package integration_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestCLI_UpHelpADR0041 pins #175: `bones up --help` no longer
+// describes the verb as "scaffold, leaf, hub" — that text predates ADR
+// 0041 (hub starts lazily) and misleads operators reading the help
+// tree. The replacement copy must mention ADR 0041 so the
+// design intent is traceable.
+func TestCLI_UpHelpADR0041(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip in -short: integration test")
+	}
+	requireBinaries(t)
+
+	cmd := exec.Command(bonesBin, "up", "--help")
+	cmd.Env = append(os.Environ(), "LEAF_BIN="+leafBinary())
+	out, _ := cmd.CombinedOutput()
+	body := string(out)
+
+	// Stale phrasing must be gone.
+	for _, stale := range []string{
+		"scaffold, leaf, hub",
+		"leaf, hub",
+	} {
+		if strings.Contains(body, stale) {
+			t.Errorf("up --help still contains stale phrasing %q:\n%s", stale, body)
+		}
+	}
+	// New copy must reference ADR 0041 so the lazy-start design is
+	// discoverable from the help itself.
+	if !strings.Contains(body, "ADR 0041") {
+		t.Errorf("up --help should reference ADR 0041:\n%s", body)
+	}
+	if !strings.Contains(strings.ToLower(body), "lazy") {
+		t.Errorf("up --help should describe lazy hub start:\n%s", body)
+	}
+}
+
+// TestCLI_UpDefaultSummary pins #173: default-mode `bones up` lists
+// per-action file footprint changes (wrote files, gitignore entries,
+// merged hooks) instead of just "ready at <wsDir>". Operators auditing
+// what bones did to their tree should not need `git status`.
+func TestCLI_UpDefaultSummary(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip in -short: integration test")
+	}
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	dir := newWorkspace(t)
+	gitInit(t, dir)
+
+	// Tear down to a known-clean state, then up once and capture summary.
+	if _, _, code := runCmd(t, bonesBin, dir, "down", "--yes"); code != 0 {
+		t.Fatalf("down --yes failed before summary check")
+	}
+	stdout, stderr, code := runCmd(t, bonesBin, dir, "up")
+	if code != 0 {
+		t.Fatalf("bones up: code=%d stderr=%s", code, stderr)
+	}
+	t.Cleanup(func() { _, _, _ = runCmd(t, bonesBin, dir, "down", "--yes") })
+
+	// Default summary must surface concrete file footprint, not just the
+	// pre-#173 "ready at" + hub status.
+	mustContain := []string{
+		"up: ready at",
+		"up:   wrote",           // file footprint marker
+		"up:   merged",          // hook merge marker
+		".claude/settings.json", // hook target named
+		"up: hub:",              // existing hub status line
+	}
+	for _, want := range mustContain {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("default-mode summary missing %q:\n--- stdout ---\n%s\n--- stderr ---\n%s",
+				want, stdout, stderr)
+		}
+	}
+}
+
+// TestCLI_UpWritesAuditLog pins #171: every `bones up` writes a
+// structured audit log to <wsDir>/.bones/up.log capturing files
+// written, hooks merged, exit code, and duration. Required for post-
+// hoc debugging when the operator's terminal is gone.
+func TestCLI_UpWritesAuditLog(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip in -short: integration test")
+	}
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	dir := newWorkspace(t)
+	gitInit(t, dir)
+
+	if _, _, code := runCmd(t, bonesBin, dir, "down", "--yes"); code != 0 {
+		t.Fatalf("down --yes failed before audit-log check")
+	}
+	if _, stderr, code := runCmd(t, bonesBin, dir, "up"); code != 0 {
+		t.Fatalf("bones up: code=%d stderr=%s", code, stderr)
+	}
+	t.Cleanup(func() { _, _, _ = runCmd(t, bonesBin, dir, "down", "--yes") })
+
+	logPath := filepath.Join(dir, ".bones", "up.log")
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("up.log not written at %s: %v", logPath, err)
+	}
+	body := string(data)
+	for _, want := range []string{
+		"INFO",      // level prefix
+		"starting",  // banner
+		"finished",  // close banner
+		"exit=0",    // success exit code
+		"duration=", // elapsed
+		"up: ready", // captured terminal output
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("up.log missing %q:\n%s", want, body)
+		}
+	}
+}
+
+// TestCLI_UpAuditLogAppendsAcrossRuns pins the idempotency clause of
+// #171: re-running `bones up` appends new entries instead of
+// truncating the prior history.
+func TestCLI_UpAuditLogAppendsAcrossRuns(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip in -short: integration test")
+	}
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	dir := newWorkspace(t)
+	gitInit(t, dir)
+
+	if _, _, code := runCmd(t, bonesBin, dir, "down", "--yes"); code != 0 {
+		t.Fatalf("down --yes failed before append check")
+	}
+	if _, _, code := runCmd(t, bonesBin, dir, "up"); code != 0 {
+		t.Fatalf("first bones up failed")
+	}
+	logPath := filepath.Join(dir, ".bones", "up.log")
+	first, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("first read: %v", err)
+	}
+
+	if _, _, code := runCmd(t, bonesBin, dir, "up"); code != 0 {
+		t.Fatalf("second bones up failed")
+	}
+	t.Cleanup(func() { _, _, _ = runCmd(t, bonesBin, dir, "down", "--yes") })
+
+	second, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("second read: %v", err)
+	}
+	if len(second) <= len(first) {
+		t.Errorf("up.log shrank or stayed equal between runs: first=%d second=%d",
+			len(first), len(second))
+	}
+	if !strings.HasPrefix(string(second), string(first)) {
+		t.Errorf("second up.log does not preserve first run's bytes — append broken")
+	}
+	// Two distinct "starting" banners must be present.
+	if strings.Count(string(second), "bones up: starting") < 2 {
+		t.Errorf("expected two start banners after two runs:\n%s", second)
+	}
+}


### PR DESCRIPTION
## Summary

Three small `bones up` UX fixes in one PR:

- **#175** — kong help text for `up` was stale (said "scaffold, leaf, hub" — predates ADR 0041). New text: `Bootstrap workspace, lazy hub (ADR 0041)`.
- **#173** — default-mode summary was sparse (just `up: ready at` + hub status). Now lists file footprint changes (files written, gitignore entries added, hooks merged) so operators can audit without `git status`.
- **#171** — `bones up` produced no log artifact for post-hoc audit. Every invocation now tees output to `<wsDir>/.bones/up.log` (append mode, project-local per maintainer choice). Records files written, hooks merged, exit code, and duration. Idempotent on re-run.

### Implementation notes

- `cli/up_log.go` — new `upLogger` type. `openUpLog` creates `<wsDir>/.bones/up.log`, writes a banner. `Close(err)` (deferred from `runUp`) records `exit=N` and `duration=`. `Infof`/`Warnf` tee to terminal + log; `Tee(io.Writer)` wraps an existing writer for `printHubStatus`.
- `cli/orchestrator.go` — `scaffoldOrchestrator` now returns a `scaffoldFootprint` describing files written, marker blocks added, gitignore entries appended, and per-event hook counts. Helpers (`writeAgentsMD`, `linkClaudeMD`, `mergeSettings`, `ensureGitignoreEntries`) record into the footprint when fp is non-nil; tests pass `nil` to keep them terse.
- `cli/up.go` — `runUp` surfaces the footprint via `emitFootprintSummary` in default mode. Verbose mode is unchanged. WARN paths (drift, missing git, recovery) now go through the logger.
- `cmd/bones/cli.go` — kong tag updated.

### Sample output (default mode)

```
up: ready at /tmp/scratch
up:   wrote AGENTS.md, CLAUDE.md, .bones/AGENT_GUIDANCE.md
up:   added 3 entries to .gitignore (.fslckout, .fossil-settings/, .bones/)
up:   merged 3 hooks into .claude/settings.json (PreCompact: 1, SessionStart: 2)
up: hub: not yet started — will start on next session (SessionStart hook) or first verb that needs it
```

### Sample log file

```
2026-05-04T10:12:17.766 INFO  bones up: starting (pid=8062, cwd=/tmp/scratch)
2026-05-04T10:12:17.781 INFO  up: ready at /tmp/scratch
...
2026-05-04T10:12:17.781 INFO  bones up: finished (exit=0, duration=15ms, result=ok)
```

## Test plan

- [x] `make check` (fmt-check, vet, lint, race, todo-check) — all pass
- [x] `go test -tags=otel -short ./...` — all pass
- [x] New unit tests in `cli/up_log_test.go`: open creates file + banner, re-run appends, exit code recorded on error, nil-safe methods, Tee fans out
- [x] New integration tests in `cmd/bones/integration/up_output_test.go`: help text, default summary content, log file written, log file appends across runs
- [x] Manual smoke test against a fresh workspace — output matches the brief

Closes #171
Closes #173
Closes #175