### PR TITLE
test(integration): git-init newWorkspace fixture for hub seed precondition

### DIFF
--- a/cmd/bones/integration/integration_test.go
+++ b/cmd/bones/integration/integration_test.go
@@ -91,11 +91,40 @@ func killPidFile(t *testing.T, path string) {
 // Pins HOME to a temp dir so any subprocess whose path reaches
 // hub.Start (via workspace.Join) does NOT write to the operator's real
 // ~/.bones/workspaces/. See issue #180.
+//
+// Initializes the tmpdir as a git repo with one tracked seed file using a
+// deterministic, non-operator committer identity. Hub auto-start (triggered
+// by any command that connects to a leaf-managed task store) refuses to
+// seed against an empty `git ls-files` — see issue #204.
 func newWorkspace(t *testing.T) string {
 	t.Helper()
 	requireBinaries(t)
 	t.Setenv("HOME", t.TempDir())
 	dir := t.TempDir()
+	// Init a fresh git repo and stage one file. Hub's seedHubRepo
+	// walks `git ls-files` and refuses to seed an empty workspace.
+	gitInit := exec.Command("git", "init", "-q", "-b", "main")
+	gitInit.Dir = dir
+	if out, err := gitInit.CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v\n%s", err, out)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "seed.txt"), []byte("seed\n"), 0o644); err != nil {
+		t.Fatalf("write seed.txt: %v", err)
+	}
+	// Configure committer for this fixture so `git commit` doesn't
+	// pull in the operator's config.
+	for _, args := range [][]string{
+		{"config", "user.email", "newworkspace-test@example.invalid"},
+		{"config", "user.name", "Newworkspace Test"},
+		{"add", "seed.txt"},
+		{"commit", "-q", "-m", "seed"},
+	} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
 	t.Cleanup(func() { killPidFile(t, filepath.Join(dir, ".bones", "leaf.pid")) })
 	if _, stderr, code := runCmd(t, bonesBin, dir, "init"); code != 0 {
 		t.Fatalf("init failed: %s", stderr)


### PR DESCRIPTION
## Summary

`TestCLI_Watch_Smoke` (and several other integration tests) failed on `main` because `newWorkspace` produced a tmpdir that was not a git repository — so when the hub auto-started on the first task verb, its `seedHubRepo` precondition (introduced in #138) shelled out to `git ls-files` and exited 128.

This change mirrors the existing `setupSwarmWorkspace` pattern in the same package: `git init`, write a single `seed.txt`, configure a deterministic non-operator committer identity (`newworkspace-test@example.invalid`), `git add` + `git commit`. `bones init` is unchanged. No production code is touched.

## Test plan

- [x] `go test -count=1 -timeout 60s ./cmd/bones/integration/... -run TestCLI_Watch_Smoke` passes (was failing on main)
- [x] `make check`
- [x] `go test -tags=otel -short ./...`
- [x] Full integration suite: 8 additional previously-failing tests now pass (Create, AutoClaim, Dispatch, Prime, Swarm, SwarmCommit_AfterHubRestart, Aggregate_Empty, Watch_Smoke); no regressions vs main.

Closes #204