### PR TITLE
fix(tasks): auto-release matching swarm slot on tasks close

### DIFF
--- a/cli/tasks_close.go
+++ b/cli/tasks_close.go
@@ -2,20 +2,38 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
+	"strings"
 	"time"
+
+	"github.com/nats-io/nats.go"
 
 	repocli "github.com/danmestas/EdgeSync/cli/repo"
 
+	"github.com/danmestas/bones/internal/swarm"
 	"github.com/danmestas/bones/internal/tasks"
+	"github.com/danmestas/bones/internal/workspace"
 )
 
-// TasksCloseCmd closes a task.
+// TasksCloseCmd closes a task. When the task is bound to a live swarm
+// slot (a session record in bones-swarm-sessions carries this task's
+// id), the matching slot is auto-released via the existing
+// `bones swarm close` path so the operator does not have to remember a
+// separate cleanup step (issue #209, ADR 0049).
+//
+// --keep-slot opts out of the auto-release for the rare case where the
+// operator wants the slot to outlive the task it was claimed for. The
+// auto-release path uses the same artifact precondition swarm close
+// uses; if it would refuse (no commit since join) then `tasks close`
+// itself refuses and leaves the task state unchanged so close is
+// atomic across the two layers.
 type TasksCloseCmd struct {
-	ID     string `arg:"" help:"task id"`
-	Reason string `name:"reason" help:"close reason (optional)"`
-	JSON   bool   `name:"json" help:"emit JSON"`
+	ID       string `arg:"" help:"task id"`
+	Reason   string `name:"reason" help:"close reason (optional)"`
+	KeepSlot bool   `name:"keep-slot" help:"close the task; leave the swarm slot intact"`
+	JSON     bool   `name:"json" help:"emit JSON"`
 }
 
 func (c *TasksCloseCmd) Run(g *repocli.Globals) error {
@@ -26,45 +44,223 @@ func (c *TasksCloseCmd) Run(g *repocli.Globals) error {
 	defer stop()
 
 	return taskCLIError(runOp(ctx, "close", func(ctx context.Context) error {
-		mgr, closeNC, err := openManager(ctx, info)
-		if err != nil {
-			return fmt.Errorf("open manager: %w", err)
-		}
-		defer closeNC()
-		defer func() { _ = mgr.Close() }()
+		return c.runClose(ctx, info)
+	}))
+}
 
-		var updated tasks.Task
-		err = mgr.Update(ctx, c.ID, func(t tasks.Task) (tasks.Task, error) {
-			now := time.Now().UTC()
-			t.Status = tasks.StatusClosed
-			t.ClosedAt = &now
-			// ClosedBy attributes the work, not the click. If the task
-			// was claimed, the claimer did the work — even if the
-			// workspace agent (or an admin) is what physically ran
-			// `bones tasks close`. Without this, invariant 11 (claimed_by
-			// empty when not claimed) erases the original claimer and
-			// every closed-task aggregate buckets under the workspace
-			// UUID. Coord-level close already attributes to the caller
-			// (which equals the claimer there, since it enforces a
-			// claim-match precondition), so this aligns the two paths.
-			if t.ClaimedBy != "" {
-				t.ClosedBy = t.ClaimedBy
-			} else {
-				t.ClosedBy = info.AgentID
-			}
-			t.ClosedReason = c.Reason
-			t.UpdatedAt = now
-			// Invariant 11: claimed_by must be empty when status != claimed.
-			t.ClaimedBy = ""
-			updated = t
-			return t, nil
-		})
-		if err != nil {
-			return err
+// runClose dispatches between the auto-release path (slot-leaf claim
+// + live session, atomic with the close) and the legacy path
+// (manager-only update). Factored out so integration tests can
+// drive close behavior without an os.Getwd dance.
+func (c *TasksCloseCmd) runClose(ctx context.Context, info workspace.Info) error {
+	mgr, closeNC, err := openManager(ctx, info)
+	if err != nil {
+		return fmt.Errorf("open manager: %w", err)
+	}
+	defer closeNC()
+	defer func() { _ = mgr.Close() }()
+
+	// Read the task before deciding which path to take so we can
+	// inspect ClaimedBy without racing the mutate closure inside
+	// Update. A concurrent re-claim between this Get and the close
+	// is rare; if it happens, the legacy Update path's CAS loop
+	// catches it and the auto-release path re-validates against
+	// the session record (which is also CAS-gated).
+	cur, _, err := mgr.Get(ctx, c.ID)
+	if err != nil {
+		return err
+	}
+
+	if !c.KeepSlot {
+		slot, ok, lookupErr := lookupSlotForTask(ctx, info, c.ID, cur.ClaimedBy)
+		if lookupErr != nil {
+			return lookupErr
 		}
+		if ok {
+			return c.autoReleaseAndClose(ctx, info, slot)
+		}
+	}
+	return c.legacyClose(ctx, mgr, info)
+}
+
+// legacyClose is today's pre-#209 path: the tasks Manager Update
+// closure stamps Status=Closed plus the close attribution fields and
+// CAS-writes them. Used when --keep-slot is set or when ClaimedBy
+// does not identify a live swarm slot.
+func (c *TasksCloseCmd) legacyClose(
+	ctx context.Context, mgr *tasks.Manager, info workspace.Info,
+) error {
+	var updated tasks.Task
+	err := mgr.Update(ctx, c.ID, func(t tasks.Task) (tasks.Task, error) {
+		now := time.Now().UTC()
+		t.Status = tasks.StatusClosed
+		t.ClosedAt = &now
+		// ClosedBy attributes the work, not the click. If the task
+		// was claimed, the claimer did the work — even if the
+		// workspace agent (or an admin) is what physically ran
+		// `bones tasks close`. Without this, invariant 11 (claimed_by
+		// empty when not claimed) erases the original claimer and
+		// every closed-task aggregate buckets under the workspace
+		// UUID. Coord-level close already attributes to the caller
+		// (which equals the claimer there, since it enforces a
+		// claim-match precondition), so this aligns the two paths.
+		if t.ClaimedBy != "" {
+			t.ClosedBy = t.ClaimedBy
+		} else {
+			t.ClosedBy = info.AgentID
+		}
+		t.ClosedReason = c.Reason
+		t.UpdatedAt = now
+		// Invariant 11: claimed_by must be empty when status != claimed.
+		t.ClaimedBy = ""
+		updated = t
+		return t, nil
+	})
+	if err != nil {
+		return err
+	}
+	if c.JSON {
+		return emitJSON(os.Stdout, updated)
+	}
+	return nil
+}
+
+// autoReleaseAndClose runs the swarm-close path on the matched slot,
+// closing the task in KV and deleting the session record in one
+// CAS-gated operation (per ADR 0028's success-close contract). When
+// the underlying swarm.ResumedLease.Close refuses (artifact
+// precondition: no commit since join) the entire tasks close
+// returns the refusal — task state is NOT updated, the session
+// record is NOT removed, and the error names the slot so the
+// operator knows where to commit or where to pass --keep-slot.
+func (c *TasksCloseCmd) autoReleaseAndClose(
+	ctx context.Context, info workspace.Info, slot string,
+) error {
+	hubURL := resolveHubURL("")
+	lease, err := swarm.Resume(ctx, info, slot, swarm.AcquireOpts{HubURL: hubURL})
+	if err != nil {
+		// Session evaporated between detection and Resume. Fall
+		// back to legacy: there is no slot to release any more so
+		// the task close should still proceed. lookupSlotForClaim
+		// already filtered ErrNotFound; this branch covers the
+		// narrow race where the record was deleted in between.
+		if errors.Is(err, swarm.ErrSessionNotFound) {
+			return c.runClose(ctx, info)
+		}
+		return fmt.Errorf("tasks close: resume slot %q: %w", slot, err)
+	}
+	closeErr := lease.Close(ctx, swarm.CloseOpts{CloseTaskOnSuccess: true})
+	if closeErr == nil {
+		fmt.Fprintf(os.Stderr,
+			"tasks close: closed task %s and released slot %s\n", c.ID, slot)
 		if c.JSON {
+			// Re-read the task so the JSON shape includes the close
+			// fields the lease/coord layer just wrote.
+			updated, err := readTaskAfterClose(ctx, info, c.ID)
+			if err != nil {
+				return err
+			}
 			return emitJSON(os.Stdout, updated)
 		}
 		return nil
-	}))
+	}
+	if errors.Is(closeErr, swarm.ErrCloseRequiresArtifact) {
+		return fmt.Errorf(
+			"tasks close: refusing — slot %q has no commit since join "+
+				"(swarm-close artifact precondition); commit pending work "+
+				"with `bones swarm commit -m ...` then retry, or pass "+
+				"--keep-slot to close the task and leave the slot intact",
+			slot,
+		)
+	}
+	return fmt.Errorf("tasks close: swarm close slot %q: %w", slot, closeErr)
+}
+
+// readTaskAfterClose re-fetches the task record after a swarm close
+// has mutated it via coord.Leaf.Close → coord.CloseTask. Pulled out
+// so the JSON-emit branch reuses the standard manager-Open shape.
+func readTaskAfterClose(
+	ctx context.Context, info workspace.Info, id string,
+) (tasks.Task, error) {
+	mgr, closeNC, err := openManager(ctx, info)
+	if err != nil {
+		return tasks.Task{}, fmt.Errorf("read after close: %w", err)
+	}
+	defer closeNC()
+	defer func() { _ = mgr.Close() }()
+	t, _, err := mgr.Get(ctx, id)
+	if err != nil {
+		return tasks.Task{}, fmt.Errorf("read after close: %w", err)
+	}
+	return t, nil
+}
+
+// lookupSlotForTask returns the slot whose live swarm session record
+// is bound to taskID. The auto-release path triggers on this match:
+// a session record carrying this task's id is the structural binding
+// between the task and the slot's leaf — it survives the inter-verb
+// windows where ClaimedBy is empty (a re-claim/release cycle inside
+// every swarm verb un-claims the task at verb exit).
+//
+// claimedBy is consulted as a tiebreaker only: when the task's
+// claim string is set and ends in `-leaf`, the slot embedded in
+// the claim is preferred over a session-table scan. This handles
+// the rare in-flight-verb window where ClaimedBy is set AND the
+// session table has multiple entries (a brand-new dispatch racing
+// the close).
+//
+// Returns ("", false, nil) when no live slot owns this task (the
+// expected case for tasks claimed via `bones tasks claim`, or
+// closed without ever joining swarm). Returns a non-nil error only
+// on substrate failure.
+func lookupSlotForTask(
+	ctx context.Context, info workspace.Info, taskID, claimedBy string,
+) (string, bool, error) {
+	// Primary detection: session record's task_id == taskID.
+	nc, err := nats.Connect(info.NATSURL)
+	if err != nil {
+		return "", false, fmt.Errorf("tasks close: nats connect: %w", err)
+	}
+	defer nc.Close()
+	sess, err := swarm.Open(ctx, swarm.Config{NATSConn: nc})
+	if err != nil {
+		return "", false, fmt.Errorf("tasks close: swarm.Open: %w", err)
+	}
+	defer func() { _ = sess.Close() }()
+
+	// Tiebreaker: if claimedBy ends in `-leaf`, prefer that slot
+	// when its session record exists and matches the task. The
+	// session-record check still gates so a stale claim string
+	// against a torn-down slot does not trigger auto-release.
+	if hint := slotFromClaim(claimedBy); hint != "" {
+		s, _, getErr := sess.Get(ctx, hint)
+		if getErr == nil && s.TaskID == taskID {
+			return hint, true, nil
+		}
+		if getErr != nil && !errors.Is(getErr, swarm.ErrNotFound) {
+			return "", false, fmt.Errorf("tasks close: read session %q: %w", hint, getErr)
+		}
+	}
+
+	all, err := sess.List(ctx)
+	if err != nil {
+		return "", false, fmt.Errorf("tasks close: list sessions: %w", err)
+	}
+	for _, s := range all {
+		if s.TaskID == taskID {
+			return s.Slot, true, nil
+		}
+	}
+	return "", false, nil
+}
+
+// slotFromClaim extracts the slot name from a `<slot>-leaf` claim
+// string. Returns "" when claimedBy is empty or does not match the
+// slot-leaf shape (e.g. an operator-claim string set by `bones
+// tasks claim`).
+func slotFromClaim(claimedBy string) string {
+	if claimedBy == "" || !strings.HasSuffix(claimedBy, "-leaf") {
+		return ""
+	}
+	return strings.TrimSuffix(claimedBy, "-leaf")
 }

--- a/cli/tasks_close_test.go
+++ b/cli/tasks_close_test.go
@@ -1,0 +1,381 @@
+// Integration tests for `bones tasks close` covering the four
+// auto-release cases from issue #209 (Layer C):
+//
+//  1. Slot-leaf claim, clean (commit since join) → task closed AND
+//     swarm session record deleted in one step.
+//  2. Slot-leaf claim, dirty (no commit since join) → tasks close
+//     refuses, task state unchanged, error names the artifact gate.
+//  3. --keep-slot on a slot-leaf claim → task closed, session record
+//     intact, regardless of slot state.
+//  4. Non-slot claim (claimed_by doesn't match "<slot>-leaf") →
+//     today's behavior, slot session lookup never triggered.
+//
+// Fixture mirrors internal/swarm/lease_test.go (real NATS + real
+// libfossil hub, no mocks; ADR 0030 discipline).
+package cli
+
+import (
+	"context"
+	"errors"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go"
+
+	"github.com/danmestas/bones/internal/coord"
+	"github.com/danmestas/bones/internal/swarm"
+	"github.com/danmestas/bones/internal/tasks"
+	"github.com/danmestas/bones/internal/workspace"
+	"github.com/danmestas/bones/internal/wspath"
+)
+
+// closeFixture brings up a workspace dir with an in-process libfossil
+// hub plus a connected swarm.Sessions handle so tasks_close tests can
+// drive both the tasks-bucket close and the swarm-session lookup
+// against real substrate.
+type closeFixture struct {
+	dir  string
+	hub  *coord.Hub
+	info workspace.Info
+}
+
+// closeFreePort returns a random unused TCP port. Mirrors freePort in
+// internal/swarm/lease_test.go (cli is a separate package so we
+// duplicate the helper rather than expose it).
+func closeFreePort(t *testing.T) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	addr := ln.Addr().String()
+	_ = ln.Close()
+	return addr
+}
+
+func newCloseFixture(t *testing.T) *closeFixture {
+	t.Helper()
+	dir := t.TempDir()
+	orch := filepath.Join(dir, ".bones")
+	if err := os.MkdirAll(orch, 0o755); err != nil {
+		t.Fatalf("mkdir .bones: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+	hub, err := coord.OpenHub(ctx, orch, closeFreePort(t))
+	if err != nil {
+		t.Fatalf("OpenHub: %v", err)
+	}
+	t.Cleanup(func() { _ = hub.Stop() })
+	return &closeFixture{
+		dir: dir,
+		hub: hub,
+		info: workspace.Info{
+			WorkspaceDir: dir,
+			NATSURL:      hub.NATSURL(),
+			AgentID:      "test-agent",
+		},
+	}
+}
+
+// createTask opens a fixture leaf and uses it to insert an open task
+// in the tasks bucket so tests have something to claim/close.
+func (f *closeFixture) createTask(t *testing.T, title, holdPath string) coord.TaskID {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	leaf, err := coord.OpenLeaf(ctx, coord.LeafConfig{
+		Hub:     f.hub,
+		Workdir: filepath.Join(f.dir, ".bones", "fixture"),
+		SlotID:  "fixture-" + title,
+	})
+	if err != nil {
+		t.Fatalf("fixture OpenLeaf: %v", err)
+	}
+	defer func() { _ = leaf.Stop() }()
+	tid, err := leaf.OpenTask(ctx, title, []string{holdPath})
+	if err != nil {
+		t.Fatalf("OpenTask: %v", err)
+	}
+	return tid
+}
+
+// acquireAndCommit runs Acquire → Release → Resume → Commit → Release
+// on the fixture's hub so the slot has a clean session record AND a
+// landed commit (artifact precondition satisfied for a success close).
+func (f *closeFixture) acquireAndCommit(t *testing.T, slot, taskID, holdPath string) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	first, err := swarm.Acquire(ctx, f.info, slot, taskID, swarm.AcquireOpts{Hub: f.hub})
+	if err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	if err := first.Release(ctx); err != nil {
+		t.Fatalf("first Release: %v", err)
+	}
+	resumed, err := swarm.Resume(ctx, f.info, slot, swarm.AcquireOpts{Hub: f.hub})
+	if err != nil {
+		t.Fatalf("Resume: %v", err)
+	}
+	files := []coord.File{{
+		Path:    wspath.Must(holdPath),
+		Name:    filepath.Base(holdPath),
+		Content: []byte("artifact for tasks-close-209"),
+	}}
+	if _, err := resumed.Commit(ctx, "task close test artifact", files); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	if err := resumed.Release(ctx); err != nil {
+		t.Fatalf("post-commit Release: %v", err)
+	}
+}
+
+// acquireOnly runs Acquire → Release without a commit so the
+// artifact precondition will refuse a success close (LastRenewed ==
+// StartedAt). Mirrors the "agent crashed before its first commit" shape.
+func (f *closeFixture) acquireOnly(t *testing.T, slot, taskID string) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	first, err := swarm.Acquire(ctx, f.info, slot, taskID, swarm.AcquireOpts{Hub: f.hub})
+	if err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	if err := first.Release(ctx); err != nil {
+		t.Fatalf("Release: %v", err)
+	}
+}
+
+// readTask reads the task record. Used to verify task state pre/post
+// runClose.
+func (f *closeFixture) readTask(t *testing.T, taskID string) tasks.Task {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	nc, err := nats.Connect(f.info.NATSURL)
+	if err != nil {
+		t.Fatalf("nats.Connect: %v", err)
+	}
+	defer nc.Close()
+	mgr, err := tasks.Open(ctx, nc, tasks.Config{
+		BucketName:   tasks.DefaultBucketName,
+		HistoryDepth: 10,
+		MaxValueSize: 64 * 1024,
+		ChanBuffer:   32,
+	})
+	if err != nil {
+		t.Fatalf("tasks.Open: %v", err)
+	}
+	defer func() { _ = mgr.Close() }()
+	task, _, err := mgr.Get(ctx, taskID)
+	if err != nil {
+		t.Fatalf("tasks.Get: %v", err)
+	}
+	return task
+}
+
+// sessionExists returns true if the swarm session record for slot is
+// still in KV. Used to verify auto-release deleted the record.
+func (f *closeFixture) sessionExists(t *testing.T, slot string) bool {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	nc, err := nats.Connect(f.info.NATSURL)
+	if err != nil {
+		t.Fatalf("nats.Connect: %v", err)
+	}
+	defer nc.Close()
+	sess, err := swarm.Open(ctx, swarm.Config{NATSConn: nc})
+	if err != nil {
+		t.Fatalf("swarm.Open: %v", err)
+	}
+	defer func() { _ = sess.Close() }()
+	_, _, err = sess.Get(ctx, slot)
+	if err == nil {
+		return true
+	}
+	if errors.Is(err, swarm.ErrNotFound) {
+		return false
+	}
+	t.Fatalf("sessions.Get: %v", err)
+	return false
+}
+
+// TestTasksClose_SlotLeafClean covers acceptance criterion 1: when the
+// task's claimed_by ends in `<slot>-leaf` and the slot has committed
+// at least once since join, `tasks close` runs the swarm-close path —
+// the task is closed AND the session record is deleted.
+func TestTasksClose_SlotLeafClean(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping NATS/fossil test in -short mode")
+	}
+	f := newCloseFixture(t)
+	holdPath := filepath.Join(f.dir, "alpha", "artifact.txt")
+	taskID := string(f.createTask(t, "alpha-task", holdPath))
+	f.acquireAndCommit(t, "alpha", taskID, holdPath)
+
+	if !f.sessionExists(t, "alpha") {
+		t.Fatal("precondition: session record should exist before close")
+	}
+
+	cmd := &TasksCloseCmd{ID: taskID, Reason: "done"}
+	if err := cmd.runClose(context.Background(), f.info); err != nil {
+		t.Fatalf("runClose: %v", err)
+	}
+
+	got := f.readTask(t, taskID)
+	if got.Status != tasks.StatusClosed {
+		t.Errorf("task status: got %q want %q", got.Status, tasks.StatusClosed)
+	}
+	if got.ClaimedBy != "" {
+		t.Errorf("ClaimedBy after close: got %q want empty (invariant 11)", got.ClaimedBy)
+	}
+	if f.sessionExists(t, "alpha") {
+		t.Error("session record should be deleted after auto-release")
+	}
+}
+
+// TestTasksClose_SlotLeafDirtyRefuses covers acceptance criterion 2:
+// when the slot-leaf claim is matched but the artifact precondition
+// would refuse the swarm close, tasks close itself refuses and the
+// task record is NOT updated. Atomicity across both layers.
+func TestTasksClose_SlotLeafDirtyRefuses(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping NATS/fossil test in -short mode")
+	}
+	f := newCloseFixture(t)
+	holdPath := filepath.Join(f.dir, "beta", "missing.txt")
+	taskID := string(f.createTask(t, "beta-task", holdPath))
+	f.acquireOnly(t, "beta", taskID)
+
+	preTask := f.readTask(t, taskID)
+	if preTask.Status == tasks.StatusClosed {
+		t.Fatalf("precondition: task already closed")
+	}
+	preClaim := preTask.ClaimedBy
+	if !f.sessionExists(t, "beta") {
+		t.Fatal("precondition: session record should exist before close")
+	}
+
+	cmd := &TasksCloseCmd{ID: taskID, Reason: "premature"}
+	err := cmd.runClose(context.Background(), f.info)
+	if err == nil {
+		t.Fatal("runClose: want error (artifact precondition refuses), got nil")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "swarm") && !strings.Contains(msg, "artifact") &&
+		!strings.Contains(msg, "commit since join") {
+		t.Errorf("error should name the artifact gate; got %q", msg)
+	}
+	if !strings.Contains(msg, "beta") {
+		t.Errorf("error should name the slot beta; got %q", msg)
+	}
+
+	// Task state must be unchanged across the refused close.
+	postTask := f.readTask(t, taskID)
+	if postTask.Status == tasks.StatusClosed {
+		t.Errorf("task should not be closed on refused tasks close: status=%q", postTask.Status)
+	}
+	if postTask.ClaimedBy != preClaim {
+		t.Errorf("ClaimedBy mutated: got %q want %q", postTask.ClaimedBy, preClaim)
+	}
+	if !f.sessionExists(t, "beta") {
+		t.Error("session record should still exist on refused close")
+	}
+}
+
+// TestTasksClose_KeepSlot covers acceptance criterion 3: --keep-slot
+// closes the task and leaves the swarm session intact regardless of
+// slot state. Even on a "would-refuse" slot (no commit since join),
+// --keep-slot succeeds because it skips the slot-side gate entirely.
+func TestTasksClose_KeepSlot(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping NATS/fossil test in -short mode")
+	}
+	f := newCloseFixture(t)
+	holdPath := filepath.Join(f.dir, "gamma", "scratch.txt")
+	taskID := string(f.createTask(t, "gamma-task", holdPath))
+	f.acquireOnly(t, "gamma", taskID)
+
+	cmd := &TasksCloseCmd{ID: taskID, Reason: "operator-keep", KeepSlot: true}
+	if err := cmd.runClose(context.Background(), f.info); err != nil {
+		t.Fatalf("runClose --keep-slot: %v", err)
+	}
+
+	got := f.readTask(t, taskID)
+	if got.Status != tasks.StatusClosed {
+		t.Errorf("task status: got %q want %q", got.Status, tasks.StatusClosed)
+	}
+	if got.ClosedReason != "operator-keep" {
+		t.Errorf("ClosedReason: got %q want %q", got.ClosedReason, "operator-keep")
+	}
+	if !f.sessionExists(t, "gamma") {
+		t.Error("session record should still exist with --keep-slot")
+	}
+}
+
+// TestTasksClose_NonSlotClaim covers acceptance criterion 4: a task
+// whose claimed_by is NOT a slot-leaf identity (e.g. a manual claim
+// via `bones tasks claim`) closes via the existing path with no slot
+// lookup, no session interaction. No regression on today's behavior.
+func TestTasksClose_NonSlotClaim(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping NATS test in -short mode")
+	}
+	f := newCloseFixture(t)
+	holdPath := filepath.Join(f.dir, "manual", "thing.txt")
+	taskID := string(f.createTask(t, "manual-task", holdPath))
+
+	// Seed a non-slot claim by writing the task record directly via
+	// the tasks Manager. The "claimed_by" string ("operator-x")
+	// deliberately has no -leaf suffix so the auto-release branch
+	// must not fire.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	nc, err := nats.Connect(f.info.NATSURL)
+	if err != nil {
+		t.Fatalf("nats.Connect: %v", err)
+	}
+	defer nc.Close()
+	mgr, err := tasks.Open(ctx, nc, tasks.Config{
+		BucketName:   tasks.DefaultBucketName,
+		HistoryDepth: 10,
+		MaxValueSize: 64 * 1024,
+		ChanBuffer:   32,
+	})
+	if err != nil {
+		t.Fatalf("tasks.Open: %v", err)
+	}
+	defer func() { _ = mgr.Close() }()
+	if err := mgr.Update(ctx, taskID, func(cur tasks.Task) (tasks.Task, error) {
+		cur.Status = tasks.StatusClaimed
+		cur.ClaimedBy = "operator-x"
+		cur.UpdatedAt = time.Now().UTC()
+		return cur, nil
+	}); err != nil {
+		t.Fatalf("seed manual claim: %v", err)
+	}
+
+	cmd := &TasksCloseCmd{ID: taskID, Reason: "manual"}
+	if err := cmd.runClose(context.Background(), f.info); err != nil {
+		t.Fatalf("runClose: %v", err)
+	}
+
+	got := f.readTask(t, taskID)
+	if got.Status != tasks.StatusClosed {
+		t.Errorf("task status: got %q want %q", got.Status, tasks.StatusClosed)
+	}
+	if got.ClosedReason != "manual" {
+		t.Errorf("ClosedReason: got %q want %q (legacy path preserves --reason)",
+			got.ClosedReason, "manual")
+	}
+	if got.ClosedBy != "operator-x" {
+		t.Errorf("ClosedBy: got %q want %q (legacy path attributes to claimer)",
+			got.ClosedBy, "operator-x")
+	}
+}

--- a/docs/adr/0028-bones-swarm-verbs.md
+++ b/docs/adr/0028-bones-swarm-verbs.md
@@ -266,6 +266,16 @@ Existing prompts using `bones tasks claim/close` keep working —
 (`.claude/skills/orchestrator/SKILL.md`) uses the `swarm` verbs; the
 `tasks`-based template stays for backward compat.
 
+`bones tasks close` is bridged to `bones swarm close` per ADR 0049:
+when the closing task is bound to a live session in
+`bones-swarm-sessions`, `tasks close` auto-runs the swarm-close path
+on the matching slot atomically with the task close, sharing the
+artifact precondition as a single decision point. The bridge
+preserves the orchestrator's primary `swarm close` flow (still the
+intended teardown) and adds a safety net for operator-driven
+`tasks close` invocations so a slot is not orphaned when the
+orchestrator-side close is skipped.
+
 ## References
 
 - ADR 0010: Fossil code artifacts (per-leaf checkouts)
@@ -277,3 +287,4 @@ Existing prompts using `bones tasks claim/close` keep working —
 - ADR 0030: Real-substrate tests over mocks (Lease tests follow this
   discipline)
 - ADR 0034: `swarm.Sessions` narrowing of the substrate-adapter type
+- ADR 0049: `bones tasks close` auto-releases the matching swarm slot

--- a/docs/adr/0049-tasks-close-auto-release.md
+++ b/docs/adr/0049-tasks-close-auto-release.md
@@ -1,0 +1,142 @@
+# ADR 0049 — `bones tasks close` auto-releases the matching swarm slot
+
+**Status:** Accepted (2026-05-05)
+
+## Context
+
+ADR 0028 introduced the `bones swarm` verb set and the
+`bones-swarm-sessions` KV bucket as the runtime-state bridge between a
+slot and the task it claimed. The bucket is authoritative for "which
+slot is doing which task on which host." `bones swarm close` is the
+canonical teardown: it closes the task in `bones-tasks`, releases the
+hold, stops the leaf, removes the host-local pid file, deletes the
+session record, and runs the success-close salvage trail before
+destroying the slot's worktree.
+
+ADR 0028 left `bones tasks close` unchanged. The CLI still calls
+`tasks.Manager.Update` to flip the task to closed in the tasks bucket
+and ignores `bones-swarm-sessions` entirely. That gap is fine when the
+task was never bound to a slot — `bones tasks claim` users, dispatch
+parents calling close from outside the slot, ad-hoc operator closes —
+but it produces a zombie session whenever the closed task did originate
+from a swarm slot. The next `bones swarm join` against that slot then
+collides with a stale record, the operator runs a manual
+`bones swarm close` to clear it, and after two such friction events the
+spy run in #209's history showed an experienced orchestrator drop the
+swarm verbs entirely (parallelism collapsed from 4–8 wide to 2–3 wide).
+
+The orchestrator's normal teardown path remains `bones swarm close`;
+that path stays untouched. This ADR formalizes a safety net for the
+manual `bones tasks close` path so a forgotten or orchestrator-skipped
+slot release no longer requires hand cleanup.
+
+## Decision
+
+`bones tasks close <id>` detects when its target task is bound to a
+live swarm slot and runs the existing `bones swarm close` path on that
+slot atomically with the close. Detection is structural: the
+implementation reads `bones-swarm-sessions` and matches by the session
+record's `task_id` field — the only durable binding between a task and
+a slot, since the lease's claim/un-claim cycle inside every swarm
+verb leaves `tasks.ClaimedBy` empty in the inter-verb windows. When
+the task's `claimed_by` is set and ends in `-leaf` it is consulted as
+a tiebreaker (preferred slot when multiple sessions list the task,
+which only happens during a brand-new dispatch racing the close).
+
+The auto-release reuses `swarm.Resume` followed by
+`ResumedLease.Close(CloseTaskOnSuccess=true)`. That is the same path
+`bones swarm close --result=success` runs, including the artifact
+precondition (`ErrCloseRequiresArtifact`: refuse close-success when
+no commit landed since join). When the precondition refuses, the
+entire `bones tasks close` refuses — `tasks.Manager.Update` is never
+called, the task record stays exactly as it was, the session record
+stays live, and the error names the slot plus both remediation paths
+(`bones swarm commit -m ...` then retry, or pass `--keep-slot`).
+Atomicity across the two layers is the point: no half-applied close
+where the task is closed in the bucket but the slot still squats on
+the session record.
+
+A new `--keep-slot` flag bypasses the auto-release entirely. With
+`--keep-slot` the close takes the legacy path (manager update only)
+regardless of slot state. Use case: the operator wants to close the
+task as a logical unit while continuing to drive the slot for
+follow-up work.
+
+When detection finds no live session matching the task — the
+`bones tasks claim` case, the dispatch-parent close case, the
+"never joined swarm" case — `bones tasks close` runs the legacy
+manager-update path with no behavior change.
+
+The new files are `cli/tasks_close.go` (rewrite, retains existing
+struct field set + adds `KeepSlot bool`) and `cli/tasks_close_test.go`
+(integration tests for the four acceptance cases). No public Go API
+changes outside `cli`.
+
+## Consequences
+
+Pulled-down complexity: the operator no longer needs to remember to
+run `bones swarm close` after `bones tasks close` for a slot-bound
+task. The orchestrator-skipped or operator-forgotten case is handled
+structurally — one verb invocation tears down both layers.
+
+Pushed-up complexity: `bones tasks close` now reads
+`bones-swarm-sessions` on every invocation. A single `swarm.Sessions`
+open + List adds one NATS round-trip on the close path. For workspaces
+with no live swarm sessions the List returns immediately. Acceptable.
+
+Trade-off: the auto-release path's task close runs through
+`coord.Leaf.Close` → `coord.CloseTask("leaf close")`, which sets
+`ClosedReason="leaf close"` on the task record. The `--reason` flag
+is therefore not preserved in the closed task record when the
+auto-release path fires — it would be in the legacy path. This is the
+"reuse, do not reimplement" trade-off from issue #209's brief: a
+parallel close-with-reason mutator on the lease/leaf surface would
+duplicate the close mutation logic. The legacy path
+(non-slot-claimed, or `--keep-slot`) preserves `--reason` exactly as
+before.
+
+Atomicity: the refuse-on-precondition path is checked before
+`tasks.Manager.Update` runs, so a refused close never mutates the
+task record. The cleaner alternative — refuse pre-emptively without
+opening the lease — would duplicate the artifact-precondition
+detection logic here. Reusing the lease and aborting before the
+mutating step keeps the precondition definition single-sourced in
+`swarm.ResumedLease.Close`.
+
+## Out of scope
+
+- **Layer A: bundled bones-aware subagent definitions.** Issue #209's
+  original brief proposed shipping Claude Code subagent definitions
+  alongside the existing skills bundle so the slot-isolation contract
+  survives without skill-author replication. Deferred — see issue
+  #209's "Scope reduced after grilling" comment. File a separate
+  issue when ready to commit to bones owning the subagent spawn path.
+
+- **Layer B: per-slot tool-use enforcement (PreToolUse hook).** Issue
+  #209's original brief proposed a `.claude/settings.local.json`
+  overlay or hook that blocks Edit/Write outside the slot's worktree
+  and blocks raw `git commit`. Deferred — depends on Layer A. File
+  alongside Layer A.
+
+- **Posting a `dispatch.ResultMessage` from the auto-release path.**
+  `bones swarm close` posts a result message on the task subject so
+  a dispatch parent (ADR 0021) can pick it up. `bones tasks close`
+  is the operator path, not the dispatch flow, and today's behavior
+  is no result post; the auto-release preserves that. If a future
+  use case wants both, surface it through `bones swarm close`.
+
+- **Changing the swarm-close artifact precondition.** The precondition
+  (`ErrCloseRequiresArtifact`: no commit since join) is the gate
+  reused here verbatim. Changes to its semantics are an ADR 0028
+  follow-up.
+
+## References
+
+- Issue #209 (ADR 0028 follow-up — auto-release the matching slot)
+- ADR 0028 — bones swarm verbs (defines `bones-swarm-sessions`,
+  `swarm.Resume`, `ResumedLease.Close`, success-close salvage trail)
+- ADR 0021 — Dispatch and auto-claim (parent dispatch consumes
+  `dispatch.ResultMessage` written by `swarm close`)
+- ADR 0030 — Real-substrate tests over mocks (the integration tests
+  added here use a real in-process libfossil hub + real NATS, no
+  mocks)


### PR DESCRIPTION
## Summary

- `bones tasks close <id>` now detects when its target task is bound to a live swarm session and runs `swarm.ResumedLease.Close(CloseTaskOnSuccess=true)` atomically with the close, so the orchestrator-skipped or operator-forgotten case no longer leaves a zombie session blocking the next dispatch.
- Detection is structural (session record's `task_id` field), not via `claimed_by`, because the lease's claim/release cycle inside every swarm verb leaves `ClaimedBy` empty in inter-verb windows. `claimed_by` ending in `-leaf` is consulted only as a tiebreaker.
- When the swarm-close artifact precondition would refuse (no commit since join), the entire `tasks close` refuses and the task record is not mutated — atomic across both layers. New `--keep-slot` flag opts out of auto-release entirely. Non-slot claims behave exactly as before.

Integration tests cover all four acceptance cases (clean release, dirty refuse, `--keep-slot`, non-slot claim) using a real in-process libfossil hub + real NATS per ADR 0030.

ADR 0049 formalizes the rule as a fresh document rather than rewriting ADR 0028's claim-semantics text — the new behavior is a structural bridge from the tasks layer to the swarm layer, not a swarm-internal change. ADR 0028 gets a forward pointer.

Trade-off: the auto-release path closes the task via `coord.Leaf.Close` → `coord.CloseTask("leaf close")`, so `--reason` is not preserved on the task's `ClosedReason` field when auto-release fires (legacy non-slot path preserves `--reason` exactly). Documented in ADR 0049's Consequences section.

**Layers A and B from #209's original brief (bundled subagent definitions, PreToolUse hook) remain deferred** per the issue's "Scope reduced after grilling" comment. Both depend on bones owning the subagent spawn path.

## Test plan

- [x] `make check`
- [x] `go test -tags=otel -short ./...`
- [x] `go test -race -short ./cli -run TestTasksClose`
- [x] Manual: review ADR 0049 prose
- [ ] CI green on the PR branch

Closes #209