### PR TITLE
ci: use RELEASE_PUSH_TOKEN for bump-upstream so CI triggers on bump PRs

### DIFF
--- a/.github/workflows/bump-upstream.yml
+++ b/.github/workflows/bump-upstream.yml
@@ -73,7 +73,7 @@ jobs:
         if: steps.in.outputs.skip != 'true'
         id: idem
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_PUSH_TOKEN || secrets.GITHUB_TOKEN }}
           BRANCH: ${{ steps.in.outputs.branch }}
         run: |
           if gh pr list --repo "${{ github.repository }}" --head "$BRANCH" --state open --json number -q '.[0].number' | grep -q .; then
@@ -85,6 +85,13 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          # PAT preferred so the bot push + `gh pr create` originate from a
+          # real user identity, which lets pull_request workflows trigger on
+          # the resulting PR. With the default GITHUB_TOKEN, GitHub's
+          # recursion safeguard suppresses workflow runs and CI never fires
+          # on the bump PR. Configure RELEASE_PUSH_TOKEN as a fine-grained
+          # PAT with contents:write + pull-requests:write on this repo.
+          token: ${{ secrets.RELEASE_PUSH_TOKEN || github.token }}
 
       - if: steps.in.outputs.skip != 'true' && steps.idem.outputs.exists != 'true'
         uses: actions/setup-go@v6
@@ -125,7 +132,7 @@ jobs:
       - if: steps.in.outputs.skip != 'true' && steps.idem.outputs.exists != 'true' && steps.bump.outputs.noop != 'true'
         name: Commit + push + open PR
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_PUSH_TOKEN || secrets.GITHUB_TOKEN }}
           BRANCH: ${{ steps.in.outputs.branch }}
           REPO: ${{ steps.in.outputs.repo }}
           VERSION: ${{ steps.in.outputs.version }}


### PR DESCRIPTION
## Summary

Mirrors the `RELEASE_PUSH_TOKEN` pattern EdgeSync's `auto-release.yml` already ships. Without this, GitHub's recursion safeguard suppresses workflow runs when `bump-upstream.yml` opens its PR via `secrets.GITHUB_TOKEN` — every EdgeSync auto-bump lands without CI auto-running. PR #202 surfaced this: had to manually close + reopen to trigger `ci.yml`.

Three sites updated to `secrets.RELEASE_PUSH_TOKEN || github.token` (graceful fallback):

- `actions/checkout@v6` — `token:` so subsequent `git push` uses the PAT-authenticated remote
- Idempotency-check step's `GH_TOKEN` — keeps auth identity consistent across steps
- Commit + push + open PR step's `GH_TOKEN` — `gh pr create` then authors as the PAT user, allowing `pull_request` events to fire on the opened PR

## Setup needed (one-time)

Configure `RELEASE_PUSH_TOKEN` as a fine-grained PAT on this repo with:
- `contents:write`
- `pull-requests:write`

Until the secret is set, the workflow falls back to `github.token` and CI will continue requiring a manual close+reopen on bump PRs (current behavior — no regression).

## Test plan

- [x] yaml parses cleanly (would surface as workflow validation error in `gh run list` after merge)
- [ ] Verify on the next EdgeSync auto-release: bump-upstream PR opens AND `ci.yml` triggers automatically (requires `RELEASE_PUSH_TOKEN` to be configured first)

No code paths touched — workflow-only change.