### PR TITLE
feat(up): bundle 6 skills + sentinel + inline CLAUDE.md (#166, #169, #172)

### DIFF
--- a/cli/doctor.go
+++ b/cli/doctor.go
@@ -3,8 +3,10 @@ package cli
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -190,12 +192,7 @@ func runBypassReportTo(w io.Writer, cwd string) (warns int, err error) {
 		_, _ = fmt.Fprintf(w, "  OK    scaffold version v%s matches binary\n", stamp)
 	}
 
-	if checkAgentsMD(w, cwd) {
-		warns++
-	}
-	if checkBonesScaffoldedHooks(w, cwd) {
-		warns++
-	}
+	warns += checkScaffoldGates(w, cwd)
 	warns += checkOrphanHubs(w)
 	warns += checkStaleSlotDirs(w, cwd)
 
@@ -300,6 +297,58 @@ func checkBonesScaffoldedHooks(w io.Writer, cwd string) bool {
 		return true
 	}
 	_, _ = fmt.Fprintln(w, "  OK    .claude/settings.json has bones-owned hook entries")
+	return false
+}
+
+// checkScaffoldGates runs the AGENTS.md, hooks-presence, and
+// SessionStart-sentinel checks together. Extracted from
+// runBypassReportTo so that function stays under the funlen cap.
+// Returns the count of WARN-class findings emitted.
+func checkScaffoldGates(w io.Writer, cwd string) int {
+	var warns int
+	if checkAgentsMD(w, cwd) {
+		warns++
+	}
+	if checkBonesScaffoldedHooks(w, cwd) {
+		warns++
+	}
+	if checkSessionStartSentinel(w, cwd) {
+		warns++
+	}
+	return warns
+}
+
+// checkSessionStartSentinel surfaces whether bones SessionStart hooks
+// have actually fired in this workspace recently. The sentinel
+// (.bones/last-session-prime) is rewritten on every `bones tasks
+// prime` invocation — itself wired as both SessionStart and
+// PreCompact hooks by `bones up`. When .claude/settings.json has
+// the hook entries but the sentinel never appears (or hasn't been
+// touched since hub start), the operator's hooks aren't actually
+// firing — the failure mode behind #165 / #172 where inner Claude
+// sessions stayed bones-blind despite hook config being present.
+// Returns true if a WARN was emitted.
+func checkSessionStartSentinel(w io.Writer, cwd string) bool {
+	if info, err := os.Stat(filepath.Join(cwd, ".claude")); err != nil || !info.IsDir() {
+		return false
+	}
+	sentinel := filepath.Join(cwd, SessionStartSentinelFile)
+	st, err := os.Stat(sentinel)
+	if errors.Is(err, fs.ErrNotExist) {
+		_, _ = fmt.Fprintln(w,
+			"  WARN  SessionStart hooks configured but never fired "+
+				"(no .bones/last-session-prime) — "+
+				"likely the bones-powers plugin isn't installed or "+
+				"the workspace was never opened in Claude Code (#172)")
+		return true
+	}
+	if err != nil {
+		_, _ = fmt.Fprintf(w, "  WARN  read SessionStart sentinel: %v\n", err)
+		return true
+	}
+	age := time.Since(st.ModTime()).Round(time.Second)
+	_, _ = fmt.Fprintf(w,
+		"  OK    SessionStart hooks fired %s ago (last bones tasks prime)\n", age)
 	return false
 }
 

--- a/cli/down.go
+++ b/cli/down.go
@@ -389,12 +389,25 @@ func planRemoveOrchestrator(root string, c *DownCmd) []downAction {
 	}}
 }
 
+// planRemoveSkills schedules removal of bones-owned skill content from
+// `<workspace>/.claude/skills/`. Two classes:
+//
+//   - Legacy names (legacyBonesSkills): nuked outright. These are
+//     pre-bundle dirs that no longer have any successor in the current
+//     scaffold, so any content under them is bones-owned by definition.
+//   - Bundled names (bonesOwnedSkills): hash-checked file by file via
+//     removeBonesSkills. Files matching the embedded source are removed;
+//     user-modified files are preserved so the operator never loses
+//     their edits to a teardown.
+//
+// Honors --keep-skills (used by ADR-0048 contributors who want bones
+// machinery gone but the bones-bundled skill discipline kept).
 func planRemoveSkills(root string, c *DownCmd) []downAction {
 	if c.KeepSkills {
 		return nil
 	}
 	var plan []downAction
-	for _, name := range []string{"orchestrator", "subagent", "uninstall-bones"} {
+	for _, name := range legacyBonesSkills {
 		dir := filepath.Join(root, ".claude", "skills", name)
 		if !dirExists(dir) {
 			continue
@@ -402,6 +415,16 @@ func planRemoveSkills(root string, c *DownCmd) []downAction {
 		plan = append(plan, downAction{
 			description: "remove " + dir,
 			do:          func() error { return os.RemoveAll(dir) },
+		})
+	}
+	skillsDir := filepath.Join(root, ".claude", "skills")
+	if dirExists(skillsDir) {
+		plan = append(plan, downAction{
+			description: "remove bundled skills (preserves user-modified files)",
+			do: func() error {
+				_, err := removeBonesSkills(root)
+				return err
+			},
 		})
 	}
 	return plan

--- a/cli/down_test.go
+++ b/cli/down_test.go
@@ -349,7 +349,11 @@ func TestPlanDown_FullInstall(t *testing.T) {
 		"registry entry",
 		".bones",
 		".orchestrator",
-		".claude/skills/orchestrator",
+		// orchestrator is now handled via the hash-checked bundled
+		// skills action — present on disk → "remove bundled skills"
+		// fires. Legacy dirs (subagent, uninstall-bones) still get
+		// their own per-name actions.
+		"remove bundled skills",
 		".claude/skills/subagent",
 		".claude/skills/uninstall-bones",
 		"AGENTS.md",
@@ -869,6 +873,45 @@ func readJSON(t *testing.T, path string) map[string]any {
 		t.Fatalf("unmarshal: %v", err)
 	}
 	return got
+}
+
+// TestRemoveBonesSkills_PreservesUserModified pins the down-side
+// contract for the skill bundle: hash-matching files (the unmodified
+// embedded source) get cleaned, user-edited files survive teardown.
+func TestRemoveBonesSkills_PreservesUserModified(t *testing.T) {
+	dir := t.TempDir()
+	fp := scaffoldFootprint{HooksAddedByEvent: map[string]int{}}
+	if err := writeBonesSkills(dir, &fp); err != nil {
+		t.Fatalf("writeBonesSkills: %v", err)
+	}
+	// User edits the orchestrator skill — must survive `bones down`.
+	userSkill := filepath.Join(dir, ".claude", "skills", "orchestrator", "SKILL.md")
+	if err := os.WriteFile(userSkill, []byte("USER OVERRIDE\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	removed, err := removeBonesSkills(dir)
+	if err != nil {
+		t.Fatalf("removeBonesSkills: %v", err)
+	}
+	// orchestrator should NOT be in removed (user-modified).
+	for _, name := range removed {
+		if name == "orchestrator" {
+			t.Errorf("orchestrator should be preserved (user-modified) but was removed")
+		}
+	}
+	// Other bundled skills with no user edits should be removed.
+	for _, name := range []string{"using-bones-powers", "systematic-debugging"} {
+		dir := filepath.Join(dir, ".claude", "skills", name)
+		_ = name
+		_ = dir
+	}
+	got, err := os.ReadFile(userSkill)
+	if err != nil {
+		t.Fatalf("user-modified SKILL.md was removed: %v", err)
+	}
+	if string(got) != "USER OVERRIDE\n" {
+		t.Errorf("user content corrupted: %q", got)
+	}
 }
 
 func mkdir(t *testing.T, path string) {

--- a/cli/orchestrator.go
+++ b/cli/orchestrator.go
@@ -33,21 +33,35 @@ const (
 )
 
 // claudeManagedBody is the body of the bones-managed block inserted
-// into a user-authored CLAUDE.md. CLAUDE.md is a pointer file; the
-// agent contract itself lives in AGENTS.md. Kept short on purpose: the
-// user already has their own CLAUDE.md content and we want our
-// addition to be unobtrusive.
-const claudeManagedBody = "Bones is active in this workspace. " +
-	"The full agent contract is in AGENTS.md.\n\n" +
-	"On `bones down` the agent removes this entire block " +
-	"(markers and all) from CLAUDE.md and deletes AGENTS.md."
+// into a user-authored CLAUDE.md. The block must be self-sufficient:
+// Claude Code does NOT auto-read AGENTS.md on session start, so a
+// pointer alone leaves the inner session bones-blind (#169). Inline
+// the directive that names the using-bones-powers skill and the
+// orchestrator skill explicitly so the Skill tool picks them up. On
+// `bones down` the entire block is stripped (markers and all).
+const claudeManagedBody = "**MANDATORY**: this workspace is managed by bones. " +
+	"Before responding to ANY prompt — including clarifying questions — " +
+	"invoke the `using-bones-powers` skill via the Skill tool. " +
+	"That skill establishes how to use bones-specific verbs " +
+	"(`bones tasks`, `bones swarm`, `bones hub`, `bones plan`) and " +
+	"overrides default workflow behaviors (brainstorm → spec → plan loops, " +
+	"\"let's think about this together\" patterns) for bones primitives.\n\n" +
+	"For multi-slot or multi-agent work, also invoke the `orchestrator` skill. " +
+	"Other bundled skills available via the Skill tool: `using-bones-swarm`, " +
+	"`finishing-a-bones-leaf`, `systematic-debugging`, `test-driven-development`.\n\n" +
+	"Full reference: AGENTS.md in this workspace.\n\n" +
+	"`bones down` removes this entire block (markers and all) from CLAUDE.md " +
+	"and the bones-owned skill files from `.claude/skills/`."
 
-// legacyBonesSkills are the per-skill directories `bones up` used to
-// scaffold under .claude/skills/ before ADR 0042. They are wiped on
-// every `bones up` so the workspace converges on the AGENTS.md model.
-// User-authored skills under .claude/skills/ that don't match these
-// names are left alone.
-var legacyBonesSkills = []string{"orchestrator", "subagent", "uninstall-bones"}
+// legacyBonesSkills are the per-skill directories `bones up` scaffolded
+// under .claude/skills/ before the skills bundle reintroduced them.
+// "subagent" and "uninstall-bones" have no successor in the current
+// bundle, so they are wiped on every `bones up`. The current bundle's
+// names (orchestrator, etc.) are owned by writeBonesSkills and live in
+// bonesOwnedSkills (see cli/skills.go) — they are NOT in this list.
+// User-authored skills under .claude/skills/ that don't match either
+// list are left alone.
+var legacyBonesSkills = []string{"subagent", "uninstall-bones"}
 
 // scaffoldFootprint captures what scaffoldOrchestrator did during a
 // single invocation, for surfacing in the default-mode `bones up`
@@ -72,6 +86,13 @@ type scaffoldFootprint struct {
 	// keyed by event name (e.g. "SessionStart": 2, "PreCompact": 1).
 	// Existing duplicates are not counted.
 	HooksAddedByEvent map[string]int
+
+	// SkillsModified lists workspace-relative paths under
+	// .claude/skills/<bones-owned skill>/ that diverged from the
+	// embedded source. Bones never overwrites these — the up summary
+	// surfaces them so the operator knows their edits are persistent
+	// but won't get fresh skill content on bones release upgrades.
+	SkillsModified []string
 }
 
 // hooksAdded returns the total count of new hook entries written, summed
@@ -105,6 +126,9 @@ func scaffoldOrchestrator(root string) (scaffoldFootprint, error) {
 
 	if err := removeLegacyBonesSkills(root); err != nil {
 		return fp, fmt.Errorf("legacy skills cleanup: %w", err)
+	}
+	if err := writeBonesSkills(root, &fp); err != nil {
+		return fp, fmt.Errorf("skills bundle: %w", err)
 	}
 	if err := writeAgentsMD(root, &fp); err != nil {
 		return fp, fmt.Errorf("agents.md: %w", err)

--- a/cli/orchestrator_test.go
+++ b/cli/orchestrator_test.go
@@ -14,25 +14,30 @@ func TestScaffoldOrchestrator_FreshWorkspace(t *testing.T) {
 	if _, err := scaffoldOrchestrator(dir); err != nil {
 		t.Fatalf("scaffoldOrchestrator: %v", err)
 	}
-	// Per ADR 0042: AGENTS.md (universal channel) + CLAUDE.md symlink
-	// + Claude-format hooks. Skill markdown trees are NOT scaffolded.
+	// AGENTS.md (universal channel) + CLAUDE.md symlink + Claude-format
+	// hooks + the skills bundle (one SKILL.md per bones-owned skill).
 	for _, want := range []string{
 		"AGENTS.md",
 		"CLAUDE.md",
 		".claude/settings.json",
+		".claude/skills/orchestrator/SKILL.md",
+		".claude/skills/using-bones-powers/SKILL.md",
+		".claude/skills/using-bones-swarm/SKILL.md",
+		".claude/skills/finishing-a-bones-leaf/SKILL.md",
+		".claude/skills/systematic-debugging/SKILL.md",
+		".claude/skills/test-driven-development/SKILL.md",
 	} {
 		if _, err := os.Stat(filepath.Join(dir, want)); err != nil {
 			t.Errorf("missing %s: %v", want, err)
 		}
 	}
 	for _, gone := range []string{
-		".claude/skills/orchestrator",
 		".claude/skills/subagent",
 		".claude/skills/uninstall-bones",
 		".orchestrator", // pre-ADR-0041
 	} {
 		if _, err := os.Stat(filepath.Join(dir, gone)); err == nil {
-			t.Errorf("%s should not be scaffolded post-ADR-0042", gone)
+			t.Errorf("%s should not be scaffolded (legacy)", gone)
 		}
 	}
 	// CLAUDE.md must be a symlink pointing at AGENTS.md.
@@ -150,6 +155,89 @@ func TestScaffoldOrchestrator_AppendsBlockToUserAuthoredAGENTS(t *testing.T) {
 	if !strings.Contains(string(got), bonesBlockBegin) ||
 		!strings.Contains(string(got), bonesBlockEnd) {
 		t.Errorf("managed block missing from AGENTS.md:\n%s", got)
+	}
+}
+
+// TestScaffold_BundledSkillsContent verifies the embedded SKILL.md
+// for the load-bearing skills lands on disk byte-for-byte. This is
+// the regression surface for #166: if the embed FS diverges from the
+// committed templates, fresh workspaces stop matching.
+func TestScaffold_BundledSkillsContent(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := scaffoldOrchestrator(dir); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{
+		"orchestrator", "using-bones-powers", "using-bones-swarm",
+		"finishing-a-bones-leaf", "systematic-debugging", "test-driven-development",
+	} {
+		want, err := skillsFS.ReadFile(skillsRoot + "/" + name + "/SKILL.md")
+		if err != nil {
+			t.Fatalf("embed %s: %v", name, err)
+		}
+		got, err := os.ReadFile(filepath.Join(dir, ".claude", "skills", name, "SKILL.md"))
+		if err != nil {
+			t.Errorf("read scaffolded %s: %v", name, err)
+			continue
+		}
+		if string(got) != string(want) {
+			t.Errorf("%s SKILL.md content drift", name)
+		}
+	}
+}
+
+// TestScaffold_Skills_PreservesUserModifiedFiles pins that a
+// user-modified SKILL.md is left alone (no overwrite) and surfaced
+// in fp.SkillsModified so `bones up` can warn about it.
+func TestScaffold_Skills_PreservesUserModifiedFiles(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := scaffoldOrchestrator(dir); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(dir, ".claude", "skills", "orchestrator", "SKILL.md")
+	if err := os.WriteFile(target, []byte("user override\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	fp, err := scaffoldOrchestrator(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, _ := os.ReadFile(target)
+	if string(got) != "user override\n" {
+		t.Errorf("user-modified SKILL.md was overwritten")
+	}
+	if !slices.Contains(fp.SkillsModified, ".claude/skills/orchestrator/SKILL.md") {
+		t.Errorf("fp.SkillsModified missing user-modified path: got %v", fp.SkillsModified)
+	}
+}
+
+// TestScaffold_ClaudeMD_InlineBlock pins the #169 fix: the bones-managed
+// block in the CLAUDE.md fallback (when CLAUDE.md exists as a non-symlink
+// user-authored file) carries the mandatory directive that names the
+// using-bones-powers skill — not just the old AGENTS.md pointer.
+func TestScaffold_ClaudeMD_InlineBlock(t *testing.T) {
+	dir := t.TempDir()
+	claudePath := filepath.Join(dir, "CLAUDE.md")
+	body := []byte("# My Project\n\nProject notes.\n")
+	if err := os.WriteFile(claudePath, body, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := scaffoldOrchestrator(dir); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(claudePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := string(got)
+	for _, want := range []string{
+		"MANDATORY",
+		"using-bones-powers",
+		"orchestrator",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("CLAUDE.md managed block missing %q:\n%s", want, out)
+		}
 	}
 }
 

--- a/cli/skills.go
+++ b/cli/skills.go
@@ -1,0 +1,205 @@
+package cli
+
+import (
+	"crypto/sha256"
+	"embed"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+//go:embed all:templates/skills
+var skillsFS embed.FS
+
+// skillsRoot is the top-level path inside skillsFS.
+const skillsRoot = "templates/skills"
+
+// bonesOwnedSkills is the canonical list of skill directory names
+// scaffolded by `bones up`. Membership in this list is what
+// `removeBonesSkills` keys off of, so adding a skill here means it
+// will also be cleaned up by `bones down`.
+var bonesOwnedSkills = []string{
+	"finishing-a-bones-leaf",
+	"orchestrator",
+	"systematic-debugging",
+	"test-driven-development",
+	"using-bones-powers",
+	"using-bones-swarm",
+}
+
+// writeBonesSkills materializes the embedded skill bundle into
+// `<root>/.claude/skills/`. For each skill directory in the bundle:
+//
+//   - If the on-disk file is missing, write it.
+//   - If the on-disk file matches the embedded hash byte-for-byte, skip.
+//   - If the on-disk file diverges, leave it alone and append a
+//     workspace-relative path to fp.SkillsModified so `bones up` can
+//     surface it. We never silently overwrite user edits.
+//
+// New files written are tracked in fp.FilesWritten using their
+// workspace-relative path so the up summary can render them.
+func writeBonesSkills(root string, fp *scaffoldFootprint) error {
+	skillsDir := filepath.Join(root, ".claude", "skills")
+	if err := os.MkdirAll(skillsDir, 0o755); err != nil {
+		return fmt.Errorf("mkdir skills: %w", err)
+	}
+	return fs.WalkDir(skillsFS, skillsRoot, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		rel, err := filepath.Rel(skillsRoot, path)
+		if err != nil {
+			return fmt.Errorf("rel %s: %w", path, err)
+		}
+		dst := filepath.Join(skillsDir, rel)
+		return materializeSkillFile(skillsFS, path, dst, root, fp)
+	})
+}
+
+// materializeSkillFile writes one embedded skill file to dst, honoring
+// the bones-owned-vs-user-modified contract. wsRoot is the workspace
+// root (used to derive the relative path for footprint tracking).
+func materializeSkillFile(
+	src fs.FS, srcPath, dst, wsRoot string, fp *scaffoldFootprint,
+) error {
+	want, err := fs.ReadFile(src, srcPath)
+	if err != nil {
+		return fmt.Errorf("read embed %s: %w", srcPath, err)
+	}
+	rel, _ := filepath.Rel(wsRoot, dst)
+	got, err := os.ReadFile(dst)
+	switch {
+	case errors.Is(err, fs.ErrNotExist):
+		if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+			return fmt.Errorf("mkdir %s: %w", filepath.Dir(dst), err)
+		}
+		if err := os.WriteFile(dst, want, 0o644); err != nil {
+			return fmt.Errorf("write %s: %w", dst, err)
+		}
+		fp.FilesWritten = append(fp.FilesWritten, rel)
+		return nil
+	case err != nil:
+		return fmt.Errorf("stat %s: %w", dst, err)
+	}
+	if hashEq(got, want) {
+		return nil
+	}
+	fp.SkillsModified = append(fp.SkillsModified, rel)
+	return nil
+}
+
+// hashEq reports whether a and b have the same SHA-256 digest. Used to
+// distinguish bones-owned skill files from user-modified ones without
+// holding both byte slices in memory longer than needed.
+func hashEq(a, b []byte) bool {
+	ha := sha256.Sum256(a)
+	hb := sha256.Sum256(b)
+	return hex.EncodeToString(ha[:]) == hex.EncodeToString(hb[:])
+}
+
+// removeBonesSkills is the bones-down counterpart to writeBonesSkills.
+// For each skill directory bones owns:
+//
+//   - Walk the embedded copy. For every file whose on-disk content
+//     matches the embedded hash, delete it. User-modified files stay.
+//   - After all files are processed, attempt to rmdir the skill dir
+//     (succeeds only if empty — which is the case unless the user left
+//     modified files or added their own).
+//
+// Returns the set of fully-removed skill directory names so `bones
+// down`'s output can surface what was cleaned vs. what was preserved.
+func removeBonesSkills(root string) ([]string, error) {
+	skillsDir := filepath.Join(root, ".claude", "skills")
+	var removed []string
+	for _, name := range bonesOwnedSkills {
+		gone, err := removeOneBonesSkill(skillsDir, name)
+		if err != nil {
+			return removed, err
+		}
+		if gone {
+			removed = append(removed, name)
+		}
+	}
+	// If skillsDir is now empty (we removed the last bones-owned dir
+	// and the user has none of their own), remove it too.
+	entries, err := os.ReadDir(skillsDir)
+	if err == nil && len(entries) == 0 {
+		_ = os.Remove(skillsDir)
+	}
+	sort.Strings(removed)
+	return removed, nil
+}
+
+// removeOneBonesSkill removes the embedded files inside a single
+// skill dir, then attempts to rmdir the dir itself. Returns (true, nil)
+// when the dir is fully gone after the call.
+func removeOneBonesSkill(skillsDir, name string) (bool, error) {
+	dir := filepath.Join(skillsDir, name)
+	if _, err := os.Stat(dir); errors.Is(err, fs.ErrNotExist) {
+		return false, nil
+	}
+	srcDir := skillsRoot + "/" + name
+	walkErr := fs.WalkDir(skillsFS, srcDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		rel := strings.TrimPrefix(path, srcDir+"/")
+		want, _ := fs.ReadFile(skillsFS, path)
+		dst := filepath.Join(dir, rel)
+		got, readErr := os.ReadFile(dst)
+		if errors.Is(readErr, fs.ErrNotExist) {
+			return nil
+		}
+		if readErr != nil {
+			return fmt.Errorf("read %s: %w", dst, readErr)
+		}
+		if !hashEq(got, want) {
+			return nil
+		}
+		if err := os.Remove(dst); err != nil {
+			return fmt.Errorf("remove %s: %w", dst, err)
+		}
+		return nil
+	})
+	if walkErr != nil {
+		return false, walkErr
+	}
+	// Best-effort rmdir up the tree — references/ subdir may now be
+	// empty, then the skill dir itself.
+	cleanupEmptyDirs(dir)
+	if _, err := os.Stat(dir); errors.Is(err, fs.ErrNotExist) {
+		return true, nil
+	}
+	return false, nil
+}
+
+// cleanupEmptyDirs walks dir bottom-up and removes any empty directory
+// it finds. Stops at the first non-empty directory.
+func cleanupEmptyDirs(dir string) {
+	_ = filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		return nil
+	})
+	// Easier: collect dirs, sort by depth descending, rmdir each.
+	var dirs []string
+	_ = filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err == nil && d.IsDir() {
+			dirs = append(dirs, path)
+		}
+		return nil
+	})
+	sort.Slice(dirs, func(i, j int) bool { return len(dirs[i]) > len(dirs[j]) })
+	for _, d := range dirs {
+		_ = os.Remove(d)
+	}
+}

--- a/cli/tasks_prime.go
+++ b/cli/tasks_prime.go
@@ -4,12 +4,21 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"time"
 
 	repocli "github.com/danmestas/EdgeSync/cli/repo"
 
 	"github.com/danmestas/bones/internal/coord"
+	"github.com/danmestas/bones/internal/version"
 )
+
+// SessionStartSentinelFile is the workspace-relative path of the
+// SessionStart hook sentinel. `bones tasks prime` (wired as both
+// SessionStart and PreCompact hooks by `bones up`) refreshes the file
+// on entry, and `bones doctor` reads it to detect "hooks configured
+// but never fire" failure modes (#172).
+const SessionStartSentinelFile = ".bones/last-session-prime"
 
 // TasksPrimeCmd prints an agent context summary (open/ready/claimed tasks,
 // recent threads, peers online).
@@ -23,6 +32,13 @@ func (c *TasksPrimeCmd) Run(g *repocli.Globals) error {
 		return err
 	}
 	defer stop()
+
+	// Drop a sentinel marking hook entry. Doctor uses this to detect
+	// "hooks configured in settings.json but never fire" — the failure
+	// mode behind #165 / #172 where operators saw hook config in place
+	// but inner Claude sessions had no bones context. Best-effort: a
+	// failure here must never block prime work.
+	writeSessionStartSentinel(info.WorkspaceDir)
 
 	return taskCLIError(runOp(ctx, "prime", func(ctx context.Context) error {
 		coordSession, err := coord.Open(ctx, newCoordConfig(info))
@@ -47,6 +63,23 @@ func (c *TasksPrimeCmd) Run(g *repocli.Globals) error {
 		fmt.Print(formatPrime(result))
 		return nil
 	}))
+}
+
+// writeSessionStartSentinel refreshes the .bones/last-session-prime
+// file with the current timestamp + bones version. Best-effort: any
+// failure (workspace read-only, permissions, etc.) is swallowed — the
+// sentinel is a diagnostic aid, not a correctness barrier.
+func writeSessionStartSentinel(workspaceDir string) {
+	if workspaceDir == "" {
+		return
+	}
+	path := filepath.Join(workspaceDir, SessionStartSentinelFile)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return
+	}
+	body := fmt.Sprintf("%s\t%s\n",
+		time.Now().UTC().Format(time.RFC3339), version.Get())
+	_ = os.WriteFile(path, []byte(body), 0o644)
 }
 
 func formatPrime(r coord.PrimeResult) string {

--- a/cli/templates/skills/finishing-a-bones-leaf/SKILL.md
+++ b/cli/templates/skills/finishing-a-bones-leaf/SKILL.md
@@ -1,0 +1,254 @@
+---
+name: finishing-a-bones-leaf
+version: 1.0.0
+targets: [claude-code]
+type: skill
+description: After a bones swarm session closes, decide what to do with the open leaf — fan-in to trunk, keep open, or abandon — and (optionally) materialize trunk into the git worktree, push, and open a PR for the swarmed changes. Use when implementation is complete, all tests pass, and you need to integrate the work back into the bones hub trunk.
+category:
+  primary: workflow
+---
+
+# Finishing a bones leaf
+
+Your swarm session has closed (`bones swarm close --result=success`), but the leaf is still open in the hub. This skill walks you through the integration decision.
+
+**Prerequisite**: at least one closed-success swarm session has produced commits on a leaf in the hub.
+
+## Requirements
+
+- A bones workspace (`.bones/repo.fossil` exists in cwd; required for all options)
+- For the optional push-to-git tail (Option 1's follow-up):
+  - The workspace is also a git repo (`.git/` exists at the same root)
+  - `bones apply` subcommand available (bones v0.X+ — calibrate against the bones release that ships it)
+  - `gh` CLI authenticated against the git remote (for `gh pr create`)
+  - Standard git: clean worktree, on the default branch
+
+## Pre-flight: review what's about to integrate
+
+Before any integration step:
+
+```bash
+bones swarm status                # which leaves are open?
+bones repo timeline --limit 20    # recent activity on the hub
+bones repo diff <trunk-rev>       # diff vs. trunk for context
+```
+
+## Three options
+
+### Option 1: Fan-in to trunk (the merge path)
+
+Merges open hub leaves back into trunk. **Always preview first.**
+
+```bash
+# 1. Preview — see what would be merged, no changes
+bones swarm fan-in --dry-run -m "merge <leaves> to trunk"
+
+# 2. If preview looks right, execute
+bones swarm fan-in -m "merge <leaves> to trunk"
+```
+
+**On conflict** (semantics not yet empirically verified — see spec § 11 — but the defensive flow is canonical given fossil's conflict model):
+
+If `fan-in` reports a non-zero exit code, conflicts likely exist. Enumerate and resolve:
+
+```bash
+bones repo conflicts ls
+bones repo conflicts show <file>
+# Choose ONE resolution strategy per conflicted file:
+bones repo conflicts pick <file>           # pick one version wholesale
+bones repo conflicts merge <file>          # re-merge with a different strategy
+bones repo conflicts extract <file>        # extract all versions to disk for manual edit
+
+# After resolving each file:
+bones repo mark-resolved <file>
+
+# Once all conflicts marked resolved, re-run fan-in:
+bones swarm fan-in -m '<original message>'
+```
+
+After fan-in succeeds, the skill offers an optional follow-up to materialize the swarmed changes into your git worktree, push them, and open a PR. See "## After fan-in: push to git remote and open PR (optional)" below.
+
+### Option 2: Keep leaf open
+
+No-op. The leaf stays open in the hub for later work. Useful when:
+- Work is complete but you want trunk integration to happen later (e.g., as part of a release batch)
+- You need the leaf for another swarm session (rare)
+
+```bash
+echo "leaf left open; integrate later via 'bones swarm fan-in'"
+```
+
+### Option 3: Abandon
+
+Discard the work. Closes the swarm session as failed (releasing the claim) without fan-in. The commits remain on the leaf in the hub but are never integrated.
+
+```bash
+bones swarm close --result=fail --summary="<why abandoned>"
+```
+
+(Note: this only applies if a session is still open. If you've already cleanly closed a successful session and want to throw away the work, you'd need to manually close the leaf branch via `bones repo branch close <leaf>`.)
+
+## After fan-in: push to git remote and open PR (optional)
+
+After Option 1's `bones swarm fan-in` succeeds and trunk has the swarmed changes, the skill offers a follow-up:
+
+> Push to git remote and open PR? (y/N)
+
+Answering `y`/`Y`/`yes` (case-insensitive) runs the flow below. Anything else finishes the skill cleanly with the fan-in committed but no further side effects.
+
+### Pre-flight git checks
+
+| Check | Command | Failure handling |
+|---|---|---|
+| Workspace has `.git/` | `[[ -d .git ]]` | Skip the push tail entirely. Skill says "no git remote available; this workspace isn't bones-over-git. Done." |
+| Git worktree clean | `git status --porcelain` (empty output) | Abort. Skill says "git worktree has uncommitted changes — commit or stash them first, then re-run." |
+| On the default branch | `git branch --show-current` matches `origin/HEAD`'s tracked branch | Abort. Skill says "currently on `<branch>`; switch to `main` (or default) first to make a clean fan-in branch." |
+
+### Materialize trunk into the git worktree
+
+```bash
+bones apply
+```
+
+This is the bones-side checkout-equivalent: it copies fossil-trunk's tip state onto the git working tree. After this, `git status` shows the swarmed changes as unstaged.
+
+`bones apply` is invoked with no arguments — assumes the default behavior is "materialize trunk tip into cwd's git worktree". If the actual `bones apply` CLI requires explicit args when the bones release ships, adjust this skill's invocation.
+
+If `bones apply` fails — likely either the subcommand isn't available (bones too old) or there's a conflict — the skill surfaces the error and aborts. Resolve manually before re-running.
+
+### Branch name
+
+The skill auto-suggests a branch name slugified from the root bones task's title. Slugification: lowercase, non-alphanumeric → `-`, collapse runs of `-`, trim leading/trailing `-`, truncate to 50 chars, prefix with `bones/`.
+
+Example: root task title "Implement search feature with full-text" → `bones/implement-search-feature-with-full-text`.
+
+If the root task title is empty or unparseable, fall back to `bones-fan-in/<YYYY-MM-DD>-<short-root-id>` where `<short-root-id>` is the first 6 chars of the root task UUID.
+
+```
+Branch name [<auto-suggested>]:
+```
+
+User presses Enter to accept the default OR types a different name.
+
+### Commit + push
+
+```bash
+git checkout -b <branch>
+git add -A
+git commit -m "<auto-generated message>"
+git push -u origin <branch>
+```
+
+The commit message is auto-generated from the bones task graph (no user prompt — the human-facing artifact is the PR text). Format:
+
+```
+<root task title>
+
+Fan-in of bones swarm work. <N> tasks completed under root <short-root-id>.
+
+- [<slot>] <child title> (<result>) — <summary>
+- [<slot>] <child title> (<result>) — <summary>
+...
+
+Plan: <plan-path>
+Bones root task: <root_id>
+```
+
+Where:
+- `<short-root-id>` = first 6 chars of root task UUID
+- `<N>` = count of children
+- Each child line uses the child's title, slot tag, result (`success`/`fail`/`fork`), and summary from `bones tasks show`
+- `<plan-path>` from root task's `--files` field
+
+### Open PR
+
+The skill prompts for the PR title and PR body, with defaults derived from the task graph.
+
+**PR title prompt** (default = root task title):
+```
+PR title [<root task title>]:
+```
+
+User presses Enter to accept OR types a different title.
+
+**PR body prompt** ($EDITOR-based, default pre-filled):
+
+The skill writes the default body to a temp file and opens `$EDITOR` (falls back to `vi` if unset). User edits, saves, and exits.
+
+Default PR body template:
+
+```markdown
+## Summary
+
+<one-line summary; falls back to "Fan-in of <N> bones tasks" if no shorter summary derivable from root task title>
+
+## Tasks completed
+
+- [<slot>] <child title> (<result>) — <summary>
+- [<slot>] <child title> (<result>) — <summary>
+...
+
+## Plan
+
+`<plan-path>`
+
+## Bones lineage
+
+- Root task: `<root_id>`
+- Children: `<child_id_1>`, `<child_id_2>`, ...
+```
+
+If any child task closed with `--result=fail` or `--result=fork`, the skill prepends a `> ⚠ <N> task(s) closed as failed:` callout listing them — visual emphasis on top of the inline `(<result>)` markers in the bullets.
+
+After both prompts:
+
+```bash
+gh pr create --title "<…>" --body "<…>"
+```
+
+### Idempotency / re-run
+
+If a previous run pushed the branch but `gh pr create` failed (e.g., auth issue), re-running `finishing-a-bones-leaf` after fixing the issue detects the already-pushed branch:
+
+- Detection: `git rev-parse --verify <branch>` succeeds AND `git log origin/<branch>..HEAD` is empty (local matches remote).
+- Skill behavior: skips re-creating branch, re-staging, re-committing, re-pushing. Goes directly to the PR-prompt step.
+
+This lets the user fix `gh auth login` (or whatever blocked the PR) and re-run without redoing the upstream work.
+
+### Cancellation
+
+| Input point | Cancel signal | Skill behavior |
+|---|---|---|
+| Initial Y/N prompt | Anything other than `y`/`Y`/`yes` | Treated as no. Skill exits cleanly; fan-in stays committed. |
+| Branch name override prompt | Empty input + Enter | Accept the auto-suggested default. |
+| PR title prompt | Empty input + Enter | Accept the default (root task title). |
+| PR body `$EDITOR` session | Save with empty body | Abort PR creation. Branch stays pushed. Skill says "PR body was empty — branch is pushed; re-run to retry, or open the PR manually at `<remote-url>/compare/<branch>`." |
+| Ctrl+C / SIGINT mid-flow | OS-level interrupt | Skill exits with non-zero. No automatic cleanup of partial state. User can `git status` to see where things stopped, then either continue manually or re-run (idempotency picks up). |
+
+### Failure modes
+
+| Step | Failure mode | Skill action |
+|---|---|---|
+| `bones apply` | Subcommand missing (older bones) | Error: "this skill requires `bones apply`. Update bones to the version that ships it." |
+| `bones apply` | Conflicts during materialize | Surface bones's error verbatim. Skill aborts; user resolves manually and re-runs. |
+| `git add -A` shows no changes | Apply produced an empty diff (no-op) | Skill says "no changes to push. Done." Cleans up the empty branch via `git checkout - && git branch -D <branch>`. |
+| `git push` | Auth / network / branch-protection error | Surface git's error. Skill aborts. User fixes and re-runs (idempotency kicks in). |
+| `gh pr create` | No `gh` auth, no remote configured, etc. | Surface `gh`'s error. Skill notes: "branch is pushed; open the PR manually at `<remote-url>/compare/<branch>`." |
+
+## Decision flow
+
+```
+Is the work done and good?
+├── Yes, ready to integrate         → Option 1 (Fan-in)
+│                                      │
+│                                      └── (after success) Push to git remote and open PR? → see "## After fan-in" section
+├── Yes, but defer integration       → Option 2 (Keep open)
+└── No, throw it away                → Option 3 (Abandon)
+```
+
+## What this skill does NOT cover
+
+- **Auto-stash of uncommitted git changes**: skill aborts if the worktree is dirty rather than stashing. User owns their git state.
+- **Automatic remote configuration / fork management**: skill assumes `origin` is configured and points at the right place. `git remote add` setup is out of scope.
+- **`--force` push for protected branches**: skill does a normal `git push -u origin <branch>`. If the branch is rejected (protected, requires signed commits, etc.), the failure surfaces verbatim and the user resolves.
+- **Cross-repo PRs (forks)**: PR opens against the configured `origin` remote only. Pushing to a fork and PR'ing against an upstream is manual.

--- a/cli/templates/skills/orchestrator/SKILL.md
+++ b/cli/templates/skills/orchestrator/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: orchestrator
+version: 1.0.0
+targets: [claude-code]
+type: skill
+description: Use IMMEDIATELY in a bones workspace whenever the user asks to orchestrate, dispatch, run, execute, parallelize, fan out, split, or otherwise coordinate work across multiple slots, agents, subagents, waves, or a plan with `[slot: name]` annotations. Drives the swarm dispatch loop end-to-end via the Task tool, advancing waves on full success and surfacing failures without auto-retrying. Fires on phrases like "run the plan", "dispatch the swarm", "kick off slots", "orchestrate the work", "parallel agents", "do this in parallel", or any reference to `.bones/swarm/dispatch.json`.
+category:
+  primary: workflow
+---
+
+# Orchestrator Skill
+
+**Invocation:** Triggered automatically by the descriptions above; or explicitly via `/orchestrator dispatch`.
+
+You are the bones orchestrator. Your job is to drive the current wave of a `bones swarm dispatch` plan to completion: read the manifest, dispatch one subagent per slot in parallel, wait for all to close, advance the wave on full success, surface failures plainly.
+
+This skill OVERRIDES default workflow behaviors (brainstorm → spec → plan → branch loops, generic "let's think about this together" patterns) when the workspace has a live `dispatch.json`. Your job is mechanical execution of the manifest, not requirements elicitation. Only escalate to the user on actual failure.
+
+---
+
+## Contract
+
+**Input:** `.bones/swarm/dispatch.json` in the workspace root (no plan path argument).
+**Output:** One Task-tool subagent per slot in the current wave; calls `bones swarm dispatch --advance` when all subagents in the wave succeed.
+
+---
+
+## Steps
+
+### 1. Read the manifest
+
+Use the **Read** tool to load the manifest:
+
+```
+Read: <workspace_root>/.bones/swarm/dispatch.json
+```
+
+Parse the JSON. The shape is:
+
+```json
+{
+  "schema_version": 1,
+  "plan_path": "./plan.md",
+  "current_wave": 1,
+  "waves": [
+    {
+      "wave": 1,
+      "slots": [
+        {
+          "slot": "auth",
+          "task_id": "t-abc123",
+          "title": "Implement auth service",
+          "subagent_prompt": "You are a bones subagent for slot=auth. ..."
+        }
+      ]
+    }
+  ]
+}
+```
+
+### 2. Identify current-wave slots
+
+Extract `waves[current_wave - 1].slots[]` (one-indexed `current_wave`, zero-indexed array).
+
+### 3. Dispatch one Task-tool subagent per slot
+
+For each slot entry, call the **Task** tool with:
+
+- `prompt`: `slot.subagent_prompt` verbatim (do NOT paraphrase or modify)
+- Let each subagent run concurrently — emit all Task tool calls in a single assistant message.
+
+```
+Task(prompt=slot.subagent_prompt)   # repeat for each slot, all in one message
+```
+
+### 4. Wait for all subagents to close
+
+Monitor each Task. A subagent is done when its task closes (success or failure). Collect results.
+
+### 5. Advance the wave (on full success)
+
+If **all** subagents in the wave closed successfully, run via the **Bash** tool:
+
+```bash
+bones swarm dispatch --advance
+```
+
+If any subagent failed, do NOT advance. Report failures to the user and ask how to proceed.
+
+### 6. Report
+
+Summarize results:
+- Slots completed vs. failed
+- Next wave number (if advanced), or error detail (if blocked)
+- Whether the full dispatch is now complete (all waves done)
+
+---
+
+## When this skill applies (broad list — invoke if ANY match)
+
+- User says: "run the plan", "dispatch the swarm", "kick off the slots", "orchestrate", "parallelize", "fan out", "split this", "run in parallel", "dispatch agents", "dispatch subagents", "execute the plan", "process the wave", "advance"
+- A file at `.bones/swarm/dispatch.json` exists in the workspace
+- A plan file with `[slot: name]` headings is provided and the user wants execution
+- The user invokes `/orchestrator` explicitly
+
+If the workspace is bones-managed (has `.bones/`) AND any of the above triggers fire, this skill is the answer. Use the `Skill` tool to invoke it.
+
+---
+
+## Notes
+
+- The manifest is the sole source of truth. Do not re-read the plan file.
+- `subagent_prompt` is a closed template rendered by `bones swarm dispatch`; pass it verbatim.
+- This skill is the **Claude Code harness-specific** orchestration layer. Other harnesses (Cursor, Aider, etc.) ship their own equivalent that reads the same `dispatch.json` schema and follows the same protocol — dispatch the current wave's slots, then call `bones swarm dispatch --advance`.
+- If `current_wave` exceeds the number of waves, the dispatch is complete — say so and stop.
+- Do not call `--advance` for partially-failed waves; surface the failure and await user input.
+- Do not write code yourself in this role. Your tools are Read (manifest), Task (dispatch), Bash (advance). If you find yourself reaching for Edit/Write to do worker-shaped work, you've drifted out of orchestrator mode.

--- a/cli/templates/skills/systematic-debugging/SKILL.md
+++ b/cli/templates/skills/systematic-debugging/SKILL.md
@@ -1,0 +1,304 @@
+---
+name: systematic-debugging
+description: Use when encountering any bug, test failure, or unexpected behavior in a bones workspace, before proposing fixes
+---
+
+# Systematic Debugging
+
+## Overview
+
+Random fixes waste time and create new bugs. Quick patches mask underlying issues.
+
+**Core principle:** ALWAYS find root cause before attempting fixes. Symptom fixes are failure.
+
+**Violating the letter of this process is violating the spirit of debugging.**
+
+## The Iron Law
+
+```
+NO FIXES WITHOUT ROOT CAUSE INVESTIGATION FIRST
+```
+
+If you haven't completed Phase 1, you cannot propose fixes.
+
+## When to Use
+
+Use for ANY technical issue:
+- Test failures
+- Bugs in production
+- Unexpected behavior
+- Performance problems
+- Build failures
+- Integration issues
+
+**Use this ESPECIALLY when:**
+- Under time pressure (emergencies make guessing tempting)
+- "Just one quick fix" seems obvious
+- You've already tried multiple fixes
+- Previous fix didn't work
+- You don't fully understand the issue
+
+**Don't skip when:**
+- Issue seems simple (simple bugs have root causes too)
+- You're in a hurry (rushing guarantees rework)
+- Manager wants it fixed NOW (systematic is faster than thrashing)
+
+## The Four Phases
+
+You MUST complete each phase before proceeding to the next.
+
+### Phase 1: Root Cause Investigation
+
+**BEFORE attempting ANY fix:**
+
+1. **Read Error Messages Carefully**
+   - Don't skip past errors or warnings
+   - They often contain the exact solution
+   - Read stack traces completely
+   - Note line numbers, file paths, error codes
+
+2. **Reproduce Consistently**
+   - Can you trigger it reliably?
+   - What are the exact steps?
+   - Does it happen every time?
+   - If not reproducible → gather more data, don't guess
+
+3. **Check Recent Changes**
+   - What changed that could cause this?
+   - Git diff, recent commits
+   - New dependencies, config changes
+   - Environmental differences
+
+4. **Gather Evidence in Multi-Component Systems**
+
+   **WHEN system has multiple components (CI → build → signing, API → service → database):**
+
+   **BEFORE proposing fixes, add diagnostic instrumentation:**
+   ```
+   For EACH component boundary:
+     - Log what data enters component
+     - Log what data exits component
+     - Verify environment/config propagation
+     - Check state at each layer
+
+   Run once to gather evidence showing WHERE it breaks
+   THEN analyze evidence to identify failing component
+   THEN investigate that specific component
+   ```
+
+   **Example (multi-layer system):**
+   ```bash
+   # Layer 1: Workflow
+   echo "=== Secrets available in workflow: ==="
+   echo "IDENTITY: ${IDENTITY:+SET}${IDENTITY:-UNSET}"
+
+   # Layer 2: Build script
+   echo "=== Env vars in build script: ==="
+   env | grep IDENTITY || echo "IDENTITY not in environment"
+
+   # Layer 3: Signing script
+   echo "=== Keychain state: ==="
+   security list-keychains
+   security find-identity -v
+
+   # Layer 4: Actual signing
+   codesign --sign "$IDENTITY" --verbose=4 "$APP"
+   ```
+
+   **This reveals:** Which layer fails (secrets → workflow ✓, workflow → build ✗)
+
+5. **Trace Data Flow**
+
+   **WHEN error is deep in call stack:**
+
+   See `root-cause-tracing.md` in this directory for the complete backward tracing technique.
+
+   **Quick version:**
+   - Where does bad value originate?
+   - What called this with bad value?
+   - Keep tracing up until you find the source
+   - Fix at source, not at symptom
+
+### Phase 2: Pattern Analysis
+
+**Find the pattern before fixing:**
+
+1. **Find Working Examples**
+   - Locate similar working code in same codebase
+   - What works that's similar to what's broken?
+
+2. **Compare Against References**
+   - If implementing pattern, read reference implementation COMPLETELY
+   - Don't skim - read every line
+   - Understand the pattern fully before applying
+
+3. **Identify Differences**
+   - What's different between working and broken?
+   - List every difference, however small
+   - Don't assume "that can't matter"
+
+4. **Understand Dependencies**
+   - What other components does this need?
+   - What settings, config, environment?
+   - What assumptions does it make?
+
+### Phase 3: Hypothesis and Testing
+
+**Scientific method:**
+
+1. **Form Single Hypothesis**
+   - State clearly: "I think X is the root cause because Y"
+   - Write it down
+   - Be specific, not vague
+
+2. **Test Minimally**
+   - Make the SMALLEST possible change to test hypothesis
+   - One variable at a time
+   - Don't fix multiple things at once
+
+3. **Verify Before Continuing**
+   - Did it work? Yes → Phase 4
+   - Didn't work? Form NEW hypothesis
+   - DON'T add more fixes on top
+
+4. **When You Don't Know**
+   - Say "I don't understand X"
+   - Don't pretend to know
+   - Ask for help
+   - Research more
+
+### Phase 4: Implementation
+
+**Fix the root cause, not the symptom:**
+
+1. **Create Failing Test Case**
+   - Simplest possible reproduction
+   - Automated test if possible
+   - One-off test script if no framework
+   - MUST have before fixing
+   - Use the `test-driven-development` skill for writing proper failing tests
+
+2. **Implement Single Fix**
+   - Address the root cause identified
+   - ONE change at a time
+   - No "while I'm here" improvements
+   - No bundled refactoring
+
+3. **Verify Fix**
+   - Test passes now?
+   - No other tests broken?
+   - Issue actually resolved?
+
+4. **If Fix Doesn't Work**
+   - STOP
+   - Count: How many fixes have you tried?
+   - If < 3: Return to Phase 1, re-analyze with new information
+   - **If ≥ 3: STOP and question the architecture (step 5 below)**
+   - DON'T attempt Fix #4 without architectural discussion
+
+5. **If 3+ Fixes Failed: Question Architecture**
+
+   **Pattern indicating architectural problem:**
+   - Each fix reveals new shared state/coupling/problem in different place
+   - Fixes require "massive refactoring" to implement
+   - Each fix creates new symptoms elsewhere
+
+   **STOP and question fundamentals:**
+   - Is this pattern fundamentally sound?
+   - Are we "sticking with it through sheer inertia"?
+   - Should we refactor architecture vs. continue fixing symptoms?
+
+   **Discuss with your human partner before attempting more fixes**
+
+   This is NOT a failed hypothesis - this is a wrong architecture.
+
+## Bones context
+
+When debugging in a bones workspace:
+
+- **Workspace state checks**: use `bones status` (not `git status`) to confirm a clean working tree during phase 1 (root-cause investigation).
+- **Log inspection**: bones swarm sessions log to `.bones/leaves/<slot>/leaf.log`. Tail this for trace data during phase 2 (pattern analysis).
+- **Reproduction in isolation**: open a fresh swarm session in a sibling slot (`bones swarm join --slot=debug-<id> --task-id=<id>`) to reproduce a bug without polluting the main workspace.
+- **Artifact preservation**: if you need to keep failed-test output across debugging iterations, commit the artifact via `bones swarm commit -m 'debug snapshot'` so it's recorded on the leaf — `swarm close --result=fail` does not lose committed work.
+
+## Red Flags - STOP and Follow Process
+
+If you catch yourself thinking:
+- "Quick fix for now, investigate later"
+- "Just try changing X and see if it works"
+- "Add multiple changes, run tests"
+- "Skip the test, I'll manually verify"
+- "It's probably X, let me fix that"
+- "I don't fully understand but this might work"
+- "Pattern says X but I'll adapt it differently"
+- "Here are the main problems: [lists fixes without investigation]"
+- Proposing solutions before tracing data flow
+- **"One more fix attempt" (when already tried 2+)**
+- **Each fix reveals new problem in different place**
+
+**ALL of these mean: STOP. Return to Phase 1.**
+
+**If 3+ fixes failed:** Question the architecture (see Phase 4.5)
+
+## your human partner's Signals You're Doing It Wrong
+
+**Watch for these redirections:**
+- "Is that not happening?" - You assumed without verifying
+- "Will it show us...?" - You should have added evidence gathering
+- "Stop guessing" - You're proposing fixes without understanding
+- "Ultrathink this" - Question fundamentals, not just symptoms
+- "We're stuck?" (frustrated) - Your approach isn't working
+
+**When you see these:** STOP. Return to Phase 1.
+
+## Common Rationalizations
+
+| Excuse | Reality |
+|--------|---------|
+| "Issue is simple, don't need process" | Simple issues have root causes too. Process is fast for simple bugs. |
+| "Emergency, no time for process" | Systematic debugging is FASTER than guess-and-check thrashing. |
+| "Just try this first, then investigate" | First fix sets the pattern. Do it right from the start. |
+| "I'll write test after confirming fix works" | Untested fixes don't stick. Test first proves it. |
+| "Multiple fixes at once saves time" | Can't isolate what worked. Causes new bugs. |
+| "Reference too long, I'll adapt the pattern" | Partial understanding guarantees bugs. Read it completely. |
+| "I see the problem, let me fix it" | Seeing symptoms ≠ understanding root cause. |
+| "One more fix attempt" (after 2+ failures) | 3+ failures = architectural problem. Question pattern, don't fix again. |
+
+## Quick Reference
+
+| Phase | Key Activities | Success Criteria |
+|-------|---------------|------------------|
+| **1. Root Cause** | Read errors, reproduce, check changes, gather evidence | Understand WHAT and WHY |
+| **2. Pattern** | Find working examples, compare | Identify differences |
+| **3. Hypothesis** | Form theory, test minimally | Confirmed or new hypothesis |
+| **4. Implementation** | Create test, fix, verify | Bug resolved, tests pass |
+
+## When Process Reveals "No Root Cause"
+
+If systematic investigation reveals issue is truly environmental, timing-dependent, or external:
+
+1. You've completed the process
+2. Document what you investigated
+3. Implement appropriate handling (retry, timeout, error message)
+4. Add monitoring/logging for future investigation
+
+**But:** 95% of "no root cause" cases are incomplete investigation.
+
+## Supporting Techniques
+
+These techniques are part of systematic debugging and available in this directory:
+
+- **`root-cause-tracing.md`** - Trace bugs backward through call stack to find original trigger
+- **`defense-in-depth.md`** - Add validation at multiple layers after finding root cause
+- **`condition-based-waiting.md`** - Replace arbitrary timeouts with condition polling
+
+**Related skills:**
+- **test-driven-development** - For creating failing test case (Phase 4, Step 1)
+
+## Real-World Impact
+
+From debugging sessions:
+- Systematic approach: 15-30 minutes to fix
+- Random fixes approach: 2-3 hours of thrashing
+- First-time fix rate: 95% vs 40%
+- New bugs introduced: Near zero vs common

--- a/cli/templates/skills/test-driven-development/SKILL.md
+++ b/cli/templates/skills/test-driven-development/SKILL.md
@@ -1,0 +1,371 @@
+---
+name: test-driven-development
+description: Use when implementing any feature or bugfix in a bones workspace, before writing implementation code
+---
+
+# Test-Driven Development (TDD)
+
+## Overview
+
+Write the test first. Watch it fail. Write minimal code to pass.
+
+**Core principle:** If you didn't watch the test fail, you don't know if it tests the right thing.
+
+**Violating the letter of the rules is violating the spirit of the rules.**
+
+## When to Use
+
+**Always:**
+- New features
+- Bug fixes
+- Refactoring
+- Behavior changes
+
+**Exceptions (ask your human partner):**
+- Throwaway prototypes
+- Generated code
+- Configuration files
+
+Thinking "skip TDD just this once"? Stop. That's rationalization.
+
+## The Iron Law
+
+```
+NO PRODUCTION CODE WITHOUT A FAILING TEST FIRST
+```
+
+Write code before the test? Delete it. Start over.
+
+**No exceptions:**
+- Don't keep it as "reference"
+- Don't "adapt" it while writing tests
+- Don't look at it
+- Delete means delete
+
+Implement fresh from tests. Period.
+
+## Red-Green-Refactor
+
+```dot
+digraph tdd_cycle {
+    rankdir=LR;
+    red [label="RED\nWrite failing test", shape=box, style=filled, fillcolor="#ffcccc"];
+    verify_red [label="Verify fails\ncorrectly", shape=diamond];
+    green [label="GREEN\nMinimal code", shape=box, style=filled, fillcolor="#ccffcc"];
+    verify_green [label="Verify passes\nAll green", shape=diamond];
+    refactor [label="REFACTOR\nClean up", shape=box, style=filled, fillcolor="#ccccff"];
+    next [label="Next", shape=ellipse];
+
+    red -> verify_red;
+    verify_red -> green [label="yes"];
+    verify_red -> red [label="wrong\nfailure"];
+    green -> verify_green;
+    verify_green -> refactor [label="yes"];
+    verify_green -> green [label="no"];
+    refactor -> verify_green [label="stay\ngreen"];
+    verify_green -> next;
+    next -> red;
+}
+```
+
+### RED - Write Failing Test
+
+Write one minimal test showing what should happen.
+
+<Good>
+```typescript
+test('retries failed operations 3 times', async () => {
+  let attempts = 0;
+  const operation = () => {
+    attempts++;
+    if (attempts < 3) throw new Error('fail');
+    return 'success';
+  };
+
+  const result = await retryOperation(operation);
+
+  expect(result).toBe('success');
+  expect(attempts).toBe(3);
+});
+```
+Clear name, tests real behavior, one thing
+</Good>
+
+<Bad>
+```typescript
+test('retry works', async () => {
+  const mock = jest.fn()
+    .mockRejectedValueOnce(new Error())
+    .mockRejectedValueOnce(new Error())
+    .mockResolvedValueOnce('success');
+  await retryOperation(mock);
+  expect(mock).toHaveBeenCalledTimes(3);
+});
+```
+Vague name, tests mock not code
+</Bad>
+
+**Requirements:**
+- One behavior
+- Clear name
+- Real code (no mocks unless unavoidable)
+
+### Verify RED - Watch It Fail
+
+**MANDATORY. Never skip.**
+
+```bash
+npm test path/to/test.test.ts
+```
+
+Confirm:
+- Test fails (not errors)
+- Failure message is expected
+- Fails because feature missing (not typos)
+
+**Test passes?** You're testing existing behavior. Fix test.
+
+**Test errors?** Fix error, re-run until it fails correctly.
+
+### GREEN - Minimal Code
+
+Write simplest code to pass the test.
+
+<Good>
+```typescript
+async function retryOperation<T>(fn: () => Promise<T>): Promise<T> {
+  for (let i = 0; i < 3; i++) {
+    try {
+      return await fn();
+    } catch (e) {
+      if (i === 2) throw e;
+    }
+  }
+  throw new Error('unreachable');
+}
+```
+Just enough to pass
+</Good>
+
+<Bad>
+```typescript
+async function retryOperation<T>(
+  fn: () => Promise<T>,
+  options?: {
+    maxRetries?: number;
+    backoff?: 'linear' | 'exponential';
+    onRetry?: (attempt: number) => void;
+  }
+): Promise<T> {
+  // YAGNI
+}
+```
+Over-engineered
+</Bad>
+
+Don't add features, refactor other code, or "improve" beyond the test.
+
+### Verify GREEN - Watch It Pass
+
+**MANDATORY.**
+
+```bash
+npm test path/to/test.test.ts
+```
+
+Confirm:
+- Test passes
+- Other tests still pass
+- Output pristine (no errors, warnings)
+
+**Test fails?** Fix code, not test.
+
+**Other tests fail?** Fix now.
+
+### REFACTOR - Clean Up
+
+After green only:
+- Remove duplication
+- Improve names
+- Extract helpers
+
+Keep tests green. Don't add behavior.
+
+### Repeat
+
+Next failing test for next feature.
+
+## Good Tests
+
+| Quality | Good | Bad |
+|---------|------|-----|
+| **Minimal** | One thing. "and" in name? Split it. | `test('validates email and domain and whitespace')` |
+| **Clear** | Name describes behavior | `test('test1')` |
+| **Shows intent** | Demonstrates desired API | Obscures what code should do |
+
+## Why Order Matters
+
+**"I'll write tests after to verify it works"**
+
+Tests written after code pass immediately. Passing immediately proves nothing:
+- Might test wrong thing
+- Might test implementation, not behavior
+- Might miss edge cases you forgot
+- You never saw it catch the bug
+
+Test-first forces you to see the test fail, proving it actually tests something.
+
+**"I already manually tested all the edge cases"**
+
+Manual testing is ad-hoc. You think you tested everything but:
+- No record of what you tested
+- Can't re-run when code changes
+- Easy to forget cases under pressure
+- "It worked when I tried it" ≠ comprehensive
+
+Automated tests are systematic. They run the same way every time.
+
+**"Deleting X hours of work is wasteful"**
+
+Sunk cost fallacy. The time is already gone. Your choice now:
+- Delete and rewrite with TDD (X more hours, high confidence)
+- Keep it and add tests after (30 min, low confidence, likely bugs)
+
+The "waste" is keeping code you can't trust. Working code without real tests is technical debt.
+
+**"TDD is dogmatic, being pragmatic means adapting"**
+
+TDD IS pragmatic:
+- Finds bugs before commit (faster than debugging after)
+- Prevents regressions (tests catch breaks immediately)
+- Documents behavior (tests show how to use code)
+- Enables refactoring (change freely, tests catch breaks)
+
+"Pragmatic" shortcuts = debugging in production = slower.
+
+**"Tests after achieve the same goals - it's spirit not ritual"**
+
+No. Tests-after answer "What does this do?" Tests-first answer "What should this do?"
+
+Tests-after are biased by your implementation. You test what you built, not what's required. You verify remembered edge cases, not discovered ones.
+
+Tests-first force edge case discovery before implementing. Tests-after verify you remembered everything (you didn't).
+
+30 minutes of tests after ≠ TDD. You get coverage, lose proof tests work.
+
+## Common Rationalizations
+
+| Excuse | Reality |
+|--------|---------|
+| "Too simple to test" | Simple code breaks. Test takes 30 seconds. |
+| "I'll test after" | Tests passing immediately prove nothing. |
+| "Tests after achieve same goals" | Tests-after = "what does this do?" Tests-first = "what should this do?" |
+| "Already manually tested" | Ad-hoc ≠ systematic. No record, can't re-run. |
+| "Deleting X hours is wasteful" | Sunk cost fallacy. Keeping unverified code is technical debt. |
+| "Keep as reference, write tests first" | You'll adapt it. That's testing after. Delete means delete. |
+| "Need to explore first" | Fine. Throw away exploration, start with TDD. |
+| "Test hard = design unclear" | Listen to test. Hard to test = hard to use. |
+| "TDD will slow me down" | TDD faster than debugging. Pragmatic = test-first. |
+| "Manual test faster" | Manual doesn't prove edge cases. You'll re-test every change. |
+| "Existing code has no tests" | You're improving it. Add tests for existing code. |
+
+## Red Flags - STOP and Start Over
+
+- Code before test
+- Test after implementation
+- Test passes immediately
+- Can't explain why test failed
+- Tests added "later"
+- Rationalizing "just this once"
+- "I already manually tested it"
+- "Tests after achieve the same purpose"
+- "It's about spirit not ritual"
+- "Keep as reference" or "adapt existing code"
+- "Already spent X hours, deleting is wasteful"
+- "TDD is dogmatic, I'm being pragmatic"
+- "This is different because..."
+
+**All of these mean: Delete code. Start over with TDD.**
+
+## Example: Bug Fix
+
+**Bug:** Empty email accepted
+
+**RED**
+```typescript
+test('rejects empty email', async () => {
+  const result = await submitForm({ email: '' });
+  expect(result.error).toBe('Email required');
+});
+```
+
+**Verify RED**
+```bash
+$ npm test
+FAIL: expected 'Email required', got undefined
+```
+
+**GREEN**
+```typescript
+function submitForm(data: FormData) {
+  if (!data.email?.trim()) {
+    return { error: 'Email required' };
+  }
+  // ...
+}
+```
+
+**Verify GREEN**
+```bash
+$ npm test
+PASS
+```
+
+**REFACTOR**
+Extract validation for multiple fields if needed.
+
+## Verification Checklist
+
+Before marking work complete:
+
+- [ ] Every new function/method has a test
+- [ ] Watched each test fail before implementing
+- [ ] Each test failed for expected reason (feature missing, not typo)
+- [ ] Wrote minimal code to pass each test
+- [ ] All tests pass
+- [ ] Output pristine (no errors, warnings)
+- [ ] Tests use real code (mocks only if unavoidable)
+- [ ] Edge cases and errors covered
+
+Can't check all boxes? You skipped TDD. Start over.
+
+## When Stuck
+
+| Problem | Solution |
+|---------|----------|
+| Don't know how to test | Write wished-for API. Write assertion first. Ask your human partner. |
+| Test too complicated | Design too complicated. Simplify interface. |
+| Must mock everything | Code too coupled. Use dependency injection. |
+| Test setup huge | Extract helpers. Still complex? Simplify design. |
+
+## Debugging Integration
+
+Bug found? Write failing test reproducing it. Follow TDD cycle. Test proves fix and prevents regression.
+
+Never fix bugs without a test.
+
+## Testing Anti-Patterns
+
+When adding mocks or test utilities, read @testing-anti-patterns.md to avoid common pitfalls:
+- Testing mock behavior instead of real behavior
+- Adding test-only methods to production classes
+- Mocking without understanding dependencies
+
+## Final Rule
+
+```
+Production code → test exists and failed first
+Otherwise → not TDD
+```
+
+No exceptions without your human partner's permission.

--- a/cli/templates/skills/using-bones-powers/SKILL.md
+++ b/cli/templates/skills/using-bones-powers/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: using-bones-powers
+version: 1.0.0
+targets: [claude-code]
+type: skill
+description: MANDATORY at the start of every Claude Code session in a bones workspace (any directory whose tree contains `.bones/`). Establishes how to find and use bones-powers skills and overrides default system-prompt workflow defaults (brainstorm → spec → plan loops, "let's think about this together" patterns) for bones primitives. Must be invoked via the Skill tool BEFORE any response — including clarifying questions, including "I'll just take a quick look first." If `.bones/` exists in the cwd or a parent, this skill applies.
+category:
+  primary: workflow
+---
+
+<SUBAGENT-STOP>
+If you were dispatched as a subagent to execute a specific task, skip this skill.
+</SUBAGENT-STOP>
+
+<EXTREMELY-IMPORTANT>
+If you think there is even a 1% chance a skill might apply to what you are doing, you ABSOLUTELY MUST invoke the skill.
+
+IF A SKILL APPLIES TO YOUR TASK, YOU DO NOT HAVE A CHOICE. YOU MUST USE IT.
+
+This is not negotiable. This is not optional. You cannot rationalize your way out of this.
+</EXTREMELY-IMPORTANT>
+
+## Instruction Priority
+
+bones-powers skills override default system prompt behavior, but **user instructions always take precedence**:
+
+1. **User's explicit instructions** (CLAUDE.md, direct requests) — highest priority
+2. **bones-powers skills** — override default system behavior where they conflict
+3. **Default system prompt** — lowest priority
+
+If CLAUDE.md says "don't use TDD" and a skill says "always use TDD," follow the user's instructions. The user is in control.
+
+## How to Access Skills
+
+**In Claude Code:** Use the `Skill` tool. When you invoke a skill, its content is loaded and presented to you—follow it directly. Never use the Read tool on skill files.
+
+**In other environments:** Check your platform's documentation for how skills are loaded.
+
+## Bones primitives
+
+bones-powers skills assume you understand these concepts. If any are unfamiliar, run `bones --help` and `bones <subcommand> --help`.
+
+| Term | Meaning |
+|---|---|
+| **workspace** | A directory bootstrapped by `bones up`. Marker: `.bones/repo.fossil`. |
+| **hub** | The Fossil repo at the center of the workspace. Holds trunk and all leaves. |
+| **trunk** | The mainline branch in the hub. Equivalent to git's `main`. |
+| **slot** | A named worker role (e.g. `alpha`, `frontend`, `infra`). Tasks are routed by slot. |
+| **leaf** | A slot's working session — a worktree + claimed task + open hub branch. Created by `bones swarm join`. |
+| **swarm session** | The lifecycle of one slot's leaf, from `swarm join` to `swarm close`. |
+| **fan-in** | `bones swarm fan-in` — merge open hub leaves back into trunk. |
+| **task** | A unit of work in `bones tasks`. Has `id`, `slot`, `parent`, `files`, `status` (pending/claimed/closed), `result` (success/fail/fork). |
+| **task graph** | Per spec § 4.4: one root task per plan, one child task per plan step, all sharing `--files=<plan-path>`. |
+
+| Tool you'd reach for | bones equivalent |
+|---|---|
+| `git worktree add` | `bones swarm join --slot=X --task-id=Y` |
+| `git commit` | `bones repo ci -m '…'` (free-form) or `bones swarm commit -m '…'` (heartbeats the active slot) |
+| `git merge`, "open a PR" | `bones swarm fan-in -m '…'` (preview with `--dry-run` first) |
+| TodoWrite (for plan tracking) | `bones tasks create/list/claim/close` |
+| TodoWrite (for in-session steps) | TodoWrite (still — see hybrid task model in § 6 of the spec) |
+
+## Cross-harness tool names
+
+bones-powers skill content uses Claude Code tool names (TodoWrite, Skill, Read, Edit, Write, Bash, Glob, Grep, Agent/Task). On non-Claude-Code harnesses, see the per-harness mapping in `references/`:
+
+- Codex: `references/codex-tools.md`
+- Gemini: `references/gemini-tools.md`
+- Copilot CLI: `references/copilot-tools.md`
+- Pi: `references/pi-tools.md`
+
+When you encounter a Claude Code tool name in a bones-powers skill running on another harness, translate using the relevant mapping. The agent reads this meta-skill at session start (via the gated SessionStart hook), so the mapping is implicit context for all downstream skill reads.
+
+apm is intentionally not listed — apm is an intermediate package format whose downstream consumers (codex, gemini, etc.) bring their own tool naming. If you're authoring an apm-published variant, refer to the consumer harness's mapping.
+
+# Using Skills
+
+## The Rule
+
+**Invoke relevant or requested skills BEFORE any response or action.** Even a 1% chance a skill might apply means that you should invoke the skill to check. If an invoked skill turns out to be wrong for the situation, you don't need to use it.
+
+```dot
+digraph skill_flow {
+    "User message received" [shape=doublecircle];
+    "About to EnterPlanMode?" [shape=doublecircle];
+    "Already brainstormed?" [shape=diamond];
+    "Invoke brainstorming skill" [shape=box];
+    "Might any skill apply?" [shape=diamond];
+    "Invoke Skill tool" [shape=box];
+    "Announce: 'Using [skill] to [purpose]'" [shape=box];
+    "Has checklist?" [shape=diamond];
+    "Create TodoWrite todo per item" [shape=box];
+    "Follow skill exactly" [shape=box];
+    "Respond (including clarifications)" [shape=doublecircle];
+
+    "About to EnterPlanMode?" -> "Already brainstormed?";
+    "Already brainstormed?" -> "Invoke brainstorming skill" [label="no"];
+    "Already brainstormed?" -> "Might any skill apply?" [label="yes"];
+    "Invoke brainstorming skill" -> "Might any skill apply?";
+
+    "User message received" -> "Might any skill apply?";
+    "Might any skill apply?" -> "Invoke Skill tool" [label="yes, even 1%"];
+    "Might any skill apply?" -> "Respond (including clarifications)" [label="definitely not"];
+    "Invoke Skill tool" -> "Announce: 'Using [skill] to [purpose]'";
+    "Announce: 'Using [skill] to [purpose]'" -> "Has checklist?";
+    "Has checklist?" -> "Create TodoWrite todo per item" [label="yes"];
+    "Has checklist?" -> "Follow skill exactly" [label="no"];
+    "Create TodoWrite todo per item" -> "Follow skill exactly";
+}
+```
+
+## Red Flags
+
+These thoughts mean STOP—you're rationalizing:
+
+| Thought | Reality |
+|---------|---------|
+| "This is just a simple question" | Questions are tasks. Check for skills. |
+| "I need more context first" | Skill check comes BEFORE clarifying questions. |
+| "Let me explore the codebase first" | Skills tell you HOW to explore. Check first. |
+| "I can check git/files quickly" | Files lack conversation context. Check for skills. |
+| "Let me gather information first" | Skills tell you HOW to gather information. |
+| "This doesn't need a formal skill" | If a skill exists, use it. |
+| "I remember this skill" | Skills evolve. Read current version. |
+| "This doesn't count as a task" | Action = task. Check for skills. |
+| "The skill is overkill" | Simple things become complex. Use it. |
+| "I'll just do this one thing first" | Check BEFORE doing anything. |
+| "This feels productive" | Undisciplined action wastes time. Skills prevent this. |
+| "I know what that means" | Knowing the concept ≠ using the skill. Invoke it. |
+
+## Skill Priority
+
+When multiple skills could apply, use this order:
+
+1. **Process skills first** (brainstorming, debugging) - these determine HOW to approach the task
+2. **Implementation skills second** (frontend-design, mcp-builder) - these guide execution
+
+"Let's build X" → brainstorming first, then implementation skills.
+"Fix this bug" → debugging first, then domain-specific skills.
+
+## Skill Types
+
+**Rigid** (TDD, debugging): Follow exactly. Don't adapt away discipline.
+
+**Flexible** (patterns): Adapt principles to context.
+
+The skill itself tells you which.
+
+## User Instructions
+
+Instructions say WHAT, not HOW. "Add X" or "Fix Y" doesn't mean skip workflows.

--- a/cli/templates/skills/using-bones-powers/references/codex-tools.md
+++ b/cli/templates/skills/using-bones-powers/references/codex-tools.md
@@ -1,0 +1,21 @@
+# Claude Code → Codex tool mapping
+
+When running on Codex, the following Claude Code tool names map to Codex equivalents.
+
+| Claude Code | Codex | Notes |
+|---|---|---|
+| `Read` | `read_file` | Read a file from disk |
+| `Edit` | `apply_patch` | In-place edit; Codex requires a patch format (diff-like) |
+| `Write` | `write_file` | Create or overwrite a file |
+| `Bash` | `run_shell` | Execute shell command |
+| `Glob` | `find_files` | Pattern-based file search |
+| `Grep` | `search_in_files` | Content search |
+| `TodoWrite` | (no exact equivalent) | Codex tracks tasks via the AGENTS.md TODO section. When a bones-powers skill says "TodoWrite a fresh checklist", treat it as "add a TODO section to your AGENTS.md scratch space and track in-task micro-steps there". |
+| `Skill` | (auto-loaded) | Codex skills are loaded via AGENTS.md frontmatter. When a skill body says "invoke skill X", X is already loaded — no explicit invocation needed. |
+| `Agent` / `Task` | `delegate_to` | Subagent dispatch in Codex |
+
+## Translation notes
+
+- bones-powers skills reference TodoWrite for in-session worker micro-steps. On Codex, use the AGENTS.md TODO section equivalent. The hybrid task model rule (plan → bones tasks, micro-steps → TodoWrite) becomes (plan → bones tasks, micro-steps → AGENTS.md TODO).
+- bones-powers' `subagent-driven-development` references the `Task` tool / `Agent` dispatch. On Codex, this is `delegate_to` (or whatever Codex calls subagent dispatch — verify against current Codex docs).
+- File-manipulation tools (Read/Edit/Write/Bash/Glob/Grep) have direct Codex equivalents — translate at face value.

--- a/cli/templates/skills/using-bones-powers/references/copilot-tools.md
+++ b/cli/templates/skills/using-bones-powers/references/copilot-tools.md
@@ -1,0 +1,23 @@
+# Claude Code → Copilot CLI tool mapping
+
+When running on GitHub Copilot CLI, the following Claude Code tool names map to Copilot equivalents.
+
+| Claude Code | Copilot CLI | Notes |
+|---|---|---|
+| `Read` | `read_file` (or `cat` via shell) | Copilot CLI primarily uses shell; some implementations expose `read_file` |
+| `Edit` | (shell-based: `sed`/`patch` via shell) | Copilot CLI doesn't have a structured Edit tool — use shell tools |
+| `Write` | (shell: `tee`/`>` redirection) | Same — shell-based |
+| `Bash` | shell (default in Copilot CLI) | Direct shell execution is the primary tool |
+| `Glob` | shell (`find` / `ls`) | Pattern matching via shell |
+| `Grep` | shell (`grep` / `rg`) | Content search via shell |
+| `TodoWrite` | (no equivalent) | Copilot CLI doesn't have a structured task-tracking tool. Track in conversation or via external file. |
+| `Skill` | (Copilot CLI skill mechanism per its docs) | If Copilot CLI supports skills, refer to its docs for invocation; otherwise skill content is implicitly loaded into context. |
+| `Agent` / `Task` | (subagent — refer to Copilot CLI docs) | Copilot CLI's multi-agent orchestration may differ — adapt dispatch patterns from skill prose. |
+
+## Translation notes
+
+- Copilot CLI is more shell-centric than Claude Code. Tool calls that Claude Code expresses via structured `Edit` / `Write` invocations become shell commands (`sed -i`, `>`, `tee`, etc.) on Copilot CLI.
+- TodoWrite has no direct equivalent — track micro-steps in conversation or a temp file.
+- bones-powers' subagent-driven-development pattern depends on subagent dispatch — verify Copilot CLI's mechanism.
+
+(Note: this doc reflects Copilot CLI v1.x patterns; verify against the version you're running.)

--- a/cli/templates/skills/using-bones-powers/references/gemini-tools.md
+++ b/cli/templates/skills/using-bones-powers/references/gemini-tools.md
@@ -1,0 +1,23 @@
+# Claude Code → Gemini tool mapping
+
+When running on Gemini, the following Claude Code tool names map to Gemini equivalents.
+
+| Claude Code | Gemini | Notes |
+|---|---|---|
+| `Read` | `read_file` | Read a file from disk |
+| `Edit` | `edit_file` | In-place edit |
+| `Write` | `write_file` | Create or overwrite a file |
+| `Bash` | `run_shell_command` | Execute shell command |
+| `Glob` | `glob` | Pattern-based file search |
+| `Grep` | `grep` | Content search |
+| `TodoWrite` | (no direct equivalent) | Gemini agents track tasks via conversation context or external tooling. When a bones-powers skill says "TodoWrite a fresh checklist", maintain that checklist as a tracked list in your context. |
+| `Skill` | (loaded via Gemini settings) | Gemini skills are loaded via `~/.gemini/settings.json` skill registration. When a skill body says "invoke skill X", X is loaded if registered. |
+| `Agent` / `Task` | (Gemini subagent equivalent) | Gemini's subagent dispatch — refer to Gemini CLI docs for the exact tool name. |
+
+## Translation notes
+
+- TodoWrite scoping (plan-level → bones tasks; in-session micro-steps → TodoWrite per spec § 6) carries over to Gemini — track micro-steps in whatever ephemeral mechanism Gemini provides (conversation context, internal scratchpad, or external file).
+- bones-powers' `subagent-driven-development` references subagent dispatch. Gemini's subagent mechanism may differ — refer to Gemini CLI subagent docs and adapt the dispatch pattern.
+- File tools translate directly.
+
+(Note: this doc is best-effort based on current Gemini CLI public surface; verify against the latest Gemini CLI docs when adopting.)

--- a/cli/templates/skills/using-bones-powers/references/pi-tools.md
+++ b/cli/templates/skills/using-bones-powers/references/pi-tools.md
@@ -1,0 +1,24 @@
+# Claude Code → Pi tool mapping
+
+When running on Pi, the following Claude Code tool names map to Pi equivalents.
+
+| Claude Code | Pi | Notes |
+|---|---|---|
+| `Read` | (file read via Pi tooling) | Pi exposes filesystem operations through its agent runtime |
+| `Edit` | (Pi edit tooling) | Refer to Pi docs for the structured edit tool |
+| `Write` | (Pi write tooling) | Same |
+| `Bash` | (Pi shell tooling) | Pi's shell access primitive |
+| `Glob` | (Pi pattern search) | File pattern matching |
+| `Grep` | (Pi content search) | File content search |
+| `TodoWrite` | (no equivalent) | Pi agents track tasks via Pi's task primitives or external files |
+| `Skill` | (Pi skill loading via package keyword `pi-package`) | Per `suit.config.yaml` pi conventions, skills are loaded via Pi packages |
+| `Agent` / `Task` | (Pi subagent / task delegation) | Refer to Pi docs for multi-agent orchestration |
+
+## Translation notes
+
+- Pi is file/package-oriented — many Claude Code tools have file-based equivalents through Pi's runtime.
+- TodoWrite scoping (plan-level → bones tasks; micro-steps → TodoWrite per spec § 6) carries over — track micro-steps in whatever ephemeral mechanism Pi provides.
+- bones-powers' subagent-driven-development pattern depends on subagent dispatch — verify Pi's mechanism.
+- Pi-specific package conventions (the `pi-package` keyword) determine how bones-powers skills appear in a Pi installation; per-skill tool naming follows Pi's runtime conventions.
+
+(Note: this doc is best-effort based on Pi's suit-build adapter conventions; verify against Pi's official docs when adopting.)

--- a/cli/templates/skills/using-bones-swarm/SKILL.md
+++ b/cli/templates/skills/using-bones-swarm/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: using-bones-swarm
+version: 1.0.0
+targets: [claude-code]
+type: skill
+description: Open, work in, and close a bones swarm session — the slot-shaped lane that bundles a worktree, a claimed task, and an open hub branch. Use when starting feature work that needs isolation from current workspace, before executing implementation plans, or when you need a worktree for parallel work in a bones workspace.
+category:
+  primary: workflow
+  secondary: [context-management]
+---
+
+# Using bones swarm
+
+`bones swarm` is the slot-scoped session primitive. One swarm session = one leaf = one worktree + one claimed task + one open hub branch. This skill walks you through the 5-step lifecycle.
+
+**Prerequisite**: a bones workspace (`.bones/repo.fossil` exists in cwd or a parent). If missing, run `bones up` first.
+
+## The lifecycle
+
+```
+1. swarm join    →  open a leaf, claim a task, prepare a worktree (atomic)
+2. swarm cwd     →  navigate to the worktree
+3. work          →  edit files; make changes
+4. swarm commit  →  heartbeat the session + commit (repeat as needed)
+5. swarm close   →  release claim, post result, stop the leaf
+```
+
+## Step 1: Join
+
+```bash
+bones swarm join --slot=<slot-name> --task-id=<task-id>
+```
+
+What this does (atomically):
+- Opens a new leaf in the hub for the given slot.
+- Claims the named task in `bones tasks` (fails if already claimed or closed).
+- Prepares a worktree on disk for that leaf.
+- Registers the swarm session so `swarm status` and `swarm cwd` can find it.
+
+**Recovery**: if a previous swarm session is stuck (crashed agent, stale lock):
+```bash
+bones swarm join --slot=<slot> --task-id=<id> --force
+```
+This clobbers the existing slot session. Use only when you're sure nothing else is using that slot.
+
+## Step 2: Navigate
+
+```bash
+cd "$(bones swarm cwd --slot=<slot-name>)"
+```
+
+Or capture the path once:
+```bash
+WORKTREE=$(bones swarm cwd --slot=<slot-name>)
+cd "$WORKTREE"
+```
+
+## Step 3: Work
+
+Edit files. The worktree is a normal filesystem checkout — your editor and tools work as usual.
+
+If you need to verify the workspace is clean:
+```bash
+bones repo status
+```
+
+## Step 4: Commit and heartbeat
+
+Every meaningful save during the session:
+
+```bash
+bones swarm commit -m "<message>" [files...]
+```
+
+This commits and emits a heartbeat. The hub knows the session is alive. Repeat as often as you'd commit normally.
+
+If you only want to commit (not heartbeat — rare), use `bones repo ci -m "…" <files>` directly. Prefer `swarm commit` while inside a session.
+
+## Step 5: Close
+
+When work is done:
+
+```bash
+bones swarm close --result=success --summary="<one-line result>"
+```
+
+This releases the claim, posts the result to the task's thread, and stops the leaf. The leaf remains in the hub (open for fan-in).
+
+If the work is incomplete or failed:
+```bash
+bones swarm close --result=fail --summary="<reason>"
+```
+
+Releases the claim so another worker (or another attempt) can pick the task back up.
+
+## Composition
+
+This skill is a primitive used by other bones-powers skills:
+- `bones-powers:executing-plans` (single-session inline) — invokes the lifecycle once per task.
+- `bones-powers:subagent-driven-development` — invokes the lifecycle per implementer subagent (one per slot, in parallel).
+- `bones-powers:dispatching-parallel-agents` — N concurrent invocations across N slots.
+- `bones-powers:finishing-a-bones-leaf` — what happens AFTER `swarm close`: fan-in, keep, or abandon.
+
+## Common pitfalls
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `swarm join` errors "slot busy" | Previous session not cleanly closed | `swarm join --force` (recovery) or `swarm close` the stale session first |
+| `swarm cwd` returns nothing | No active session for that slot | Run `bones swarm status` to see what's open |
+| Heartbeat stops being sent | Agent crashed mid-task | The hub will eventually time the leaf out; recover with `--force` |
+| `swarm close` errors "no active session" | Already closed, or never joined | `bones swarm status` to confirm |

--- a/docs/adr/0048-skills-bundle.md
+++ b/docs/adr/0048-skills-bundle.md
@@ -1,0 +1,63 @@
+# ADR 0048: Bones owns the skills bundle as workspace contract
+
+## Context
+
+ADR 0042 made AGENTS.md the universal channel and explicitly removed the per-skill markdown trees that earlier versions of `bones up` scaffolded under `.claude/skills/{orchestrator,subagent,uninstall-bones}/`. The intent: harness-agnostic surface, no per-platform proliferation.
+
+Field experience after ADR 0042 surfaced three failure modes documented as #165, #166, and #169:
+
+- **#166 — bones CLI ships without the bones-powers plugin.** The `bones-powers` plugin (a superpowers fork containing skills like `using-bones-powers`, `using-bones-swarm`, `finishing-a-bones-leaf`) lives in a separate repo. After `bones up`, the inner Claude Code session has zero bones knowledge until the operator hand-copies the skills. Operator's verbatim symptom: *"the session doesn't seem to know that it is supposed to use bones."*
+
+- **#165 — bones up writes hooks but they never effectively prime the session.** The hooks are correctly written to `.claude/settings.json` and Claude Code does fire them — but `bones tasks prime --json` output lands in a session with no skills present to invoke. The hook's payload is correctly delivered; the session has no apparatus to act on it.
+
+- **#169 — CLAUDE.md BONES block is a 2-line pointer to AGENTS.md.** ADR 0045 designed the block as a pointer, on the assumption that the agent would follow it. In practice, Claude Code does not auto-read AGENTS.md on session start. The pointer-only block leaves the inner session bones-blind even when CLAUDE.md is correctly scaffolded.
+
+The common thread: ADR 0042's "harness-agnostic, no skill scaffolding" stance assumed the agent would compose bones knowledge from AGENTS.md prose. That assumption doesn't hold for Claude Code's skill-tool-driven invocation model. The skills are how Claude Code agents discover and apply bounded directives; without skills present, hooks and AGENTS.md are insufficient in practice.
+
+## Decision
+
+Bones owns a curated skill bundle and scaffolds it into `<workspace>/.claude/skills/` on `bones up`. The bundle is the substrate-level contract for "this is a bones workspace."
+
+### What's bundled
+
+Six skills, embedded in the binary via `//go:embed all:templates/skills`:
+
+- `orchestrator` — drives `bones swarm dispatch` waves end-to-end via the Task tool. Description tightened for aggressive trigger coverage (any orchestration-shaped phrase: dispatch, parallelize, fan out, run plan, etc.).
+- `using-bones-powers` — entry-point skill, invoked at session start. Establishes how to access the rest of the bundle via the Skill tool. Description marked MANDATORY at session start in any bones workspace.
+- `using-bones-swarm` — slot-shaped session lifecycle: join → cwd → commit → close.
+- `finishing-a-bones-leaf` — fan-in / git-materialize / PR flow once a slot's work is integrated.
+- `systematic-debugging` — discipline floor for debugging (matches the ousterhout pattern).
+- `test-driven-development` — TDD discipline floor.
+
+The first four are bones-specific. The last two are general-purpose disciplines bones opts every workspace into; the cost of bundling them is small and the value of "every bones workspace ships with debugging + TDD floors" is high. If user feedback says otherwise we drop them — exits are cheap.
+
+### How scaffolding works
+
+`writeBonesSkills` walks the embedded FS. For each file under `templates/skills/<name>/`:
+
+1. **Missing on disk** → written verbatim, tracked in the up-summary's `FilesWritten`.
+2. **Hash-matches the embedded source** → no-op (idempotent re-run).
+3. **Diverges from the embedded source** → preserved as-is; surfaced in `fp.SkillsModified` so `bones up` warns the operator. Bones never silently overwrites user edits.
+
+`removeBonesSkills` (called by `bones down`) is the symmetric teardown: hash-matching files removed, user-modified files preserved, dirs rmdir'd if and only if empty after cleanup.
+
+### CLAUDE.md becomes inline content (#169)
+
+The `claudeManagedBody` in `cli/orchestrator.go` is no longer a 2-line pointer to AGENTS.md. The body now names the `using-bones-powers` skill explicitly with a MANDATORY directive that Claude Code's skill-tool dispatch picks up at session start. AGENTS.md remains the long-form contract for non-Claude harnesses; CLAUDE.md is now self-sufficient for Claude Code sessions.
+
+### SessionStart sentinel + doctor surface (#172)
+
+`bones tasks prime` writes `<workspace>/.bones/last-session-prime` (RFC3339 timestamp + bones version) on every invocation. `bones doctor` reads it and surfaces "last fired N min ago" or "never fired since hub start" so operators can detect "hooks configured but never effective" failure modes without spelunking through Claude Code's session JSONL transcripts.
+
+## What this supersedes
+
+- **ADR 0042's "no skill scaffolding" decision.** The harness-agnostic intent stays — AGENTS.md remains the universal channel, hooks remain in `.claude/settings.json` — but the per-platform skill bundle is now part of the bones contract for Claude Code workspaces. Other harnesses still pay no per-platform cost from bones; they read AGENTS.md and ignore `.claude/skills/`.
+- **ADR 0045's CLAUDE.md pointer asymmetry.** The block body is now self-contained inline content, not a pointer. The marker-block model itself is unchanged.
+
+## Consequences
+
+- **Pro:** Fresh `bones up` produces a workspace where Claude Code sessions arrive with skills present, hooks firing, and CLAUDE.md content that actually instructs. Operator setup collapses from "install bones, install bones-powers, sync them, hand-copy on every workspace" to "install bones."
+- **Pro:** Bones release cadence couples to skill content. We can ship orchestrator-skill improvements alongside CLI bug fixes without a separate plugin release.
+- **Con:** Skills evolve with bones, not independently. If we ever want a skill to ship faster than a bones release, we'd need a side-channel mechanism. Not a concern at current cadence.
+- **Con:** Operators with custom skills under those exact names would get an upgrade-path warning the first time they `bones up` post-bundle. The hash-check-and-preserve flow makes this safe (their content stays), but the warning is unavoidable.
+- **Neutral:** ADR 0042's harness-agnostic intent stands. AGENTS.md remains the long-form contract. The skills bundle is additive: Claude Code workspaces get the skill files; non-Claude harnesses continue to read AGENTS.md and ignore the bundle.


### PR DESCRIPTION
## Summary

Bones now embeds and scaffolds 6 curated skills into `<workspace>/.claude/skills/` on `bones up`. Closes #166 (CLI shipped without bones-powers — inner Claude had no bones knowledge), #169 (CLAUDE.md BONES block was a 2-line pointer Claude never followed to AGENTS.md), and #172 (no way to detect when configured hooks failed to fire). #165 collapses transitively — once skills are present, the SessionStart hook's `bones tasks prime` payload lands in a session that knows the verbs.

## Bundle

- **orchestrator** — drives `bones swarm dispatch` waves end-to-end via the Task tool. Description tightened for aggressive Skill-tool trigger coverage (any orchestration-shaped phrase: "run plan", "dispatch the swarm", "parallelize", "fan out", "kick off slots", reference to `dispatch.json`, etc.).
- **using-bones-powers** — entry-point skill, MANDATORY at session start in any bones workspace. Description specifies "before any response — including clarifying questions."
- **using-bones-swarm** — slot-shaped session lifecycle: join → cwd → commit → close.
- **finishing-a-bones-leaf** — fan-in / git materialize / PR flow.
- **systematic-debugging** — debugging discipline floor.
- **test-driven-development** — TDD discipline floor.

## Implementation

- **`cli/skills.go`** — `//go:embed all:templates/skills`, hash-based idempotency. Three-way logic: missing → write, hash-match → no-op, divergent → preserve + surface in `fp.SkillsModified`. Bones never silently overwrites user edits.
- **`cli/templates/skills/<name>/SKILL.md`** — 6 vendored skills. The orchestrator and using-bones-powers descriptions are tightened with explicit MANDATORY language, broad keyword coverage, and instruction-priority overrides for default workflow defaults (brainstorm → spec → plan loops, "let's think about this together" patterns).
- **`cli/orchestrator.go`** — `writeBonesSkills` wired into `scaffoldOrchestrator`. `claudeManagedBody` becomes inline content naming `using-bones-powers` + `orchestrator` explicitly (closes #169). `legacyBonesSkills` shrinks to `{subagent, uninstall-bones}`.
- **`cli/down.go`** — `planRemoveSkills` uses hash-checked `removeBonesSkills` for the bundle (preserves user edits), keeps blind-nuke for legacy names.
- **`cli/tasks_prime.go`** — writes `<ws>/.bones/last-session-prime` sentinel on every invocation. The SessionStart + PreCompact hooks already call this verb, so the sentinel refreshes for free.
- **`cli/doctor.go`** — `checkSessionStartSentinel` surfaces "fired N min ago" (OK) or "configured but never fired" (WARN) — closes #172.
- **`docs/adr/0048-skills-bundle.md`** — documents the reversal of ADR 0042's no-skill-scaffolding stance + ADR 0045's CLAUDE.md pointer asymmetry. The harness-agnostic intent stays — non-Claude harnesses still ignore `.claude/skills/` and read AGENTS.md.

## Tests

- `TestScaffold_BundledSkillsContent` — embed-to-disk byte equality for all 6 skills
- `TestScaffold_Skills_PreservesUserModifiedFiles` — user edits survive re-up, surfaced in `fp.SkillsModified`
- `TestScaffold_ClaudeMD_InlineBlock` — block names `using-bones-powers` + `orchestrator` explicitly
- `TestRemoveBonesSkills_PreservesUserModified` — `bones down` preserves user-edited SKILL.md
- `TestPlanDown_FullInstall` updated for new "remove bundled skills" action
- `TestScaffoldOrchestrator_FreshWorkspace` updated to assert all 6 skill files present

## Test plan

- [x] `make check` — fmt-check, vet, lint, race -short, todo-check all pass
- [x] `go test -count=1 -tags=otel -short ./...` — full CI parity
- [x] Live verify: fresh `bones up` → 6 skills written; `bones doctor` warns on missing sentinel; `bones tasks prime` writes sentinel and doctor flips to OK; `bones down` cleans bundle; user-modified `SKILL.md` survives `bones down --yes`

Closes #166
Closes #169
Closes #172