### PR TITLE
chore: test HOME isolation, workspaces ls --prune, lll tab-width alignment

### DIFF
--- a/cli/workspaces.go
+++ b/cli/workspaces.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bufio"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -26,13 +27,21 @@ type WorkspacesCmd struct {
 
 // WorkspacesLsCmd renders the registry as a human-readable table.
 //
-// We deliberately do NOT prune stopped entries here (unlike
+// We deliberately do NOT prune stopped entries here by default (unlike
 // `bones status --all`, which has live-only semantics): the operator
 // running `bones workspaces ls` is asking "what does bones think it
 // knows about?", and silently discarding stale entries makes it harder
 // to debug "why is bones up showing the wrong project?" scenarios.
+//
+// --prune is the explicit cleanup verb (#180): list dead entries
+// (HubStatus == stopped), confirm, and delete the registry files.
+// Entries whose status is "unknown" are skipped — those could be
+// workspaces whose hub never recorded a HubURL, and pruning them
+// would be wrong.
 type WorkspacesLsCmd struct {
-	JSON bool `name:"json" help:"emit machine-readable JSON"`
+	JSON  bool `name:"json" help:"emit machine-readable JSON"`
+	Prune bool `name:"prune" help:"remove registry entries whose hub is stopped"`
+	Yes   bool `name:"yes" short:"y" help:"skip the confirmation prompt for --prune"`
 }
 
 // Run gathers the registry view via registry.ListInfo (which performs
@@ -43,10 +52,78 @@ func (c *WorkspacesLsCmd) Run() error {
 	if err != nil {
 		return fmt.Errorf("workspaces ls: %w", err)
 	}
+	if c.Prune {
+		return runPrune(os.Stdout, os.Stdin, infos, c.Yes)
+	}
 	if c.JSON {
 		return writeWorkspacesJSON(os.Stdout, infos)
 	}
 	return writeWorkspacesTable(os.Stdout, infos, time.Now())
+}
+
+// runPrune removes registry entries whose HubStatus is "stopped".
+// Without yes, the dead entries are listed and the operator is prompted
+// for y/N on stdin before any file is removed. With yes, deletion runs
+// unconditionally. Entries with HubStatus == unknown are NEVER touched:
+// they could be workspaces whose hub never wrote a HubURL, and pruning
+// them is unsafe.
+//
+// Output: one "pruned: <name> (<id>)" line per removed entry. An empty
+// dead-set is reported as "no stopped entries to prune" and exits 0.
+//
+// Stdin / stdout are passed in so tests can drive the prompt
+// deterministically without touching the real terminal.
+func runPrune(out io.Writer, in io.Reader, infos []registry.Info, yes bool) error {
+	dead := make([]registry.Info, 0, len(infos))
+	for _, i := range infos {
+		if i.HubStatus == registry.HubStopped {
+			dead = append(dead, i)
+		}
+	}
+	if len(dead) == 0 {
+		_, err := fmt.Fprintln(out, "no stopped entries to prune")
+		return err
+	}
+	if !yes {
+		if _, err := fmt.Fprintf(out, "%d stopped entries:\n", len(dead)); err != nil {
+			return err
+		}
+		for _, i := range dead {
+			if _, err := fmt.Fprintf(out, "  %s  %s  %s\n",
+				i.ID, fallbackString(i.Name, emDash), i.Cwd); err != nil {
+				return err
+			}
+		}
+		if !pruneConfirm(out, in, len(dead)) {
+			_, err := fmt.Fprintln(out, "aborted; no entries pruned")
+			return err
+		}
+	}
+	for _, i := range dead {
+		if err := registry.Remove(i.Cwd); err != nil {
+			return fmt.Errorf("workspaces prune: %w", err)
+		}
+		if _, err := fmt.Fprintf(out, "pruned: %s (%s)\n",
+			fallbackString(i.Name, emDash), i.ID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// pruneConfirm is the y/N prompt used when --prune runs without --yes.
+// Mirrors confirm() in down.go but writes the prompt to the supplied
+// out writer (rather than os.Stdout directly) so tests can capture it.
+// Anything except an explicit "y"/"yes" returns false, including EOF.
+func pruneConfirm(out io.Writer, in io.Reader, n int) bool {
+	_, _ = fmt.Fprintf(out, "Prune %d stopped entries? [y/N] ", n)
+	rdr := bufio.NewReader(in)
+	line, err := rdr.ReadString('\n')
+	if err != nil && line == "" {
+		return false
+	}
+	answer := strings.TrimSpace(strings.ToLower(line))
+	return answer == "y" || answer == "yes"
 }
 
 // WorkspacesShowCmd prints one workspace's full registry entry.

--- a/cli/workspaces_test.go
+++ b/cli/workspaces_test.go
@@ -285,3 +285,114 @@ func scrubVolatile(s, wsA, wsB, idA, idB string) string {
 	}
 	return strings.Join(out, "\n")
 }
+
+// TestRunPrune_YesRemovesStopped covers the non-interactive flow (#180):
+// two seeded entries, both reported as HubStatus=stopped (HubPID=-1
+// fails IsAlive), are prune-eligible. With yes=true the command
+// removes both and the registry directory is empty afterwards.
+//
+// We also assert that pruning a workspace whose HubURL is empty (and
+// thus reports HubStatus=unknown) is NOT touched — the contract for
+// --prune is "stopped only". A separate seed exercises that case so
+// the test fails if a regression starts pruning unknown entries.
+func TestRunPrune_YesRemovesStopped(t *testing.T) {
+	wsA, wsB := seedTwoWorkspaces(t)
+	wsC := t.TempDir()
+	mkBonesDir(t, wsC)
+	writeAgentIDForTest(t, wsC)
+	if err := registry.Write(registry.Entry{
+		Cwd: wsC, Name: "unknown",
+		HubURL: "", NATSURL: "", HubPID: 0,
+		StartedAt: time.Now().UTC().Truncate(time.Second),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	infos, err := registry.ListInfo()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(infos) != 3 {
+		t.Fatalf("seed: have %d infos, want 3", len(infos))
+	}
+
+	var buf bytes.Buffer
+	if err := runPrune(&buf, strings.NewReader(""), infos, true); err != nil {
+		t.Fatalf("runPrune: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{"pruned: alpha", "pruned: beta"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in output:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "pruned: unknown") {
+		t.Errorf("unknown-status entry should NOT be pruned:\n%s", out)
+	}
+
+	after, err := registry.ListInfo()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(after) != 1 || after[0].Cwd != wsC {
+		t.Errorf("after prune: want only wsC=%s, got %+v", wsC, after)
+	}
+	for _, cwd := range []string{wsA, wsB} {
+		if _, err := os.Stat(registry.EntryPath(cwd)); !os.IsNotExist(err) {
+			t.Errorf("entry file for %s should be removed; err=%v", cwd, err)
+		}
+	}
+}
+
+// TestRunPrune_NoConfirmKeepsEntries covers the prompt-rejected path:
+// the operator types "n" (or anything that is not "y"/"yes"), and the
+// registry is left untouched. Exercises the "list-with-confirm" branch
+// of the spec — the most common interactive flow.
+func TestRunPrune_NoConfirmKeepsEntries(t *testing.T) {
+	wsA, wsB := seedTwoWorkspaces(t)
+	infos, err := registry.ListInfo()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	if err := runPrune(&buf, strings.NewReader("n\n"), infos, false); err != nil {
+		t.Fatalf("runPrune: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "2 stopped entries") {
+		t.Errorf("missing dead-entry summary in output:\n%s", out)
+	}
+	if !strings.Contains(out, "Prune 2 stopped entries? [y/N]") {
+		t.Errorf("missing prompt in output:\n%s", out)
+	}
+	if !strings.Contains(out, "aborted; no entries pruned") {
+		t.Errorf("missing aborted-line in output:\n%s", out)
+	}
+	if strings.Contains(out, "pruned:") {
+		t.Errorf("output should not contain any pruned: lines:\n%s", out)
+	}
+
+	for _, cwd := range []string{wsA, wsB} {
+		if _, err := os.Stat(registry.EntryPath(cwd)); err != nil {
+			t.Errorf("entry for %s should still exist after abort; err=%v", cwd, err)
+		}
+	}
+}
+
+// TestRunPrune_EmptyRegistryNoOp pins the friendly-no-op path. An empty
+// registry must exit 0 with a clear message rather than an error.
+func TestRunPrune_EmptyRegistryNoOp(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	infos, err := registry.ListInfo()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	if err := runPrune(&buf, strings.NewReader(""), infos, true); err != nil {
+		t.Fatalf("runPrune: %v", err)
+	}
+	if !strings.Contains(buf.String(), "no stopped entries to prune") {
+		t.Errorf("missing friendly no-op line:\n%s", buf.String())
+	}
+}

--- a/cmd/bones/integration/integration_test.go
+++ b/cmd/bones/integration/integration_test.go
@@ -87,9 +87,14 @@ func killPidFile(t *testing.T, path string) {
 
 // newWorkspace bootstraps a workspace in a tmpdir and returns it. The caller
 // registers killPidFile cleanup itself via t.Cleanup (done once per test).
+//
+// Pins HOME to a temp dir so any subprocess whose path reaches
+// hub.Start (via workspace.Join) does NOT write to the operator's real
+// ~/.bones/workspaces/. See issue #180.
 func newWorkspace(t *testing.T) string {
 	t.Helper()
 	requireBinaries(t)
+	t.Setenv("HOME", t.TempDir())
 	dir := t.TempDir()
 	t.Cleanup(func() { killPidFile(t, filepath.Join(dir, ".bones", "leaf.pid")) })
 	if _, stderr, code := runCmd(t, bonesBin, dir, "init"); code != 0 {

--- a/cmd/bones/integration/swarm_test.go
+++ b/cmd/bones/integration/swarm_test.go
@@ -303,8 +303,13 @@ func TestCLI_SwarmJoin_RefusesBootstrapFromLeafContext(t *testing.T) {
 // setupSwarmWorkspace creates a git-initialized tmpdir with a single
 // tracked file so the Go-implemented hub's seedHubRepo finds something
 // to commit. Then runs `bones init` to bring up the workspace leaf.
+//
+// Pins HOME to a temp dir so subprocess `bones hub start` invocations
+// from startSwarmHub do NOT leak entries into the operator's real
+// ~/.bones/workspaces/. See issue #180.
 func setupSwarmWorkspace(t *testing.T) string {
 	t.Helper()
+	t.Setenv("HOME", t.TempDir())
 	dir := t.TempDir()
 	// Init a fresh git repo and stage one file. Hub's seedHubRepo
 	// walks `git ls-files` and refuses to seed an empty workspace.

--- a/cmd/bones/integration/up_recovery_test.go
+++ b/cmd/bones/integration/up_recovery_test.go
@@ -80,6 +80,9 @@ func TestCLI_UpFreshNoRecoveryAnnouncement(t *testing.T) {
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not available; skipping up integration")
 	}
+	// Isolate HOME so subprocess `bones up` cannot leak into the
+	// operator's real ~/.bones/workspaces/. See #180.
+	t.Setenv("HOME", t.TempDir())
 	dir := t.TempDir()
 	gitInit(t, dir)
 	t.Cleanup(func() { _, _, _ = runCmd(t, bonesBin, dir, "down", "--yes") })

--- a/internal/hub/hub_test.go
+++ b/internal/hub/hub_test.go
@@ -37,6 +37,10 @@ func TestStartStopRoundTrip(t *testing.T) {
 		t.Skip("git not available; skipping hub round-trip")
 	}
 
+	// Isolate HOME so hub.Start's registry.Write does not leak entries
+	// into the operator's real ~/.bones/workspaces/ on test crash. See
+	// issue #180.
+	t.Setenv("HOME", t.TempDir())
 	root := newGitRepoWithFile(t)
 	fossilPort, natsPort := freePort(t), freePort(t)
 
@@ -120,6 +124,10 @@ func TestStartNoGitTrackedFiles(t *testing.T) {
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not available")
 	}
+	// Defensive isolation: Start fails before registry.Write here, but
+	// keep HOME pinned to a tempdir so a regression that reorders the
+	// seed-precondition check after registry.Write cannot leak. See #180.
+	t.Setenv("HOME", t.TempDir())
 	root := t.TempDir()
 	mustRun(t, root, "git", "init", "-q")
 	mustRun(t, root,

--- a/internal/hub/port_collision_test.go
+++ b/internal/hub/port_collision_test.go
@@ -28,6 +28,9 @@ func TestSpawnDetachedChild_DetectsPortCollision(t *testing.T) {
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not available")
 	}
+	// Isolate HOME so the detached-child path does not leak a registry
+	// entry into the operator's real ~/.bones/workspaces/. See #180.
+	t.Setenv("HOME", t.TempDir())
 	root := t.TempDir()
 	if out, err := exec.Command("git", "-C", root, "init", "-q").CombinedOutput(); err != nil {
 		t.Fatalf("git init: %v\n%s", err, out)

--- a/internal/hub/precondition_test.go
+++ b/internal/hub/precondition_test.go
@@ -23,6 +23,10 @@ func TestStart_FailsFastOnEmptyGitRepo(t *testing.T) {
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not available")
 	}
+	// Defensive isolation: precondition fires before registry.Write,
+	// but pin HOME to a tempdir so a regression that reorders the
+	// check cannot leak into ~/.bones/workspaces/. See #180.
+	t.Setenv("HOME", t.TempDir())
 	root := t.TempDir()
 	if out, err := exec.Command("git", "-C", root, "init", "-q").CombinedOutput(); err != nil {
 		t.Fatalf("git init: %v\n%s", err, out)

--- a/repo_conventions_test.go
+++ b/repo_conventions_test.go
@@ -9,6 +9,10 @@ import (
 	"testing"
 )
 
+// Tab width is 4, matching golangci-lint's lll default. See issue #181.
+// If you change one, change the other — the dual-enforcement model only
+// works when both checks agree on what counts as a column.
+
 func TestRepoGoFiles_Max100Columns(t *testing.T) {
 	violations, err := findGoLineLengthViolations(100)
 	if err != nil {
@@ -19,7 +23,24 @@ func TestRepoGoFiles_Max100Columns(t *testing.T) {
 	}
 }
 
+// lineColumns returns the rendered column count of line, treating each
+// tab as tabWidth columns. Matches the convention golangci-lint's lll
+// linter uses by default. Without this, a leading-tab line that lll
+// flags can pass the in-test check, or vice-versa — see issue #181.
+func lineColumns(line string, tabWidth int) int {
+	cols := 0
+	for _, r := range line {
+		if r == '\t' {
+			cols += tabWidth
+		} else {
+			cols++
+		}
+	}
+	return cols
+}
+
 func findGoLineLengthViolations(max int) ([]string, error) {
+	const tabWidth = 4
 	roots := []string{"cmd", "internal", "examples"}
 	var out []string
 	for _, root := range roots {
@@ -42,8 +63,8 @@ func findGoLineLengthViolations(max int) ([]string, error) {
 			for s.Scan() {
 				lineNo++
 				line := s.Text()
-				if len(line) > max {
-					out = append(out, fmt.Sprintf("%s:%d (%d chars)", path, lineNo, len(line)))
+				if cols := lineColumns(line, tabWidth); cols > max {
+					out = append(out, fmt.Sprintf("%s:%d (%d cols)", path, lineNo, cols))
 				}
 			}
 			scanErr := s.Err()
@@ -58,4 +79,21 @@ func findGoLineLengthViolations(max int) ([]string, error) {
 		}
 	}
 	return out, nil
+}
+
+// TestLineColumns_TabWidthMatchesLll guards the convention #181 pinned:
+// a line of 25 leading tabs followed by 1 space renders as 101 columns
+// when tabs are 4 cols wide (25*4 + 1 = 101) and so should violate the
+// 100-col limit. Pre-#181 the in-test check counted tabs as 1, so the
+// same line came out as 26 cols and silently passed.
+func TestLineColumns_TabWidthMatchesLll(t *testing.T) {
+	line := strings.Repeat("\t", 25) + " "
+	if got, want := lineColumns(line, 4), 101; got != want {
+		t.Fatalf("lineColumns(25 tabs + 1 space, tabWidth=4) = %d, want %d", got, want)
+	}
+	// And the inverse: under tabs=1 the same line is 26 cols, which is
+	// what made the dual-enforcement mismatch possible.
+	if got, want := lineColumns(line, 1), 26; got != want {
+		t.Fatalf("lineColumns(25 tabs + 1 space, tabWidth=1) = %d, want %d", got, want)
+	}
 }


### PR DESCRIPTION
## Summary

Three follow-ups from PR #178/#179:

- **HOME isolation in tests** — tests that reach `hub.Start` (directly or via `workspace.Join` in subprocess `bones up` / `bones hub start`) now pin `HOME` to `t.TempDir()` so the operator's real `~/.bones/workspaces/` does not collect entries on test crash. Covers `internal/hub` round-trip + port-collision + precondition tests, and the `cmd/bones/integration` helpers (`newWorkspace`, `setupSwarmWorkspace`, `TestCLI_UpFreshNoRecoveryAnnouncement`).
- **`bones workspaces ls --prune`** — explicit cleanup verb. Lists `HubStatus=stopped` entries, prompts `Prune N stopped entries? [y/N] ` on stdin, then deletes the registry files. `--yes` skips the prompt for non-interactive use. Entries with `HubStatus=unknown` are never touched — those could be workspaces whose hub never wrote a `HubURL`, and pruning them is unsafe.
- **lll tab-width alignment** — `repo_conventions_test.go` now counts a tab as 4 columns, matching `golangci-lint`'s `lll` default. Added a regression test that a line of 25 tabs + 1 space (= 101 cols when tabs=4) fails the 100-col check.

## Test plan

- [x] `make check` passes (fmt, vet, lint, race, todo-check)
- [x] `go test -tags=otel -short ./...` passes
- [x] `bones workspaces ls --prune --yes` against the real registry pruned 21 stale entries (16 `TestStartStopRoundTrip*`, 1 `TestSpawnDetachedChild_DetectsPortCollision`, 1 `TestCLI_HubStartReadoutPid`, 4 manual `bones-*` repros, 1 `ws-original`)
- [x] New unit tests cover `--prune --yes` (removes stopped, leaves unknown), prompt-rejected, and empty-registry no-op paths

Closes #180
Closes #181