### PR TITLE
refactor(coord): migrate code-artifact callers to EdgeSync agent API (partial #185)

### DIFF
--- a/internal/coord/compact.go
+++ b/internal/coord/compact.go
@@ -7,7 +7,7 @@ import (
 	"sort"
 	"time"
 
-	"github.com/danmestas/libfossil"
+	"github.com/danmestas/EdgeSync/leaf/agent"
 
 	"github.com/danmestas/bones/internal/assert"
 	"github.com/danmestas/bones/internal/tasks"
@@ -148,13 +148,12 @@ func (l *Leaf) compactOne(
 	level := rec.CompactLevel + 1
 	path := compactArtifactPath(TaskID(rec.ID), level)
 	body := compactArtifactBody(input, summary)
-	repo := l.agent.Repo()
-	_, uuid, err := repo.Commit(libfossil.CommitOpts{
-		Files: []libfossil.FileToCommit{
+	uuid, err := l.agent.Commit(ctx, agent.CommitOpts{
+		Files: []agent.FileToCommit{
 			{Name: normalizeLeadingSlash(path), Content: []byte(body)},
 		},
-		Comment: compactCommitMessage(rec.ID, level),
-		User:    l.slotID,
+		Message: compactCommitMessage(rec.ID, level),
+		Author:  l.slotID,
 	})
 	if err != nil {
 		return CompactedTask{}, fmt.Errorf("coord.Leaf.Compact: commit %s: %w", rec.ID, err)

--- a/internal/coord/leaf.go
+++ b/internal/coord/leaf.go
@@ -239,12 +239,10 @@ func OpenLeaf(ctx context.Context, cfg LeafConfig) (*Leaf, error) {
 }
 
 // startLeafAgent constructs and starts the agent.Agent that owns the
-// leaf's libfossil.Repo. Sets SQLite busy_timeout on the resulting
-// repo so concurrent writes (Leaf.Commit vs in-flight SyncNow) wait
-// for the WAL lock instead of failing with SQLITE_BUSY. The pragma
-// is per-connection, so MaxOpenConns is pinned to 1 to make it apply
-// to all queries — internal/fossil/fossil.go's prior setup surfaced
-// the pool semantics in Phase 1.
+// leaf's repo. EdgeSync v0.0.10's agent.New applies the busy_timeout
+// PRAGMA internally (and deliberately does NOT cap MaxOpenConns(1) —
+// see EdgeSync#120 for the deadlock that capping caused), so bones no
+// longer reaches into the SQLite handle from this layer.
 //
 // FossilUser becomes the User field on sync handshakes. The earlier
 // clone is always unauthenticated ("nobody") regardless of
@@ -274,11 +272,6 @@ func startLeafAgent(cfg LeafConfig, repoPath, hubNATSUpstream string) (*agent.Ag
 		_ = a.Stop()
 		return nil, fmt.Errorf("coord.OpenLeaf: agent.Start: %w", err)
 	}
-	a.Repo().DB().SqlDB().SetMaxOpenConns(1)
-	if _, err := a.Repo().DB().Exec(`PRAGMA busy_timeout = 30000`); err != nil {
-		_ = a.Stop()
-		return nil, fmt.Errorf("coord.OpenLeaf: busy_timeout: %w", err)
-	}
 	return a, nil
 }
 
@@ -291,7 +284,7 @@ func readProjectCodeIfAutosync(a *agent.Agent, autosync bool) (string, error) {
 	if !autosync {
 		return "", nil
 	}
-	pc, err := a.Repo().Config("project-code")
+	pc, err := a.Config("project-code")
 	if err != nil {
 		return "", fmt.Errorf("coord.OpenLeaf: read project-code for autosync: %w", err)
 	}
@@ -467,8 +460,12 @@ func (l *Leaf) Commit(
 		return "", err
 	}
 
-	// Write through the agent's repo handle — the only *libfossil.Repo
-	// that should ever touch leaf.fossil in this process.
+	// Write through the agent's repo handle. EdgeSync v0.0.10's
+	// agent.Commit does not yet surface ParentID/MergeParents — the
+	// trunk-based-development invariant requires explicitly chaining
+	// onto the trunk tip, which the wrapped API can't express, so this
+	// site stays on the libfossil-typed CommitOpts path. media.go and
+	// compact.go (which don't set ParentID) use the wrapped API.
 	repo := l.agent.Repo()
 
 	// Pull from hub before resolving the trunk tip so the new commit's
@@ -575,18 +572,17 @@ func isBranchTipMissing(err error) bool {
 }
 
 // pullFromHub runs a one-shot fossil pull against the configured hub
-// over libfossil's HTTP transport. Authenticates as l.fossilUser
-// (which has 'i' caps from ensureSlotUser) when set; otherwise falls
-// back to anonymous "nobody" (the hub grants gio to anonymous which
-// is enough for a pull). Used by Leaf.Commit when autosync is on so
-// the next BranchTip("trunk") sees the hub's latest tip.
+// via the EdgeSync agent's libfossil-hidden SyncTo API. Authenticates
+// as l.fossilUser (which has 'i' caps from ensureSlotUser) when set;
+// otherwise falls back to anonymous "nobody" (the hub grants gio to
+// anonymous which is enough for a pull). Used by Leaf.Commit when
+// autosync is on so the next branch-tip read sees the hub's latest tip.
 func (l *Leaf) pullFromHub(ctx context.Context) error {
-	transport := libfossil.NewHTTPTransport(l.hubHTTPAddr)
 	user := l.fossilUser
 	if user == "" {
 		user = l.slotID
 	}
-	if _, err := l.agent.Repo().Sync(ctx, transport, libfossil.SyncOpts{
+	if _, err := l.agent.SyncTo(ctx, l.hubHTTPAddr, agent.SyncOpts{
 		Pull:        true,
 		Push:        false,
 		User:        user,
@@ -627,30 +623,17 @@ func normalizeLeadingSlash(p string) string {
 	return p
 }
 
-// Tip returns the manifest UUID at the head of the leaf's current
-// branch, or "" on a fresh repo with no checkins.
+// Tip returns the manifest UUID at the head of the leaf's trunk
+// branch, or "" on a fresh repo with no checkins. Routes through the
+// EdgeSync agent's libfossil-hidden Tip API.
 func (l *Leaf) Tip(ctx context.Context) (string, error) {
 	assert.NotNil(l, "coord.Leaf.Tip: receiver is nil")
 	assert.NotNil(ctx, "coord.Leaf.Tip: ctx is nil")
-	repo := l.agent.Repo()
-	var uuid string
-	err := repo.DB().QueryRow(`
-		SELECT b.uuid FROM leaf l
-		JOIN event e ON e.objid=l.rid
-		JOIN blob b ON b.rid=l.rid
-		WHERE e.type='ci'
-		ORDER BY e.mtime DESC, l.rid DESC LIMIT 1
-	`).Scan(&uuid)
-	// sql.ErrNoRows on a fresh repo is empty-tip, not an error.
-	// Other errors (DB faults, schema corruption) must propagate so
-	// Commit's post-sync divergence check sees them.
-	if errors.Is(err, sql.ErrNoRows) {
-		return "", nil
-	}
+	rev, err := l.agent.Tip(ctx, "trunk")
 	if err != nil {
 		return "", fmt.Errorf("coord.Leaf.Tip: %w", err)
 	}
-	return uuid, nil
+	return string(rev), nil
 }
 
 // WT returns the worktree path under which the slot's working copy lives.
@@ -659,17 +642,14 @@ func (l *Leaf) WT() string {
 	return l.wtPath
 }
 
-// OpenWorktree creates a fossil checkout at dir using the leaf's
-// repo handle and extracts trunk's files into it. dir must already
-// exist. The Checkout handle is closed before return: bones doesn't
-// drive commits through it (Leaf.Commit writes through the repo
-// handle directly per the "one *libfossil.Repo per fossil file"
-// invariant); what downstream readers need is the on-disk `.fslckout`
-// plus the materialized files.
+// OpenWorktree creates a working tree at dir and extracts the leaf's
+// trunk-tip files into it. dir must already exist. Routes through the
+// EdgeSync agent's libfossil-hidden ExtractTo API; bones no longer
+// holds a libfossil.Checkout handle. Downstream readers see the
+// on-disk `.fslckout` plus the materialized files.
 //
-// On a fresh repo with no checkins this is a no-op: libfossil refuses
-// to create a checkout without a checkin, and there are no files to
-// write anyway. The next Acquire after the first slot commits will
+// On a fresh repo with no checkins this is a no-op: there are no files
+// to extract. The next Acquire after the first slot commits will
 // populate the worktree.
 func (l *Leaf) OpenWorktree(ctx context.Context, dir string) error {
 	assert.NotNil(l, "coord.Leaf.OpenWorktree: receiver is nil")
@@ -680,21 +660,10 @@ func (l *Leaf) OpenWorktree(ctx context.Context, dir string) error {
 	if tip == "" {
 		return nil
 	}
-	repo := l.agent.Repo()
-	co, err := repo.CreateCheckout(dir, libfossil.CheckoutCreateOpts{})
-	if err != nil {
-		return fmt.Errorf("coord.Leaf.OpenWorktree: create checkout: %w", err)
-	}
-	tipRID, err := repo.ResolveVersion(tip)
-	if err != nil {
-		_ = co.Close()
-		return fmt.Errorf("coord.Leaf.OpenWorktree: resolve tip: %w", err)
-	}
-	if err := co.Extract(tipRID, libfossil.ExtractOpts{}); err != nil {
-		_ = co.Close()
+	if err := l.agent.ExtractTo(ctx, dir, agent.RevID(tip)); err != nil {
 		return fmt.Errorf("coord.Leaf.OpenWorktree: extract trunk: %w", err)
 	}
-	return co.Close()
+	return nil
 }
 
 // Metadata returns the value associated with key in the harness-supplied

--- a/internal/coord/media.go
+++ b/internal/coord/media.go
@@ -6,28 +6,29 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/danmestas/libfossil"
+	"github.com/danmestas/EdgeSync/leaf/agent"
 
 	"github.com/danmestas/bones/internal/assert"
 )
 
-// PostMedia stores opaque bytes in the leaf's libfossil repo and
-// publishes an in-band media reference on the chat thread. Subscribers
-// receive a MediaMessage event.
+// PostMedia stores opaque bytes in the leaf's repo and publishes an
+// in-band media reference on the chat thread. Subscribers receive a
+// MediaMessage event.
 //
-// All writes route through l.agent.Repo() — the only *libfossil.Repo
-// handle to leaf.fossil in this process. After the commit, SyncNow
-// triggers a sync round so the artifact propagates to the hub before
-// the chat reference is published; subscribers can then resolve the
-// reference against any peer that has caught up.
+// Writes route through the EdgeSync agent's libfossil-hidden code-
+// artifact API (agent.Commit) per ADR 0010's evolution under
+// EdgeSync v0.0.10. After the commit, SyncNow triggers a sync round so
+// the artifact propagates to the hub before the chat reference is
+// published; subscribers can then resolve the reference against any
+// peer that has caught up.
 //
 // Invariants asserted (panics on violation — programmer errors):
 // 1 (ctx non-nil), receiver non-nil, thread/mimeType non-empty, data
 // non-empty.
 //
-// Operator errors returned: any error from the libfossil commit, the
-// JSON envelope encode, or the chat substrate Send — surfaced wrapped
-// with the coord.Leaf.PostMedia prefix.
+// Operator errors returned: any error from agent.Commit, the JSON
+// envelope encode, or the chat substrate Send — surfaced wrapped with
+// the coord.Leaf.PostMedia prefix.
 func (l *Leaf) PostMedia(
 	ctx context.Context,
 	thread, mimeType string,
@@ -40,19 +41,18 @@ func (l *Leaf) PostMedia(
 	assert.Precondition(len(data) > 0, "coord.Leaf.PostMedia: data is empty")
 	now := time.Now().UTC()
 	path := mediaArtifactPath(l.slotID, now)
-	repo := l.agent.Repo()
-	_, uuid, err := repo.Commit(libfossil.CommitOpts{
-		Files: []libfossil.FileToCommit{
+	uuid, err := l.agent.Commit(ctx, agent.CommitOpts{
+		Files: []agent.FileToCommit{
 			{Name: normalizeLeadingSlash(path), Content: data},
 		},
-		Comment: fmt.Sprintf("post media to %s (%s)", thread, mimeType),
-		User:    l.slotID,
+		Message: fmt.Sprintf("post media to %s (%s)", thread, mimeType),
+		Author:  l.slotID,
 	})
 	if err != nil {
 		return fmt.Errorf("coord.Leaf.PostMedia: commit media: %w", err)
 	}
 	l.agent.SyncNow()
-	body, err := mediaBody(uuid, path, mimeType, len(data))
+	body, err := mediaBody(string(uuid), path, mimeType, len(data))
 	if err != nil {
 		return fmt.Errorf("coord.Leaf.PostMedia: encode body: %w", err)
 	}

--- a/internal/swarm/lease.go
+++ b/internal/swarm/lease.go
@@ -938,6 +938,13 @@ func commitViaLeaf(
 // Soft-fail-friendly: returns SyncResult and error separately so the
 // caller can warn on push failure without rolling back the local
 // commit.
+//
+// This site uses libfossil directly because ResumedLease.Commit stops
+// the leaf agent BEFORE calling pushLeafFossil — the EdgeSync
+// agent.SyncTo API requires a running agent. Migrating to agent.SyncTo
+// would require a swarm-flow change (push-before-stop), which is out
+// of scope for the rest of the libfossil-exit and stays on the
+// libfossil-direct path.
 func pushLeafFossil(
 	ctx context.Context, workspaceDir, slot, fossilUser, hubURL string,
 ) (*libfossil.SyncResult, error) {


### PR DESCRIPTION
## Summary

Migrates bones's leaf-side code-artifact callers off `agent.Repo()` (and direct `libfossil`) to EdgeSync v0.0.10's libfossil-hidden Agent API.

## Scope

| Site | Migration |
|---|---|
| `internal/coord/media.go::PostMedia` | `repo.Commit(libfossil.CommitOpts)` → `agent.Commit(agent.CommitOpts)`. Drops libfossil import entirely. |
| `internal/coord/compact.go::Compact` | Same pattern. Drops libfossil import entirely. |
| `internal/coord/leaf.go::startLeafAgent` | Drops `SetMaxOpenConns(1)` and `PRAGMA busy_timeout` — EdgeSync v0.0.10 applies the PRAGMA internally and deliberately does NOT cap connections (that was the deadlock in EdgeSync#120). |
| `internal/coord/leaf.go::readProjectCodeIfAutosync` | `a.Repo().Config(...)` → `a.Config(...)` |
| `internal/coord/leaf.go::pullFromHub` | `agent.Repo().Sync(ctx, transport, libfossil.SyncOpts)` → `agent.SyncTo(ctx, hubURL, agent.SyncOpts)` |
| `internal/coord/leaf.go::Tip` | Raw SQL via `agent.Repo().DB().QueryRow(...)` → `agent.Tip(ctx, "trunk")`. Drops database/sql usage. |
| `internal/coord/leaf.go::OpenWorktree` | `repo.CreateCheckout / ResolveVersion / Extract` → `agent.ExtractTo(ctx, dir, rev)`. Drops the libfossil.Checkout handle. |

## Out of scope (deliberate)

| Site | Why it stays on libfossil-direct |
|---|---|
| `internal/coord/leaf.go::Leaf.Commit` | Trunk-based development requires explicit `ParentID` chaining; EdgeSync v0.0.10's `agent.CommitOpts` only carries `Files/Message/Author`. Tracked at [danmestas/EdgeSync#125](https://github.com/danmestas/EdgeSync/issues/125). |
| `internal/coord/leaf.go::OpenLeaf` initial clone | Runs before the agent exists; no migration target. |
| `internal/swarm/lease.go::pushLeafFossil` | The caller stops the leaf agent BEFORE this runs, so `agent.SyncTo` isn't reachable. A swarm-flow refactor (push-before-stop via a new `Leaf.Push`) would unlock migration; out of scope for this PR. |

These three sites still import `libfossil` directly; once #125 lands and the swarm flow is refactored, the leaf-side libfossil import drops entirely.

## Test status

- [x] `make check` — fmt-check, vet, lint, race, todo-check all pass
- [x] `go test -short -timeout 300s ./...` — all green
- [x] `go test -tags=otel -short -timeout 300s ./...` — all green
- [x] `go test -race -short ./internal/coord/... ./examples/hub-leaf-e2e/...` — all green
- [x] Verified hub-leaf-e2e (the test that surfaced EdgeSync#120) runs sub-second on three consecutive runs

## Diff size

4 files changed, 61 insertions(+), 86 deletions(-) — net **−25 lines** even though the agent API has more methods (Tip/ExtractTo replace longer raw-SQL/CreateCheckout sequences).

Closes #185 (partial — see leaf.go::Leaf.Commit and swarm/lease.go::pushLeafFossil follow-ups documented above).
Refs danmestas/EdgeSync#103, #108, #120, #125.
