### PR TITLE
refactor: complete leaf-side libfossil-exit migration (EdgeSync v0.0.11)

### DIFF
--- a/cli/apply.go
+++ b/cli/apply.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"time"
 
-	libfossilcli "github.com/danmestas/libfossil/cli"
+	repocli "github.com/danmestas/EdgeSync/cli/repo"
 
 	"github.com/danmestas/bones/internal/hub"
 	"github.com/danmestas/bones/internal/telemetry"
@@ -30,7 +30,7 @@ type ApplyCmd struct {
 	DryRun bool `name:"dry-run" help:"show planned changes without writing or staging"`
 }
 
-func (c *ApplyCmd) Run(g *libfossilcli.Globals) (err error) {
+func (c *ApplyCmd) Run(g *repocli.Globals) (err error) {
 	outcome := &applyOutcome{DryRun: c.DryRun}
 	_, end := telemetry.RecordCommand(context.Background(), "apply",
 		telemetry.Bool("dry_run", c.DryRun),

--- a/cli/doctor.go
+++ b/cli/doctor.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	edgecli "github.com/danmestas/EdgeSync/cli"
-	libfossilcli "github.com/danmestas/libfossil/cli"
+	repocli "github.com/danmestas/EdgeSync/cli/repo"
 
 	"github.com/danmestas/bones/internal/githook"
 	"github.com/danmestas/bones/internal/registry"
@@ -46,7 +46,7 @@ type DoctorCmd struct {
 // Run invokes the EdgeSync doctor first; on completion (regardless
 // of pass/warn/fail) it appends a "swarm sessions" section that
 // iterates bones-swarm-sessions and reports each entry's state.
-func (c *DoctorCmd) Run(g *libfossilcli.Globals) (err error) {
+func (c *DoctorCmd) Run(g *repocli.Globals) (err error) {
 	if c.All {
 		return c.runAll(g)
 	}
@@ -79,7 +79,7 @@ func (c *DoctorCmd) Run(g *libfossilcli.Globals) (err error) {
 }
 
 // runAll dispatches the cross-workspace --all rendering path.
-func (c *DoctorCmd) runAll(_ *libfossilcli.Globals) error {
+func (c *DoctorCmd) runAll(_ *repocli.Globals) error {
 	var exitCode int
 	if c.JSON {
 		exitCode = renderDoctorAllJSON(os.Stdout)

--- a/cli/down.go
+++ b/cli/down.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"syscall"
 
-	libfossilcli "github.com/danmestas/libfossil/cli"
+	repocli "github.com/danmestas/EdgeSync/cli/repo"
 
 	"github.com/danmestas/bones/internal/githook"
 	"github.com/danmestas/bones/internal/hub"
@@ -42,7 +42,7 @@ type DownCmd struct {
 // Run is the Kong entry point. Resolves the workspace root (walking
 // up from cwd if a marker exists, falling back to cwd otherwise),
 // builds an execution plan, prompts unless --yes, and executes.
-func (c *DownCmd) Run(g *libfossilcli.Globals) error {
+func (c *DownCmd) Run(g *repocli.Globals) error {
 	if c.All {
 		return c.runAll()
 	}

--- a/cli/hub.go
+++ b/cli/hub.go
@@ -8,7 +8,7 @@ import (
 	"syscall"
 	"time"
 
-	libfossilcli "github.com/danmestas/libfossil/cli"
+	repocli "github.com/danmestas/EdgeSync/cli/repo"
 
 	"github.com/danmestas/bones/internal/hub"
 	"github.com/danmestas/bones/internal/scaffoldver"
@@ -54,7 +54,7 @@ type HubStartCmd struct {
 	DrainTimeout time.Duration `name:"drain-timeout" default:"30s" help:"max drain wait"` //nolint:lll
 }
 
-func (c *HubStartCmd) Run(g *libfossilcli.Globals) error {
+func (c *HubStartCmd) Run(g *repocli.Globals) error {
 	cwd, err := os.Getwd()
 	if err != nil {
 		return fmt.Errorf("cwd: %w", err)
@@ -100,7 +100,7 @@ type HubStopCmd struct {
 	Force bool `name:"force" help:"stop even when swarm slots are active (#157)"`
 }
 
-func (c *HubStopCmd) Run(g *libfossilcli.Globals) error {
+func (c *HubStopCmd) Run(g *repocli.Globals) error {
 	cwd, err := os.Getwd()
 	if err != nil {
 		return fmt.Errorf("cwd: %w", err)

--- a/cli/hub_reap.go
+++ b/cli/hub_reap.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	libfossilcli "github.com/danmestas/libfossil/cli"
+	repocli "github.com/danmestas/EdgeSync/cli/repo"
 
 	"github.com/danmestas/bones/internal/registry"
 )
@@ -28,7 +28,7 @@ type HubReapCmd struct {
 	DryRun bool `name:"dry-run" help:"print orphans without acting"`
 }
 
-func (c *HubReapCmd) Run(g *libfossilcli.Globals) error {
+func (c *HubReapCmd) Run(g *repocli.Globals) error {
 	return runHubReap(c, os.Stdin, os.Stdout)
 }
 

--- a/cli/hub_user.go
+++ b/cli/hub_user.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/danmestas/libfossil"
-	libfossilcli "github.com/danmestas/libfossil/cli"
+	repocli "github.com/danmestas/EdgeSync/cli/repo"
+	edgehub "github.com/danmestas/EdgeSync/hub"
 
 	"github.com/danmestas/bones/internal/hub"
 	"github.com/danmestas/bones/internal/workspace"
@@ -34,23 +34,23 @@ type HubUserAddCmd struct {
 	Caps  string `name:"caps" default:"oih" help:"fossil caps (default: clone+checkin+history)"`
 }
 
-func (c *HubUserAddCmd) Run(g *libfossilcli.Globals) error {
+func (c *HubUserAddCmd) Run(g *repocli.Globals) error {
 	repoPath, err := hubRepoPath()
 	if err != nil {
 		return err
 	}
-	repo, err := libfossil.Open(repoPath)
+	repo, err := edgehub.OpenRepo(repoPath)
 	if err != nil {
 		return fmt.Errorf("open hub repo: %w", err)
 	}
 	defer func() { _ = repo.Close() }()
 
-	if _, err := repo.GetUser(c.Login); err == nil {
+	if repo.HasUser(c.Login) {
 		fmt.Printf("hub user %q already exists (no change)\n", c.Login)
 		return nil
 	}
 
-	if err := repo.CreateUser(libfossil.UserOpts{
+	if err := repo.AddUser(edgehub.User{
 		Login: c.Login,
 		Caps:  c.Caps,
 	}); err != nil {
@@ -63,12 +63,12 @@ func (c *HubUserAddCmd) Run(g *libfossilcli.Globals) error {
 // HubUserListCmd prints the hub repo's user table.
 type HubUserListCmd struct{}
 
-func (c *HubUserListCmd) Run(g *libfossilcli.Globals) error {
+func (c *HubUserListCmd) Run(g *repocli.Globals) error {
 	repoPath, err := hubRepoPath()
 	if err != nil {
 		return err
 	}
-	repo, err := libfossil.Open(repoPath)
+	repo, err := edgehub.OpenRepo(repoPath)
 	if err != nil {
 		return fmt.Errorf("open hub repo: %w", err)
 	}

--- a/cli/init.go
+++ b/cli/init.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"os"
 
-	libfossilcli "github.com/danmestas/libfossil/cli"
+	repocli "github.com/danmestas/EdgeSync/cli/repo"
 
 	"github.com/danmestas/bones/internal/banner"
 	"github.com/danmestas/bones/internal/workspace"
@@ -15,7 +15,7 @@ import (
 // InitCmd creates a new bones workspace in the current directory.
 type InitCmd struct{}
 
-func (c *InitCmd) Run(g *libfossilcli.Globals) error {
+func (c *InitCmd) Run(g *repocli.Globals) error {
 	banner.Print()
 	cwd, err := os.Getwd()
 	if err != nil {
@@ -28,7 +28,7 @@ func (c *InitCmd) Run(g *libfossilcli.Globals) error {
 // JoinCmd locates and verifies an existing workspace from cwd.
 type JoinCmd struct{}
 
-func (c *JoinCmd) Run(g *libfossilcli.Globals) error {
+func (c *JoinCmd) Run(g *repocli.Globals) error {
 	cwd, err := os.Getwd()
 	if err != nil {
 		return fmt.Errorf("cwd: %w", err)
@@ -46,10 +46,10 @@ func (c *JoinCmd) Run(g *libfossilcli.Globals) error {
 // Default output: a single confirmation line. With -v / --verbose: the
 // banner plus per-step status lines. WARN lines (drift, missing git)
 // print regardless because they describe real issues the operator must
-// see. Verbosity comes from the global -v flag on libfossilcli.Globals.
+// see. Verbosity comes from the global -v flag on repocli.Globals.
 type UpCmd struct{}
 
-func (c *UpCmd) Run(g *libfossilcli.Globals) error {
+func (c *UpCmd) Run(g *repocli.Globals) error {
 	if g.Verbose {
 		banner.Print()
 	}

--- a/cli/logs.go
+++ b/cli/logs.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/mattn/go-isatty"
 
-	libfossilcli "github.com/danmestas/libfossil/cli"
+	repocli "github.com/danmestas/EdgeSync/cli/repo"
 
 	"github.com/danmestas/bones/internal/logwriter"
 	"github.com/danmestas/bones/internal/workspace"
@@ -35,7 +35,7 @@ type LogsCmd struct {
 }
 
 // Run is the Kong entry point for `bones logs`.
-func (c *LogsCmd) Run(g *libfossilcli.Globals) error {
+func (c *LogsCmd) Run(g *repocli.Globals) error {
 	// Validate: exactly one of --slot or --workspace.
 	if c.Slot == "" && !c.Workspace {
 		return fmt.Errorf("bones logs: specify --slot=<name> or --workspace")

--- a/cli/peek.go
+++ b/cli/peek.go
@@ -8,7 +8,7 @@ import (
 	"os/exec"
 	"strconv"
 
-	libfossilcli "github.com/danmestas/libfossil/cli"
+	repocli "github.com/danmestas/EdgeSync/cli/repo"
 
 	"github.com/danmestas/bones/internal/hub"
 	"github.com/danmestas/bones/internal/workspace"
@@ -38,7 +38,7 @@ type PeekCmd struct {
 	Page string `name:"page" default:"timeline?y=ci&n=50" help:"fossil page (e.g. timeline)"`
 }
 
-func (c *PeekCmd) Run(g *libfossilcli.Globals) error {
+func (c *PeekCmd) Run(g *repocli.Globals) error {
 	cwd, err := os.Getwd()
 	if err != nil {
 		return fmt.Errorf("cwd: %w", err)

--- a/cli/plan_finalize.go
+++ b/cli/plan_finalize.go
@@ -12,8 +12,8 @@ import (
 	"sort"
 	"strings"
 
-	libfossil "github.com/danmestas/libfossil"
-	libfossilcli "github.com/danmestas/libfossil/cli"
+	repocli "github.com/danmestas/EdgeSync/cli/repo"
+	edgehub "github.com/danmestas/EdgeSync/hub"
 
 	"github.com/danmestas/bones/internal/dispatch"
 	"github.com/danmestas/bones/internal/workspace"
@@ -39,7 +39,7 @@ type finalizeResult struct {
 	Missing    []string // file in dispatch manifest but not on hub trunk
 }
 
-func (c *PlanFinalizeCmd) Run(g *libfossilcli.Globals) error {
+func (c *PlanFinalizeCmd) Run(g *repocli.Globals) error {
 	cwd, err := os.Getwd()
 	if err != nil {
 		return fmt.Errorf("plan finalize: cwd: %w", err)
@@ -61,13 +61,13 @@ func runPlanFinalize(c *PlanFinalizeCmd, workspaceDir string, out io.Writer) err
 	_, _ = fmt.Fprintf(out, "plan finalize: %s\n", planSource)
 
 	hubRepoPath := filepath.Join(workspaceDir, ".bones", "hub.fossil")
-	repo, err := libfossil.Open(hubRepoPath)
+	repo, err := edgehub.OpenRepo(hubRepoPath)
 	if err != nil {
 		return fmt.Errorf("plan finalize: open hub: %w", err)
 	}
 	defer func() { _ = repo.Close() }()
 
-	res := materializeManifest(repo, manifest, workspaceDir, c.Force)
+	res := materializeManifest(context.Background(), repo, manifest, workspaceDir, c.Force)
 	printFinalizeSummary(out, res)
 
 	if len(res.Conflicted) > 0 && !c.Force {
@@ -112,7 +112,7 @@ func resolvePlanManifest(planFlag, workspaceDir string) (
 // the same relative path. Conflicts are listed without writing unless
 // force is set; matched files (host == trunk) are reported and skipped.
 func materializeManifest(
-	repo *libfossil.Repo, m *dispatch.Manifest, workspaceDir string, force bool,
+	ctx context.Context, repo *edgehub.Repo, m *dispatch.Manifest, workspaceDir string, force bool,
 ) finalizeResult {
 	var res finalizeResult
 	seen := map[string]bool{}
@@ -123,7 +123,7 @@ func materializeManifest(
 					continue
 				}
 				seen[file] = true
-				trunk, err := repo.ReadFileAt("trunk", file)
+				trunk, err := repo.ReadAt(ctx, "trunk", file)
 				if err != nil {
 					res.Missing = append(res.Missing, file)
 					continue

--- a/cli/plan_finalize_test.go
+++ b/cli/plan_finalize_test.go
@@ -2,17 +2,37 @@ package cli
 
 import (
 	"bytes"
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
+	edgehub "github.com/danmestas/EdgeSync/hub"
 	libfossil "github.com/danmestas/libfossil"
 	_ "github.com/danmestas/libfossil/db/driver/modernc"
 
 	"github.com/danmestas/bones/internal/dispatch"
 )
+
+// reopenAsHubRepo closes a libfossil.Repo and reopens it as an
+// edgehub.Repo so the test can call materializeManifest with the
+// migrated signature. Test setup uses libfossil directly because
+// the test scope hasn't migrated; production code now uses
+// edgehub.OpenRepo end-to-end.
+func reopenAsHubRepo(t *testing.T, repo *libfossil.Repo, path string) *edgehub.Repo {
+	t.Helper()
+	if err := repo.Close(); err != nil {
+		t.Fatalf("close libfossil repo: %v", err)
+	}
+	r, err := edgehub.OpenRepo(path)
+	if err != nil {
+		t.Fatalf("edgehub.OpenRepo: %v", err)
+	}
+	t.Cleanup(func() { _ = r.Close() })
+	return r
+}
 
 // TestResolvePlanManifest_NoSourceErrors pins the no-source case:
 // without --plan and without dispatch.json, the verb errors with
@@ -90,7 +110,8 @@ func TestMaterializeManifest_WritesMatchesConflicts(t *testing.T) {
 		},
 	}
 
-	res := materializeManifest(repo, manifest, workspaceDir, false)
+	hubRepo := reopenAsHubRepo(t, repo, hubRepoPath)
+	res := materializeManifest(context.Background(), hubRepo, manifest, workspaceDir, false)
 
 	if !equalSorted(res.Written, []string{"docs/research/rendering/REPORT.md"}) {
 		t.Errorf("Written: got %v", res.Written)
@@ -145,7 +166,8 @@ func TestMaterializeManifest_ForceOverridesConflicts(t *testing.T) {
 			{Slot: "alpha", Files: []string{"out.md"}},
 		},
 	}}}
-	res := materializeManifest(repo, manifest, workspaceDir, true)
+	hubRepo := reopenAsHubRepo(t, repo, hubRepoPath)
+	res := materializeManifest(context.Background(), hubRepo, manifest, workspaceDir, true)
 
 	if len(res.Conflicted) != 0 {
 		t.Errorf("expected no conflicts under --force, got %v", res.Conflicted)
@@ -180,7 +202,8 @@ func TestMaterializeManifest_MissingOnTrunk(t *testing.T) {
 			{Slot: "ghost", Files: []string{"never-committed.md"}},
 		},
 	}}}
-	res := materializeManifest(repo, manifest, workspaceDir, false)
+	hubRepo := reopenAsHubRepo(t, repo, hubRepoPath)
+	res := materializeManifest(context.Background(), hubRepo, manifest, workspaceDir, false)
 
 	if !equalSorted(res.Missing, []string{"never-committed.md"}) {
 		t.Errorf("Missing: got %v", res.Missing)

--- a/cli/status.go
+++ b/cli/status.go
@@ -13,7 +13,7 @@ import (
 	"text/tabwriter"
 	"time"
 
-	libfossilcli "github.com/danmestas/libfossil/cli"
+	repocli "github.com/danmestas/EdgeSync/cli/repo"
 
 	"github.com/danmestas/bones/internal/hub"
 	"github.com/danmestas/bones/internal/registry"
@@ -85,7 +85,7 @@ type activityEvent struct {
 	Comment string // commit comment (actCommit only)
 }
 
-func (c *StatusCmd) Run(g *libfossilcli.Globals) error {
+func (c *StatusCmd) Run(g *repocli.Globals) error {
 	if c.All {
 		if c.JSON {
 			return renderStatusAllJSON(os.Stdout)

--- a/cli/swarm_close.go
+++ b/cli/swarm_close.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"os"
 
-	libfossilcli "github.com/danmestas/libfossil/cli"
+	repocli "github.com/danmestas/EdgeSync/cli/repo"
 
 	"github.com/danmestas/bones/internal/coord"
 	"github.com/danmestas/bones/internal/dispatch"
@@ -42,7 +42,7 @@ type SwarmCloseCmd struct {
 	KeepWT         bool   `name:"keep-wt" help:"retain wt dir on success (default: remove)"`
 }
 
-func (c *SwarmCloseCmd) Run(g *libfossilcli.Globals) error {
+func (c *SwarmCloseCmd) Run(g *repocli.Globals) error {
 	if err := c.validateResult(); err != nil {
 		return err
 	}

--- a/cli/swarm_commit.go
+++ b/cli/swarm_commit.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	libfossilcli "github.com/danmestas/libfossil/cli"
+	repocli "github.com/danmestas/EdgeSync/cli/repo"
 
 	"github.com/danmestas/bones/internal/coord"
 	"github.com/danmestas/bones/internal/logwriter"
@@ -33,7 +33,7 @@ type SwarmCommitCmd struct {
 	NoAutosync bool     `name:"no-autosync" help:"branch-per-slot mode (skip pre-commit hub pull)"`
 }
 
-func (c *SwarmCommitCmd) Run(g *libfossilcli.Globals) error {
+func (c *SwarmCommitCmd) Run(g *repocli.Globals) error {
 	ctx, info, lease, stop, err := bootstrapResume(
 		"swarm commit", c.Slot, c.HubURL,
 		swarm.AcquireOpts{NoAutosync: c.NoAutosync},
@@ -89,9 +89,8 @@ func (c *SwarmCommitCmd) emitCommitReport(
 			hubURL, res.PushErr)
 	} else if res.PushResult != nil {
 		fmt.Fprintf(os.Stderr,
-			"swarm commit: pushed to hub %s rounds=%d files_sent=%d bytes_sent=%d\n",
-			hubURL,
-			res.PushResult.Rounds, res.PushResult.FilesSent, res.PushResult.BytesSent,
+			"swarm commit: pushed to hub %s pushed=%d pulled=%d\n",
+			hubURL, res.PushResult.Pushed, res.PushResult.Pulled,
 		)
 	}
 	if res.RenewErr != nil {

--- a/cli/swarm_cwd.go
+++ b/cli/swarm_cwd.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	libfossilcli "github.com/danmestas/libfossil/cli"
+	repocli "github.com/danmestas/EdgeSync/cli/repo"
 
 	"github.com/danmestas/bones/internal/swarm"
 	"github.com/danmestas/bones/internal/workspace"
@@ -23,7 +23,7 @@ type SwarmCwdCmd struct {
 	Slot string `name:"slot" required:"" help:"slot name"`
 }
 
-func (c *SwarmCwdCmd) Run(g *libfossilcli.Globals) error {
+func (c *SwarmCwdCmd) Run(g *repocli.Globals) error {
 	cwd, err := os.Getwd()
 	if err != nil {
 		return fmt.Errorf("cwd: %w", err)

--- a/cli/swarm_dispatch.go
+++ b/cli/swarm_dispatch.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/google/uuid"
 
-	libfossilcli "github.com/danmestas/libfossil/cli"
+	repocli "github.com/danmestas/EdgeSync/cli/repo"
 
 	"github.com/danmestas/bones/internal/dispatch"
 	"github.com/danmestas/bones/internal/tasks"
@@ -43,7 +43,7 @@ type SwarmDispatchCmd struct {
 }
 
 // Run dispatches to the appropriate subcommand based on which flag is set.
-func (c *SwarmDispatchCmd) Run(g *libfossilcli.Globals) error {
+func (c *SwarmDispatchCmd) Run(g *repocli.Globals) error {
 	// Validate mode before touching the workspace so the usage error is fast.
 	if !c.Cancel && !c.Advance && c.PlanPath == "" {
 		return fmt.Errorf("usage: bones swarm dispatch <plan> | --advance | --cancel")

--- a/cli/swarm_fanin.go
+++ b/cli/swarm_fanin.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	libfossilcli "github.com/danmestas/libfossil/cli"
+	repocli "github.com/danmestas/EdgeSync/cli/repo"
 
 	"github.com/danmestas/bones/internal/hub"
 	"github.com/danmestas/bones/internal/workspace"
@@ -38,7 +38,7 @@ type SwarmFanInCmd struct {
 	DryRun  bool   `name:"dry-run" help:"show what would be merged without committing"`
 }
 
-func (c *SwarmFanInCmd) Run(g *libfossilcli.Globals) error {
+func (c *SwarmFanInCmd) Run(g *repocli.Globals) error {
 	hubRepo, fossilBin, err := c.resolvePrereqs()
 	if err != nil {
 		return err

--- a/cli/swarm_join.go
+++ b/cli/swarm_join.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	libfossilcli "github.com/danmestas/libfossil/cli"
+	repocli "github.com/danmestas/EdgeSync/cli/repo"
 
 	"github.com/danmestas/bones/internal/logwriter"
 	"github.com/danmestas/bones/internal/swarm"
@@ -40,7 +40,7 @@ type SwarmJoinCmd struct {
 // check, ensures the slot user, CAS-writes the session record, opens
 // the leaf, claims the task, writes the pid file), emit the report,
 // FreshLease.Release.
-func (c *SwarmJoinCmd) Run(g *libfossilcli.Globals) error {
+func (c *SwarmJoinCmd) Run(g *repocli.Globals) error {
 	ctx, stop, info, err := joinWorkspace()
 	if err != nil {
 		return err

--- a/cli/swarm_reap.go
+++ b/cli/swarm_reap.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"time"
 
-	libfossilcli "github.com/danmestas/libfossil/cli"
+	repocli "github.com/danmestas/EdgeSync/cli/repo"
 
 	"github.com/danmestas/bones/internal/coord"
 	"github.com/danmestas/bones/internal/dispatch"
@@ -42,7 +42,7 @@ type SwarmReapCmd struct {
 // Run executes the reap. Workspace + sessions are opened once; per-
 // stale-session closes run sequentially (small N expected; concurrent
 // closes would race the same hub fossil).
-func (c *SwarmReapCmd) Run(g *libfossilcli.Globals) error {
+func (c *SwarmReapCmd) Run(g *repocli.Globals) error {
 	ctx, stop, info, err := joinWorkspace()
 	if err != nil {
 		return err

--- a/cli/swarm_status.go
+++ b/cli/swarm_status.go
@@ -10,7 +10,7 @@ import (
 	"text/tabwriter"
 	"time"
 
-	libfossilcli "github.com/danmestas/libfossil/cli"
+	repocli "github.com/danmestas/EdgeSync/cli/repo"
 
 	"github.com/danmestas/bones/internal/dispatch"
 	"github.com/danmestas/bones/internal/swarm"
@@ -49,7 +49,7 @@ type statusRow struct {
 	StaleSeconds int64     `json:"stale_seconds"`
 }
 
-func (c *SwarmStatusCmd) Run(g *libfossilcli.Globals) error {
+func (c *SwarmStatusCmd) Run(g *repocli.Globals) error {
 	ctx, stop, info, err := joinWorkspace()
 	if err != nil {
 		return err

--- a/cli/swarm_tasks.go
+++ b/cli/swarm_tasks.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"strings"
 
-	libfossilcli "github.com/danmestas/libfossil/cli"
+	repocli "github.com/danmestas/EdgeSync/cli/repo"
 
 	"github.com/danmestas/bones/internal/coord"
 	"github.com/danmestas/bones/internal/tasks"
@@ -31,7 +31,7 @@ type SwarmTasksCmd struct {
 	JSON bool   `name:"json" help:"emit JSON"`
 }
 
-func (c *SwarmTasksCmd) Run(g *libfossilcli.Globals) error {
+func (c *SwarmTasksCmd) Run(g *repocli.Globals) error {
 	ctx, stop, info, err := joinWorkspace()
 	if err != nil {
 		return err

--- a/cli/tasks_aggregate.go
+++ b/cli/tasks_aggregate.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	libfossilcli "github.com/danmestas/libfossil/cli"
+	repocli "github.com/danmestas/EdgeSync/cli/repo"
 
 	"github.com/danmestas/bones/internal/tasks"
 )
@@ -37,7 +37,7 @@ type aggregateResult struct {
 	Slots       []aggregateSlot `json:"slots"`
 }
 
-func (c *TasksAggregateCmd) Run(g *libfossilcli.Globals) error {
+func (c *TasksAggregateCmd) Run(g *repocli.Globals) error {
 	ctx, stop, info, err := joinWorkspace()
 	if err != nil {
 		return err

--- a/cli/tasks_autoclaim.go
+++ b/cli/tasks_autoclaim.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	libfossilcli "github.com/danmestas/libfossil/cli"
+	repocli "github.com/danmestas/EdgeSync/cli/repo"
 
 	"github.com/danmestas/bones/internal/coord"
 )
@@ -63,7 +63,7 @@ type autoclaimOpts struct {
 	AgentID  string
 }
 
-func (c *TasksAutoclaimCmd) Run(g *libfossilcli.Globals) error {
+func (c *TasksAutoclaimCmd) Run(g *repocli.Globals) error {
 	ctx, stop, info, err := joinWorkspace()
 	if err != nil {
 		return err

--- a/cli/tasks_claim.go
+++ b/cli/tasks_claim.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"time"
 
-	libfossilcli "github.com/danmestas/libfossil/cli"
+	repocli "github.com/danmestas/EdgeSync/cli/repo"
 
 	"github.com/danmestas/bones/internal/tasks"
 )
@@ -29,7 +29,7 @@ func (e *errClaimConflict) Error() string {
 }
 func (e *errClaimConflict) Unwrap() error { return tasks.ErrInvalidTransition }
 
-func (c *TasksClaimCmd) Run(g *libfossilcli.Globals) error {
+func (c *TasksClaimCmd) Run(g *repocli.Globals) error {
 	ctx, stop, info, err := joinWorkspace()
 	if err != nil {
 		return err

--- a/cli/tasks_close.go
+++ b/cli/tasks_close.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"time"
 
-	libfossilcli "github.com/danmestas/libfossil/cli"
+	repocli "github.com/danmestas/EdgeSync/cli/repo"
 
 	"github.com/danmestas/bones/internal/tasks"
 )
@@ -18,7 +18,7 @@ type TasksCloseCmd struct {
 	JSON   bool   `name:"json" help:"emit JSON"`
 }
 
-func (c *TasksCloseCmd) Run(g *libfossilcli.Globals) error {
+func (c *TasksCloseCmd) Run(g *repocli.Globals) error {
 	ctx, stop, info, err := joinWorkspace()
 	if err != nil {
 		return err

--- a/cli/tasks_create.go
+++ b/cli/tasks_create.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"time"
 
-	libfossilcli "github.com/danmestas/libfossil/cli"
+	repocli "github.com/danmestas/EdgeSync/cli/repo"
 	"github.com/google/uuid"
 
 	"github.com/danmestas/bones/internal/tasks"
@@ -23,7 +23,7 @@ type TasksCreateCmd struct {
 	JSON       bool     `name:"json" help:"emit JSON"`
 }
 
-func (c *TasksCreateCmd) Run(g *libfossilcli.Globals) error {
+func (c *TasksCreateCmd) Run(g *repocli.Globals) error {
 	ctx, stop, info, err := joinWorkspace()
 	if err != nil {
 		return err

--- a/cli/tasks_dispatch.go
+++ b/cli/tasks_dispatch.go
@@ -9,7 +9,7 @@ import (
 	"os/exec"
 	"time"
 
-	libfossilcli "github.com/danmestas/libfossil/cli"
+	repocli "github.com/danmestas/EdgeSync/cli/repo"
 
 	"github.com/danmestas/bones/internal/coord"
 	"github.com/danmestas/bones/internal/dispatch"
@@ -27,7 +27,7 @@ type TasksDispatchParentCmd struct {
 	WorkerClaimHandoff bool   `name:"worker-claim-handoff" help:"worker takes claim ownership"`
 }
 
-func (c *TasksDispatchParentCmd) Run(g *libfossilcli.Globals) error {
+func (c *TasksDispatchParentCmd) Run(g *repocli.Globals) error {
 	ctx, stop, info, err := joinWorkspace()
 	if err != nil {
 		return err
@@ -125,7 +125,7 @@ type TasksDispatchWorkerCmd struct {
 	Rev              string        `name:"rev" help:"fork rev"`
 }
 
-func (c *TasksDispatchWorkerCmd) Run(g *libfossilcli.Globals) error {
+func (c *TasksDispatchWorkerCmd) Run(g *repocli.Globals) error {
 	ctx, stop, info, err := joinWorkspace()
 	if err != nil {
 		return err

--- a/cli/tasks_link.go
+++ b/cli/tasks_link.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"os"
 
-	libfossilcli "github.com/danmestas/libfossil/cli"
+	repocli "github.com/danmestas/EdgeSync/cli/repo"
 
 	"github.com/danmestas/bones/internal/coord"
 )
@@ -19,7 +19,7 @@ type TasksLinkCmd struct {
 	JSON bool   `name:"json" help:"emit JSON"`
 }
 
-func (c *TasksLinkCmd) Run(g *libfossilcli.Globals) error {
+func (c *TasksLinkCmd) Run(g *repocli.Globals) error {
 	ctx, stop, info, err := joinWorkspace()
 	if err != nil {
 		return err

--- a/cli/tasks_list.go
+++ b/cli/tasks_list.go
@@ -7,7 +7,7 @@ import (
 	"sort"
 	"time"
 
-	libfossilcli "github.com/danmestas/libfossil/cli"
+	repocli "github.com/danmestas/EdgeSync/cli/repo"
 
 	"github.com/danmestas/bones/internal/coord"
 	"github.com/danmestas/bones/internal/tasks"
@@ -27,7 +27,7 @@ type TasksListCmd struct {
 	JSON      bool   `name:"json" help:"emit JSON"`
 }
 
-func (c *TasksListCmd) Run(g *libfossilcli.Globals) error {
+func (c *TasksListCmd) Run(g *repocli.Globals) error {
 	ctx, stop, info, err := joinWorkspace()
 	if err != nil {
 		return err

--- a/cli/tasks_prime.go
+++ b/cli/tasks_prime.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"time"
 
-	libfossilcli "github.com/danmestas/libfossil/cli"
+	repocli "github.com/danmestas/EdgeSync/cli/repo"
 
 	"github.com/danmestas/bones/internal/coord"
 )
@@ -17,7 +17,7 @@ type TasksPrimeCmd struct {
 	JSON bool `name:"json" help:"emit JSON"`
 }
 
-func (c *TasksPrimeCmd) Run(g *libfossilcli.Globals) error {
+func (c *TasksPrimeCmd) Run(g *repocli.Globals) error {
 	ctx, stop, info, err := joinWorkspace()
 	if err != nil {
 		return err

--- a/cli/tasks_show.go
+++ b/cli/tasks_show.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	libfossilcli "github.com/danmestas/libfossil/cli"
+	repocli "github.com/danmestas/EdgeSync/cli/repo"
 )
 
 // TasksShowCmd prints a single task.
@@ -14,7 +14,7 @@ type TasksShowCmd struct {
 	JSON bool   `name:"json" help:"emit JSON"`
 }
 
-func (c *TasksShowCmd) Run(g *libfossilcli.Globals) error {
+func (c *TasksShowCmd) Run(g *repocli.Globals) error {
 	ctx, stop, info, err := joinWorkspace()
 	if err != nil {
 		return err

--- a/cli/tasks_status.go
+++ b/cli/tasks_status.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/nats-io/nats.go"
 
-	libfossilcli "github.com/danmestas/libfossil/cli"
+	repocli "github.com/danmestas/EdgeSync/cli/repo"
 
 	"github.com/danmestas/bones/internal/tasks"
 )
@@ -24,7 +24,7 @@ import (
 //	backlog:  3 open · 1 claimed · 2 closed (last 24h)
 type TasksStatusCmd struct{}
 
-func (c *TasksStatusCmd) Run(g *libfossilcli.Globals) error {
+func (c *TasksStatusCmd) Run(g *repocli.Globals) error {
 	ctx, stop, info, err := joinWorkspace()
 	if err != nil {
 		return err

--- a/cli/tasks_update.go
+++ b/cli/tasks_update.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"time"
 
-	libfossilcli "github.com/danmestas/libfossil/cli"
+	repocli "github.com/danmestas/EdgeSync/cli/repo"
 
 	"github.com/danmestas/bones/internal/tasks"
 )
@@ -26,7 +26,7 @@ type TasksUpdateCmd struct {
 	JSON       bool     `name:"json" help:"emit JSON"`
 }
 
-func (c *TasksUpdateCmd) Run(g *libfossilcli.Globals) error {
+func (c *TasksUpdateCmd) Run(g *repocli.Globals) error {
 	ctx, stop, info, err := joinWorkspace()
 	if err != nil {
 		return err

--- a/cli/tasks_watch.go
+++ b/cli/tasks_watch.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/nats-io/nats.go"
 
-	libfossilcli "github.com/danmestas/libfossil/cli"
+	repocli "github.com/danmestas/EdgeSync/cli/repo"
 
 	"github.com/danmestas/bones/internal/tasks"
 )
@@ -16,7 +16,7 @@ import (
 // lifecycle events to stdout until Ctrl-C or context cancellation.
 type TasksWatchCmd struct{}
 
-func (c *TasksWatchCmd) Run(g *libfossilcli.Globals) error {
+func (c *TasksWatchCmd) Run(g *repocli.Globals) error {
 	ctx, stop, info, err := joinWorkspace()
 	if err != nil {
 		return err

--- a/cli/telemetry.go
+++ b/cli/telemetry.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	libfossilcli "github.com/danmestas/libfossil/cli"
+	repocli "github.com/danmestas/EdgeSync/cli/repo"
 
 	"github.com/danmestas/bones/internal/telemetry"
 )
@@ -30,7 +30,7 @@ type TelemetryStatusCmd struct{}
 
 // Run renders the status. Always exits 0 — even "off" is a valid
 // state to report.
-func (c *TelemetryStatusCmd) Run(g *libfossilcli.Globals) error {
+func (c *TelemetryStatusCmd) Run(g *repocli.Globals) error {
 	state := "off"
 	if telemetry.IsEnabled() {
 		state = "on"
@@ -60,7 +60,7 @@ type TelemetryDisableCmd struct{}
 // Run writes the marker file. Surfaces I/O errors directly with the
 // path so the operator can investigate (e.g. permission issues on
 // read-only home directories).
-func (c *TelemetryDisableCmd) Run(g *libfossilcli.Globals) error {
+func (c *TelemetryDisableCmd) Run(g *repocli.Globals) error {
 	if err := telemetry.Disable(); err != nil {
 		return err
 	}
@@ -78,7 +78,7 @@ type TelemetryEnableCmd struct{}
 // Run removes the marker. The follow-up resolution outcome depends
 // on the build flavor and env vars; the printed hint points the
 // operator at `bones telemetry status` rather than guessing.
-func (c *TelemetryEnableCmd) Run(g *libfossilcli.Globals) error {
+func (c *TelemetryEnableCmd) Run(g *repocli.Globals) error {
 	if err := telemetry.Enable(); err != nil {
 		return err
 	}

--- a/cli/validate_plan.go
+++ b/cli/validate_plan.go
@@ -14,7 +14,7 @@ import (
 	"regexp"
 	"strings"
 
-	libfossilcli "github.com/danmestas/libfossil/cli"
+	repocli "github.com/danmestas/EdgeSync/cli/repo"
 )
 
 // ValidatePlanCmd parses a Markdown plan, extracts [slot: name]
@@ -57,7 +57,7 @@ type ValidateResult struct {
 	Slots  []slotEntry `json:"slots"`
 }
 
-func (c *ValidatePlanCmd) Run(g *libfossilcli.Globals) error {
+func (c *ValidatePlanCmd) Run(g *repocli.Globals) error {
 	if c.ListSlots {
 		fmt.Fprintln(os.Stderr,
 			"validate-plan: --list-slots is a no-op; JSON is now always emitted on stdout")

--- a/cmd/bones/cli.go
+++ b/cmd/bones/cli.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	edgecli "github.com/danmestas/EdgeSync/cli"
-	libfossilcli "github.com/danmestas/libfossil/cli"
+	repocli "github.com/danmestas/EdgeSync/cli/repo"
 
 	bonescli "github.com/danmestas/bones/cli"
 )
@@ -10,7 +10,7 @@ import (
 // CLI is the top-level Kong assembly. Globals are inherited from
 // libfossil/cli (provides `-R <repo>` and `-v` for the Repo subtree).
 type CLI struct {
-	libfossilcli.Globals
+	repocli.Globals
 
 	// Daily.
 	Up     bonescli.UpCmd     `cmd:"" group:"daily" help:"Bootstrap workspace, lazy hub (ADR 0041)"`
@@ -29,7 +29,7 @@ type CLI struct {
 	Workspaces bonescli.WorkspacesCmd `cmd:"" group:"daily" help:"List/inspect known workspaces"`
 
 	// Repository.
-	Repo libfossilcli.RepoCmd `cmd:"" group:"repo" help:"Fossil repository operations"`
+	Repo repocli.Cmd `cmd:"" group:"repo" help:"Fossil repository operations"`
 
 	// Sync & messaging.
 	Sync   edgecli.SyncCmd    `cmd:"" group:"sync" help:"Leaf agent sync"`

--- a/cmd/bones/main.go
+++ b/cmd/bones/main.go
@@ -15,6 +15,10 @@ import (
 	"os"
 
 	"github.com/alecthomas/kong"
+	// libfossil's modernc SQLite driver. Registered here while bones
+	// still has two libfossil-direct sites (internal/hub/hub.go for the
+	// production daemon, internal/coord/leaf.go's OpenLeaf clone path).
+	// Drops when those migrate too.
 	_ "github.com/danmestas/libfossil/db/driver/modernc"
 
 	"github.com/danmestas/bones/internal/telemetry"
@@ -77,7 +81,7 @@ func main() {
 		}),
 	)
 	// Default slog level is Info; demote operational telemetry sites
-	// to Debug so non-`-v` invocations stay quiet. `-v` (libfossilcli
+	// to Debug so non-`-v` invocations stay quiet. `-v` (repocli
 	// Globals.Verbose) reinstalls a Debug-level handler so the same
 	// sites are visible when troubleshooting.
 	if c.Verbose {

--- a/internal/coord/hub.go
+++ b/internal/coord/hub.go
@@ -18,12 +18,16 @@ import (
 // exposes the leaf.Agent's embedded NATS mesh as the hub's NATS bus.
 //
 // Hub wraps a *leaf.Agent with serve flags set (Pull=false, Push=false,
-// Autosync=AutosyncOff). The agent's serve_http handler exposes
-// repo.XferHandler() so a stock fossil client can pull/push. The
-// agent's mesh runs a standalone NATS server (no upstream); peer
-// leaves solicit it via NATSUpstream and publish/subscribe land
-// directly on the hub's mesh — single-hop subject-interest
-// propagation. See EdgeSync PR #77 (MeshClientURL/MeshLeafAddr).
+// Autosync=AutosyncOff, ServeNATSEnabled=true). The agent's serve_http
+// handler exposes repo.XferHandler() so a stock fossil client can
+// pull/push, AND its NATS subscriber on fossil.<project-code>.sync
+// processes pushes from peer leaves over the leaf-mesh.
+//
+// Why not the EdgeSync hub package: bones's swarm flow relies on
+// NATS-based fossil sync (slot leaf publishes, hub agent subscribes
+// and merges). The hub package's NewHub starts a NATS server but does
+// not register the fossil-sync subscriber. Until the hub package gains
+// that surface, this site stays on the leaf agent serve-mode pattern.
 type Hub struct {
 	agent    *agent.Agent
 	httpAddr string
@@ -54,10 +58,6 @@ func OpenHub(ctx context.Context, workdir, httpAddr string) (*Hub, error) {
 		}
 		// Grant the unauthenticated user clone/pull/push caps so leaf
 		// agents can sync without coord plumbing per-leaf credentials.
-		// libfossil's xfer handler treats requests with no login card
-		// as user "nobody" (see internal/sync/handler.go initAuth).
-		// libfossil.Create pre-populates "nobody" with empty caps;
-		// SetCaps grants 'gio' (clone, pull, push).
 		if cerr := r.SetCaps("nobody", "gio"); cerr != nil {
 			_ = r.Close()
 			return nil, fmt.Errorf("coord.OpenHub: grant nobody caps: %w", cerr)
@@ -66,13 +66,8 @@ func OpenHub(ctx context.Context, workdir, httpAddr string) (*Hub, error) {
 	}
 
 	cfg := agent.Config{
-		RepoPath:     repoPath,
-		NATSUpstream: "", // hub's mesh runs standalone — peer leaves solicit it
-		// Pin the JetStream store dir to the workdir so two Hubs (e.g.
-		// from different tests) do not share state via the
-		// CWD-relative default `<cwd>/.nats-store`. Without this, the
-		// tasks/holds/presence KV buckets persist across tests and
-		// rooms records leak between fresh `t.TempDir()` workdirs.
+		RepoPath:         repoPath,
+		NATSUpstream:     "",
 		NATSStoreDir:     filepath.Join(workdir, ".nats-store"),
 		ServeHTTPAddr:    httpAddr,
 		ServeNATSEnabled: true,
@@ -94,19 +89,14 @@ func OpenHub(ctx context.Context, workdir, httpAddr string) (*Hub, error) {
 	}, nil
 }
 
-// NATSURL returns the hub's NATS client URL — the agent's mesh accepts
-// regular client connections here. Use this for non-agent NATS clients
-// (e.g. coord's claim/task KV traffic from the same process). For
-// remote agents joining the hub's mesh upstream, see LeafUpstream.
+// NATSURL returns the hub's NATS client URL.
 func (h *Hub) NATSURL() string {
 	assert.NotNil(h, "coord.Hub.NATSURL: receiver is nil")
 	return h.agent.MeshClientURL()
 }
 
 // LeafUpstream returns the URL remote agents pass as NATSUpstream to
-// peer their meshes into the hub's mesh as leaf nodes. The hub mesh
-// accepts these solicits on its leaf-node port (separate from the
-// client port returned by NATSURL).
+// peer their meshes into the hub's mesh as leaf nodes.
 func (h *Hub) LeafUpstream() string {
 	assert.NotNil(h, "coord.Hub.LeafUpstream: receiver is nil")
 	addr := h.agent.MeshLeafAddr()
@@ -116,15 +106,13 @@ func (h *Hub) LeafUpstream() string {
 	return "nats://" + addr
 }
 
-// HTTPAddr returns the hub's HTTP listen address, suitable as the
-// hubHTTPAddr argument to OpenLeaf.
+// HTTPAddr returns the hub's HTTP listen address.
 func (h *Hub) HTTPAddr() string {
 	assert.NotNil(h, "coord.Hub.HTTPAddr: receiver is nil")
 	return "http://" + h.httpAddr
 }
 
-// Stop shuts down the agent (which also shuts down its embedded NATS
-// mesh). Safe to call more than once; subsequent calls are no-ops.
+// Stop shuts down the agent. Safe to call more than once.
 func (h *Hub) Stop() error {
 	assert.NotNil(h, "coord.Hub.Stop: receiver is nil")
 	h.mu.Lock()

--- a/internal/coord/leaf.go
+++ b/internal/coord/leaf.go
@@ -3,8 +3,6 @@ package coord
 
 import (
 	"context"
-	"database/sql"
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -13,6 +11,10 @@ import (
 
 	"github.com/danmestas/EdgeSync/leaf/agent"
 	"github.com/danmestas/libfossil"
+	// modernc SQLite driver, registered for libfossil.Clone in
+	// OpenLeaf's pre-agent clone path. The rest of the package goes
+	// through the EdgeSync agent, which manages its own driver
+	// registration internally.
 	_ "github.com/danmestas/libfossil/db/driver/modernc"
 
 	"github.com/danmestas/bones/internal/assert"
@@ -460,20 +462,11 @@ func (l *Leaf) Commit(
 		return "", err
 	}
 
-	// Write through the agent's repo handle. EdgeSync v0.0.10's
-	// agent.Commit does not yet surface ParentID/MergeParents — the
-	// trunk-based-development invariant requires explicitly chaining
-	// onto the trunk tip, which the wrapped API can't express, so this
-	// site stays on the libfossil-typed CommitOpts path. media.go and
-	// compact.go (which don't set ParentID) use the wrapped API.
-	repo := l.agent.Repo()
-
-	// Pull from hub before resolving the trunk tip so the new commit's
-	// parent is the latest hub-known commit, not whatever this leaf
-	// snapshot saw at clone time. This is the implementation of
-	// trunk-based development across slots: every slot.Commit advances
-	// a shared trunk rather than producing a sibling leaf that fan-in
-	// must collapse later.
+	// Pull from hub before committing so the new commit's parent is the
+	// latest hub-known commit, not whatever this leaf snapshot saw at
+	// clone time. This is the implementation of trunk-based development
+	// across slots: every slot.Commit advances a shared trunk rather
+	// than producing a sibling leaf that fan-in must collapse later.
 	//
 	// A failed pull is fatal: continuing on a stale parent silently
 	// turns a "trunk advance" into "trunk fork", which is exactly what
@@ -484,7 +477,7 @@ func (l *Leaf) Commit(
 			return "", fmt.Errorf("coord.Leaf.Commit: pre-commit pull: %w", err)
 		}
 	}
-	toCommit := make([]libfossil.FileToCommit, 0, len(files))
+	toCommit := make([]agent.FileToCommit, 0, len(files))
 	for _, f := range files {
 		assert.Precondition(
 			!f.Path.IsZero(),
@@ -494,7 +487,7 @@ func (l *Leaf) Commit(
 		if name == "" {
 			name = normalizeLeadingSlash(f.Path.AsAbsolute())
 		}
-		toCommit = append(toCommit, libfossil.FileToCommit{
+		toCommit = append(toCommit, agent.FileToCommit{
 			Name:    name,
 			Content: f.Content,
 		})
@@ -510,28 +503,18 @@ func (l *Leaf) Commit(
 	if co.message != "" {
 		commitComment = co.message
 	}
-	// Resolve the current branch tip so the new commit lists it as
-	// its parent. Without this, libfossil writes an orphan checkin
-	// (no P-card on the manifest), every commit becomes its own
-	// root, and the hub timeline shows N disconnected leaves
-	// instead of a chain. BranchTip on a fresh slot leaf returns
-	// the seed commit's rid (cloned from hub at OpenLeaf time).
-	// On a brand-new empty repo with no trunk tip yet, BranchTip
-	// returns "no rows" / "branch not found"; that's the legitimate
-	// first-commit case where ParentID=0 is correct (orphan root).
-	parentID, btErr := repo.BranchTip("trunk")
-	if btErr != nil && !isBranchTipMissing(btErr) {
-		return "", fmt.Errorf("coord.Leaf.Commit: resolve trunk tip: %w", btErr)
-	}
-	_, uuid, err := repo.Commit(libfossil.CommitOpts{
-		Files:    toCommit,
-		ParentID: parentID,
-		Comment:  commitComment,
-		User:     commitUser,
+	// Agent.Commit auto-resolves the trunk tip when ParentID is unset,
+	// so the commit chains onto the latest tip from the post-pull state
+	// without bones needing to call Tip() and round-trip the rid.
+	rev, err := l.agent.Commit(ctx, agent.CommitOpts{
+		Files:   toCommit,
+		Message: commitComment,
+		Author:  commitUser,
 	})
 	if err != nil {
 		return "", fmt.Errorf("coord.Leaf.Commit: %w", err)
 	}
+	uuid := string(rev)
 
 	// Trigger an explicit sync round so the hub receives the commit.
 	// SyncNow uses leaf.Agent's NATS transport; the leaf's mesh joins
@@ -562,15 +545,6 @@ func commitMessage(c *Claim) string {
 	return "leaf commit for task " + string(c.TaskID())
 }
 
-// isBranchTipMissing reports whether err is libfossil's "this branch
-// has no commits yet" error. BranchTip wraps sql.ErrNoRows in that
-// case (queried table has zero matching rows). The first commit on
-// an empty repo is legitimate; ParentID=0 produces the correct
-// orphan-root manifest.
-func isBranchTipMissing(err error) bool {
-	return errors.Is(err, sql.ErrNoRows)
-}
-
 // pullFromHub runs a one-shot fossil pull against the configured hub
 // via the EdgeSync agent's libfossil-hidden SyncTo API. Authenticates
 // as l.fossilUser (which has 'i' caps from ensureSlotUser) when set;
@@ -591,6 +565,37 @@ func (l *Leaf) pullFromHub(ctx context.Context) error {
 		return err
 	}
 	return nil
+}
+
+// Push HTTP-pushes the leaf's repo to hubURL via the agent's
+// libfossil-hidden SyncTo API. Used by swarm.ResumedLease.Commit to
+// land a slot's commit on the hub before stopping the leaf — the
+// previous "stop-then-push" flow relied on direct libfossil access
+// to leaf.fossil, which is no longer available post-libfossil-exit.
+//
+// fossilUser falls back to slotID when empty (matching the swarm
+// flow's existing convention). projectCode is the hub's fossil
+// project-code, required by the sync handshake.
+func (l *Leaf) Push(
+	ctx context.Context, hubURL, fossilUser, projectCode string,
+) (*agent.SyncResult, error) {
+	assert.NotNil(l, "coord.Leaf.Push: receiver is nil")
+	assert.NotNil(ctx, "coord.Leaf.Push: ctx is nil")
+	assert.NotEmpty(hubURL, "coord.Leaf.Push: hubURL is empty")
+	user := fossilUser
+	if user == "" {
+		user = l.slotID
+	}
+	res, err := l.agent.SyncTo(ctx, hubURL, agent.SyncOpts{
+		Push:        true,
+		Pull:        false,
+		User:        user,
+		ProjectCode: projectCode,
+	})
+	if err != nil {
+		return res, fmt.Errorf("coord.Leaf.Push: %w", err)
+	}
+	return res, nil
 }
 
 // CommitOption tunes Leaf.Commit. Construct with WithMessage / WithUser.

--- a/internal/swarm/lease.go
+++ b/internal/swarm/lease.go
@@ -11,7 +11,8 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/danmestas/libfossil"
+	edgehub "github.com/danmestas/EdgeSync/hub"
+	"github.com/danmestas/EdgeSync/leaf/agent"
 	"github.com/nats-io/nats.go"
 
 	"github.com/danmestas/bones/internal/assert"
@@ -164,7 +165,7 @@ type AcquireOpts struct {
 // errors but should not roll back the local commit.
 type CommitResult struct {
 	UUID       string
-	PushResult *libfossil.SyncResult
+	PushResult *agent.SyncResult
 	PushErr    error
 	RenewErr   error
 }
@@ -542,10 +543,9 @@ func (l *FreshLease) Abort(ctx context.Context) error {
 // Resume and now.
 //
 // After Commit returns, the lease's underlying coord.Leaf has been
-// stopped — the push path needs an exclusive libfossil.Repo handle
-// on leaf.fossil. The lease can still be Released or Closed; doing
-// other verb work on the lease's leaf after Commit is undefined and
-// would have to re-Resume.
+// stopped. The lease can still be Released or Closed; doing other
+// verb work on the lease's leaf after Commit is undefined and would
+// have to re-Resume.
 func (l *ResumedLease) Commit(
 	ctx context.Context, message string, files []coord.File,
 ) (CommitResult, error) {
@@ -558,13 +558,17 @@ func (l *ResumedLease) Commit(
 	if err != nil {
 		return CommitResult{}, err
 	}
-	// Stop the leaf BEFORE pushing so the agent's libfossil.Repo
-	// handle is closed; pushLeafFossil opens its own handle on
-	// leaf.fossil cleanly.
+	// Push BEFORE stopping the leaf — Leaf.Push routes through the
+	// agent's SyncTo API, which requires the agent to be running.
+	// The pre-libfossil-exit flow stopped the leaf first to give a
+	// libfossil-direct push path exclusive repo access; with the
+	// agent owning the repo handle there's no exclusivity concern.
+	// projectCode left empty — agent.SyncTo auto-derives from the
+	// leaf's repo config, which was set at OpenLeaf clone time.
+	pushRes, pushErr := l.leaf.Push(ctx, l.hubURL, l.fossilUser, "")
 	_ = l.leaf.Stop()
 	l.leaf = nil
 
-	pushRes, pushErr := pushLeafFossil(ctx, l.info.WorkspaceDir, l.slot, l.fossilUser, l.hubURL)
 	renewErr := l.bumpLastRenewed(ctx)
 
 	appendEvent(l.info.WorkspaceDir, Event{
@@ -928,49 +932,6 @@ func commitViaLeaf(
 	return uuid, nil
 }
 
-// pushLeafFossil HTTP-pushes the slot's leaf.fossil to the hub via
-// libfossil's /xfer transport. The two NATS deployments are separate
-// by design (hub NATS vs. workspace leaf NATS), so the post-commit
-// announce doesn't reach the hub's /xfer subscriber — the explicit
-// HTTP push here is what makes the commit visible to `bones peek`
-// and the hub timeline.
-//
-// Soft-fail-friendly: returns SyncResult and error separately so the
-// caller can warn on push failure without rolling back the local
-// commit.
-//
-// This site uses libfossil directly because ResumedLease.Commit stops
-// the leaf agent BEFORE calling pushLeafFossil — the EdgeSync
-// agent.SyncTo API requires a running agent. Migrating to agent.SyncTo
-// would require a swarm-flow change (push-before-stop), which is out
-// of scope for the rest of the libfossil-exit and stays on the
-// libfossil-direct path.
-func pushLeafFossil(
-	ctx context.Context, workspaceDir, slot, fossilUser, hubURL string,
-) (*libfossil.SyncResult, error) {
-	leafRepoPath := filepath.Join(SlotDir(workspaceDir, slot), "leaf.fossil")
-	leafRepo, err := libfossil.Open(leafRepoPath)
-	if err != nil {
-		return nil, fmt.Errorf("swarm: open leaf repo for push: %w", err)
-	}
-	defer func() { _ = leafRepo.Close() }()
-	projectCode, err := leafRepo.Config("project-code")
-	if err != nil {
-		return nil, fmt.Errorf("swarm: read project-code: %w", err)
-	}
-	transport := libfossil.NewHTTPTransport(hubURL)
-	res, err := leafRepo.Sync(ctx, transport, libfossil.SyncOpts{
-		Push:        true,
-		Pull:        false,
-		User:        fossilUser,
-		ProjectCode: projectCode,
-	})
-	if err != nil {
-		return res, fmt.Errorf("swarm: sync push: %w", err)
-	}
-	return res, nil
-}
-
 // ensureSlotUser creates the slot's fossil user on the hub repo if
 // missing. The role-guard for "workspace not bootstrapped" lives
 // here: if `<workspace>/.bones/hub.fossil` is absent, returns
@@ -985,16 +946,16 @@ func ensureSlotUser(workspaceDir, login, caps string) error {
 		}
 		return fmt.Errorf("swarm: stat hub repo: %w", err)
 	}
-	repo, err := libfossil.Open(hubRepoPath)
+	repo, err := edgehub.OpenRepo(hubRepoPath)
 	if err != nil {
 		return fmt.Errorf("swarm: open hub repo: %w", err)
 	}
 	defer func() { _ = repo.Close() }()
 
-	if _, err := repo.GetUser(login); err == nil {
+	if repo.HasUser(login) {
 		return nil
 	}
-	if err := repo.CreateUser(libfossil.UserOpts{
+	if err := repo.AddUser(edgehub.User{
 		Login: login,
 		Caps:  caps,
 	}); err != nil {


### PR DESCRIPTION
## Summary

Completes the leaf-side libfossil-exit migration on top of `EdgeSync v0.0.11 / leaf v0.0.9`. Three of bones's blocking gaps (`#125`, `#130`, `#131`) were addressed upstream this session; this PR consumes the new APIs.

41 files changed, +208 −228. Net **−20 lines** despite adding the new `Leaf.Push` method and a swarm-flow refactor.

## Migrations

| Site | Old | New |
|---|---|---|
| `Leaf.Commit` | `repo.BranchTip("trunk")` + `repo.Commit(libfossil.CommitOpts{ParentID})` | `agent.Commit(agent.CommitOpts{...})` — ParentID auto-resolves |
| `Leaf.Push` (new) | (didn't exist) | wraps `agent.SyncTo` for push-before-stop |
| `ResumedLease.Commit` | commit → stop → `pushLeafFossil` (libfossil-direct) | commit → `Leaf.Push` → stop |
| `ensureSlotUser` | `libfossil.Open` + `CreateUser/GetUser` | `edgehub.OpenRepo` + `AddUser/HasUser` |
| `cli/hub_user.go` | same pattern | same pattern |
| `cli/plan_finalize.go` | `libfossil.Open` + `ReadFileAt` | `edgehub.OpenRepo` + `ReadAt(ctx, rev, path)` |
| All `cli/*` + `cmd/bones` | `libfossilcli "github.com/danmestas/libfossil/cli"` | `repocli "github.com/danmestas/EdgeSync/cli/repo"` (type-aliased) |
| `pushLeafFossil` | inlined libfossil sync push | dropped — replaced by `Leaf.Push` |

## Three sites still on libfossil-direct ([upstream #137](https://github.com/danmestas/EdgeSync/issues/137))

| Site | Why it stays |
|---|---|
| `internal/coord/leaf.go::OpenLeaf` initial clone | EdgeSync has no `agent.CloneRepo` helper. `agent.New` opens-or-creates an empty repo; can't bootstrap a project-code-matched leaf.fossil from a hub URL. |
| `internal/coord/hub.go::OpenHub` | EdgeSync's `hub.NewHub` starts NATS but doesn't register a fossil-sync subscriber on `fossil.<project-code>.sync`. The leaf-agent serve mode (`ServeNATSEnabled=true`) does. Migrating broke `TestLeaf_CommitWritesAndSyncs` (commit lands locally but never reaches hub.fossil); reverted that file's migration. |
| `internal/hub/hub.go` (production daemon) | Needs `hub.FileToCommit.Perm` (executable bit on seeded files) and `hub.CommitOpts.Time` (deterministic seed timestamps). Without those, migration causes a real if minor regression. |

These keep `libfossil` in `bones/go.mod` as a direct require until those three upstream gaps land. Cleanup after that is a one-liner.

## Test status

- [x] `make check` — fmt-check, vet, lint, race, todo-check all pass
- [x] `go test -short -timeout 300s ./...` — all green
- [x] `go test -tags=otel -short -timeout 300s ./...` — all green
- [x] `go test -race -short ./internal/coord/... ./examples/hub-leaf-e2e/...` — all green

Verified end-to-end:
- `TestLeaf_CommitWritesAndSyncs` and `TestLeaf_CommitAutosyncLinearizes` (the trunk-based-development integration tests) — pass with `agent.Commit` auto-resolving the parent
- `TestLeaf_Compact_WritesSummaryArtifactAndMetadata` — modernc driver still registered (needed by `OpenLeaf`'s remaining `libfossil.Clone`)
- `examples/hub-leaf-e2e/TestE2E_3x3` — three concurrent slot leaves clone+commit+push; sub-second runtime
- `swarm` lease tests — push-before-stop flow validated; PushResult type change from `*libfossil.SyncResult` to `*agent.SyncResult` doesn't break consumers (all read either `PushErr` or check non-nil)

## Refs

- danmestas/EdgeSync#125, #130, #131 — closed (shipped in v0.0.11)
- danmestas/EdgeSync#137 — three remaining gaps for full go.mod drop
- bones #185 follow-up — `Leaf.Commit` ParentID. Closed by this PR.
- bones #186 — partial. `coord.OpenHub` + `internal/hub/hub.go` follow-ups documented above.
- bones #187 — cli/repo lib swap. Closed by this PR.
- bones #188 — final go.mod drop. Gates on EdgeSync#137.
