### PR TITLE
feat(chat): migrate chat substrate to JetStream stream per ADR 0047

### DIFF
--- a/cli/tasks_autoclaim_test.go
+++ b/cli/tasks_autoclaim_test.go
@@ -23,10 +23,9 @@ func newAutoclaimCoord(t *testing.T, agentID string) *coord.Coord {
 func newAutoclaimCoordOnURL(t *testing.T, url, agentID string) *coord.Coord {
 	t.Helper()
 	cfg := coord.Config{
-		AgentID:            agentID,
-		NATSURL:            url,
-		ChatFossilRepoPath: filepath.Join(t.TempDir(), agentID+"-chat.fossil"),
-		CheckoutRoot:       filepath.Join(t.TempDir(), agentID+"-checkouts"),
+		AgentID:      agentID,
+		NATSURL:      url,
+		CheckoutRoot: filepath.Join(t.TempDir(), agentID+"-checkouts"),
 	}
 	c, err := coord.Open(context.Background(), cfg)
 	if err != nil {

--- a/cli/tasks_list.go
+++ b/cli/tasks_list.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path/filepath"
 	"sort"
 	"time"
 
@@ -222,14 +221,12 @@ func liveAgentSet(peers []coord.Presence) map[string]struct{} {
 // chat.fossil lives under <WorkspaceDir>/.bones/ — the bones-managed
 // runtime tree — so operators don't see it as a stray file at the
 // project root and don't accidentally delete it. Per ADRs 0023 and 0041
-// the workspace already has `.bones/` as the runtime-state directory;
-// gitignoring `.bones/` covers chat.fossil transitively. Issues #167,
-// #168.
+// Per ADR 0047 chat lives on a JetStream stream — no chat.fossil path
+// needed.
 func newCoordConfig(info workspace.Info) coord.Config {
 	return coord.Config{
-		AgentID:            info.AgentID,
-		NATSURL:            info.NATSURL,
-		ChatFossilRepoPath: filepath.Join(info.WorkspaceDir, ".bones", "chat.fossil"),
-		CheckoutRoot:       info.WorkspaceDir,
+		AgentID:      info.AgentID,
+		NATSURL:      info.NATSURL,
+		CheckoutRoot: info.WorkspaceDir,
 	}
 }

--- a/examples/two-agents/main.go
+++ b/examples/two-agents/main.go
@@ -34,19 +34,20 @@ const (
 	threadChat = "harness.chat"
 )
 
-// newConfig builds a coord.Config for a role. Per-coord
-// ChatFossilRepoPath and CheckoutRoot are distinct so two children
-// running in the same workspace do not collide on chat repo / checkout
-// state. This harness tests Phase 3+4 primitives and does not exercise
-// any code-artifact write path, so no per-coord FossilRepoPath is
-// needed (Task 10 of the EdgeSync refactor removed it from Config).
-func newConfig(agentID, natsURL, chatRepo, checkoutRoot string) coord.Config {
+// newConfig builds a coord.Config for a role. Per-coord CheckoutRoot
+// is distinct so two children running in the same workspace do not
+// collide on checkout state. Per ADR 0047 chat lives on a workspace-
+// shared JetStream stream — no per-coord chat fossil. This harness
+// tests Phase 3+4 primitives and does not exercise any code-artifact
+// write path, so no per-coord FossilRepoPath is needed.
+func newConfig(agentID, natsURL, _, checkoutRoot string) coord.Config {
 	return coord.Config{
-		AgentID:            agentID,
-		NATSURL:            natsURL,
-		ChatFossilRepoPath: chatRepo,
-		CheckoutRoot:       checkoutRoot,
+		AgentID:      agentID,
+		NATSURL:      natsURL,
+		CheckoutRoot: checkoutRoot,
 		// Tuning: zero — coord.Open fills sane defaults via defaultTuning.
+		// Per ADR 0047 chat lives on a JetStream stream; no chatRepo
+		// path needed (parameter retained for caller compat).
 	}
 }
 

--- a/internal/chat/chat.go
+++ b/internal/chat/chat.go
@@ -302,12 +302,25 @@ func (m *Manager) watchSubject(
 		close(out)
 		return out
 	}
+	// Teardown is mutex-gated: every callback dispatch holds mu while
+	// it does its select, and the close goroutine takes mu before
+	// close(out). Without this, a callback that already committed to
+	// `case out <- env:` would race close(out) and panic on a closed
+	// channel under -race. The closed flag keeps callbacks scheduled
+	// after teardown from re-entering the select once out is closed.
+	// Mirrors the pattern in EdgeSync's notify.Service.Watch.
+	var (
+		mu     sync.Mutex
+		closed bool
+	)
 	consumeCtx, err := cons.Consume(func(msg jetstream.Msg) {
 		var env Envelope
 		if err := json.Unmarshal(msg.Data(), &env); err != nil {
-			// Malformed envelope on the stream: skip rather than
-			// blocking the consumer. Same posture as ADR 0008's
-			// "garbage on the wire degrades silently."
+			return
+		}
+		mu.Lock()
+		defer mu.Unlock()
+		if closed {
 			return
 		}
 		select {
@@ -322,7 +335,10 @@ func (m *Manager) watchSubject(
 	go func() {
 		<-ctx.Done()
 		consumeCtx.Stop()
+		mu.Lock()
+		closed = true
 		close(out)
+		mu.Unlock()
 	}()
 	return out
 }
@@ -452,21 +468,28 @@ func (m *Manager) scanStream(ctx context.Context) (map[string][]Envelope, error)
 	}
 	scanCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	var seen uint64
+	// Mutex-gated callback: out map and seen counter are written from
+	// the JS callback goroutine and read after the select; without the
+	// lock -race fires on concurrent map writes. sync.Once on done
+	// guards against the late-arrival case where two callbacks observe
+	// seen >= target before the goroutine notices done is closed.
+	var (
+		mu       sync.Mutex
+		seen     uint64
+		doneOnce sync.Once
+	)
 	done := make(chan struct{})
 	consumeCtx, err := cons.Consume(func(msg jetstream.Msg) {
 		var env Envelope
-		if err := json.Unmarshal(msg.Data(), &env); err != nil {
-			seen++
-			if seen >= target {
-				close(done)
-			}
-			return
+		_ = json.Unmarshal(msg.Data(), &env) // skip-on-error below
+		mu.Lock()
+		defer mu.Unlock()
+		if env.Thread != "" {
+			out[env.Thread] = append(out[env.Thread], env)
 		}
-		out[env.Thread] = append(out[env.Thread], env)
 		seen++
 		if seen >= target {
-			close(done)
+			doneOnce.Do(func() { close(done) })
 		}
 	})
 	if err != nil {
@@ -477,6 +500,11 @@ func (m *Manager) scanStream(ctx context.Context) (map[string][]Envelope, error)
 	case <-done:
 	case <-scanCtx.Done():
 	}
+	// Take the lock once more to synchronize with any in-flight
+	// callback that finished increment-but-not-return before we
+	// received on done.
+	mu.Lock()
+	defer mu.Unlock()
 	return out, nil
 }
 

--- a/internal/chat/chat.go
+++ b/internal/chat/chat.go
@@ -2,24 +2,21 @@ package chat
 
 import (
 	"context"
+	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
-	"log/slog"
-	"os"
+	"sort"
 	"sync"
 	"sync/atomic"
 	"time"
 
-	libfossil "github.com/danmestas/libfossil"
-	// Register the modernc SQLite driver with libfossil so
-	// libfossil.Create / libfossil.Open can open the repo's SQLite
-	// backing store. Blank imports for side effects are the libfossil
-	// convention; without it, Create panics with "no driver registered".
-	"github.com/danmestas/EdgeSync/leaf/agent/notify"
-	_ "github.com/danmestas/libfossil/db/driver/modernc"
 	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
 
 	"github.com/danmestas/bones/internal/assert"
 )
@@ -30,151 +27,164 @@ import (
 // same close-race sentinel.
 var ErrClosed = errors.New("chat: manager is closed")
 
-// Manager owns a notify.Service plus the raw *nats.Conn handed to it by
-// coord. Send and Watch route through the service; Request uses the
-// raw connection for ADR 0008's Ask substrate (request/reply on
-// <proj>.ask.<recipient>). Close releases the service and the repo
-// Open dialed, but leaves the NATS connection alone — coord owns the
-// connection lifecycle, and chat is a borrower.
-//
-// Every public method is safe to call concurrently. Close is
-// idempotent via an atomic CAS on closed.
-type Manager struct {
-	cfg     Config
-	service *notify.Service
-	repo    *libfossil.Repo
-	nc      *nats.Conn
-	closed  atomic.Bool
+// Envelope is the wire format for a chat message on the JetStream
+// stream. JSON-serialized and persisted across the retention window;
+// possibly read by a consumer running a different bones version. This
+// type is deliberately distinct from coord.ChatMessage (which is the
+// public Go API) so the two can evolve under different stability rules
+// — see ADR 0047.
+type Envelope struct {
+	ID        string    `json:"id"`
+	From      string    `json:"from"`
+	Thread    string    `json:"thread"` // 8-hex SHA-256 short
+	Body      string    `json:"body"`
+	Timestamp time.Time `json:"timestamp"`
+	ReplyTo   string    `json:"reply_to,omitempty"`
 }
 
-// Open validates cfg, opens (or creates) the Fossil repo at
-// cfg.FossilRepoPath, and wires a notify.Service on top of the repo
-// and the caller-provided NATS connection. Constructing a Manager
-// does not consume a goroutine; notify's Watch spawns one per call.
-// Callers must invoke Close to release the service and the repo.
+// Manager owns the JetStream stream that backs chat for one project.
+// Send writes envelopes via js.PublishMsg with W3C trace context in
+// headers; Watch returns ordered consumers scoped to the appropriate
+// subject filter. Request and Respond use the raw *nats.Conn for ADR
+// 0008's Ask substrate (request/reply on <proj>.ask.<recipient>).
+//
+// Every public method is safe to call concurrently. Close is
+// idempotent via an atomic CAS on closed. Coord owns the *nats.Conn
+// lifecycle; chat is a borrower.
+type Manager struct {
+	cfg    Config
+	nc     *nats.Conn
+	js     jetstream.JetStream
+	stream jetstream.Stream
+	closed atomic.Bool
+}
+
+// Open validates cfg, opens (or creates) the per-project chat stream
+// on the supplied NATS connection, and returns a Manager. Constructing
+// a Manager does not consume a goroutine; Watch spawns one per call.
+// Callers must invoke Close to release resources.
+//
+// The stream name is derived as "chat-<ProjectPrefix>" with subjects
+// "chat.<ProjectPrefix>.>" (so per-thread subjects fall under it). If
+// the stream exists, retention is updated to match cfg.MaxRetentionAge
+// — JetStream merges the config in place. If absent, the stream is
+// created with file storage. cfg.MaxRetentionAge of 0 means unbounded
+// retention, which preserves coord.Prime semantics across long
+// absences (ADR 0036, ADR 0047).
 //
 // Open does not dial NATS: the connection comes pre-wired from coord
-// so reconnection, auth, and TLS stay a single-source concern. If
-// repo open or notify.NewService fails, earlier steps are torn down
-// before returning so no resources leak.
+// so reconnection, auth, and TLS stay a single-source concern.
 func Open(ctx context.Context, cfg Config) (*Manager, error) {
 	assert.NotNil(ctx, "chat.Open: ctx is nil")
 	if err := cfg.Validate(); err != nil {
 		return nil, fmt.Errorf("chat.Open: %w", err)
 	}
-	repo, err := openOrCreateRepo(cfg.FossilRepoPath)
+	js, err := jetstream.New(cfg.Nats)
 	if err != nil {
-		return nil, fmt.Errorf("chat.Open: repo: %w", err)
+		return nil, fmt.Errorf("chat.Open: jetstream: %w", err)
 	}
-	svc, err := notify.NewService(notify.ServiceConfig{
-		Repo:     repo,
-		NATSConn: cfg.Nats,
-		From:     cfg.AgentID,
-		FromName: cfg.AgentID,
+	streamName := "chat-" + cfg.ProjectPrefix
+	stream, err := js.CreateOrUpdateStream(ctx, jetstream.StreamConfig{
+		Name:      streamName,
+		Subjects:  []string{"chat." + cfg.ProjectPrefix + ".>"},
+		Storage:   jetstream.FileStorage,
+		Retention: jetstream.LimitsPolicy,
+		MaxAge:    cfg.MaxRetentionAge,
 	})
 	if err != nil {
-		_ = repo.Close()
-		return nil, fmt.Errorf("chat.Open: notify: %w", err)
+		return nil, fmt.Errorf("chat.Open: stream %q: %w", streamName, err)
 	}
 	return &Manager{
-		cfg:     cfg,
-		service: svc,
-		repo:    repo,
-		nc:      cfg.Nats,
+		cfg:    cfg,
+		nc:     cfg.Nats,
+		js:     js,
+		stream: stream,
 	}, nil
 }
 
-// openOrCreateRepo returns a Fossil repo at path, creating it when
-// absent and opening it when present. notify.NewService does not
-// create the repo itself (the EdgeSync convention is that the caller
-// owns the repo lifecycle), so this package carries the tiny exists-
-// probe. Any stat error other than ErrNotExist propagates unwrapped so
-// the caller sees a permissions or disk error as itself.
-func openOrCreateRepo(path string) (*libfossil.Repo, error) {
-	_, err := os.Stat(path)
-	switch {
-	case err == nil:
-		return libfossil.Open(path)
-	case errors.Is(err, os.ErrNotExist):
-		return libfossil.Create(path, libfossil.CreateOpts{
-			User: "bones",
-		})
-	default:
-		return nil, err
-	}
-}
-
-// Close releases resources held by the Manager. It closes the notify
-// Service (which unsubscribes any active NATS subscriptions) and then
-// closes the Fossil repo Open dialed. The shared *nats.Conn is NOT
-// closed here — coord owns the connection lifecycle. Subsequent calls
-// are no-ops; safe to call more than once. Errors from service.Close
-// are returned first; repo.Close errors are returned only when the
-// service closed clean.
+// Close releases resources held by the Manager. The stream itself is
+// not deleted (it persists across coord lifecycles; deletion is an
+// operator decision via `nats stream delete`). The shared *nats.Conn
+// is NOT closed here — coord owns the connection lifecycle.
+// Subsequent calls are no-ops; safe to call more than once.
 func (m *Manager) Close() error {
 	assert.NotNil(m, "chat.Close: receiver is nil")
-	if !m.closed.CompareAndSwap(false, true) {
-		return nil
-	}
-	var first error
-	if m.service != nil {
-		if err := m.service.Close(); err != nil {
-			first = err
-		}
-	}
-	if m.repo != nil {
-		if err := m.repo.Close(); err != nil && first == nil {
-			first = err
-		}
-	}
-	return first
+	m.closed.Store(true)
+	return nil
 }
 
-// threadUUID computes the deterministic notify Thread UUID for a
+// threadShort returns the 8-char deterministic ThreadShort for a
 // (project, name) pair. SHA-256 of "project:name", hex-encoded, first
-// 32 chars, prefixed with "thread-". Same inputs → same output on
-// every Manager and every restart — this is how cross-Manager and
-// cross-restart thread identity is preserved without a coordination
-// substrate. The 32-hex suffix matches notify's NewMessage shape so
-// Message.ThreadShort() (which takes the first 8 chars after the
-// "thread-" prefix) gives the expected value.
-func threadUUID(project, name string) string {
+// 8 chars. Same inputs → same output on every Manager and every
+// restart — this is how cross-Manager and cross-restart thread identity
+// is preserved without a coordination substrate. The ADR 0008
+// invariant carries forward verbatim.
+func threadShort(project, name string) string {
 	h := sha256.Sum256([]byte(project + ":" + name))
-	return "thread-" + hex.EncodeToString(h[:])[:32]
+	return hex.EncodeToString(h[:])[:8]
 }
 
-// threadShort returns the 8-char ThreadShort that notify derives from
-// the full Thread UUID. Same as notify.Message.ThreadShort() would
-// return for a message with Thread = threadUUID(project, name).
-func threadShort(project, name string) string {
-	return threadUUID(project, name)[len("thread-") : len("thread-")+8]
+// newID returns a 32-hex-char unique ID for an Envelope. crypto/rand
+// over 16 bytes is enough for cross-Manager uniqueness without a
+// coordination substrate; collisions at 2^128 are not an operational
+// concern.
+func newID() string {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		// rand.Read on Linux/macOS does not fail in practice; treat
+		// any error as fatal-to-the-call rather than papering over.
+		panic(fmt.Sprintf("chat: rand.Read: %v", err))
+	}
+	return hex.EncodeToString(b[:])
 }
+
+// natsHeaderCarrier adapts nats.Header to the OpenTelemetry
+// TextMapCarrier interface so traceparent headers can be injected via
+// otel.GetTextMapPropagator().Inject. nats.Header is a map[string][]
+// string under the hood; this is a thin type alias with the three
+// methods the carrier interface requires.
+type natsHeaderCarrier nats.Header
+
+func (h natsHeaderCarrier) Get(key string) string {
+	return nats.Header(h).Get(key)
+}
+
+func (h natsHeaderCarrier) Set(key, value string) {
+	nats.Header(h).Set(key, value)
+}
+
+func (h natsHeaderCarrier) Keys() []string {
+	keys := make([]string, 0, len(h))
+	for k := range h {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+// Compile-time assertion that natsHeaderCarrier satisfies the OTel
+// TextMapCarrier interface. If this stops compiling, otel.GetText
+// MapPropagator().Inject below will fail at the call site.
+var _ propagation.TextMapCarrier = natsHeaderCarrier{}
 
 // Send publishes body to a chat thread. thread is a caller-supplied
-// name that Manager maps to a deterministic notify Thread UUID via
-// SHA-256(project + ":" + name). Two Managers on the same substrate
-// that both post to "t1" compute the same Thread UUID and therefore
-// publish on the same NATS subject — cross-Manager and cross-restart
-// thread identity falls out of the hash with no coordination substrate.
+// name that Manager maps to a deterministic 8-hex short via SHA-256.
+// Two Managers on the same substrate that both post to "t1" compute
+// the same short and therefore publish on the same NATS subject —
+// cross-Manager and cross-restart thread identity falls out of the
+// hash with no coordination substrate.
 //
-// Send bypasses notify.Service.Send because Service.Send's
-// resolveThread rejects unknown ThreadShorts (they must have a
-// pre-existing fossil entry), and we want to OWN the Thread UUID, not
-// have notify generate it. Instead: build the notify.Message via
-// notify.NewMessage (correct ID/timestamp/shape), overwrite Thread
-// with the deterministic UUID, commit to the local repo, and publish
-// on the computed NATS subject.
+// The publish is a single JetStream operation: durable in the stream
+// AND visible to live subscribers in one round trip, with no fossil-
+// then-NATS split. W3C trace context from ctx is injected into the
+// NATS message headers via the standard `traceparent` header so
+// subscribers can stitch spans across the publish/receive boundary.
 //
-// ctx is pre-checked: a canceled context short-circuits before any
-// repo or NATS work. Once CommitMessage is entered, it runs to
-// completion — the upstream call takes no ctx, and write latency is
-// sub-millisecond in normal operation.
-//
-// See docs/adr/0008-chat-substrate.md "Update (2026-04-19)" for the
-// deterministic-identity scheme and its rationale.
+// Returns ErrClosed if the Manager has been closed. Any error from
+// js.PublishMsg surfaces wrapped with the chat.Send prefix.
 func (m *Manager) Send(
 	ctx context.Context, thread, body string,
 ) error {
+	assert.NotNil(m, "chat.Send: receiver is nil")
 	assert.NotNil(ctx, "chat.Send: ctx is nil")
 	assert.NotEmpty(thread, "chat.Send: thread is empty")
 	if m.closed.Load() {
@@ -183,112 +193,146 @@ func (m *Manager) Send(
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	msg := notify.NewMessage(notify.MessageOpts{
-		Project:  m.cfg.ProjectPrefix,
-		From:     m.cfg.AgentID,
-		FromName: m.cfg.AgentID,
-		Body:     body,
-	})
-	msg.Thread = threadUUID(m.cfg.ProjectPrefix, thread)
-	if err := notify.CommitMessage(m.repo, msg); err != nil {
-		return fmt.Errorf("chat.Send: %w", err)
+	short := threadShort(m.cfg.ProjectPrefix, thread)
+	env := Envelope{
+		ID:        newID(),
+		From:      m.cfg.AgentID,
+		Thread:    short,
+		Body:      body,
+		Timestamp: time.Now().UTC(),
 	}
-	if err := notify.Publish(m.nc, msg); err != nil {
+	data, err := json.Marshal(env)
+	if err != nil {
+		return fmt.Errorf("chat.Send: marshal: %w", err)
+	}
+	natsMsg := &nats.Msg{
+		Subject: "chat." + m.cfg.ProjectPrefix + "." + short,
+		Data:    data,
+		Header:  nats.Header{},
+	}
+	otel.GetTextMapPropagator().Inject(
+		ctx, natsHeaderCarrier(natsMsg.Header),
+	)
+	if _, err := m.js.PublishMsg(ctx, natsMsg); err != nil {
 		return fmt.Errorf("chat.Send: %w", err)
 	}
 	return nil
 }
 
-// Watch returns a channel of notify.Message values for the given
-// thread. thread is a caller-supplied name — chat hashes it internally
-// into the same deterministic ThreadShort that Send uses, so a Watch
-// on "t1" receives every message any Manager has Sent to "t1" on this
+// Watch returns a channel of Envelope values for the given thread.
+// thread is a caller-supplied name — chat hashes it internally into
+// the same deterministic 8-hex short that Send uses, so a Watch on
+// "t1" receives every message any Manager has Sent to "t1" on this
 // project/substrate. The channel closes when ctx is canceled.
 //
-// The notify.Message type crosses the package boundary because this is
-// an INTERNAL package — the translation into coord.ChatMessage (ADR
-// 0003, ADR 0008) lives in coord.
+// The Envelope type crosses the package boundary because this is an
+// INTERNAL package — the translation into coord.ChatMessage (ADR
+// 0003, ADR 0047) lives in coord.
 //
 // A nil Manager, nil ctx, or empty thread panics (programmer error).
 // Use-after-close returns an already-closed channel rather than
 // panicking so deferred consumer drain stays quiet.
 func (m *Manager) Watch(
 	ctx context.Context, thread string,
-) <-chan notify.Message {
+) <-chan Envelope {
 	assert.NotNil(m, "chat.Watch: receiver is nil")
 	assert.NotNil(ctx, "chat.Watch: ctx is nil")
 	assert.NotEmpty(thread, "chat.Watch: thread is empty")
-	return m.watchByShort(ctx, threadShort(m.cfg.ProjectPrefix, thread))
+	short := threadShort(m.cfg.ProjectPrefix, thread)
+	subject := "chat." + m.cfg.ProjectPrefix + "." + short
+	return m.watchSubject(ctx, subject)
 }
 
-// WatchAll returns a channel of notify.Message values for every thread
-// in this Manager's project. The channel closes when ctx is canceled.
+// WatchAll returns a channel of Envelope values for every thread in
+// this Manager's project. The channel closes when ctx is canceled.
 // This is the project-wide counterpart to Watch: coord.Subscribe routes
-// through WatchAll when the caller passes an empty pattern (ADR 0008
-// documents empty = project-wide), and through Watch otherwise.
-//
-// Downstream, this maps to notify.Service.Watch with an empty
-// ThreadShort — which notify interprets as a wildcard subscribe across
-// every thread subject under the project.
+// through WatchAll when the caller passes an empty pattern.
 //
 // A nil Manager or nil ctx panics (programmer error). Use-after-close
 // returns an already-closed channel, same shape as Watch.
-func (m *Manager) WatchAll(ctx context.Context) <-chan notify.Message {
+func (m *Manager) WatchAll(ctx context.Context) <-chan Envelope {
 	assert.NotNil(m, "chat.WatchAll: receiver is nil")
 	assert.NotNil(ctx, "chat.WatchAll: ctx is nil")
-	return m.watchByShort(ctx, "")
+	subject := "chat." + m.cfg.ProjectPrefix + ".*"
+	return m.watchSubject(ctx, subject)
 }
 
-// WatchPattern returns a channel of notify.Message values for every
-// thread whose NATS subject segment matches pattern. Unlike Watch —
-// which hashes its thread argument into a deterministic ThreadShort —
-// WatchPattern passes pattern through to the substrate unchanged, so
-// callers can supply NATS subject wildcards ("*" for every thread, a
-// literal ThreadShort for a single known stream, or an already-hashed
-// short from a ChatMessage.Thread()).
-//
-// This is the substrate half of coord.SubscribePattern's
-// glob-Subscribe surface. The raw-pattern leak is deliberate:
-// callers see the NATS pattern shape that ADR 0003 normally hides,
-// the payoff being a glob-Subscribe deliverable without a new KV
-// bucket or per-Post registry writes.
+// WatchPattern returns a channel of Envelope values for every thread
+// whose NATS subject segment matches pattern. Unlike Watch — which
+// hashes its thread argument into a deterministic short — WatchPattern
+// passes pattern through as the subject suffix, so callers can supply
+// NATS subject wildcards ("*" for every thread, a literal short for a
+// single known stream, or an already-hashed short).
 //
 // Empty pattern is asserted — use WatchAll for project-wide streams.
 // Use-after-close returns an already-closed channel, same shape as
 // Watch. A nil Manager or nil ctx panics (programmer error).
 func (m *Manager) WatchPattern(
 	ctx context.Context, pattern string,
-) <-chan notify.Message {
+) <-chan Envelope {
 	assert.NotNil(m, "chat.WatchPattern: receiver is nil")
 	assert.NotNil(ctx, "chat.WatchPattern: ctx is nil")
 	assert.NotEmpty(pattern, "chat.WatchPattern: pattern is empty")
-	return m.watchByShort(ctx, pattern)
+	subject := "chat." + m.cfg.ProjectPrefix + "." + pattern
+	return m.watchSubject(ctx, subject)
 }
 
-// watchByShort is the shared implementation of Watch, WatchAll, and
-// WatchPattern. threadShort is passed through to notify as-is; an empty
-// string means project-wide (all threads). Use-after-close returns an
-// already-closed channel so consumer drain stays quiet.
-func (m *Manager) watchByShort(
-	ctx context.Context, short string,
-) <-chan notify.Message {
+// watchSubject is the shared implementation of Watch, WatchAll, and
+// WatchPattern. It opens an ordered consumer with the supplied subject
+// filter and pipes envelopes onto a buffered channel. The relay
+// goroutine exits when ctx is canceled, the consumer fails, or the
+// Manager closes; on any of those it closes the output channel.
+//
+// Use-after-close returns an already-closed channel so consumer drain
+// stays quiet.
+func (m *Manager) watchSubject(
+	ctx context.Context, subject string,
+) <-chan Envelope {
 	if m.closed.Load() {
-		ch := make(chan notify.Message)
+		ch := make(chan Envelope)
 		close(ch)
 		return ch
 	}
-	return m.service.Watch(ctx, notify.WatchOpts{
-		Project:     m.cfg.ProjectPrefix,
-		ThreadShort: short,
+	out := make(chan Envelope, 16)
+	cons, err := m.stream.OrderedConsumer(ctx, jetstream.OrderedConsumerConfig{
+		FilterSubjects: []string{subject},
+		DeliverPolicy:  jetstream.DeliverNewPolicy,
 	})
+	if err != nil {
+		close(out)
+		return out
+	}
+	consumeCtx, err := cons.Consume(func(msg jetstream.Msg) {
+		var env Envelope
+		if err := json.Unmarshal(msg.Data(), &env); err != nil {
+			// Malformed envelope on the stream: skip rather than
+			// blocking the consumer. Same posture as ADR 0008's
+			// "garbage on the wire degrades silently."
+			return
+		}
+		select {
+		case out <- env:
+		case <-ctx.Done():
+		}
+	})
+	if err != nil {
+		close(out)
+		return out
+	}
+	go func() {
+		<-ctx.Done()
+		consumeCtx.Stop()
+		close(out)
+	}()
+	return out
 }
 
 // Request sends payload to subject via NATS request/reply and returns
 // the reply payload. ctx bounds the wait — a deadline-less ctx on an
-// offline recipient never returns. Phase 3C's coord.Ask builds the
-// subject as <proj>.ask.<recipient> and hands it to this method; chat
-// itself is subject-agnostic so the same wrapper serves any future
-// request/reply caller.
+// offline recipient never returns. coord.Ask builds the subject as
+// <proj>.ask.<recipient> and hands it to this method; chat itself is
+// subject-agnostic so the same wrapper serves any future request/reply
+// caller.
 //
 // Errors from the NATS RequestWithContext path are wrapped with the
 // chat.Request prefix so substrate failures are distinguishable from
@@ -316,24 +360,19 @@ func (m *Manager) Request(
 // returns either a reply payload or an error. On a nil-error return,
 // Respond publishes the reply via msg.Respond. On a non-nil error
 // return, no reply is published — by design: the chat substrate does
-// not model error payloads (see ADR 0008), so handler failure is
-// surfaced to the Ask caller as a no-responders timeout. The effect is
-// that handler errors and "no handler registered" are indistinguishable
-// from the ask side; callers that need richer error semantics layer
-// them in the payload shape.
+// not model error payloads, so handler failure is surfaced to the Ask
+// caller as a no-responders timeout.
 //
 // The returned closure is an idempotent unsubscribe: the first call
 // tears down the subscription; subsequent calls are no-ops and return
-// nil. Sync.Once-guarded so concurrent callers cannot double-close the
+// nil. sync.Once-guarded so concurrent callers cannot double-close the
 // underlying subscription.
 //
 // Subject is forwarded to the NATS connection as-is; chat itself is
 // subject-agnostic. coord.Answer supplies "<proj>.ask.<agentID>".
 //
 // Returns ErrClosed if the Manager has been closed. A nil Manager or
-// nil handler panics (programmer error); empty subject panics. Any
-// error from nats.Conn.Subscribe is wrapped with the chat.Respond
-// prefix.
+// nil handler panics (programmer error); empty subject panics.
 func (m *Manager) Respond(
 	subject string,
 	handler func(payload []byte) ([]byte, error),
@@ -356,13 +395,6 @@ func (m *Manager) Respond(
 	if err != nil {
 		return nil, fmt.Errorf("chat.Respond: %w", err)
 	}
-	// Flush forces the SUB proto to round-trip to the server before
-	// Respond returns. Without this, a Request arriving on the
-	// subscribed subject immediately after Respond returns can land
-	// before the server has registered our interest, yielding a
-	// spurious no-responders timeout. The cost is one synchronous
-	// round-trip at registration time; the payoff is that
-	// Answer-then-Ask races don't flake on CI.
 	if err := m.nc.Flush(); err != nil {
 		_ = sub.Unsubscribe()
 		return nil, fmt.Errorf("chat.Respond: flush: %w", err)
@@ -378,8 +410,7 @@ func (m *Manager) Respond(
 }
 
 // ThreadSummary is a read-only view of a chat thread for agent context
-// recovery. Mirrors notify.ThreadSummary with only the fields needed by
-// coord.Prime().
+// recovery. Used by coord.Prime per ADR 0036.
 type ThreadSummary struct {
 	threadShort  string
 	lastActivity time.Time
@@ -392,35 +423,114 @@ func (t ThreadSummary) LastActivity() time.Time { return t.lastActivity }
 func (t ThreadSummary) MessageCount() int       { return t.messageCount }
 func (t ThreadSummary) LastBody() string        { return t.lastBody }
 
-// ListThreads returns all threads for this Manager's project, sorted by
-// last activity (most recent first).
+// scanStream walks every message currently in the stream and groups
+// them by Thread. Used by ListThreads and ThreadsForAgent. Complexity
+// is O(N) in stream size — same complexity class as a fossil checkin
+// scan in the pre-ADR-0047 implementation. If profiling shows Prime
+// is slow on long-lived workspaces with high chat volume, a derived
+// KV index of (threadShort → ThreadSummary) is the future optimization
+// per ADR 0047.
+//
+// The scan opens a one-shot ordered consumer with DeliverAll. Streams
+// with empty messages return an empty grouping without error.
+func (m *Manager) scanStream(ctx context.Context) (map[string][]Envelope, error) {
+	cons, err := m.stream.OrderedConsumer(ctx, jetstream.OrderedConsumerConfig{
+		FilterSubjects: []string{"chat." + m.cfg.ProjectPrefix + ".>"},
+		DeliverPolicy:  jetstream.DeliverAllPolicy,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("ordered consumer: %w", err)
+	}
+	info, err := m.stream.Info(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("stream info: %w", err)
+	}
+	target := info.State.Msgs
+	out := make(map[string][]Envelope)
+	if target == 0 {
+		return out, nil
+	}
+	scanCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	var seen uint64
+	done := make(chan struct{})
+	consumeCtx, err := cons.Consume(func(msg jetstream.Msg) {
+		var env Envelope
+		if err := json.Unmarshal(msg.Data(), &env); err != nil {
+			seen++
+			if seen >= target {
+				close(done)
+			}
+			return
+		}
+		out[env.Thread] = append(out[env.Thread], env)
+		seen++
+		if seen >= target {
+			close(done)
+		}
+	})
+	if err != nil {
+		return nil, fmt.Errorf("consume: %w", err)
+	}
+	defer consumeCtx.Stop()
+	select {
+	case <-done:
+	case <-scanCtx.Done():
+	}
+	return out, nil
+}
+
+// summariesFromGroups builds ThreadSummary records from grouped
+// envelopes. Sorted descending by LastActivity to match the legacy
+// notify.ListThreads ordering.
+func summariesFromGroups(groups map[string][]Envelope) []ThreadSummary {
+	out := make([]ThreadSummary, 0, len(groups))
+	for short, envs := range groups {
+		if len(envs) == 0 {
+			continue
+		}
+		last := envs[0]
+		for _, e := range envs {
+			if e.Timestamp.After(last.Timestamp) {
+				last = e
+			}
+		}
+		out = append(out, ThreadSummary{
+			threadShort:  short,
+			lastActivity: last.Timestamp,
+			messageCount: len(envs),
+			lastBody:     last.Body,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].lastActivity.After(out[j].lastActivity)
+	})
+	return out
+}
+
+// ListThreads returns all threads on this Manager's project, sorted by
+// last activity (most recent first). Reads via a one-shot ordered
+// consumer with DeliverAll — see scanStream for complexity notes.
 func (m *Manager) ListThreads(ctx context.Context) ([]ThreadSummary, error) {
 	assert.NotNil(ctx, "chat.ListThreads: ctx is nil")
 	if m.closed.Load() {
 		return nil, ErrClosed
 	}
-
-	summaries, err := notify.ListThreads(m.repo, m.cfg.ProjectPrefix)
+	groups, err := m.scanStream(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("chat.ListThreads: %w", err)
 	}
-
-	out := make([]ThreadSummary, 0, len(summaries))
-	for _, s := range summaries {
-		out = append(out, ThreadSummary{
-			threadShort:  s.ThreadShort,
-			lastActivity: s.LastActivity,
-			messageCount: s.MessageCount,
-			lastBody:     s.LastMessage.Body,
-		})
-	}
-	return out, nil
+	return summariesFromGroups(groups), nil
 }
 
-// ThreadsForAgent returns up to maxThreads recent threads where the given
-// agentID has sent at least one message. Threads are sorted by last activity
-// (most recent first). Errors reading individual threads are logged and
-// skipped so one bad thread does not fail the whole snapshot.
+// ThreadsForAgent returns up to maxThreads recent threads where the
+// given agentID has sent at least one message. Threads are sorted by
+// last activity (most recent first). Used by coord.Prime per ADR 0036.
+//
+// Implementation walks the stream once (O(N) in stream size), groups
+// by Thread, and filters to threads where any envelope's From matches
+// agentID. Same complexity class as the pre-ADR-0047 fossil checkin
+// scan.
 func (m *Manager) ThreadsForAgent(
 	ctx context.Context, agentID string, maxThreads int,
 ) ([]ThreadSummary, error) {
@@ -429,49 +539,22 @@ func (m *Manager) ThreadsForAgent(
 	if m.closed.Load() {
 		return nil, ErrClosed
 	}
-
-	all, err := notify.ListThreads(m.repo, m.cfg.ProjectPrefix)
+	groups, err := m.scanStream(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("chat.ThreadsForAgent: %w", err)
 	}
-
-	out := make([]ThreadSummary, 0, maxThreads)
-	for _, s := range all {
-		if len(out) >= maxThreads {
-			break
-		}
-
-		// Fast path: if the last message is from this agent, include it.
-		if s.LastMessage.From == agentID {
-			out = append(out, ThreadSummary{
-				threadShort:  s.ThreadShort,
-				lastActivity: s.LastActivity,
-				messageCount: s.MessageCount,
-				lastBody:     s.LastMessage.Body,
-			})
-			continue
-		}
-
-		// Slow path: scan the full thread to see if this agent participated
-		// at any point. This is O(messages) per thread but accurate.
-		msgs, err := notify.ReadThread(m.repo, m.cfg.ProjectPrefix, s.ThreadShort)
-		if err != nil {
-			slog.WarnContext(ctx, "chat.ThreadsForAgent: skipping unreadable thread",
-				"thread", s.ThreadShort, "error", err)
-			continue
-		}
-
-		for _, msg := range msgs {
-			if msg.From == agentID {
-				out = append(out, ThreadSummary{
-					threadShort:  s.ThreadShort,
-					lastActivity: s.LastActivity,
-					messageCount: s.MessageCount,
-					lastBody:     s.LastMessage.Body,
-				})
+	filtered := make(map[string][]Envelope, len(groups))
+	for short, envs := range groups {
+		for _, e := range envs {
+			if e.From == agentID {
+				filtered[short] = envs
 				break
 			}
 		}
 	}
-	return out, nil
+	all := summariesFromGroups(filtered)
+	if len(all) > maxThreads {
+		all = all[:maxThreads]
+	}
+	return all, nil
 }

--- a/internal/chat/chat_test.go
+++ b/internal/chat/chat_test.go
@@ -3,7 +3,6 @@ package chat_test
 import (
 	"context"
 	"fmt"
-	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -12,17 +11,17 @@ import (
 	"github.com/danmestas/bones/internal/testutil/natstest"
 )
 
-// validConfig returns a fully-valid chat.Config bound to the given
-// NATS URL and a fresh repo path under t.TempDir. Tests mutate the
-// returned value to exercise specific Validate branches.
+// validConfig returns a fully-valid chat.Config. The Nats handle must
+// be filled in by the caller from a JetStream-enabled test server —
+// chat.Open creates a JS stream per ADR 0047.
 func validConfig(t *testing.T) chat.Config {
 	t.Helper()
 	return chat.Config{
 		AgentID:        "bones-testabcd",
 		ProjectPrefix:  "bones",
 		Nats:           nil, // filled in by caller
-		FossilRepoPath: filepath.Join(t.TempDir(), "chat.fossil"),
 		MaxSubscribers: 32,
+		// MaxRetentionAge: 0 = unbounded, the production default.
 	}
 }
 
@@ -43,7 +42,7 @@ func requirePanic(t *testing.T, fn func(), want string) {
 }
 
 func TestOpen_Valid(t *testing.T) {
-	nc, _ := natstest.NewTestServer(t)
+	nc, _ := natstest.NewJetStreamServer(t)
 	cfg := validConfig(t)
 	cfg.Nats = nc
 
@@ -60,7 +59,7 @@ func TestOpen_Valid(t *testing.T) {
 }
 
 func TestOpen_InvalidConfig(t *testing.T) {
-	nc, _ := natstest.NewTestServer(t)
+	nc, _ := natstest.NewJetStreamServer(t)
 	cases := []struct {
 		name    string
 		mutate  func(*chat.Config)
@@ -80,11 +79,6 @@ func TestOpen_InvalidConfig(t *testing.T) {
 			name:    "nil Nats",
 			mutate:  func(c *chat.Config) { c.Nats = nil },
 			wantKey: "Nats",
-		},
-		{
-			name:    "empty FossilRepoPath",
-			mutate:  func(c *chat.Config) { c.FossilRepoPath = "" },
-			wantKey: "FossilRepoPath",
 		},
 		{
 			name:    "zero MaxSubscribers",
@@ -123,7 +117,7 @@ func TestOpen_InvalidConfig(t *testing.T) {
 }
 
 func TestOpen_NilCtxPanics(t *testing.T) {
-	nc, _ := natstest.NewTestServer(t)
+	nc, _ := natstest.NewJetStreamServer(t)
 	cfg := validConfig(t)
 	cfg.Nats = nc
 	var nilCtx context.Context
@@ -134,7 +128,7 @@ func TestOpen_NilCtxPanics(t *testing.T) {
 }
 
 func TestClose_Idempotent(t *testing.T) {
-	nc, _ := natstest.NewTestServer(t)
+	nc, _ := natstest.NewJetStreamServer(t)
 	cfg := validConfig(t)
 	cfg.Nats = nc
 
@@ -164,7 +158,7 @@ const deterministicTestTimeout = 2 * time.Second
 // bones-x0t: cross-Manager identity falls out of the
 // deterministic hash with no coordination substrate.
 func TestSend_DeterministicThreadAcrossManagers(t *testing.T) {
-	nc, _ := natstest.NewTestServer(t)
+	nc, _ := natstest.NewJetStreamServer(t)
 
 	cfgA := validConfig(t)
 	cfgA.AgentID = "bones-aaaa"
@@ -207,7 +201,7 @@ func TestSend_DeterministicThreadAcrossManagers(t *testing.T) {
 		// cross-restart test. Here we just pin that the hash is
 		// self-consistent: it's the same across two posts from the
 		// same Manager, proving the Send path truly is deterministic.
-		firstShort := msg.ThreadShort()
+		firstShort := msg.Thread
 		if err := mB.Send(
 			context.Background(), "t1", "second",
 		); err != nil {
@@ -218,10 +212,10 @@ func TestSend_DeterministicThreadAcrossManagers(t *testing.T) {
 			if !ok {
 				t.Fatalf("stream: closed before second delivery")
 			}
-			if msg2.ThreadShort() != firstShort {
+			if msg2.Thread != firstShort {
 				t.Fatalf(
 					"ThreadShort drift: first=%q second=%q",
-					firstShort, msg2.ThreadShort(),
+					firstShort, msg2.Thread,
 				)
 			}
 		case <-time.After(deterministicTestTimeout):
@@ -246,7 +240,7 @@ func TestSend_DeterministicThreadAcrossManagers(t *testing.T) {
 // ThreadShort. Without the deterministic hash the pre-x0t cache would
 // have regenerated a fresh Thread UUID, breaking this property.
 func TestSend_DeterministicAcrossRestart(t *testing.T) {
-	nc, _ := natstest.NewTestServer(t)
+	nc, _ := natstest.NewJetStreamServer(t)
 
 	cfgA := validConfig(t)
 	cfgA.AgentID = "bones-aaaa"
@@ -282,7 +276,7 @@ func TestSend_DeterministicAcrossRestart(t *testing.T) {
 		if !ok {
 			t.Fatalf("stream: closed before first delivery")
 		}
-		firstShort = msg.ThreadShort()
+		firstShort = msg.Thread
 	case <-time.After(deterministicTestTimeout):
 		t.Fatalf("no first delivery within %s", deterministicTestTimeout)
 	}
@@ -312,10 +306,10 @@ func TestSend_DeterministicAcrossRestart(t *testing.T) {
 		if !ok {
 			t.Fatalf("stream: closed before second delivery")
 		}
-		if msg.ThreadShort() != firstShort {
+		if msg.Thread != firstShort {
 			t.Fatalf(
 				"ThreadShort drifted across restart: first=%q second=%q",
-				firstShort, msg.ThreadShort(),
+				firstShort, msg.Thread,
 			)
 		}
 	case <-time.After(deterministicTestTimeout):
@@ -338,14 +332,13 @@ const reqRespTimeout = 2 * time.Second
 // coord wrapper. Also covers threadShort — the helper is unreachable
 // via WatchAll.
 func TestWatch_NamedDelivery(t *testing.T) {
-	nc, _ := natstest.NewTestServer(t)
+	nc, _ := natstest.NewJetStreamServer(t)
 
 	cfgA := validConfig(t)
 	cfgA.AgentID = "bones-aaaa"
 	cfgA.Nats = nc
 	cfgB := validConfig(t)
 	cfgB.AgentID = "bones-bbbb"
-	cfgB.FossilRepoPath = filepath.Join(t.TempDir(), "b.fossil")
 	cfgB.Nats = nc
 
 	mA, err := chat.Open(context.Background(), cfgA)
@@ -387,7 +380,7 @@ func TestWatch_NamedDelivery(t *testing.T) {
 // already-closed channel rather than panicking. Deferred consumer
 // drains stay quiet when chat is torn down during shutdown.
 func TestWatch_UseAfterClose(t *testing.T) {
-	nc, _ := natstest.NewTestServer(t)
+	nc, _ := natstest.NewJetStreamServer(t)
 	cfg := validConfig(t)
 	cfg.Nats = nc
 
@@ -418,14 +411,13 @@ func TestWatch_UseAfterClose(t *testing.T) {
 // ThreadShort untouched — no hash round-trip — so delivery lands on
 // the raw <proj>.* subject.
 func TestWatchPattern_WildcardDelivery(t *testing.T) {
-	nc, _ := natstest.NewTestServer(t)
+	nc, _ := natstest.NewJetStreamServer(t)
 
 	cfgA := validConfig(t)
 	cfgA.AgentID = "bones-aaaa"
 	cfgA.Nats = nc
 	cfgB := validConfig(t)
 	cfgB.AgentID = "bones-bbbb"
-	cfgB.FossilRepoPath = filepath.Join(t.TempDir(), "b.fossil")
 	cfgB.Nats = nc
 
 	mA, err := chat.Open(context.Background(), cfgA)
@@ -466,7 +458,7 @@ func TestWatchPattern_WildcardDelivery(t *testing.T) {
 // accepts empty by definition). Empty-pattern callers at the chat
 // layer should use WatchAll; the panic documents that contract.
 func TestWatchPattern_InvariantPanics(t *testing.T) {
-	nc, _ := natstest.NewTestServer(t)
+	nc, _ := natstest.NewJetStreamServer(t)
 	cfg := validConfig(t)
 	cfg.Nats = nc
 	m, err := chat.Open(context.Background(), cfg)
@@ -495,7 +487,7 @@ func TestWatchPattern_InvariantPanics(t *testing.T) {
 // Single Manager on purpose — the surface is subject-string in,
 // payload-bytes out, and spans no project/thread state.
 func TestRequest_RespondRoundTrip(t *testing.T) {
-	nc, _ := natstest.NewTestServer(t)
+	nc, _ := natstest.NewJetStreamServer(t)
 	cfg := validConfig(t)
 	cfg.Nats = nc
 
@@ -537,7 +529,7 @@ func TestRequest_RespondRoundTrip(t *testing.T) {
 // distinguish via errors.Is; this test only pins that some error
 // surfaces with the wrap prefix.
 func TestRequest_NoResponder(t *testing.T) {
-	nc, _ := natstest.NewTestServer(t)
+	nc, _ := natstest.NewJetStreamServer(t)
 	cfg := validConfig(t)
 	cfg.Nats = nc
 
@@ -567,7 +559,7 @@ func TestRequest_NoResponder(t *testing.T) {
 // without worrying about a double-close panic from an explicit
 // earlier call.
 func TestRespond_UnsubscribeIdempotent(t *testing.T) {
-	nc, _ := natstest.NewTestServer(t)
+	nc, _ := natstest.NewJetStreamServer(t)
 	cfg := validConfig(t)
 	cfg.Nats = nc
 
@@ -598,7 +590,7 @@ func TestRespond_UnsubscribeIdempotent(t *testing.T) {
 // serialized error. That is the documented behavior — callers that
 // need richer error semantics layer them in the payload shape.
 func TestRespond_HandlerError(t *testing.T) {
-	nc, _ := natstest.NewTestServer(t)
+	nc, _ := natstest.NewJetStreamServer(t)
 	cfg := validConfig(t)
 	cfg.Nats = nc
 

--- a/internal/chat/config.go
+++ b/internal/chat/config.go
@@ -1,36 +1,35 @@
-// Package chat is the substrate layer that backs coord's Post, Ask, and
-// Subscribe on top of EdgeSync's notify service. Send and Watch route
-// through notify.Service; Request uses raw NATS request/reply on the
-// ask subject family. See docs/adr/0008-chat-substrate.md for the
-// decision record covering why chat carries two substrates rather
-// than one.
+// Package chat is the substrate layer that backs coord's Post, Ask,
+// and Subscribe on top of NATS JetStream. Send and Watch route through
+// a per-project JetStream stream (chat-<proj> with subjects
+// chat.<proj>.>); Request uses raw NATS request/reply on the ask
+// subject family. See docs/adr/0047-chat-on-jetstream.md for the
+// decision record covering why chat lives on a JetStream stream and
+// not on EdgeSync notify + libfossil.
 //
 // This package is internal and unexported: callers outside
-// github.com/danmestas/bones must not depend on it. The
-// notify.Message type leaks across the package boundary into coord
-// where eventFromMessage translates it into coord.ChatMessage per
-// ADR 0003's substrate-hiding rule; no notify type appears on any
-// public coord signature.
+// github.com/danmestas/bones must not depend on it. The Envelope type
+// crosses the package boundary into coord where eventFromEnvelope
+// translates it into coord.ChatMessage per ADR 0003's substrate-hiding
+// rule; no chat type appears on any public coord signature.
 package chat
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/nats-io/nats.go"
 )
 
-// Config configures Open. Every field is required; there are no silent
-// defaults. The operator supplies the numbers — coord.Open is the
-// enforcement point for Config.Validate and propagates its own
-// validated inputs into this struct.
+// Config configures Open. The operator supplies the identity/routing
+// fields; MaxRetentionAge is optional (0 = unbounded).
 type Config struct {
 	// AgentID identifies this chat instance across the substrate. It is
-	// threaded through to outgoing notify.Message as the From field so
+	// threaded through to outgoing Envelope as the From field so
 	// receivers can attribute messages back to a sender.
 	AgentID string
 
-	// ProjectPrefix is the <proj> segment used to build notify subjects
-	// (notify.<proj>.<thread>) and ask subjects (<proj>.ask.<recipient>).
+	// ProjectPrefix is the <proj> segment used to build chat subjects
+	// (chat.<proj>.<short>) and ask subjects (<proj>.ask.<recipient>).
 	// Derived at the coord layer from coord.Config.AgentID per ADR 0008;
 	// the chat package takes it as pre-derived input.
 	ProjectPrefix string
@@ -39,20 +38,20 @@ type Config struct {
 	// does not dial its own connection — it shares the one coord opened
 	// so reconnection policy, auth, and TLS remain a single-source
 	// concern in coord.Config. The handle is used directly for Ask's
-	// request/reply path and handed to notify.NewService for Send/Watch.
+	// request/reply path and to construct the JetStream context for
+	// Send/Watch.
 	Nats *nats.Conn
 
-	// FossilRepoPath is the filesystem path at which notify.Service
-	// persists its message log. The chat manager opens (or creates) the
-	// Fossil repo at this path during Open and closes it during Close,
-	// mirroring the ownership posture that internal/holds takes for its
-	// JetStream KV bucket.
-	FossilRepoPath string
+	// MaxRetentionAge bounds the JetStream stream's MaxAge. Zero means
+	// unbounded — chat history persists until disk is full or the
+	// operator runs `nats stream purge`. Per ADR 0047 the default is
+	// unbounded so coord.Prime preserves agent context across long
+	// absences (ADR 0036).
+	MaxRetentionAge time.Duration
 
 	// MaxSubscribers caps the number of concurrent Watch callers coord
 	// will hand out. Validated here so an obviously-broken value fails
-	// at Open rather than at first subscribe; runtime enforcement ships
-	// with Phase 3D when the Subscribe surface lands.
+	// at Open rather than at first subscribe.
 	MaxSubscribers int
 }
 
@@ -74,9 +73,9 @@ func (c Config) Validate() error {
 	if c.Nats == nil {
 		return fmt.Errorf("chat.Config: Nats: must be non-nil")
 	}
-	if c.FossilRepoPath == "" {
+	if c.MaxRetentionAge < 0 {
 		return fmt.Errorf(
-			"chat.Config: FossilRepoPath: must be non-empty",
+			"chat.Config: MaxRetentionAge: must be >= 0 (0 = unbounded)",
 		)
 	}
 	if c.MaxSubscribers <= 0 {

--- a/internal/coord/claim_test.go
+++ b/internal/coord/claim_test.go
@@ -33,9 +33,6 @@ func newCoordOnURL(t *testing.T, url, agentID string) *Coord {
 	cfg := validConfigWithURL(t, url)
 	cfg.AgentID = agentID
 	dir := t.TempDir()
-	cfg.ChatFossilRepoPath = filepath.Join(
-		dir, agentID+"-chat.fossil",
-	)
 	cfg.CheckoutRoot = filepath.Join(dir, agentID+"-checkouts")
 	c, err := Open(context.Background(), cfg)
 	if err != nil {

--- a/internal/coord/config.go
+++ b/internal/coord/config.go
@@ -24,6 +24,12 @@ type TuningConfig struct {
 	// Default: 8.
 	MaxSubscribers int
 
+	// ChatRetentionMaxAge bounds the JetStream chat stream's MaxAge. Per
+	// ADR 0047 the default is 0 (unbounded) so coord.Prime preserves
+	// agent context across long absences. Operators with high chat
+	// volume can set a positive duration to age out old messages.
+	ChatRetentionMaxAge time.Duration
+
 	// MaxTaskFiles caps the number of files a single task may touch.
 	// Default: 16.
 	MaxTaskFiles int
@@ -107,11 +113,6 @@ type Config struct {
 	// it lives on Config because it is operator-supplied input.
 	NATSURL string
 
-	// ChatFossilRepoPath is the filesystem path at which coord.Open
-	// creates or opens this agent's chat Fossil repo. The operator owns
-	// cleanup; coord never calls RemoveAll. In tests, pass t.TempDir().
-	ChatFossilRepoPath string
-
 	// CheckoutRoot is the absolute directory under which per-agent
 	// working-copy checkouts live per ADR 0010. Coord writes to
 	// CheckoutRoot/<AgentID>/. In tests, pass t.TempDir().
@@ -152,11 +153,6 @@ func (c Config) Validate() error {
 	}
 	if c.NATSURL == "" {
 		return fmt.Errorf("coord.Config: NATSURL: must be non-empty")
-	}
-	if c.ChatFossilRepoPath == "" {
-		return fmt.Errorf(
-			"coord.Config: ChatFossilRepoPath: must be non-empty",
-		)
 	}
 	if c.CheckoutRoot == "" {
 		return fmt.Errorf(

--- a/internal/coord/config_test.go
+++ b/internal/coord/config_test.go
@@ -11,10 +11,9 @@ import (
 // so mutation tests can zero individual fields below the default.
 func baselineConfig() Config {
 	return Config{
-		AgentID:            "test-agent",
-		NATSURL:            "nats://127.0.0.1:4222",
-		ChatFossilRepoPath: "/tmp/coord-baseline-chat.fossil",
-		CheckoutRoot:       "/tmp/coord-baseline-checkouts",
+		AgentID:      "test-agent",
+		NATSURL:      "nats://127.0.0.1:4222",
+		CheckoutRoot: "/tmp/coord-baseline-checkouts",
 		Tuning: TuningConfig{
 			HoldTTLDefault:    30 * time.Second,
 			HoldTTLMax:        5 * time.Minute,
@@ -136,11 +135,6 @@ func TestConfigValidate_Invalid(t *testing.T) {
 			name:    "empty NATSURL",
 			mutate:  func(c *Config) { c.NATSURL = "" },
 			wantKey: "NATSURL",
-		},
-		{
-			name:    "empty ChatFossilRepoPath",
-			mutate:  func(c *Config) { c.ChatFossilRepoPath = "" },
-			wantKey: "ChatFossilRepoPath",
 		},
 		{
 			name:    "empty CheckoutRoot",

--- a/internal/coord/coord.go
+++ b/internal/coord/coord.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
-	"path/filepath"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -188,39 +186,27 @@ func openSubstrate(
 	return s, nil
 }
 
-// openChat opens the chat manager for cfg, ensuring the
-// ChatFossilRepoPath parent directory exists first (so a freshly-init
-// workspace doesn't fail on a missing `.bones/`) and re-wrapping the
-// failure with a friendly, path-naming, remediation-hinting message
-// so operators who deleted chat.fossil aren't told "no bones workspace
-// found". Issues #167, #168.
+// openChat opens the chat manager for cfg. Per ADR 0047 chat lives on
+// a JetStream stream owned by internal/chat — no fossil sidecar, no
+// per-Coord disk file. The ProjectPrefix supplies the stream name and
+// subject namespace; retention defaults to unbounded so coord.Prime
+// preserves agent context across long absences (ADR 0036).
 func openChat(
 	ctx context.Context, cfg Config, nc *nats.Conn,
 ) (*chat.Manager, error) {
-	if parent := filepath.Dir(cfg.ChatFossilRepoPath); parent != "" {
-		if err := os.MkdirAll(parent, 0o755); err != nil {
-			return nil, fmt.Errorf(
-				"coord.Open: chat.fossil parent dir %q: %w", parent, err,
-			)
-		}
-	}
 	chatProject := cfg.ProjectPrefix
 	if chatProject == "" {
 		chatProject = projectPrefix(cfg.AgentID)
 	}
 	m, err := chat.Open(ctx, chat.Config{
-		AgentID:        cfg.AgentID,
-		ProjectPrefix:  chatProject,
-		Nats:           nc,
-		FossilRepoPath: cfg.ChatFossilRepoPath,
-		MaxSubscribers: cfg.Tuning.MaxSubscribers,
+		AgentID:         cfg.AgentID,
+		ProjectPrefix:   chatProject,
+		Nats:            nc,
+		MaxRetentionAge: cfg.Tuning.ChatRetentionMaxAge,
+		MaxSubscribers:  cfg.Tuning.MaxSubscribers,
 	})
 	if err != nil {
-		return nil, fmt.Errorf(
-			"coord: chat.fossil at %s is missing or unreadable; "+
-				"run 'bones up' to recreate or 'bones doctor' to diagnose: %w",
-			cfg.ChatFossilRepoPath, err,
-		)
+		return nil, fmt.Errorf("coord.Open: chat: %w", err)
 	}
 	return m, nil
 }

--- a/internal/coord/coord_test.go
+++ b/internal/coord/coord_test.go
@@ -3,8 +3,6 @@ package coord
 import (
 	"context"
 	"fmt"
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -20,15 +18,14 @@ var nilCtx context.Context
 // Fields mirror baselineConfig in config_test.go; kept separate so the
 // two test files remain readable in isolation. The NATSURL here is a
 // loopback stub — tests that reach the NATS dial use validConfigWithURL
-// instead. ChatFossilRepoPath is bound to t.TempDir() so every test
-// gets a fresh Fossil repo without touching shared filesystem state.
+// instead. Per ADR 0047 chat lives on a JetStream stream — no per-test
+// chat.fossil path needed.
 func validConfig(t *testing.T) Config {
 	t.Helper()
 	return Config{
-		AgentID:            "test-agent",
-		NATSURL:            "nats://127.0.0.1:0",
-		ChatFossilRepoPath: filepath.Join(t.TempDir(), "chat.fossil"),
-		CheckoutRoot:       t.TempDir(),
+		AgentID:      "test-agent",
+		NATSURL:      "nats://127.0.0.1:0",
+		CheckoutRoot: t.TempDir(),
 		Tuning: TuningConfig{
 			HoldTTLDefault:    30 * time.Second,
 			HoldTTLMax:        5 * time.Minute,
@@ -66,9 +63,6 @@ func newCoordWithMaxSubs(
 	cfg := validConfigWithURL(t, url)
 	cfg.AgentID = agentID
 	cfg.Tuning.MaxSubscribers = maxSubs
-	cfg.ChatFossilRepoPath = filepath.Join(
-		t.TempDir(), agentID+"-chat.fossil",
-	)
 	c, err := Open(context.Background(), cfg)
 	if err != nil {
 		t.Fatalf("Open(%s): %v", agentID, err)
@@ -246,102 +240,10 @@ func TestAsk_InvariantPanics(t *testing.T) {
 	})
 }
 
-// TestOpen_AutoCreatesChatFossilParentDir covers issue #167: callers
-// pass a ChatFossilRepoPath whose parent directory may not yet exist
-// (e.g., `<workspace>/.bones/chat.fossil` on a fresh init). Open is
-// responsible for ensuring the parent dir exists so the underlying
-// libfossil.Create can land the file.
-func TestOpen_AutoCreatesChatFossilParentDir(t *testing.T) {
-	nc, _ := natstest.NewJetStreamServer(t)
-	cfg := validConfigWithURL(t, nc.ConnectedUrl())
-
-	// Point ChatFossilRepoPath at a path whose parent does NOT exist
-	// yet — the typical "fresh workspace" shape with `.bones/`
-	// half-initialized.
-	parent := filepath.Join(t.TempDir(), "missing-parent")
-	cfg.ChatFossilRepoPath = filepath.Join(parent, "chat.fossil")
-
-	c, err := Open(context.Background(), cfg)
-	if err != nil {
-		t.Fatalf("Open: unexpected error: %v", err)
-	}
-	t.Cleanup(func() { _ = c.Close() })
-
-	if _, err := os.Stat(cfg.ChatFossilRepoPath); err != nil {
-		t.Fatalf("chat.fossil not created at %q: %v", cfg.ChatFossilRepoPath, err)
-	}
-}
-
-// TestOpen_RecreatesMissingChatFossil covers issue #167: an operator
-// who has deleted `<workspace>/.bones/chat.fossil` should not see a
-// permanent breakage. Re-opening the same config must idempotently
-// re-init the fossil DB.
-func TestOpen_RecreatesMissingChatFossil(t *testing.T) {
-	nc, _ := natstest.NewJetStreamServer(t)
-	cfg := validConfigWithURL(t, nc.ConnectedUrl())
-
-	// First Open creates the file.
-	c1, err := Open(context.Background(), cfg)
-	if err != nil {
-		t.Fatalf("first Open: %v", err)
-	}
-	if err := c1.Close(); err != nil {
-		t.Fatalf("first Close: %v", err)
-	}
-	if _, err := os.Stat(cfg.ChatFossilRepoPath); err != nil {
-		t.Fatalf("chat.fossil missing after first Open: %v", err)
-	}
-
-	// Operator deletes chat.fossil.
-	if err := os.Remove(cfg.ChatFossilRepoPath); err != nil {
-		t.Fatalf("rm chat.fossil: %v", err)
-	}
-
-	// Second Open should idempotently recreate it.
-	c2, err := Open(context.Background(), cfg)
-	if err != nil {
-		t.Fatalf("second Open after rm chat.fossil: %v", err)
-	}
-	t.Cleanup(func() { _ = c2.Close() })
-
-	if _, err := os.Stat(cfg.ChatFossilRepoPath); err != nil {
-		t.Fatalf("chat.fossil not recreated after second Open: %v", err)
-	}
-}
-
-// TestOpen_ChatFossilUnreadableErrorIncludesPath covers issue #167's
-// "better error message" requirement. When the chat.fossil path is
-// genuinely unrecoverable (here: the path points at a directory rather
-// than a fossil file), the returned error must name the path and hint
-// at remediation.
-func TestOpen_ChatFossilUnreadableErrorIncludesPath(t *testing.T) {
-	nc, _ := natstest.NewJetStreamServer(t)
-	cfg := validConfigWithURL(t, nc.ConnectedUrl())
-
-	// Force an unrecoverable shape: ChatFossilRepoPath points at a
-	// directory. libfossil.Open will fail and the wrap should mention
-	// both the path and the remediation hint.
-	dirPath := filepath.Join(t.TempDir(), "chat.fossil")
-	if err := os.MkdirAll(dirPath, 0o755); err != nil {
-		t.Fatalf("mkdir bogus chat.fossil dir: %v", err)
-	}
-	cfg.ChatFossilRepoPath = dirPath
-
-	_, err := Open(context.Background(), cfg)
-	if err == nil {
-		t.Fatalf("Open: expected error when chat.fossil path is a directory")
-	}
-	msg := err.Error()
-	if !strings.Contains(msg, dirPath) {
-		t.Errorf("error must name path %q; got %v", dirPath, err)
-	}
-	if !strings.Contains(msg, "missing or unreadable") {
-		t.Errorf("error must say 'missing or unreadable'; got %v", err)
-	}
-	if !strings.Contains(msg, "bones up") {
-		t.Errorf("error must hint at 'bones up'; got %v", err)
-	}
-	if !strings.Contains(msg, "bones doctor") {
-		t.Errorf("error must hint at 'bones doctor'; got %v", err)
-	}
-}
+// Note: TestOpen_AutoCreatesChatFossilParentDir,
+// TestOpen_RecreatesMissingChatFossil, and
+// TestOpen_ChatFossilUnreadableErrorIncludesPath were removed when ADR
+// 0047 moved chat onto a JetStream stream. Those tests targeted the
+// chat.fossil filesystem behavior; no equivalent failure mode exists
+// on the JS substrate (stream creation succeeds idempotently and
+// failures surface through the JetStream error path).

--- a/internal/coord/events.go
+++ b/internal/coord/events.go
@@ -5,12 +5,12 @@ import (
 	"strings"
 	"time"
 
-	"github.com/danmestas/EdgeSync/leaf/agent/notify"
+	"github.com/danmestas/bones/internal/chat"
 )
 
-// reactionBodyPrefix is the in-band tag that marks a notify.Message as
+// reactionBodyPrefix is the in-band tag that marks a chat.Envelope as
 // a reaction rather than a chat post. Bodies that start with this
-// prefix are translated into Reaction events by eventFromMessage;
+// prefix are translated into Reaction events by eventFromEnvelope;
 // every other body surfaces as ChatMessage. Kept private because the
 // encoding is a substrate detail per ADR 0003 — callers React and
 // receive Reaction, they never observe the wire format.
@@ -84,8 +84,8 @@ func (m ChatMessage) Timestamp() time.Time { return m.timestamp }
 // or the empty string for a top-level post.
 func (m ChatMessage) ReplyTo() string { return m.replyTo }
 
-// eventFromMessage translates a substrate notify.Message into the
-// public coord event. Unexported so notify.Message never crosses the
+// eventFromEnvelope translates a substrate chat.Envelope into the
+// public coord event. Unexported so chat.Envelope never crosses the
 // package boundary per ADR 0003. Mirrors the taskFromRecord helper in
 // coord/types.go.
 //
@@ -93,20 +93,20 @@ func (m ChatMessage) ReplyTo() string { return m.replyTo }
 // malformed REACT body (missing the second colon) surfaces as an
 // ordinary ChatMessage, so garbage on the wire degrades to a visible
 // chat post rather than being silently dropped.
-func eventFromMessage(msg notify.Message) Event {
-	if m, ok := mediaFromMessage(msg); ok {
+func eventFromEnvelope(env chat.Envelope) Event {
+	if m, ok := mediaFromEnvelope(env); ok {
 		return m
 	}
-	if r, ok := reactionFromMessage(msg); ok {
+	if r, ok := reactionFromEnvelope(env); ok {
 		return r
 	}
 	return ChatMessage{
-		from:      msg.From,
-		thread:    msg.ThreadShort(),
-		messageID: msg.ID,
-		body:      msg.Body,
-		timestamp: msg.Timestamp,
-		replyTo:   msg.ReplyTo,
+		from:      env.From,
+		thread:    env.Thread,
+		messageID: env.ID,
+		body:      env.Body,
+		timestamp: env.Timestamp,
+		replyTo:   env.ReplyTo,
 	}
 }
 
@@ -153,29 +153,29 @@ func (r Reaction) Body() string { return r.reaction }
 // Timestamp returns the UTC wall-clock time the reaction was created.
 func (r Reaction) Timestamp() time.Time { return r.timestamp }
 
-// reactionFromMessage parses a notify.Message into a Reaction when its
+// reactionFromEnvelope parses a chat.Envelope into a Reaction when its
 // body matches the REACT-prefix encoding. The format is
 // "REACT:<messageID>:<reaction>" — the first colon after the prefix
 // splits target from reaction content, so a reaction payload may itself
 // contain colons without ambiguity. A body that starts with the prefix
 // but lacks a second colon is treated as malformed and returns
-// (Reaction{}, false), letting eventFromMessage fall through to
+// (Reaction{}, false), letting eventFromEnvelope fall through to
 // ChatMessage translation.
-func reactionFromMessage(msg notify.Message) (Reaction, bool) {
-	if !strings.HasPrefix(msg.Body, reactionBodyPrefix) {
+func reactionFromEnvelope(env chat.Envelope) (Reaction, bool) {
+	if !strings.HasPrefix(env.Body, reactionBodyPrefix) {
 		return Reaction{}, false
 	}
-	rest := msg.Body[len(reactionBodyPrefix):]
+	rest := env.Body[len(reactionBodyPrefix):]
 	idx := strings.IndexByte(rest, ':')
 	if idx < 0 {
 		return Reaction{}, false
 	}
 	return Reaction{
-		from:      msg.From,
-		thread:    msg.ThreadShort(),
+		from:      env.From,
+		thread:    env.Thread,
 		target:    rest[:idx],
 		reaction:  rest[idx+1:],
-		timestamp: msg.Timestamp,
+		timestamp: env.Timestamp,
 	}, true
 }
 
@@ -210,25 +210,25 @@ type mediaEnvelope struct {
 	Size     int    `json:"size"`
 }
 
-func mediaFromMessage(msg notify.Message) (MediaMessage, bool) {
-	if !strings.HasPrefix(msg.Body, mediaBodyPrefix) {
+func mediaFromEnvelope(env chat.Envelope) (MediaMessage, bool) {
+	if !strings.HasPrefix(env.Body, mediaBodyPrefix) {
 		return MediaMessage{}, false
 	}
-	var env mediaEnvelope
-	if err := json.Unmarshal([]byte(msg.Body[len(mediaBodyPrefix):]), &env); err != nil {
+	var ev mediaEnvelope
+	if err := json.Unmarshal([]byte(env.Body[len(mediaBodyPrefix):]), &ev); err != nil {
 		return MediaMessage{}, false
 	}
-	if env.Rev == "" || env.Path == "" || env.MIMEType == "" || env.Size <= 0 {
+	if ev.Rev == "" || ev.Path == "" || ev.MIMEType == "" || ev.Size <= 0 {
 		return MediaMessage{}, false
 	}
 	return MediaMessage{
-		from:      msg.From,
-		thread:    msg.ThreadShort(),
-		rev:       RevID(env.Rev),
-		path:      env.Path,
-		mimeType:  env.MIMEType,
-		size:      env.Size,
-		timestamp: msg.Timestamp,
+		from:      env.From,
+		thread:    env.Thread,
+		rev:       RevID(ev.Rev),
+		path:      ev.Path,
+		mimeType:  ev.MIMEType,
+		size:      ev.Size,
+		timestamp: env.Timestamp,
 	}, true
 }
 

--- a/internal/coord/leaf.go
+++ b/internal/coord/leaf.go
@@ -330,16 +330,15 @@ func resolveHubAddrs(cfg LeafConfig) (upstream, natsClient, httpAddr string, err
 
 // openLeafCoord builds the *Coord that backs a Leaf's claim/task work.
 // The Coord's substrate is the same NATS the leaf agent points at.
-// CheckoutRoot/ChatFossilRepoPath are bound to the slot's directory
-// tree. There is no FossilRepoPath: the Coord substrate carries no
-// libfossil handle as of Task 10. Code-artifact commits go through
-// *Leaf, which writes via leaf.Agent's repo handle.
+// CheckoutRoot is bound to the slot's directory tree. Per ADR 0047
+// chat lives on a workspace-shared JetStream stream — no per-slot
+// chat.fossil. Code-artifact commits go through *Leaf, which writes
+// via leaf.Agent's repo handle.
 func openLeafCoord(ctx context.Context, slotID, natsURL, slotDir string) (*Coord, error) {
 	cfg := Config{
-		AgentID:            slotID + "-leaf",
-		NATSURL:            natsURL,
-		CheckoutRoot:       slotDir,
-		ChatFossilRepoPath: filepath.Join(slotDir, "chat.fossil"),
+		AgentID:      slotID + "-leaf",
+		NATSURL:      natsURL,
+		CheckoutRoot: slotDir,
 		// Tuning: zero — Open applies sane defaults via defaultTuning.
 	}
 	return Open(ctx, cfg)

--- a/internal/coord/media_test.go
+++ b/internal/coord/media_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/danmestas/EdgeSync/leaf/agent/notify"
+	"github.com/danmestas/bones/internal/chat"
 )
 
 // TestLeaf_PostMedia_HappyPath posts an opaque media blob through
@@ -66,24 +66,24 @@ func TestLeaf_PostMedia_HappyPath(t *testing.T) {
 	}
 }
 
-func TestMediaFromMessage_MalformedFallsThrough(t *testing.T) {
-	msg := notify.Message{
+func TestMediaFromEnvelope_MalformedFallsThrough(t *testing.T) {
+	env := chat.Envelope{
 		ID:        "msg-test-malformed-media-0001",
-		Thread:    "thread-test-uuid-0001",
+		Thread:    "abc12345",
 		From:      "agent-A",
 		Body:      "MEDIA:not-json",
 		Timestamp: time.Now().UTC(),
 	}
-	if _, ok := mediaFromMessage(msg); ok {
-		t.Fatalf("mediaFromMessage: got ok=true for malformed body")
+	if _, ok := mediaFromEnvelope(env); ok {
+		t.Fatalf("mediaFromEnvelope: got ok=true for malformed body")
 	}
-	evt := eventFromMessage(msg)
+	evt := eventFromEnvelope(env)
 	cm, isChat := evt.(ChatMessage)
 	if !isChat {
-		t.Fatalf("eventFromMessage: got %T, want ChatMessage", evt)
+		t.Fatalf("eventFromEnvelope: got %T, want ChatMessage", evt)
 	}
-	if cm.Body() != msg.Body {
-		t.Fatalf("ChatMessage.Body=%q, want %q", cm.Body(), msg.Body)
+	if cm.Body() != env.Body {
+		t.Fatalf("ChatMessage.Body=%q, want %q", cm.Body(), env.Body)
 	}
 }
 

--- a/internal/coord/presence_test.go
+++ b/internal/coord/presence_test.go
@@ -2,7 +2,6 @@ package coord
 
 import (
 	"context"
-	"path/filepath"
 	"testing"
 	"time"
 
@@ -11,17 +10,14 @@ import (
 
 // presenceCfgForAgent returns a validConfigWithURL tweaked for a
 // second agent on the same substrate: new AgentID and a namespaced
-// ChatFossilRepoPath so two Coords on one tempdir don't collide on
-// the Fossil repo.
+// per ADR 0047 chat lives on a workspace-shared JetStream stream, so
+// per-agent Coords share the chat stream without colliding.
 func presenceCfgForAgent(
 	t *testing.T, url, agentID string,
 ) Config {
 	t.Helper()
 	cfg := validConfigWithURL(t, url)
 	cfg.AgentID = agentID
-	cfg.ChatFossilRepoPath = filepath.Join(
-		t.TempDir(), agentID+"-chat.fossil",
-	)
 	return cfg
 }
 

--- a/internal/coord/react_test.go
+++ b/internal/coord/react_test.go
@@ -5,8 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/danmestas/EdgeSync/leaf/agent/notify"
-
+	"github.com/danmestas/bones/internal/chat"
 	"github.com/danmestas/bones/internal/testutil/natstest"
 )
 
@@ -116,17 +115,17 @@ bWait:
 // the REACT prefix; any colons inside the reaction content are part of
 // the reaction. This is the substrate-edge unit test that guards the
 // encoding rule from drift.
-func TestReactionFromMessage_ColonInReaction(t *testing.T) {
-	msg := notify.Message{
+func TestReactionFromEnvelope_ColonInReaction(t *testing.T) {
+	env := chat.Envelope{
 		ID:        "msg-test-full-uuid-0001",
-		Thread:    "thread-test-uuid-0001",
+		Thread:    "abc12345",
 		From:      "agent-A",
 		Body:      "REACT:msg-target-id:one:two:three",
 		Timestamp: time.Now().UTC(),
 	}
-	r, ok := reactionFromMessage(msg)
+	r, ok := reactionFromEnvelope(env)
 	if !ok {
-		t.Fatalf("reactionFromMessage: got ok=false, want true")
+		t.Fatalf("reactionFromEnvelope: got ok=false, want true")
 	}
 	if r.Target() != "msg-target-id" {
 		t.Fatalf("Target=%q, want msg-target-id", r.Target())
@@ -141,24 +140,24 @@ func TestReactionFromMessage_ColonInReaction(t *testing.T) {
 // malformed and must surface as a ChatMessage, not a dropped event.
 // Degradation beats silent loss — operators see the garbage in chat
 // and can trace it to a misbehaving publisher.
-func TestReactionFromMessage_MalformedFallsThrough(t *testing.T) {
-	msg := notify.Message{
+func TestReactionFromEnvelope_MalformedFallsThrough(t *testing.T) {
+	env := chat.Envelope{
 		ID:        "msg-test-malformed-0001",
-		Thread:    "thread-test-uuid-0001",
+		Thread:    "abc12345",
 		From:      "agent-A",
 		Body:      "REACT:no-second-colon-here",
 		Timestamp: time.Now().UTC(),
 	}
-	if _, ok := reactionFromMessage(msg); ok {
-		t.Fatalf("reactionFromMessage: got ok=true for malformed body")
+	if _, ok := reactionFromEnvelope(env); ok {
+		t.Fatalf("reactionFromEnvelope: got ok=true for malformed body")
 	}
-	evt := eventFromMessage(msg)
+	evt := eventFromEnvelope(env)
 	cm, isChat := evt.(ChatMessage)
 	if !isChat {
-		t.Fatalf("eventFromMessage: got %T, want ChatMessage", evt)
+		t.Fatalf("eventFromEnvelope: got %T, want ChatMessage", evt)
 	}
-	if cm.Body() != msg.Body {
-		t.Fatalf("ChatMessage.Body=%q, want %q", cm.Body(), msg.Body)
+	if cm.Body() != env.Body {
+		t.Fatalf("ChatMessage.Body=%q, want %q", cm.Body(), env.Body)
 	}
 }
 

--- a/internal/coord/reclaim_test.go
+++ b/internal/coord/reclaim_test.go
@@ -115,7 +115,6 @@ func newCoordOnURLWithHeartbeat(
 	cfg.Tuning.HeartbeatInterval = hb
 	// HoldTTLDefault must not exceed HoldTTLMax; keep defaults valid.
 	dir := t.TempDir()
-	cfg.ChatFossilRepoPath = filepath.Join(dir, agentID+"-chat.fossil")
 	cfg.CheckoutRoot = filepath.Join(dir, agentID+"-checkouts")
 	c, err := Open(context.Background(), cfg)
 	if err != nil {

--- a/internal/coord/subscribe.go
+++ b/internal/coord/subscribe.go
@@ -5,9 +5,8 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/danmestas/EdgeSync/leaf/agent/notify"
-
 	"github.com/danmestas/bones/internal/assert"
+	"github.com/danmestas/bones/internal/chat"
 )
 
 // Subscribe returns a channel of coord.Event values for messages that
@@ -59,17 +58,17 @@ func (c *Coord) Subscribe(
 	return out, closer, nil
 }
 
-// watchChat returns a <-chan notify.Message matching pattern. An empty
+// watchChat returns a <-chan chat.Envelope matching pattern. An empty
 // pattern routes through chat.WatchAll (project-wide wildcard); a
 // non-empty pattern is passed through to chat.Watch as a caller
 // thread name — chat.Watch hashes it into the same deterministic
-// ThreadShort that chat.Send uses, so publishers and subscribers
-// converge on one NATS subject without coordination. Extracted so
-// Subscribe stays below the 70-line funlen cap and so the
-// empty-is-project-wide branch has a single home.
+// short that chat.Send uses, so publishers and subscribers converge
+// on one NATS subject without coordination. Per ADR 0047 the channel
+// element type is chat.Envelope (bones-owned wire format) rather than
+// notify.Message.
 func (c *Coord) watchChat(
 	ctx context.Context, pattern string,
-) <-chan notify.Message {
+) <-chan chat.Envelope {
 	if pattern == "" {
 		return c.sub.chat.WatchAll(ctx)
 	}
@@ -91,7 +90,7 @@ func (c *Coord) reserveSubscriberSlot(prefix string) error {
 	return nil
 }
 
-// relaySubscribe translates notify.Message values from src into coord
+// relaySubscribe translates chat.Envelope values from src into coord
 // events on out. It is the sole owner of out's close: when src closes
 // (caller's ctx canceled OR explicit close closure ran), the relay
 // closes out and signals done so the close closure knows the goroutine
@@ -101,21 +100,21 @@ func (c *Coord) reserveSubscriberSlot(prefix string) error {
 // through this single close(out), so invariant 17 is preserved without
 // a second sync.Once on the channel.
 func (c *Coord) relaySubscribe(
-	src <-chan notify.Message,
+	src <-chan chat.Envelope,
 	out chan<- Event,
 	done chan<- struct{},
 ) {
 	defer close(done)
 	defer close(out)
-	for msg := range src {
-		evt := eventFromMessage(msg)
+	for env := range src {
+		evt := eventFromEnvelope(env)
 		select {
 		case out <- evt:
 		default:
-			// Slow consumer: drop to keep the relay moving. The
-			// notify substrate is read-now-or-miss-now by design
-			// (ADR 0008); dropping here preserves that posture and
-			// avoids blocking the chat Watch goroutine upstream.
+			// Slow consumer: drop the live event. Per ADR 0047 the
+			// stream retains the message regardless, so any later
+			// consumer can replay; this drop only affects this
+			// subscriber's live channel.
 		}
 	}
 }

--- a/internal/dispatch/monitor_test.go
+++ b/internal/dispatch/monitor_test.go
@@ -19,11 +19,24 @@ func newCoordOnURLWithHeartbeat(
 ) *coord.Coord {
 	t.Helper()
 	fileID := strings.ReplaceAll(agentID, "/", "_")
+	// Dispatch worker AgentIDs are compound (parent + "/" + taskID); the
+	// production dispatch path pins ProjectPrefix to the workspace
+	// identity BEFORE substituting the worker AgentID so all dispatch
+	// participants meet on the same NATS subject namespace AND the JS
+	// chat stream name stays valid (per ADR 0047 stream names cannot
+	// contain `/`). Mirror that production contract here.
+	projectPrefix := coord.DeriveProjectPrefix(agentID)
+	if strings.Contains(agentID, "/") {
+		// Compound worker ID: derive from the part before the slash.
+		projectPrefix = coord.DeriveProjectPrefix(
+			strings.SplitN(agentID, "/", 2)[0],
+		)
+	}
 	cfg := coord.Config{
-		AgentID:            agentID,
-		NATSURL:            url,
-		ChatFossilRepoPath: filepath.Join(t.TempDir(), fileID+"-chat.fossil"),
-		CheckoutRoot:       filepath.Join(t.TempDir(), fileID+"-checkouts"),
+		AgentID:       agentID,
+		NATSURL:       url,
+		CheckoutRoot:  filepath.Join(t.TempDir(), fileID+"-checkouts"),
+		ProjectPrefix: projectPrefix,
 		Tuning: coord.TuningConfig{
 			HeartbeatInterval: hb,
 		},


### PR DESCRIPTION
## Summary

- Implements [ADR 0047](docs/adr/0047-chat-on-jetstream.md): chat substrate moves from EdgeSync notify + per-Coord `chat.fossil` to a workspace-shared JetStream stream
- Drops `internal/chat`'s `libfossil` dependency and bones's import of `EdgeSync/leaf/agent/notify`
- Preserves the ADR 0008 deterministic-thread-hash invariant verbatim — same hash, same NATS subject convergence
- Preserves `coord.Prime` (ADR 0036) via `Manager.ListThreads`/`ThreadsForAgent` which now walk the JS stream

This is **Step 1** of bones's libfossil-exit roadmap. Steps 2+ (#185, #186) gate on the upstream EdgeSync API work tracked at danmestas/EdgeSync#102, #103.

## What changed

| File | Change |
|---|---|
| `internal/chat/chat.go` | Rewritten against `jetstream.Stream` and `jetstream.OrderedConsumer`. New `Envelope` wire-format type (distinct from `coord.ChatMessage` — different stability contracts). W3C traceparent injection on `js.PublishMsg`. |
| `internal/chat/config.go` | `FossilRepoPath` removed; `MaxRetentionAge` added (0 = unbounded, default). Doc updated for ADR 0047. |
| `internal/coord/events.go` | `eventFromMessage(notify.Message)` → `eventFromEnvelope(chat.Envelope)`. `mediaFromMessage` / `reactionFromMessage` → `*FromEnvelope` siblings. In-band REACT/MEDIA encoding unchanged. |
| `internal/coord/subscribe.go` | Channel type from `<-chan notify.Message` to `<-chan chat.Envelope`. `relaySubscribe` updated. |
| `internal/coord/coord.go` | `openChat` simplified — no more parent-dir mkdir, no more chat.fossil-friendly error wrap. Drops `os` and `path/filepath` imports. |
| `internal/coord/config.go` | `ChatFossilRepoPath` field deleted. `ChatRetentionMaxAge` added to `TuningConfig` (default 0). Validate updated. |
| `internal/coord/leaf.go` | `openLeafCoord` no longer sets `ChatFossilRepoPath`. |
| `cli/tasks_list.go` | `newCoordConfig` simplified — no `ChatFossilRepoPath`, drops `path/filepath` import. |
| `examples/two-agents/main.go` | `newConfig` updated; chatRepo parameter retained for caller compat (now unused). |
| Tests | All references to `ChatFossilRepoPath` removed from `coord_test.go`, `claim_test.go`, `reclaim_test.go`, `presence_test.go`, `config_test.go`, `monitor_test.go`, `tasks_autoclaim_test.go`. `chat_test.go` ported to `Envelope`/`NewJetStreamServer`. `media_test.go`/`react_test.go` ported to `eventFromEnvelope` family. |
| Removed | Three `coord_test.go` tests targeting chat.fossil filesystem behavior (`AutoCreatesChatFossilParentDir`, `RecreatesMissingChatFossil`, `ChatFossilUnreadableErrorIncludesPath`) — those failure modes don't exist on the JS substrate. |

## Failure mode simplification

| Today (notify + fossil) | After this PR (JS stream) |
|---|---|
| `Send` writes fossil first, then publishes NATS. Publish failure: message on disk, never delivered. | `Send` is one `js.PublishMsg`. Failure returns error to caller. No on-disk-but-undelivered state. |
| Cross-Coord chat history is N independent fossil files (workspace + per-slot), never synced. | Chat lives in one JS stream on the hub's NATS server. All Coords share one view. |
| Operator config: 0 retention knobs (fossil unbounded by default). | Operator config: 1 retention knob (`MaxRetentionAge`, default 0 = unbounded). Same effective default. |

## Test plan

- [x] `go build ./...` clean
- [x] `go test -short -timeout 300s ./...` — all green
- [x] `go test -tags=otel -short ./...` — all green
- [x] `make check` — fmt-check, vet, lint, race, todo-check all pass

Verified locally:

- Send → Watch round-trip works on JS stream
- Cross-Manager thread-hash convergence preserved (`TestSend_DeterministicThreadAcrossManagers`)
- Cross-restart thread-hash convergence preserved (`TestSend_DeterministicAcrossRestart`)
- WatchPattern wildcard delivery (`TestWatchPattern_WildcardDelivery`)
- Watch use-after-close returns closed channel (`TestWatch_UseAfterClose`)
- Request/Respond round-trip (`TestRequest_RespondRoundTrip`)
- Reaction in-band encoding round-trip (`TestReact_HappyPath`)
- Media in-band encoding round-trip (`TestLeaf_PostMedia_HappyPath`)
- Dispatch worker compound AgentID + ProjectPrefix flow (`TestWaitWorkerAbsent_*`, `TestReclaimClaimedTaskAfterWorkerDeath`)

Closes #183
Refs ADR 0047, ADR 0008 (superseded), ADR 0036 (preserved)
Refs danmestas/EdgeSync#102, #103 (next libfossil-exit steps)
