### PR TITLE
ci: bump actions/checkout v4→v6 and setup-go v5→v6 for Node.js 24

### DIFF
--- a/.github/workflows/bump-upstream.yml
+++ b/.github/workflows/bump-upstream.yml
@@ -82,12 +82,12 @@ jobs:
           fi
 
       - if: steps.in.outputs.skip != 'true' && steps.idem.outputs.exists != 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - if: steps.in.outputs.skip != 'true' && steps.idem.outputs.exists != 'true'
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,17 +31,17 @@ jobs:
       # Check out bones into ./bones so the sibling EdgeSync
       # clone can sit at ../EdgeSync.
       - name: Checkout bones
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: bones
 
       - name: Checkout EdgeSync (sibling dir)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: danmestas/EdgeSync
           path: EdgeSync
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: '1.26.0'
           cache: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,12 +13,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1.26.0'
 


### PR DESCRIPTION
## Summary

Bumps two GitHub Actions to clear the Node.js 20 deprecation warning visible on every recent workflow run.

| Action | Before | After |
|---|---|---|
| actions/checkout | v4 | v6 |
| actions/setup-go | v5 | v6 |

## Why

GitHub deprecated Node.js 20 runners. v4 of checkout and v5 of setup-go run on Node 20; v6 of both targets Node 24 natively.

Forced default to Node 24: **2026-06-02**.
Node 20 removal: **2026-09-16**.

Bumping ahead of those deadlines clears the warning now and dodges the forced-migration window.

## Test plan

- [x] No behavior change beyond the runtime — both actions are stable APIs across v4→v6 (checkout) and v5→v6 (setup-go) for our usage shape (`checkout`, `setup-go` with `go-version-file: go.mod`)
- [ ] CI run on this PR validates that v6 of both works on the runner

## Refs

- https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/