### PR TITLE
fix(status): don't auto-start hub when resolving workspace root

### DIFF
--- a/cli/status.go
+++ b/cli/status.go
@@ -92,6 +92,23 @@ func (c *StatusCmd) Run(g *repocli.Globals) error {
 		}
 		return renderStatusAll(os.Stdout)
 	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("cwd: %w", err)
+	}
+	root, err := resolveStatusRoot(cwd)
+	if err != nil {
+		return err
+	}
+	// Read-only hub probe (#207). If the hub isn't healthy, render
+	// the existing degraded-mode branch (HubAvailable=false) without
+	// touching workspace.Join — Join would lazy-start the hub via
+	// hubStartFunc, contradicting the lazy-hub promise printed by
+	// `bones up` and silently writing .bones/pids/ + URL files on
+	// every `bones status` invocation.
+	if !workspace.HubIsHealthy(root) {
+		return renderStatus(degradedStatusReport(root), os.Stdout)
+	}
 	ctx, stop, info, err := joinWorkspace()
 	if err != nil {
 		return err
@@ -102,6 +119,32 @@ func (c *StatusCmd) Run(g *repocli.Globals) error {
 		return err
 	}
 	return renderStatus(report, os.Stdout)
+}
+
+// resolveStatusRoot walks up from cwd to the workspace marker
+// (.bones/agent.id) without touching the hub, mirroring
+// resolveDownRoot's #138 fix. `bones status` is read-only and has a
+// fully degraded HubAvailable=false render path; routing through
+// workspace.Join would lazy-start the hub on every invocation,
+// contradicting the lazy-hub promise printed by `bones up` (#207).
+func resolveStatusRoot(cwd string) (string, error) {
+	return workspace.FindRoot(cwd)
+}
+
+// degradedStatusReport assembles a statusReport with HubAvailable=false
+// for workspaces whose hub isn't running. Populated fields are limited
+// to what's available from on-disk state (workspace dir, scaffold
+// stamp); NATS-backed views (tasks, sessions, fossil timeline) stay
+// empty so the renderer's degraded branch fires.
+func degradedStatusReport(root string) statusReport {
+	stamp, _ := scaffoldver.Read(root)
+	return statusReport{
+		WorkspaceDir:     root,
+		GeneratedAt:      timeNow(),
+		TasksByStatus:    map[tasks.Status]int{},
+		TasksByID:        map[string]tasks.Task{},
+		ScaffoldComplete: stamp != "",
+	}
 }
 
 // gatherStatus collects every input the snapshot needs. NATS-side

--- a/cli/status_test.go
+++ b/cli/status_test.go
@@ -6,9 +6,12 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
+
+	repocli "github.com/danmestas/EdgeSync/cli/repo"
 
 	"github.com/danmestas/bones/internal/registry"
 	"github.com/danmestas/bones/internal/swarm"
@@ -243,6 +246,144 @@ func TestStatusAllEmptyRegistry(t *testing.T) {
 	}
 	if !strings.Contains(buf.String(), "No workspaces running") {
 		t.Fatalf("expected 'No workspaces running', got: %s", buf.String())
+	}
+}
+
+// TestResolveStatusRoot_DoesNotAutoStartHub mirrors the #138 item 7
+// fix for `bones down` (TestResolveDownRoot_DoesNotAutoStartHub) for
+// `bones status` (#207). Pre-fix, every CLI verb resolved the
+// workspace via workspace.Join, which lazy-starts the hub via
+// hubStartFunc when none is healthy. That contradicts the lazy-hub
+// promise printed by `bones up` ("hub: not yet started — will start
+// on next session or first verb that needs it"): a read-only verb
+// like status would silently boot a hub on every invocation.
+//
+// Post-fix, status's root resolver calls workspace.FindRoot
+// (read-only), so no hub start is attempted at all. The renderer's
+// existing degraded-mode branch (HubAvailable=false) handles output
+// when the hub is genuinely down.
+func TestResolveStatusRoot_DoesNotAutoStartHub(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".bones"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".bones", "agent.id"),
+		[]byte("test-agent-id\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := resolveStatusRoot(root)
+	if err != nil {
+		t.Fatalf("resolveStatusRoot: %v", err)
+	}
+	if got != root {
+		t.Errorf("resolveStatusRoot: got %q, want %q", got, root)
+	}
+
+	// Hub state files must NOT have been created. workspace.Join would
+	// have written hub-fossil-url and hub-nats-url and started a leaf;
+	// FindRoot writes nothing.
+	for _, name := range []string{"hub-fossil-url", "hub-nats-url"} {
+		path := filepath.Join(root, ".bones", name)
+		if _, err := os.Stat(path); err == nil {
+			t.Errorf("resolveStatusRoot must not auto-start hub; "+
+				"found %s (#207)", path)
+		} else if !os.IsNotExist(err) {
+			t.Errorf("stat %s: unexpected error: %v", path, err)
+		}
+	}
+	// pids dir is hub.Start's first side effect; presence indicates
+	// the auto-start branch ran.
+	if _, err := os.Stat(filepath.Join(root, ".bones", "pids")); err == nil {
+		t.Errorf("resolveStatusRoot created .bones/pids/; hub auto-start ran (#207)")
+	}
+}
+
+// TestStatusRun_NoHub_DoesNotStartOne is the end-to-end pin of #207.
+// Against a fresh workspace marker with no hub running, StatusCmd.Run
+// must:
+//   - exit 0 (degraded mode is non-error),
+//   - emit the "Hub fossil unavailable" hint from the existing
+//     HubAvailable=false renderer branch,
+//   - leave the workspace's .bones/ directory in the same shape it
+//     found (no pids/, no hub-*-url files).
+//
+// Pre-fix this would emit `bones: starting hub for workspace ...` to
+// stderr and write hub state.
+func TestStatusRun_NoHub_DoesNotStartOne(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".bones"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".bones", "agent.id"),
+		[]byte("test-agent-id\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// scaffold_version stamp keeps the WARN out of output (separate
+	// concern from #207); this test is about the hub-start side effect.
+	if err := os.WriteFile(filepath.Join(root, ".bones", "scaffold_version"),
+		[]byte("0001\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(root)
+
+	// Capture stdout to verify the degraded-mode hint appears and no
+	// "starting hub" line leaks. finish() closes the pipe writer and
+	// drains the reader; must run BEFORE inspecting the buffer.
+	stdout, finish := captureStdout(t)
+
+	cmd := &StatusCmd{}
+	runErr := cmd.Run(&repocli.Globals{})
+	finish()
+	if runErr != nil {
+		t.Fatalf("StatusCmd.Run: %v", runErr)
+	}
+
+	out := stdout.String()
+	if !strings.Contains(out, "Hub fossil unavailable") {
+		t.Errorf("expected degraded-mode hint in output, got:\n%s", out)
+	}
+	if strings.Contains(out, "starting hub for workspace") {
+		t.Errorf("status auto-started hub (#207); output:\n%s", out)
+	}
+
+	// No hub state files created.
+	for _, name := range []string{"hub-fossil-url", "hub-nats-url"} {
+		path := filepath.Join(root, ".bones", name)
+		if _, err := os.Stat(path); err == nil {
+			t.Errorf("status created %s; #207 says it must not write hub state", path)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(root, ".bones", "pids")); err == nil {
+		t.Errorf("status created .bones/pids/; #207 says it must not write hub state")
+	}
+}
+
+// captureStdout swaps os.Stdout for a pipe and returns a buffer plus
+// a finish func. Caller must invoke finish() AFTER the function under
+// test returns and BEFORE reading the buffer — finish closes the
+// writer, drains the reader goroutine, and restores os.Stdout. Used
+// because StatusCmd.Run writes directly to os.Stdout and we want to
+// assert on its content in-process.
+func captureStdout(t *testing.T) (*bytes.Buffer, func()) {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	orig := os.Stdout
+	os.Stdout = w
+	buf := &bytes.Buffer{}
+	done := make(chan struct{})
+	go func() {
+		_, _ = buf.ReadFrom(r)
+		close(done)
+	}()
+	return buf, func() {
+		_ = w.Close()
+		<-done
+		os.Stdout = orig
+		_ = r.Close()
 	}
 }
 

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -205,7 +205,7 @@ func joinLogic(ctx context.Context, cwd string) (Info, error) {
 	// hubStartFunc's nil return is contracted to mean both ports are
 	// already bound; if a future refactor changes that, this code must
 	// re-probe healthz.
-	if !hubIsHealthy(workspaceDir) {
+	if !HubIsHealthy(workspaceDir) {
 		fmt.Fprintf(os.Stderr,
 			"bones: starting hub for workspace %s\n", workspaceDir)
 		if err := hubStartFunc(ctx, workspaceDir, hub.WithDetach(true)); err != nil {
@@ -230,10 +230,15 @@ func joinLogic(ctx context.Context, cwd string) (Info, error) {
 	}, nil
 }
 
-// hubIsHealthy returns true when both the fossil and nats pid files
+// HubIsHealthy returns true when both the fossil and nats pid files
 // resolve to live processes and a /healthz GET succeeds within 500ms.
-// False on any failure — caller responds by calling hubStartFunc.
-func hubIsHealthy(workspaceDir string) bool {
+// False on any failure — caller responds by calling hubStartFunc, or
+// (for read-only verbs) by rendering degraded-mode output.
+//
+// Exported so read-only verbs (e.g. `bones status`, #207) can probe
+// hub liveness without going through Join, whose auto-start branch
+// would contradict the lazy-hub promise printed by `bones up`.
+func HubIsHealthy(workspaceDir string) bool {
 	pidsDir := filepath.Join(workspaceDir, markerDirName, "pids")
 	if !pidFileLive(filepath.Join(pidsDir, "fossil.pid")) {
 		return false

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -253,7 +253,7 @@ func TestJoin_NoOpWhenHubHealthy(t *testing.T) {
 			t.Fatalf("write %s: %v", name, err)
 		}
 	}
-	// Stand up a tiny healthz server so hubIsHealthy's GET succeeds.
+	// Stand up a tiny healthz server so HubIsHealthy's GET succeeds.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)
 	}))


### PR DESCRIPTION
## Summary

\`bones up\` advertised a lazy hub ("hub: not yet started — will start on next session or first verb that needs it"), but every CLI verb resolved the workspace via \`workspace.Join\`, which lazy-starts the hub. That meant \`bones status\` — which already has a fully degraded \`HubAvailable=false\` rendering path — silently booted a hub on every invocation and wrote \`.bones/pids/\` + URL files into a workspace the operator intended to leave dormant.

Mirrors the #138 fix for \`bones down\` (commit 295bec5):

- \`resolveStatusRoot\` calls \`workspace.FindRoot\` (read-only) instead of \`workspace.Join\`.
- \`StatusCmd.Run\` probes hub liveness via the newly exported \`workspace.HubIsHealthy\` (PID file + URL files + healthz, all read-only). When healthy, the existing \`Join\`-backed gather path runs. When not healthy, \`Run\` renders directly from a degraded \`statusReport\`; the renderer hits its existing "Hub fossil unavailable — run \`bones up\` to bootstrap" branch.

Out of scope (per the brief): \`workspace.Join\`'s auto-start behavior; adding a \`--no-start\` flag; migrating verbs that require NATS/fossil.

## Test plan

- [x] \`TestResolveStatusRoot_DoesNotAutoStartHub\` (mirrors \`TestResolveDownRoot_DoesNotAutoStartHub\`)
- [x] \`TestStatusRun_NoHub_DoesNotStartOne\` (end-to-end: stdout hint present, no "starting hub" line, no \`.bones/pids/\`, no URL files)
- [x] \`make check\` (fmt-check, vet, lint, race, todo-check)
- [x] \`go test -tags=otel -short ./...\`
- [x] Manual repro: \`bones up\` then \`bones status\` no longer prints "starting hub for workspace ..." and leaves \`.bones/\` clean. \`--json\` and \`--all\` likewise leave no hub state.

Closes #207