### PR TITLE
fix(swarm): preflight holds-bucket reachability on swarm join (#155)

### DIFF
--- a/cmd/bones/integration/swarm_test.go
+++ b/cmd/bones/integration/swarm_test.go
@@ -182,6 +182,79 @@ func TestCLI_Swarm(t *testing.T) {
 	})
 }
 
+// TestCLI_SwarmCommit_AfterHubRestart exercises the regression
+// surface from #155 + #157: a hub stop/start cycle must leave the
+// substrate healthy enough that a fresh slot's join + commit
+// succeeds. With the swarm.Acquire preflight in place
+// (Leaf.ProbeSubstrate), an unreachable holds bucket would be
+// surfaced at join time with "hub up but holds bucket unreachable"
+// rather than the original "no responders" at commit time.
+func TestCLI_SwarmCommit_AfterHubRestart(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip in -short: integration test")
+	}
+	requireBinaries(t)
+	dir := setupSwarmWorkspace(t)
+	if resolved, err := filepath.EvalSymlinks(dir); err == nil {
+		dir = resolved
+	}
+	httpPort, natsPort := pickPortPair(t)
+	startSwarmHub(t, dir, httpPort, natsPort)
+
+	// Stop the hub via the CLI (matches the operator-visible repro).
+	if _, stderr, code := runCmd(t, bonesBin, dir, "hub", "stop"); code != 0 {
+		t.Fatalf("hub stop exit=%d stderr=%s", code, stderr)
+	}
+	// Restart on the same recorded ports — #157's fix preserves the
+	// URL across restart so leaf-side discovery doesn't drift.
+	if _, stderr, code := runCmd(t, bonesBin, dir, "hub", "start", "--detach"); code != 0 {
+		t.Fatalf("hub restart exit=%d stderr=%s", code, stderr)
+	}
+
+	// The recorded URL after restart is the source of truth.
+	hubURLBytes, err := os.ReadFile(filepath.Join(dir, ".bones", "hub-fossil-url"))
+	if err != nil {
+		t.Fatalf("read hub-fossil-url: %v", err)
+	}
+	hubURL := strings.TrimSpace(string(hubURLBytes))
+
+	relFile := "rendering/post-restart.txt"
+	absFile := filepath.Join(dir, relFile)
+	taskID := createSwarmTask(t, dir, absFile, "[slot: rendering] post-restart")
+	slot := "rendering"
+
+	if _, stderr, code := runCmd(t, bonesBin, dir,
+		"swarm", "join",
+		"--slot="+slot, "--task-id="+taskID,
+		"--hub-url="+hubURL,
+	); code != 0 {
+		t.Fatalf("swarm join after restart exit=%d stderr=%s", code, stderr)
+	}
+
+	wt := filepath.Join(dir, ".bones", "swarm", slot, "wt")
+	filePath := filepath.Join(wt, "rendering", "post-restart.txt")
+	if err := os.MkdirAll(filepath.Dir(filePath), 0o755); err != nil {
+		t.Fatalf("mkdir wt subdir: %v", err)
+	}
+	if err := os.WriteFile(filePath, []byte("post-restart\n"), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	stdout, stderr, code := runCmd(t, bonesBin, dir,
+		"swarm", "commit",
+		"--slot="+slot, "-m=post-restart commit",
+		"--hub-url="+hubURL,
+		"rendering/post-restart.txt",
+	)
+	if code != 0 {
+		t.Fatalf("swarm commit after restart exit=%d stderr=%s stdout=%s",
+			code, stderr, stdout)
+	}
+	if uuid := firstLine(stdout); len(uuid) < 16 {
+		t.Errorf("expected commit uuid on first line, got %q", stdout)
+	}
+}
+
 // TestCLI_SwarmReap exercises the end-to-end reap flow: join a
 // slot, never commit, then run `bones swarm reap --threshold=1ms`
 // to force the session into stale classification and verify it

--- a/internal/coord/leaf.go
+++ b/internal/coord/leaf.go
@@ -395,6 +395,18 @@ func (l *Leaf) AnnounceHolds(
 	return rel, nil
 }
 
+// ProbeSubstrate verifies the hub's holds-bucket KV is reachable
+// end-to-end. Returns nil when the substrate is healthy; surfaces the
+// underlying transport error otherwise (commonly nats.ErrNoResponders
+// when JetStream KV cannot be reached). Used by `bones swarm join` as
+// a preflight so a doomed-at-commit-time substrate fails fast at join
+// time with the same root-cause error rather than later (#155).
+func (l *Leaf) ProbeSubstrate(ctx context.Context) error {
+	assert.NotNil(l, "coord.Leaf.ProbeSubstrate: receiver is nil")
+	assert.NotNil(ctx, "coord.Leaf.ProbeSubstrate: ctx is nil")
+	return l.coord.sub.holds.Probe(ctx)
+}
+
 // Commit writes files into the leaf's libfossil repo as a new checkin
 // authored by the slot, then triggers a sync round (SyncNow).
 //

--- a/internal/holds/holds.go
+++ b/internal/holds/holds.go
@@ -92,6 +92,33 @@ func Open(ctx context.Context, nc *nats.Conn, cfg Config) (*Manager, error) {
 	return &Manager{cfg: cfg, nc: nc, js: js, kv: kv, buf: buf}, nil
 }
 
+// probeKey is the sentinel KV key Probe reads. Reserved name in the
+// bucket's allowed alphabet ([A-Za-z0-9/_=.-]+) — never written, so a
+// successful Probe always observes ErrKeyNotFound.
+const probeKey = "_probe"
+
+// Probe verifies the bucket is reachable end-to-end by issuing a Get
+// on a sentinel key that is never written. A healthy bucket returns
+// ErrKeyNotFound (which Probe maps to nil); any other error is
+// returned verbatim so callers see the underlying transport failure
+// (commonly nats.ErrNoResponders when JetStream KV is unreachable).
+//
+// Used by `bones swarm join` as a preflight: the alternative is
+// accepting the join and failing later at commit time with the same
+// underlying error but a worse failure surface (#155).
+func (m *Manager) Probe(ctx context.Context) error {
+	assert.NotNil(m, "holds.Probe: receiver is nil")
+	assert.NotNil(ctx, "holds.Probe: ctx is nil")
+	if m.done.Load() {
+		return ErrClosed
+	}
+	_, err := m.kv.Get(ctx, probeKey)
+	if err == nil || errors.Is(err, jetstream.ErrKeyNotFound) {
+		return nil
+	}
+	return fmt.Errorf("holds.Probe: %w", err)
+}
+
 // Close releases resources held by the Manager. It closes every live
 // Subscribe channel and marks the Manager as closed so subsequent
 // public calls return ErrClosed. Safe to call more than once.

--- a/internal/holds/holds_test.go
+++ b/internal/holds/holds_test.go
@@ -178,6 +178,32 @@ func TestWhoHas_NotClaimed_ReturnsFalse(t *testing.T) {
 	}
 }
 
+// TestProbe_HappyPath asserts that Probe returns nil against a healthy
+// JetStream KV bucket — the sentinel key is intentionally never written
+// so a successful round-trip surfaces ErrKeyNotFound, which Probe maps
+// to nil. This is the swarm-join preflight's success path (#155).
+func TestProbe_HappyPath(t *testing.T) {
+	m, _, cleanup := openTestManager(t)
+	defer cleanup()
+	if err := m.Probe(context.Background()); err != nil {
+		t.Fatalf("Probe: %v", err)
+	}
+}
+
+// TestProbe_AfterClose asserts that Probe returns ErrClosed once the
+// Manager has been closed, mirroring the contract of the other public
+// methods.
+func TestProbe_AfterClose(t *testing.T) {
+	m, _, cleanup := openTestManager(t)
+	defer cleanup()
+	if err := m.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if err := m.Probe(context.Background()); !errors.Is(err, holds.ErrClosed) {
+		t.Fatalf("Probe after Close: got %v, want ErrClosed", err)
+	}
+}
+
 func TestKeyEncoding_PreservesPathWithSpaces(t *testing.T) {
 	m, _, cleanup := openTestManager(t)
 	defer cleanup()

--- a/internal/swarm/lease.go
+++ b/internal/swarm/lease.go
@@ -843,9 +843,14 @@ func defaultAcquireOpts(opts AcquireOpts) (func() time.Time, string, string) {
 	return now, hubURL, caps
 }
 
-// openLeafAndClaim opens the per-slot coord.Leaf and acquires a
-// claim on the named task. On error, any partially-opened leaf is
-// stopped before return.
+// openLeafAndClaim opens the per-slot coord.Leaf, probes the substrate
+// for end-to-end reachability, and acquires a claim on the named task.
+// On error, any partially-opened leaf is stopped before return.
+//
+// The substrate probe (Leaf.ProbeSubstrate) gates the rest of the join
+// flow on holds-bucket reachability so a doomed-at-commit-time
+// substrate fails fast at join time with the same root-cause error
+// rather than later (#155).
 func openLeafAndClaim(
 	ctx context.Context, info workspace.Info,
 	slot, fossilUser, hubURL, taskID string, hub *coord.Hub, autosync bool,
@@ -853,6 +858,12 @@ func openLeafAndClaim(
 	leaf, err := openLeaf(ctx, info, slot, fossilUser, hubURL, hub, autosync)
 	if err != nil {
 		return nil, nil, fmt.Errorf("swarm.Acquire: open leaf: %w", err)
+	}
+	if perr := leaf.ProbeSubstrate(ctx); perr != nil {
+		_ = leaf.Stop()
+		return nil, nil, fmt.Errorf(
+			"swarm.Acquire: hub up but holds bucket unreachable on %s: %w",
+			hubURL, perr)
 	}
 	if err := os.MkdirAll(leaf.WT(), 0o755); err != nil {
 		_ = leaf.Stop()


### PR DESCRIPTION
## Summary

Closes #155 — `bones swarm commit` was failing late with `nats: no responders available` when the holds-bucket KV was unreachable. The substrate fault was present at join time but only surfaced at commit time, costing the operator retry loops with no actionable signal.

- **internal/holds/holds.go** — add `Manager.Probe(ctx)`: cheap KV.Get on a reserved sentinel key (`_probe`), KeyNotFound mapped to nil, anything else returned verbatim so callers see the underlying transport error
- **internal/coord/leaf.go** — `Leaf.ProbeSubstrate(ctx)` delegates to `coord.sub.holds.Probe`, exposing the same check at the leaf surface
- **internal/swarm/lease.go** — `openLeafAndClaim` runs the probe between leaf open and worktree mkdir. On failure: stop the leaf cleanly and return `swarm.Acquire: hub up but holds bucket unreachable on <url>: <underlying err>`
- **cmd/bones/integration/swarm_test.go** — `TestCLI_SwarmCommit_AfterHubRestart` covers hub stop/start → fresh join + commit (regression surface for #155 + #157 together)

## On dominant root cause

#155's original failures were mostly downstream of two issues that already merged:

- **#157** — refuse hub stop on active slots, preserve URL across restart (closed)
- **cccdf32** — NATS-failure diagnostic on swarm verb errors

This PR adds the preflight that #155's acceptance criteria explicitly asked for ("`bones swarm join` succeeds only when commit-time AnnounceHolds will succeed; otherwise it fails fast"). With #157's URL persistence + this preflight, the original repro can't trigger anymore — but if any new failure mode reintroduces an unreachable substrate, the join will surface it at the front door rather than at commit.

## Test plan

- [x] `make check` — fmt-check, vet, lint, race -short, todo-check all pass
- [x] `go test -count=1 -tags=otel -short ./...` — full CI parity
- [x] `TestCLI_SwarmCommit_AfterHubRestart` passes (new integration test)
- [x] `TestProbe_HappyPath` + `TestProbe_AfterClose` pass (Probe contract)
- [x] End-to-end live repro: `bones up` → `hub start` → `tasks create` → `swarm join` → `swarm commit` succeeds against a fresh workspace

Note: pre-existing `TestCLI_Watch_Smoke` failure on main is unrelated (`git ls-files: exit status 128` from a workspace setup that doesn't `git init`); will file separately.

Closes #155