### PR TITLE
fix(hub): write pid files before NewHub to close detach race (#199 regression)

### DIFF
--- a/internal/hub/hub.go
+++ b/internal/hub/hub.go
@@ -193,22 +193,33 @@ func runForeground(ctx context.Context, p paths, o opts) error {
 	if err := os.MkdirAll(p.natsStore, 0o755); err != nil {
 		return fmt.Errorf("hub: nats store dir: %w", err)
 	}
+	// Write pid files BEFORE NewHub binds the HTTP listener. edgehub.NewHub
+	// calls net.Listen at construction (the HTTP socket is up before
+	// ServeHTTP runs), and the kernel SYN-ACKs connections to a bound-but-
+	// unaccepted socket — so the detach parent's waitForTCP probe succeeds
+	// the moment NewHub returns. If we wrote pids after NewHub, the
+	// parent's port-collision check (readPid against cmd.Process.Pid)
+	// would race ahead of the pid write and fire a false-positive
+	// "fossil port responded but pids/fossil.pid does not name our child
+	// (recorded 0)" error on every detach start. Pid files name the
+	// foreground process either way (os.Getpid() is stable across the
+	// NewHub call), so writing them first is correct.
+	if err := writePid(p.fossilPid, os.Getpid()); err != nil {
+		return fmt.Errorf("hub: write fossil.pid: %w", err)
+	}
+	if err := writePid(p.natsPid, os.Getpid()); err != nil {
+		_ = os.Remove(p.fossilPid)
+		return fmt.Errorf("hub: write nats.pid: %w", err)
+	}
 	freshSeed := false
 	if _, err := os.Stat(p.hubRepo); errors.Is(err, os.ErrNotExist) {
 		freshSeed = true
 	}
 	h, err := openAndSeedHub(ctx, p, o, freshSeed)
 	if err != nil {
-		return err
-	}
-	if err := writePid(p.fossilPid, os.Getpid()); err != nil {
-		_ = h.Stop()
-		return fmt.Errorf("hub: write fossil.pid: %w", err)
-	}
-	if err := writePid(p.natsPid, os.Getpid()); err != nil {
 		_ = os.Remove(p.fossilPid)
-		_ = h.Stop()
-		return fmt.Errorf("hub: write nats.pid: %w", err)
+		_ = os.Remove(p.natsPid)
+		return err
 	}
 	httpDone := make(chan struct{})
 	httpCtx, httpCancel := context.WithCancel(context.Background())

--- a/internal/hub/runforeground_test.go
+++ b/internal/hub/runforeground_test.go
@@ -65,6 +65,50 @@ func TestWaitOrTimeout_ZeroFallsBackToDefault(t *testing.T) {
 	}
 }
 
+// TestRunForeground_PidsWrittenBeforeHubOpen pins the fix for the
+// detach pid-race regression introduced by the libfossil-exit migration.
+// edgehub.NewHub binds the HTTP listener at construction (the kernel
+// SYN-ACKs on the bound socket immediately), so the detach parent's
+// waitForTCP would race ahead of the child's writePid if pid writes
+// happened post-NewHub. Verifies fossil.pid + nats.pid both name the
+// foreground process by the time openAndSeedHub is invoked. Runs a
+// synthetic seed-failure to keep the test fast: we only need to assert
+// pid files are present on entry into the seed step, not that the full
+// hub bring-up succeeds.
+func TestRunForeground_PidsWrittenBeforeHubOpen(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".bones", "pids"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	p, err := newPaths(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	orig := seedHubRepoFunc
+	defer func() { seedHubRepoFunc = orig }()
+	var fossilPidAtSeed, natsPidAtSeed int
+	seedHubRepoFunc = func(_ context.Context, _ *edgehub.Hub, p paths) error {
+		// Read pid files at the moment seedHubRepo runs — well after
+		// runForeground's writePid calls completed but before any of
+		// the post-NewHub return paths could clean them up.
+		fossilPidAtSeed, _ = readPid(p.fossilPid)
+		natsPidAtSeed, _ = readPid(p.natsPid)
+		return errors.New("synthetic seed failure to short-circuit")
+	}
+
+	_ = runForeground(context.Background(), p, opts{})
+
+	if fossilPidAtSeed != os.Getpid() {
+		t.Errorf("fossil.pid at seed time: got %d, want %d (foreground process)",
+			fossilPidAtSeed, os.Getpid())
+	}
+	if natsPidAtSeed != os.Getpid() {
+		t.Errorf("nats.pid at seed time: got %d, want %d (foreground process)",
+			natsPidAtSeed, os.Getpid())
+	}
+}
+
 // TestRunForeground_SeedFailureCleansSidecars asserts that when seed
 // fails after libfossil has begun creating SQLite sidecar files,
 // runForeground removes the orphan -shm/-wal (and any partial


### PR DESCRIPTION
## Summary

Fixes a P0 regression introduced by #199's libfossil-exit migration. Every detached `bones hub start` — the SessionStart hook's auto-start path, which is the only path operators hit in the field — failed with:

```
fossil port responded but pids/fossil.pid does not name our child (pid N, recorded 0) — likely port collision
```

## Root cause

`edgehub.NewHub` calls `net.Listen("tcp", httpAddr)` at construction (the HTTP listener is bound before `ServeHTTP` runs). The kernel SYN-ACKs connections to a bound-but-unaccepted socket immediately, so `spawnDetachedChild`'s parent-side `waitForTCP` probe succeeds the moment `NewHub` returns. The post-NewHub-but-pre-writePid window in `runForeground` was a race the false-positive-readiness check at line 394 tripped on every start.

Timeline (broken):

```
parent: cmd.Start()
child:  openAndSeedHub() -> NewHub() -> net.Listen()  [port bound]
parent: waitForTCP(fossilAddr) -> succeeds
parent: readPid(fossilPid) -> recorded=0 (child hasn't reached writePid yet)
parent: error "port collision"
```

## Fix

Move `writePid(p.fossilPid)` + `writePid(p.natsPid)` to BEFORE `openAndSeedHub`. Pid files name `os.Getpid()` of the foreground process, which is stable across `NewHub`, so writing them earlier is correct. On seed failure post-NewHub we now cleanup pid files alongside the existing repo+sidecar cleanup so partially-started state doesn't leak.

## Test

Adds `TestRunForeground_PidsWrittenBeforeHubOpen` — injects a synthetic seed failure and asserts both pid files name the foreground process by the time the seed step runs. Covers the exact ordering contract the parent's port-collision check relies on.

## Test plan

- [x] `make check` — full pass
- [x] `go test -count=1 -tags=otel -short ./...` — full pass
- [x] Manual end-to-end: `mkdir tmp && cd tmp && git init && bones up && bones tasks prime --json` — hub starts cleanly via auto-start; sentinel writes correctly; `bones doctor` shows `OK SessionStart hooks fired 0s ago`
- [x] Pre-fix repro: same flow fails reliably with `recorded 0` error on main

Discovered while attempting to live-verify #165 (the Cluster A skill-bundle loop closure) — couldn't get past `bones tasks prime` running because the auto-start hook errored out.