### PR TITLE
refactor: complete hub libfossil-exit migration to EdgeSync v0.0.12

### DIFF
--- a/cmd/bones/main.go
+++ b/cmd/bones/main.go
@@ -15,10 +15,10 @@ import (
 	"os"
 
 	"github.com/alecthomas/kong"
-	// libfossil's modernc SQLite driver. Registered here while bones
-	// still has two libfossil-direct sites (internal/hub/hub.go for the
-	// production daemon, internal/coord/leaf.go's OpenLeaf clone path).
-	// Drops when those migrate too.
+	// modernc SQLite driver — registered here so libfossil (transitive
+	// via EdgeSync's hub and agent packages) finds a driver at runtime.
+	// EdgeSync's library packages don't auto-register; downstream binary
+	// callers do. Tests register via internal/{coord,hub}/driver_test.go.
 	_ "github.com/danmestas/libfossil/db/driver/modernc"
 
 	"github.com/danmestas/bones/internal/telemetry"

--- a/examples/hub-leaf-e2e/driver_test.go
+++ b/examples/hub-leaf-e2e/driver_test.go
@@ -1,0 +1,8 @@
+package hubleafe2e
+
+// Test-only: register the modernc SQLite driver so libfossil's
+// transitive uses (via EdgeSync's hub.NewHub, which opens SQLite-backed
+// fossil repos internally) can find a driver during
+// `go test ./examples/hub-leaf-e2e/...`. Production binaries register
+// the driver at cmd/bones/main.go.
+import _ "github.com/danmestas/libfossil/db/driver/modernc"

--- a/internal/coord/driver_test.go
+++ b/internal/coord/driver_test.go
@@ -1,0 +1,8 @@
+package coord
+
+// Test-only: register the modernc SQLite driver so libfossil's
+// transitive uses (via EdgeSync's hub.NewHub and agent.New, both of
+// which open SQLite-backed fossil repos internally) can find a driver
+// during `go test ./internal/coord/...`. Production binaries register
+// the driver at cmd/bones/main.go.
+import _ "github.com/danmestas/libfossil/db/driver/modernc"

--- a/internal/coord/hub.go
+++ b/internal/coord/hub.go
@@ -6,42 +6,42 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 
-	"github.com/danmestas/EdgeSync/leaf/agent"
-	"github.com/danmestas/libfossil"
+	edgehub "github.com/danmestas/EdgeSync/hub"
 
 	"github.com/danmestas/bones/internal/assert"
 )
 
 // Hub owns the orchestrator's hub fossil repo + HTTP xfer endpoint and
-// exposes the leaf.Agent's embedded NATS mesh as the hub's NATS bus.
-//
-// Hub wraps a *leaf.Agent with serve flags set (Pull=false, Push=false,
-// Autosync=AutosyncOff, ServeNATSEnabled=true). The agent's serve_http
-// handler exposes repo.XferHandler() so a stock fossil client can
-// pull/push, AND its NATS subscriber on fossil.<project-code>.sync
-// processes pushes from peer leaves over the leaf-mesh.
-//
-// Why not the EdgeSync hub package: bones's swarm flow relies on
-// NATS-based fossil sync (slot leaf publishes, hub agent subscribes
-// and merges). The hub package's NewHub starts a NATS server but does
-// not register the fossil-sync subscriber. Until the hub package gains
-// that surface, this site stays on the leaf agent serve-mode pattern.
+// the embedded NATS server. Wraps EdgeSync's hub package end-to-end:
+// bones holds no libfossil or nats-server types, no per-coord
+// repo/server lifecycle. NobodyCaps="gio" grants unauthenticated leaf
+// clone/pull/push at hub bootstrap; DisableFossilSyncOverNATS is left
+// at default false so the hub's NATS subscriber on
+// "fossil.<project-code>.sync" continues to accept pushes from peer
+// leaves over the leaf-mesh (the swarm flow's commit-propagation path).
 type Hub struct {
-	agent    *agent.Agent
+	hub      *edgehub.Hub
 	httpAddr string
+	cancel   context.CancelFunc
+	done     chan struct{}
 	mu       sync.Mutex
 	stopped  bool
 }
 
 // OpenHub starts a hub at workdir/hub.fossil that serves HTTP on
-// httpAddr (e.g. "127.0.0.1:8765") and runs the embedded leaf.Agent
-// mesh NATS as the hub's NATS bus. The hub is a passive receiver of
-// pushes from peer leaves; it never client-syncs out.
+// httpAddr (e.g. "127.0.0.1:8765") and runs an embedded NATS server
+// with the fossil-sync subscriber enabled. The hub is a passive
+// receiver of pushes from peer leaves; it never client-syncs out.
 //
-// workdir is created if missing; hub.fossil is created if missing.
-// Caller owns workdir and is responsible for cleanup.
+// httpAddr's port is honored when free; the hub package falls back to
+// auto-pick if bind fails. The actual address is exposed via HTTPAddr().
+//
+// workdir is created if missing; hub.fossil is created if missing
+// with NobodyCaps="gio" so unauthenticated leaf clones work without
+// per-leaf credential plumbing.
 func OpenHub(ctx context.Context, workdir, httpAddr string) (*Hub, error) {
 	assert.NotNil(ctx, "coord.OpenHub: ctx is nil")
 	assert.NotEmpty(workdir, "coord.OpenHub: workdir is empty")
@@ -50,60 +50,59 @@ func OpenHub(ctx context.Context, workdir, httpAddr string) (*Hub, error) {
 	if err := os.MkdirAll(workdir, 0o755); err != nil {
 		return nil, fmt.Errorf("coord.OpenHub: mkdir workdir: %w", err)
 	}
-	repoPath := filepath.Join(workdir, "hub.fossil")
-	if _, err := os.Stat(repoPath); os.IsNotExist(err) {
-		r, cerr := libfossil.Create(repoPath, libfossil.CreateOpts{User: "hub"})
-		if cerr != nil {
-			return nil, fmt.Errorf("coord.OpenHub: create repo: %w", cerr)
-		}
-		// Grant the unauthenticated user clone/pull/push caps so leaf
-		// agents can sync without coord plumbing per-leaf credentials.
-		if cerr := r.SetCaps("nobody", "gio"); cerr != nil {
-			_ = r.Close()
-			return nil, fmt.Errorf("coord.OpenHub: grant nobody caps: %w", cerr)
-		}
-		_ = r.Close()
-	}
-
-	cfg := agent.Config{
-		RepoPath:         repoPath,
-		NATSUpstream:     "",
-		NATSStoreDir:     filepath.Join(workdir, ".nats-store"),
-		ServeHTTPAddr:    httpAddr,
-		ServeNATSEnabled: true,
-		Pull:             false,
-		Push:             false,
-		Autosync:         agent.AutosyncOff,
-	}
-	a, err := agent.New(cfg)
+	port, err := portFromAddr(httpAddr)
 	if err != nil {
-		return nil, fmt.Errorf("coord.OpenHub: agent.New: %w", err)
+		return nil, fmt.Errorf("coord.OpenHub: %w", err)
 	}
-	if err := a.Start(); err != nil {
-		_ = a.Stop()
-		return nil, fmt.Errorf("coord.OpenHub: agent.Start: %w", err)
+	h, err := edgehub.NewHub(ctx, edgehub.Config{
+		RepoPath:       filepath.Join(workdir, "hub.fossil"),
+		BootstrapUser:  "hub",
+		NobodyCaps:     "gio",
+		NATSStoreDir:   filepath.Join(workdir, ".nats-store"),
+		FossilHTTPPort: port,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("coord.OpenHub: %w", err)
 	}
+	serveCtx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		_ = h.ServeHTTP(serveCtx)
+		close(done)
+	}()
 	return &Hub{
-		agent:    a,
-		httpAddr: httpAddr,
+		hub:      h,
+		httpAddr: h.HTTPAddr(),
+		cancel:   cancel,
+		done:     done,
 	}, nil
+}
+
+// portFromAddr extracts the port from a host:port string. Returns 0 for
+// auto-pick when the input is empty or has no port.
+func portFromAddr(addr string) (int, error) {
+	idx := strings.LastIndex(addr, ":")
+	if idx < 0 {
+		return 0, nil
+	}
+	var port int
+	if _, err := fmt.Sscanf(addr[idx+1:], "%d", &port); err != nil {
+		return 0, fmt.Errorf("parse port from %q: %w", addr, err)
+	}
+	return port, nil
 }
 
 // NATSURL returns the hub's NATS client URL.
 func (h *Hub) NATSURL() string {
 	assert.NotNil(h, "coord.Hub.NATSURL: receiver is nil")
-	return h.agent.MeshClientURL()
+	return h.hub.NATSURL()
 }
 
 // LeafUpstream returns the URL remote agents pass as NATSUpstream to
 // peer their meshes into the hub's mesh as leaf nodes.
 func (h *Hub) LeafUpstream() string {
 	assert.NotNil(h, "coord.Hub.LeafUpstream: receiver is nil")
-	addr := h.agent.MeshLeafAddr()
-	if addr == "" {
-		return ""
-	}
-	return "nats://" + addr
+	return h.hub.LeafUpstream()
 }
 
 // HTTPAddr returns the hub's HTTP listen address.
@@ -112,7 +111,8 @@ func (h *Hub) HTTPAddr() string {
 	return "http://" + h.httpAddr
 }
 
-// Stop shuts down the agent. Safe to call more than once.
+// Stop shuts down the embedded NATS server and HTTP listener. Safe to
+// call more than once; subsequent calls are no-ops.
 func (h *Hub) Stop() error {
 	assert.NotNil(h, "coord.Hub.Stop: receiver is nil")
 	h.mu.Lock()
@@ -121,9 +121,15 @@ func (h *Hub) Stop() error {
 		return nil
 	}
 	h.stopped = true
-	if h.agent != nil {
-		if err := h.agent.Stop(); err != nil {
-			return fmt.Errorf("coord.Hub.Stop: agent: %w", err)
+	if h.cancel != nil {
+		h.cancel()
+	}
+	if h.done != nil {
+		<-h.done
+	}
+	if h.hub != nil {
+		if err := h.hub.Stop(); err != nil {
+			return fmt.Errorf("coord.Hub.Stop: %w", err)
 		}
 	}
 	return nil

--- a/internal/coord/leaf.go
+++ b/internal/coord/leaf.go
@@ -10,12 +10,6 @@ import (
 	"time"
 
 	"github.com/danmestas/EdgeSync/leaf/agent"
-	"github.com/danmestas/libfossil"
-	// modernc SQLite driver, registered for libfossil.Clone in
-	// OpenLeaf's pre-agent clone path. The rest of the package goes
-	// through the EdgeSync agent, which manages its own driver
-	// registration internally.
-	_ "github.com/danmestas/libfossil/db/driver/modernc"
 
 	"github.com/danmestas/bones/internal/assert"
 )
@@ -187,28 +181,13 @@ func OpenLeaf(ctx context.Context, cfg LeafConfig) (*Leaf, error) {
 	repoPath := filepath.Join(slotDir, "leaf.fossil")
 	wtPath := filepath.Join(slotDir, "wt")
 
-	// Clone the hub repo at OpenLeaf time so leaf.fossil and hub.fossil
+	// agent.New clones from hubHTTPAddr when leaf.fossil doesn't exist
+	// (CloneFromHubURL config field), so leaf.fossil and hub.fossil
 	// share the same project-code. NATS sync subjects are
 	// "<prefix>.<project-code>.sync"; without matching codes the hub's
 	// serve-nats subscriber and the leaf's sync publisher land on
 	// different subjects and the leaf gets "no responders" errors.
-	// Idempotent: skip the clone if leaf.fossil already exists.
-	if _, err := os.Stat(repoPath); os.IsNotExist(err) {
-		// Clone with no User so libfossil skips the login card and the
-		// hub authenticates as "nobody" (which OpenHub grants 'gio').
-		// Passing User: slotID would emit a login card the hub can't
-		// verify (slotID isn't in the user table) and clone fails with
-		// "authentication failed". See internal/sync/clone.go round-1
-		// login-card logic.
-		transport := libfossil.NewHTTPTransport(hubHTTPAddr)
-		r, _, cerr := libfossil.Clone(ctx, repoPath, transport, libfossil.CloneOpts{})
-		if cerr != nil {
-			return nil, fmt.Errorf("coord.OpenLeaf: clone hub: %w", cerr)
-		}
-		_ = r.Close()
-	}
-
-	a, err := startLeafAgent(cfg, repoPath, hubNATSUpstream)
+	a, err := startLeafAgent(cfg, repoPath, hubNATSUpstream, hubHTTPAddr)
 	if err != nil {
 		return nil, err
 	}
@@ -241,24 +220,27 @@ func OpenLeaf(ctx context.Context, cfg LeafConfig) (*Leaf, error) {
 }
 
 // startLeafAgent constructs and starts the agent.Agent that owns the
-// leaf's repo. EdgeSync v0.0.10's agent.New applies the busy_timeout
-// PRAGMA internally (and deliberately does NOT cap MaxOpenConns(1) —
-// see EdgeSync#120 for the deadlock that capping caused), so bones no
-// longer reaches into the SQLite handle from this layer.
+// leaf's repo. agent.New applies SQLite tuning internally and
+// (when CloneFromHubURL is set and RepoPath doesn't exist) clones the
+// repo from the hub before opening — so OpenLeaf no longer carries a
+// pre-agent libfossil.Clone step.
 //
-// FossilUser becomes the User field on sync handshakes. The earlier
-// clone is always unauthenticated ("nobody") regardless of
+// FossilUser becomes the User field on sync handshakes. The agent's
+// internal clone is always unauthenticated ("nobody") regardless of
 // FossilUser — SlotID isn't in the hub's user table and setting User
 // during clone would fail authentication. FossilUser only affects
 // post-clone sync sessions and Commit author attribution.
-func startLeafAgent(cfg LeafConfig, repoPath, hubNATSUpstream string) (*agent.Agent, error) {
+func startLeafAgent(
+	cfg LeafConfig, repoPath, hubNATSUpstream, hubHTTPAddr string,
+) (*agent.Agent, error) {
 	agentCfg := agent.Config{
-		RepoPath:     repoPath,
-		NATSUpstream: hubNATSUpstream,
-		PeerID:       cfg.SlotID,
-		Pull:         true,
-		Push:         true,
-		Autosync:     agent.AutosyncOff,
+		RepoPath:        repoPath,
+		CloneFromHubURL: hubHTTPAddr,
+		NATSUpstream:    hubNATSUpstream,
+		PeerID:          cfg.SlotID,
+		Pull:            true,
+		Push:            true,
+		Autosync:        agent.AutosyncOff,
 	}
 	if cfg.PollInterval != 0 {
 		agentCfg.PollInterval = cfg.PollInterval

--- a/internal/hub/driver_test.go
+++ b/internal/hub/driver_test.go
@@ -1,0 +1,8 @@
+package hub
+
+// Test-only: register the modernc SQLite driver so libfossil's
+// transitive uses (via EdgeSync's hub.NewHub, which opens SQLite-backed
+// fossil repos internally) can find a driver during
+// `go test ./internal/hub/...`. Production binaries register the
+// driver at cmd/bones/main.go.
+import _ "github.com/danmestas/libfossil/db/driver/modernc"

--- a/internal/hub/hub.go
+++ b/internal/hub/hub.go
@@ -13,9 +13,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/danmestas/libfossil"
-	_ "github.com/danmestas/libfossil/db/driver/modernc"
-	natsserver "github.com/nats-io/nats-server/v2/server"
+	edgehub "github.com/danmestas/EdgeSync/hub"
 
 	"github.com/danmestas/bones/internal/registry"
 	"github.com/danmestas/bones/internal/slotgc"
@@ -186,89 +184,100 @@ func Start(ctx context.Context, root string, options ...Option) (err error) {
 func runForeground(ctx context.Context, p paths, o opts) error {
 	// Fresh-start detection (ADR 0023): if no fossil PID is alive,
 	// wipe stale checkout state so each session starts from a clean
-	// substrate. Working-tree files are untouched.
-	//
-	// SQLite -shm and -wal sidecars are part of "stale checkout state":
-	// when a prior run crashed mid-seed, libfossil leaves a 0-byte WAL
-	// and a populated SHM. The next CreateWithEnv hits
-	// SQLITE_IOERR_SHORT_READ (522) on those orphan blocks. See #138.
+	// substrate. Working-tree files are untouched. SQLite -shm and -wal
+	// sidecars are part of stale state — without removing them, the
+	// next bootstrap hits SQLITE_IOERR_SHORT_READ (522). See #138.
 	if !pidIsLive(p.fossilPid) {
 		removeRepoAndSidecars(p)
 	}
-
+	if err := os.MkdirAll(p.natsStore, 0o755); err != nil {
+		return fmt.Errorf("hub: nats store dir: %w", err)
+	}
+	freshSeed := false
 	if _, err := os.Stat(p.hubRepo); errors.Is(err, os.ErrNotExist) {
-		if err := seedHubRepoFunc(p); err != nil {
-			// Roll back any partial repo state — libfossil may have
-			// created hub.fossil and/or its -shm/-wal sidecars before
-			// the schema apply step that failed. Leaving those in
-			// place poisons the next bones hub start (#138).
-			removeRepoAndSidecars(p)
-			return fmt.Errorf("hub: seed: %w", err)
-		}
+		freshSeed = true
 	}
-
-	fossilCancel, fossilDone, err := startFossil(p, o.fossilPort)
+	h, err := openAndSeedHub(ctx, p, o, freshSeed)
 	if err != nil {
-		return fmt.Errorf("hub: fossil: %w", err)
+		return err
 	}
-
-	natsSrv, err := startNATS(p, o.natsPort)
-	if err != nil {
-		fossilCancel()
-		<-fossilDone
+	if err := writePid(p.fossilPid, os.Getpid()); err != nil {
+		_ = h.Stop()
+		return fmt.Errorf("hub: write fossil.pid: %w", err)
+	}
+	if err := writePid(p.natsPid, os.Getpid()); err != nil {
 		_ = os.Remove(p.fossilPid)
-		return fmt.Errorf("hub: nats: %w", err)
+		_ = h.Stop()
+		return fmt.Errorf("hub: write nats.pid: %w", err)
 	}
-
-	fmt.Printf("hub: fossil at http://127.0.0.1:%d, nats at nats://127.0.0.1:%d\n",
-		o.fossilPort, o.natsPort)
-
-	// Record this workspace in the cross-workspace registry so
-	// `bones status --all` can discover running hubs. Non-fatal: the hub
-	// still works without registry visibility.
+	httpDone := make(chan struct{})
+	httpCtx, httpCancel := context.WithCancel(context.Background())
+	go func() {
+		defer close(httpDone)
+		_ = h.ServeHTTP(httpCtx)
+	}()
+	fmt.Printf("hub: fossil at %s, nats at %s\n", h.HTTPAddr(), h.NATSURL())
 	if err := registry.Write(registry.Entry{
 		Cwd:       p.root,
 		Name:      filepath.Base(p.root),
-		HubURL:    fmt.Sprintf("http://127.0.0.1:%d", o.fossilPort),
-		NATSURL:   fmt.Sprintf("nats://127.0.0.1:%d", o.natsPort),
+		HubURL:    "http://" + h.HTTPAddr(),
+		NATSURL:   h.NATSURL(),
 		HubPID:    os.Getpid(),
 		StartedAt: time.Now().UTC(),
 	}); err != nil {
 		fmt.Fprintf(os.Stderr, "hub: registry write failed (non-fatal): %v\n", err)
 	}
-
 	<-ctx.Done()
-	fossilCancel()
-	natsSrv.Shutdown()
-
-	// Bound both drain waits so a stuck NATS connection (no leaf to
-	// disconnect) or a wedged Fossil checkpoint cannot keep this
-	// process alive forever (#158). On timeout, abandon the wait,
-	// log the forced exit, and propagate errDrainTimeout so the CLI
-	// exits non-zero.
-	natsDone := make(chan struct{})
-	go func() {
-		natsSrv.WaitForShutdown()
-		close(natsDone)
-	}()
-
-	var drainErr error
-	if err := waitOrTimeout(natsDone, o.drainTimeout); err != nil {
-		fmt.Fprintf(os.Stderr,
-			"hub: nats shutdown exceeded %s; forcing exit (#158)\n",
-			effectiveDrainTimeout(o.drainTimeout))
-		drainErr = err
-	}
-	if err := waitOrTimeout(fossilDone, o.drainTimeout); err != nil {
-		fmt.Fprintf(os.Stderr,
-			"hub: fossil drain exceeded %s; forcing exit (#158)\n",
-			effectiveDrainTimeout(o.drainTimeout))
-		drainErr = err
-	}
-
+	httpCancel()
+	drainErr := drainHub(h, httpDone, o.drainTimeout)
 	_ = os.Remove(p.fossilPid)
 	_ = os.Remove(p.natsPid)
 	return drainErr
+}
+
+// openAndSeedHub brings up the EdgeSync hub and seeds the repo if
+// freshSeed is true. On any failure the partial state is rolled back.
+func openAndSeedHub(
+	ctx context.Context, p paths, o opts, freshSeed bool,
+) (*edgehub.Hub, error) {
+	h, err := edgehub.NewHub(ctx, edgehub.Config{
+		RepoPath:       p.hubRepo,
+		BootstrapUser:  "orchestrator",
+		NATSStoreDir:   p.natsStore,
+		FossilHTTPPort: o.fossilPort,
+		NATSClientPort: o.natsPort,
+	})
+	if err != nil {
+		removeRepoAndSidecars(p)
+		return nil, fmt.Errorf("hub: %w", err)
+	}
+	if freshSeed {
+		if err := seedHubRepoFunc(ctx, h, p); err != nil {
+			_ = h.Stop()
+			removeRepoAndSidecars(p)
+			return nil, fmt.Errorf("hub: seed: %w", err)
+		}
+	}
+	return h, nil
+}
+
+// drainHub stops the hub and waits for ServeHTTP to exit, bounded by
+// drainTimeout. On timeout, abandons the wait, logs the forced exit,
+// and returns errDrainTimeout so the CLI exits non-zero (#158).
+func drainHub(h *edgehub.Hub, httpDone <-chan struct{}, drainTimeout time.Duration) error {
+	hubDone := make(chan struct{})
+	go func() {
+		_ = h.Stop()
+		<-httpDone
+		close(hubDone)
+	}()
+	if err := waitOrTimeout(hubDone, drainTimeout); err != nil {
+		fmt.Fprintf(os.Stderr,
+			"hub: shutdown exceeded %s; forcing exit (#158)\n",
+			effectiveDrainTimeout(drainTimeout))
+		return err
+	}
+	return nil
 }
 
 // effectiveDrainTimeout returns d when positive, otherwise the package
@@ -686,6 +695,22 @@ func writePid(pidFile string, pid int) error {
 // SQLite sidecars). Production code reaches the real implementation.
 var seedHubRepoFunc = seedHubRepo
 
+// waitForTCP polls addr until something is accepting connections or
+// timeout elapses. Used for detach-mode parent-side readiness probes
+// against the child's fossil HTTP and NATS listeners.
+func waitForTCP(addr string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		conn, err := net.DialTimeout("tcp", addr, pollInterval)
+		if err == nil {
+			_ = conn.Close()
+			return nil
+		}
+		time.Sleep(pollInterval)
+	}
+	return fmt.Errorf("timeout waiting for %s after %s", addr, timeout)
+}
+
 // removeRepoAndSidecars deletes the hub.fossil file and its SQLite
 // -shm / -wal sidecars together. The three travel as a unit: deleting
 // only hub.fossil leaves the sidecars to poison the next CreateWithEnv
@@ -702,50 +727,34 @@ func removeRepoAndSidecars(p paths) {
 	}
 }
 
-func seedHubRepo(p paths) error {
-	r, err := libfossil.Create(p.hubRepo, libfossil.CreateOpts{User: "orchestrator"})
-	if err != nil {
-		return fmt.Errorf("create repo: %w", err)
-	}
-	_ = r.Close()
-
+func seedHubRepo(ctx context.Context, h *edgehub.Hub, p paths) error {
 	files, err := gitTrackedFiles(p.root)
 	if err != nil {
-		_ = os.Remove(p.hubRepo)
 		return err
 	}
 	if len(files) == 0 {
-		_ = os.Remove(p.hubRepo)
 		return errors.New("no git-tracked files to seed from")
 	}
 
 	shortSHA, err := gitShortSHA(p.root)
 	if err != nil {
-		_ = os.Remove(p.hubRepo)
 		return err
 	}
-
-	repo, err := libfossil.Open(p.hubRepo)
-	if err != nil {
-		return fmt.Errorf("reopen repo: %w", err)
-	}
-	defer func() { _ = repo.Close() }()
 
 	// Build FileToCommit list from every tracked path. Reading every
 	// file into memory mirrors the bash flow (xargs fossil add); for
 	// the workspace sizes we target (single repo, hundreds of MB at
-	// most) this is fine. If it ever isn't, switch to OpenCheckout +
-	// Add + Checkin which streams off disk.
-	commitFiles := make([]libfossil.FileToCommit, 0, len(files))
+	// most) this is fine.
+	commitFiles := make([]edgehub.FileToCommit, 0, len(files))
 	for _, rel := range files {
 		abs := filepath.Join(p.root, rel)
 		info, err := os.Lstat(abs)
 		if err != nil {
 			return fmt.Errorf("stat %s: %w", rel, err)
 		}
-		// Skip symlinks and non-regular files: libfossil's commit path
-		// expects bytes, and the bash script's `fossil add` handled
-		// these as a no-op via fossil's own filters.
+		// Skip symlinks and non-regular files; the bash script's
+		// `fossil add` handled these as a no-op via fossil's own
+		// filters.
 		if !info.Mode().IsRegular() {
 			continue
 		}
@@ -757,17 +766,17 @@ func seedHubRepo(p paths) error {
 		if info.Mode()&0o111 != 0 {
 			perm = "x"
 		}
-		commitFiles = append(commitFiles, libfossil.FileToCommit{
+		commitFiles = append(commitFiles, edgehub.FileToCommit{
 			Name:    rel,
 			Content: data,
 			Perm:    perm,
 		})
 	}
 
-	_, _, err = repo.Commit(libfossil.CommitOpts{
+	_, err = h.Commit(ctx, edgehub.CommitOpts{
 		Files:   commitFiles,
-		Comment: fmt.Sprintf("session base: %s", shortSHA),
-		User:    "orchestrator",
+		Message: fmt.Sprintf("session base: %s", shortSHA),
+		Author:  "orchestrator",
 		Time:    time.Now().UTC(),
 	})
 	if err != nil {
@@ -837,119 +846,3 @@ func gitShortSHA(root string) (string, error) {
 // Returns a cancel func that stops the server, a done channel that
 // closes when the server goroutine exits, and the readiness check has
 // already succeeded by the time this returns.
-func startFossil(p paths, port int) (cancel context.CancelFunc, done chan struct{}, err error) {
-	repo, err := libfossil.Open(p.hubRepo)
-	if err != nil {
-		return nil, nil, fmt.Errorf("open repo: %w", err)
-	}
-
-	addr := fmt.Sprintf("127.0.0.1:%d", port)
-	ctx, cancelFn := context.WithCancel(context.Background())
-	done = make(chan struct{})
-
-	// libfossil.ServeHTTP blocks until ctx is canceled. Run it in a
-	// goroutine and probe the listener for readiness.
-	go func() {
-		defer close(done)
-		defer func() { _ = repo.Close() }()
-		_ = repo.ServeHTTP(ctx, addr)
-	}()
-
-	if err := waitForTCP(addr, readyTimeout); err != nil {
-		cancelFn()
-		<-done
-		return nil, nil, fmt.Errorf("fossil readiness: %w", err)
-	}
-
-	if err := writePid(p.fossilPid, os.Getpid()); err != nil {
-		cancelFn()
-		<-done
-		return nil, nil, fmt.Errorf("write fossil.pid: %w", err)
-	}
-	return cancelFn, done, nil
-}
-
-// startNATS launches an embedded NATS server with JetStream rooted at
-// p.natsStore. Equivalent to `nats-server -js -p <port>`. The store
-// directory persists across hub restarts so JetStream streams survive a
-// reopen — the bash flow relied on the OS process owning that state.
-//
-// Retries readiness up to natsBootstrapAttempts times with exponential
-// backoff between attempts (ADR 0034). The single-attempt 5s probe in
-// the original implementation was the documented cause of operators
-// believing bones was unreliable on loaded machines.
-func startNATS(p paths, port int) (*natsserver.Server, error) {
-	if err := os.MkdirAll(p.natsStore, 0o755); err != nil {
-		return nil, fmt.Errorf("nats store dir: %w", err)
-	}
-	opts := &natsserver.Options{
-		Host:      "127.0.0.1",
-		Port:      port,
-		JetStream: true,
-		StoreDir:  p.natsStore,
-		// Use a stable name so JetStream metadata is reusable across
-		// restarts. NoLog/NoSigs differ from the test fixture: this is
-		// a daemon, not a test server, so we want logs and we don't
-		// want NATS to install signal handlers (the parent process owns
-		// shutdown via Stop / ctx).
-		NoSigs:     true,
-		ServerName: "bones-hub",
-	}
-
-	backoff := natsBootstrapBackoff
-	var lastErr error
-	for attempt := 1; attempt <= natsBootstrapAttempts; attempt++ {
-		srv, err := tryStartNATS(opts, p)
-		if err == nil {
-			return srv, nil
-		}
-		lastErr = err
-		if attempt < natsBootstrapAttempts {
-			time.Sleep(backoff)
-			backoff *= 2
-		}
-	}
-	return nil, fmt.Errorf("nats bootstrap failed after %d attempts: %w",
-		natsBootstrapAttempts, lastErr)
-}
-
-// tryStartNATS performs one bootstrap attempt. Caller retries on
-// failure. A failed attempt fully tears down the server so the
-// retry sees a clean state; this is correct because NATS holds
-// listening sockets that would otherwise block the next attempt.
-func tryStartNATS(opts *natsserver.Options, p paths) (*natsserver.Server, error) {
-	srv, err := natsserver.NewServer(opts)
-	if err != nil {
-		return nil, fmt.Errorf("new server: %w", err)
-	}
-
-	go srv.Start()
-	if !srv.ReadyForConnections(readyTimeout) {
-		srv.Shutdown()
-		srv.WaitForShutdown()
-		return nil, fmt.Errorf("nats not ready within %s", readyTimeout)
-	}
-	if err := writePid(p.natsPid, os.Getpid()); err != nil {
-		srv.Shutdown()
-		srv.WaitForShutdown()
-		return nil, fmt.Errorf("write nats.pid: %w", err)
-	}
-	return srv, nil
-}
-
-// waitForTCP polls addr until something is accepting connections or
-// timeout elapses. Used as the fossil-server readiness probe; libfossil
-// does not currently expose a ReadyForConnections-style hook so we
-// dial-test instead.
-func waitForTCP(addr string, timeout time.Duration) error {
-	deadline := time.Now().Add(timeout)
-	for time.Now().Before(deadline) {
-		conn, err := net.DialTimeout("tcp", addr, pollInterval)
-		if err == nil {
-			_ = conn.Close()
-			return nil
-		}
-		time.Sleep(pollInterval)
-	}
-	return fmt.Errorf("timeout waiting for %s after %s", addr, timeout)
-}

--- a/internal/hub/runforeground_test.go
+++ b/internal/hub/runforeground_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	edgehub "github.com/danmestas/EdgeSync/hub"
 )
 
 // TestWaitOrTimeout_DoneClosed asserts the bounded-wait helper returns
@@ -82,17 +84,7 @@ func TestRunForeground_SeedFailureCleansSidecars(t *testing.T) {
 
 	orig := seedHubRepoFunc
 	defer func() { seedHubRepoFunc = orig }()
-	seedHubRepoFunc = func(p paths) error {
-		// Simulate libfossil partial init: a 0-byte hub.fossil and the
-		// SQLite -shm / -wal sidecars land before schema apply errors.
-		if err := os.WriteFile(p.hubRepo, []byte{}, 0o644); err != nil {
-			return err
-		}
-		for _, suffix := range []string{"-shm", "-wal"} {
-			if err := os.WriteFile(p.hubRepo+suffix, []byte{}, 0o644); err != nil {
-				return err
-			}
-		}
+	seedHubRepoFunc = func(_ context.Context, _ *edgehub.Hub, p paths) error {
 		return errors.New("synthetic seed failure")
 	}
 
@@ -106,7 +98,9 @@ func TestRunForeground_SeedFailureCleansSidecars(t *testing.T) {
 
 	// hub.fossil and its -shm/-wal sidecars must all be cleaned so the
 	// next bones hub start does not hit SQLITE_IOERR_SHORT_READ on
-	// stale journal state.
+	// stale journal state. NewHub creates hub.fossil before
+	// seedHubRepoFunc runs; runForeground's seed-failure branch calls
+	// h.Stop() (closing the libfossil handle) then removeRepoAndSidecars.
 	leftovers := []string{p.hubRepo, p.hubRepo + "-shm", p.hubRepo + "-wal"}
 	for _, path := range leftovers {
 		if _, statErr := os.Stat(path); statErr == nil {
@@ -118,10 +112,12 @@ func TestRunForeground_SeedFailureCleansSidecars(t *testing.T) {
 	}
 }
 
-// TestRunForeground_FreshStartCleansStaleSidecars asserts the
-// pre-seed cleanup at the top of runForeground also removes
-// SQLite sidecars left from a prior crash. Otherwise the very next
-// seedHubRepo call inherits stale WAL state and reports a short-read.
+// TestRunForeground_FreshStartCleansStaleSidecars asserts that stale
+// SQLite sidecars from a prior crashed run don't poison the next
+// startup with SQLITE_IOERR_SHORT_READ (522). runForeground's
+// pre-NewHub cleanup (removeRepoAndSidecars when fossil.pid is dead)
+// removes them before edgehub.NewHub opens the repo, so NewHub
+// succeeds and the synthetic seed-failure path runs cleanly.
 // See issue #138.
 func TestRunForeground_FreshStartCleansStaleSidecars(t *testing.T) {
 	root := t.TempDir()
@@ -134,31 +130,28 @@ func TestRunForeground_FreshStartCleansStaleSidecars(t *testing.T) {
 	}
 
 	// Plant stale sidecars from a prior failed run. No fossil.pid → the
-	// fresh-start branch should fire and wipe them.
+	// fresh-start branch should fire and wipe them before NewHub runs.
 	for _, suffix := range []string{"-shm", "-wal"} {
 		if err := os.WriteFile(p.hubRepo+suffix, []byte("stale"), 0o644); err != nil {
 			t.Fatal(err)
 		}
 	}
 
-	// Replace seed with one that observes whether the sidecars are
-	// gone by the time it's invoked. Returns an error to keep the rest
-	// of runForeground from spinning up real servers.
+	// Synthetic seed failure to keep the rest of runForeground from
+	// spinning up real servers. The interesting assertion is that
+	// runForeground reaches the seed step at all (it would have failed
+	// inside NewHub with SQLITE_IOERR_SHORT_READ if cleanup hadn't run).
 	orig := seedHubRepoFunc
 	defer func() { seedHubRepoFunc = orig }()
-	var sawSidecars bool
-	seedHubRepoFunc = func(p paths) error {
-		for _, suffix := range []string{"-shm", "-wal"} {
-			if _, err := os.Stat(p.hubRepo + suffix); err == nil {
-				sawSidecars = true
-			}
-		}
+	seedHubRepoFunc = func(_ context.Context, _ *edgehub.Hub, p paths) error {
 		return errors.New("synthetic post-cleanup seed failure")
 	}
 
-	_ = runForeground(context.Background(), p, opts{})
-	if sawSidecars {
-		t.Fatal("fresh-start should remove stale -shm/-wal before seedHubRepo " +
-			"runs; sidecars still present")
+	err = runForeground(context.Background(), p, opts{})
+	if err == nil {
+		t.Fatal("expected seed-failure error")
+	}
+	if !strings.Contains(err.Error(), "synthetic post-cleanup seed failure") {
+		t.Fatalf("expected synthetic seed-failure error, got: %v", err)
 	}
 }

--- a/internal/swarm/driver_test.go
+++ b/internal/swarm/driver_test.go
@@ -1,0 +1,8 @@
+package swarm
+
+// Test-only: register the modernc SQLite driver so libfossil's
+// transitive uses (via EdgeSync's hub.NewHub, which opens SQLite-backed
+// fossil repos internally) can find a driver during
+// `go test ./internal/swarm/...`. Production binaries register the
+// driver at cmd/bones/main.go.
+import _ "github.com/danmestas/libfossil/db/driver/modernc"


### PR DESCRIPTION
## Summary

Completes the hub-side libfossil migration tracked by #186. With EdgeSync v0.0.12 + leaf v0.0.10 shipping the last three API gaps (CloneFromHubURL, DisableFossilSyncOverNATS default-false, hub.FileToCommit.Perm + CommitOpts.Time), bones core no longer makes any direct libfossil calls outside SQLite driver registration.

- **internal/coord/leaf.go** — drop libfossil.Clone in OpenLeaf; agent.Config.CloneFromHubURL handles initial clone inside the agent
- **internal/coord/hub.go** — re-migrate to edgehub.NewHub with NobodyCaps="gio" (default fossil-sync-over-NATS subscriber stays enabled)
- **internal/hub/hub.go** — replace startFossil + startNATS + seedHubRepo with edgehub.NewHub + Hub.ServeHTTP + Hub.Commit. runForeground refactored into runForeground / openAndSeedHub / drainHub to satisfy funlen
- **driver_test.go** in internal/coord, internal/hub, internal/swarm, examples/hub-leaf-e2e — test-only blank import for libfossil/db/driver/modernc since EdgeSync's hub package transitively uses libfossil but doesn't auto-register the driver

## On #188

This PR does NOT close #188 (final go.mod drop). libfossil v0.5.0 + db/driver/modernc v0.1.0 stay as direct requires:

- **modernc** is needed for SQLite driver registration in production (cmd/bones/main.go) and tests. EdgeSync packages don't auto-register
- **libfossil v0.5.0** is still imported by examples (libfossil.Open + r.DB().QueryRow for raw event-table introspection that hub.Repo doesn't expose) and demos

To finish #188, two new EdgeSync gaps would need to ship:
1. EdgeSync owns SQLite driver registration (so consumers don't need the modernc subpackage directly)
2. hub.Repo exposes a CheckinCount or DB accessor (so examples can drop libfossil.Open)

## Test plan

- [x] make check — fmt-check, vet, lint, race -short, todo-check all pass
- [x] go test -count=1 -tags=otel -short -timeout 300s ./... — full CI parity, all pass
- [x] hub-leaf-e2e TestE2E_3x3 passes (new driver_test.go registration verified)
- [x] internal/swarm/lease_test.go passes (driver_test.go fixes the panic that surfaced after coord.OpenHub started routing through edgehub.NewHub → libfossil.Create)

Closes #186