### PR TITLE
feat(tasks): surface one-leaf-per-slot rule (list --by-slot, create warning, AGENTS.md)

### DIFF
--- a/cli/orchestrator_test.go
+++ b/cli/orchestrator_test.go
@@ -1434,3 +1434,35 @@ func TestAgentsMDTemplate_ConsistentAcrossAllShapes(t *testing.T) {
 		})
 	}
 }
+
+// TestAgentsMDTemplate_TeachesPerSlotSerialization pins issue #214: the
+// bundled AGENTS.md template must teach the one-leaf-per-slot rule so
+// plan-authoring agents (including third-party `writing-plans` skills
+// that read AGENTS.md) stop packing many tasks into one slot. The
+// template must:
+//
+//   - State that bones runs at most one leaf per slot at a time and
+//     therefore tasks sharing a slot run serially.
+//   - State that parallelism comes from N distinct slots, not from
+//     packing one slot.
+//   - Point at the inspection command (`bones tasks list --by-slot`)
+//     so an author can audit a plan's slot distribution before dispatch.
+func TestAgentsMDTemplate_TeachesPerSlotSerialization(t *testing.T) {
+	tmpl := string(agentsMDTemplate)
+	mustContain := []string{
+		// Names the rule explicitly; matches the canonical wording from
+		// ADR 0028 architectural invariant 1.
+		"one leaf per slot",
+		// Names the consequence so plan authors understand the cost.
+		"serial",
+		// Points at the inspection command from fix A.
+		"--by-slot",
+	}
+	for _, sub := range mustContain {
+		if !strings.Contains(strings.ToLower(tmpl), strings.ToLower(sub)) {
+			t.Errorf("AGENTS.md template missing required teaching substring %q "+
+				"(issue #214: per-slot serialization rule must be surfaced "+
+				"to plan-authoring agents)", sub)
+		}
+	}
+}

--- a/cli/tasks_create.go
+++ b/cli/tasks_create.go
@@ -68,6 +68,19 @@ func (c *TasksCreateCmd) Run(g *repocli.Globals) error {
 		if err := mgr.Create(ctx, t); err != nil {
 			return err
 		}
+		// Hot-slot advisory (issue #214 fix C). Re-list and count after
+		// the successful Create so the warning reflects the just-stored
+		// state, not a stale pre-mutation snapshot. The advisory is
+		// non-fatal: it goes to stderr, leaves stdout (the task ID or
+		// JSON) untouched, and does not change the exit code. Listing
+		// errors are swallowed deliberately — the create has already
+		// succeeded, and a transient List failure must not be allowed
+		// to convert that into a non-zero exit.
+		if c.Slot != "" {
+			if all, listErr := mgr.List(ctx); listErr == nil {
+				maybeWarnHotSlot(os.Stderr, c.Slot, countOpenInSlot(all, c.Slot))
+			}
+		}
 		if c.JSON {
 			return emitJSON(os.Stdout, t)
 		}

--- a/cli/tasks_create_test.go
+++ b/cli/tasks_create_test.go
@@ -1,0 +1,82 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/danmestas/bones/internal/tasks"
+)
+
+// TestCountOpenInSlot verifies the predicate the hot-slot warning uses to
+// compute the post-mutation depth: only non-closed tasks count, matching
+// the serialization invariant (closed tasks free the slot).
+func TestCountOpenInSlot(t *testing.T) {
+	all := []tasks.Task{
+		{ID: "1", Status: tasks.StatusOpen, Context: map[string]string{"slot": "alpha"}},
+		{ID: "2", Status: tasks.StatusClaimed, Context: map[string]string{"slot": "alpha"}},
+		{ID: "3", Status: tasks.StatusClosed, Context: map[string]string{"slot": "alpha"}},
+		{ID: "4", Status: tasks.StatusOpen, Context: map[string]string{"slot": "beta"}},
+		{ID: "5", Status: tasks.StatusOpen}, // unslotted
+	}
+	if got := countOpenInSlot(all, "alpha"); got != 2 {
+		t.Errorf("alpha: got %d, want 2 (closed must not count)", got)
+	}
+	if got := countOpenInSlot(all, "beta"); got != 1 {
+		t.Errorf("beta: got %d, want 1", got)
+	}
+	if got := countOpenInSlot(all, "missing"); got != 0 {
+		t.Errorf("missing slot: got %d, want 0", got)
+	}
+	// Empty slot key — feature is opt-in via --slot, so empty is a no-op.
+	if got := countOpenInSlot(all, ""); got != 0 {
+		t.Errorf("empty slot: got %d, want 0", got)
+	}
+}
+
+// TestMaybeWarnHotSlot covers the create/update warning-emission rule
+// (issue #214 acceptance criteria 4 & 5):
+//
+//   - Crossing the threshold upward (depth transitions from <=N to >N)
+//     emits a one-line stderr warning naming slot + new depth + the
+//     "will serialize" consequence.
+//   - Already-hot slots (depth >N before AND after) re-warn — every
+//     create that adds to a hot slot is a packing mistake to surface.
+//   - Closed tasks freeing the slot must not trigger the warning, which
+//     this helper expresses by only being called from create/update; the
+//     test asserts the cool-slot path emits nothing.
+//   - Empty slot is a no-op (the feature is slot-scoped).
+func TestMaybeWarnHotSlot(t *testing.T) {
+	cases := []struct {
+		name     string
+		slot     string
+		depth    int
+		wantWarn bool
+	}{
+		{"empty_slot_noop", "", 99, false},
+		{"cool_below_threshold", "alpha", HotSlotThreshold, false},
+		{"crosses_threshold", "alpha", HotSlotThreshold + 1, true},
+		{"already_hot_keeps_warning", "alpha", HotSlotThreshold + 5, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			maybeWarnHotSlot(&buf, tc.slot, tc.depth)
+			out := buf.String()
+			gotWarn := out != ""
+			if gotWarn != tc.wantWarn {
+				t.Fatalf("warn=%v want %v; output=%q", gotWarn, tc.wantWarn, out)
+			}
+			if !tc.wantWarn {
+				return
+			}
+			// Must name slot, depth, and consequence.
+			if !strings.Contains(out, tc.slot) {
+				t.Errorf("output missing slot name %q; got %q", tc.slot, out)
+			}
+			if !strings.Contains(out, "serialize") {
+				t.Errorf("output must mention 'serialize' consequence; got %q", out)
+			}
+		})
+	}
+}

--- a/cli/tasks_list.go
+++ b/cli/tasks_list.go
@@ -17,6 +17,14 @@ import (
 // TasksListCmd lists tasks. Filter flags compose: status → ready → stale →
 // orphans. --ready and --orphans require a coord session; --stale and the
 // others run from the in-memory task list only.
+//
+// --by-slot is the inspection mode added for issue #214: it groups open
+// tasks by Context["slot"] and flags slots whose open-task count exceeds
+// HotSlotThreshold, so plan authors see the cost of slot packing before
+// dispatch (per ADR 0023's slot disjointness contract and ADR 0028's
+// per-slot leaf invariant). When set, --by-slot replaces the per-task
+// rendering with a per-slot summary; the other filter flags still scope
+// which tasks the grouping considers (e.g. `--by-slot --status=open`).
 type TasksListCmd struct {
 	All       bool   `name:"all" help:"include closed tasks"`
 	Status    string `name:"status" help:"open|claimed|closed"`
@@ -24,6 +32,7 @@ type TasksListCmd struct {
 	Ready     bool   `name:"ready" help:"only tasks ready to claim (open, unblocked, not deferred)"`
 	Stale     int    `name:"stale" help:"only tasks not updated in N days; 0 = off"`
 	Orphans   bool   `name:"orphans" help:"only claimed tasks whose claimer is offline"`
+	BySlot    bool   `name:"by-slot" help:"group by slot; flag hot slots"`
 	JSON      bool   `name:"json" help:"emit JSON"`
 }
 
@@ -92,6 +101,16 @@ func (c *TasksListCmd) Run(g *repocli.Globals) error {
 				return err
 			}
 			out = filterOrphans(out, liveAgentSet(peers))
+		}
+
+		// --by-slot replaces the per-task rendering with the per-slot
+		// summary (issue #214). Composes with the other filters: e.g.
+		// `--by-slot --claimed-by=-` shows hot slots among unclaimed
+		// open work. groupBySlot drops closed tasks even when --all is
+		// set — closed tasks free the slot, so counting them would
+		// misrepresent the serialization depth.
+		if c.BySlot {
+			return emitBySlot(os.Stdout, groupBySlot(out), c.JSON)
 		}
 
 		return emitTasks(out, c.JSON)

--- a/cli/tasks_list_test.go
+++ b/cli/tasks_list_test.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"bytes"
+	"strings"
 	"testing"
 	"time"
 
@@ -69,6 +71,120 @@ func TestSelectByStatus(t *testing.T) {
 	}
 	if got := selectByStatus(all, ""); len(got) != 3 {
 		t.Errorf("empty status: want all 3; got %#v", got)
+	}
+}
+
+// TestGroupBySlot covers the inspection-mode aggregation introduced for
+// issue #214 — grouping open tasks by their Context["slot"] value with a
+// hot-slot indicator. Closed tasks free the slot and must not be counted.
+// Tasks without a slot context land in the synthetic "(unslotted)" bucket
+// so plan authors don't lose sight of them.
+func TestGroupBySlot(t *testing.T) {
+	all := []tasks.Task{
+		// Slot "alpha": 5 open + 1 closed → hot (open count > 4)
+		{ID: "a1", Status: tasks.StatusOpen, Context: map[string]string{"slot": "alpha"}},
+		{ID: "a2", Status: tasks.StatusClaimed, Context: map[string]string{"slot": "alpha"}},
+		{ID: "a3", Status: tasks.StatusOpen, Context: map[string]string{"slot": "alpha"}},
+		{ID: "a4", Status: tasks.StatusOpen, Context: map[string]string{"slot": "alpha"}},
+		{ID: "a5", Status: tasks.StatusOpen, Context: map[string]string{"slot": "alpha"}},
+		{ID: "a6", Status: tasks.StatusClosed, Context: map[string]string{"slot": "alpha"}},
+		// Slot "beta": 2 open → cool
+		{ID: "b1", Status: tasks.StatusOpen, Context: map[string]string{"slot": "beta"}},
+		{ID: "b2", Status: tasks.StatusClaimed, Context: map[string]string{"slot": "beta"}},
+		// Unslotted open task lands in the synthetic bucket
+		{ID: "u1", Status: tasks.StatusOpen},
+	}
+	groups := groupBySlot(all)
+	if len(groups) != 3 {
+		t.Fatalf("len=%d want 3 (alpha, beta, unslotted); got %#v", len(groups), groups)
+	}
+	// Alphabetical order on slot name; unslotted bucket sorts first by
+	// using a leading "(" — assert the visible output ordering.
+	if groups[0].Slot != unslottedSlotKey {
+		t.Errorf("groups[0].Slot=%q want %q (unslotted bucket sorts first)",
+			groups[0].Slot, unslottedSlotKey)
+	}
+	if groups[1].Slot != "alpha" {
+		t.Errorf("groups[1].Slot=%q want %q", groups[1].Slot, "alpha")
+	}
+	if groups[2].Slot != "beta" {
+		t.Errorf("groups[2].Slot=%q want %q", groups[2].Slot, "beta")
+	}
+	// Alpha: 5 open (3 open + 1 claimed + 1 open + ... excluding 1 closed),
+	// recount: a1 open, a2 claimed, a3 open, a4 open, a5 open → 5 open
+	// (claimed counts as open for serialization-depth purposes; closed does not).
+	if groups[1].OpenCount != 5 {
+		t.Errorf("alpha.OpenCount=%d want 5", groups[1].OpenCount)
+	}
+	if !groups[1].Hot {
+		t.Errorf("alpha must be hot (5 > %d)", HotSlotThreshold)
+	}
+	if groups[2].OpenCount != 2 || groups[2].Hot {
+		t.Errorf("beta want OpenCount=2 hot=false; got %+v", groups[2])
+	}
+	if groups[0].OpenCount != 1 || groups[0].Hot {
+		t.Errorf("unslotted want OpenCount=1 hot=false; got %+v", groups[0])
+	}
+}
+
+// TestEmitBySlotPlain verifies the plain-text inspection rendering names
+// the serialization rule explicitly (issue #214 acceptance criterion 2).
+func TestEmitBySlotPlain(t *testing.T) {
+	groups := []slotGroup{
+		{
+			Slot:      "alpha",
+			OpenCount: 6,
+			Hot:       true,
+			TaskIDs:   []string{"a1", "a2", "a3", "a4", "a5", "a6"},
+		},
+		{Slot: "beta", OpenCount: 1, Hot: false, TaskIDs: []string{"b1"}},
+	}
+	var buf bytes.Buffer
+	if err := emitBySlot(&buf, groups, false); err != nil {
+		t.Fatalf("emitBySlot: %v", err)
+	}
+	out := buf.String()
+	// Must name the rule (not just print numbers)
+	if !strings.Contains(out, "serialize") {
+		t.Errorf("output must mention serialization rule; got:\n%s", out)
+	}
+	// Must mark the hot slot visibly.
+	if !strings.Contains(out, "alpha") {
+		t.Errorf("output missing slot name alpha; got:\n%s", out)
+	}
+	if !strings.Contains(out, "HOT") {
+		t.Errorf("output must visibly mark hot slot; got:\n%s", out)
+	}
+	// Cool slot must not be marked hot.
+	betaLine := ""
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, "beta") {
+			betaLine = line
+		}
+	}
+	if betaLine == "" {
+		t.Fatalf("output missing beta line; got:\n%s", out)
+	}
+	if strings.Contains(betaLine, "HOT") {
+		t.Errorf("cool slot beta must not be HOT-marked; got %q", betaLine)
+	}
+}
+
+// TestEmitBySlotJSON pins the harness-consumable JSON shape (issue #214
+// acceptance criterion 3): per-slot open counts plus a hot boolean.
+func TestEmitBySlotJSON(t *testing.T) {
+	groups := []slotGroup{
+		{Slot: "alpha", OpenCount: 6, Hot: true, TaskIDs: []string{"a1"}},
+	}
+	var buf bytes.Buffer
+	if err := emitBySlot(&buf, groups, true); err != nil {
+		t.Fatalf("emitBySlot json: %v", err)
+	}
+	out := buf.String()
+	for _, sub := range []string{`"slot":"alpha"`, `"open_count":6`, `"hot":true`} {
+		if !strings.Contains(out, sub) {
+			t.Errorf("json output missing %q; got %s", sub, out)
+		}
 	}
 }
 

--- a/cli/tasks_slot.go
+++ b/cli/tasks_slot.go
@@ -1,0 +1,179 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+
+	"github.com/danmestas/bones/internal/tasks"
+)
+
+// HotSlotThreshold is the open-task count above which a slot is
+// considered "hot" — packed past the point of plausibly-deliberate
+// authoring. The substrate runs exactly one `coord.Leaf` per slot at a
+// time (ADR 0023 architectural invariant 5; ADR 0028 architectural
+// invariant 1: "Per-slot leaf process — each active slot owns exactly
+// one `coord.Leaf`"), so N tasks in one slot run serially regardless of
+// file-disjointness or task-graph independence. Issue #214's heuristic:
+// more than 4 open tasks in a single slot is almost certainly a
+// packing mistake, because parallelism in bones comes from N distinct
+// slots, not from depth within one slot. Kept as a single named
+// constant (not a flag, not workspace-configurable) per the issue's
+// "avoid per-workspace tuning becoming a foot-gun" guidance.
+const HotSlotThreshold = 4
+
+// unslottedSlotKey is the synthetic bucket label used when grouping
+// tasks that lack a Context["slot"] annotation. The leading "(" makes
+// it sort before any real slot name so plan authors see un-annotated
+// work first; ADR 0023's plan validator forbids slot-less tasks at
+// dispatch time, but the inspection view is run at plan-authoring time
+// where tasks may legitimately not yet carry a slot.
+const unslottedSlotKey = "(unslotted)"
+
+// slotGroup is one row of the by-slot inspection view. JSON tags
+// match the documented harness-consumable shape so callers can parse
+// the same payload regardless of whether `--by-slot` was rendered for
+// a human or a tool.
+type slotGroup struct {
+	// Slot is the Context["slot"] value, or unslottedSlotKey for tasks
+	// without a slot annotation.
+	Slot string `json:"slot"`
+
+	// OpenCount is the number of non-closed (open or claimed) tasks in
+	// this slot. Closed tasks free the slot for the next leaf — they
+	// must not count against serialization depth.
+	OpenCount int `json:"open_count"`
+
+	// Hot is true when OpenCount exceeds HotSlotThreshold. The boolean
+	// is the harness-consumable form of the textual indicator the
+	// plain-text view renders ("HOT").
+	Hot bool `json:"hot"`
+
+	// TaskIDs lists the IDs of the non-closed tasks in this slot, in
+	// the order they appeared in the source list. Useful for harnesses
+	// that want to drill down without a second `tasks list` call.
+	TaskIDs []string `json:"task_ids"`
+}
+
+// groupBySlot buckets tasks by their Context["slot"] value, counting
+// non-closed tasks per slot. Closed tasks are dropped — they do not
+// occupy a leaf. Slot ordering is alphabetical, with the synthetic
+// unslotted bucket sorting first by virtue of its leading "(".
+func groupBySlot(in []tasks.Task) []slotGroup {
+	buckets := map[string]*slotGroup{}
+	for _, t := range in {
+		if t.Status == tasks.StatusClosed {
+			continue
+		}
+		key := t.Context["slot"]
+		if key == "" {
+			key = unslottedSlotKey
+		}
+		g, ok := buckets[key]
+		if !ok {
+			g = &slotGroup{Slot: key}
+			buckets[key] = g
+		}
+		g.OpenCount++
+		g.TaskIDs = append(g.TaskIDs, t.ID)
+	}
+	out := make([]slotGroup, 0, len(buckets))
+	for _, g := range buckets {
+		g.Hot = g.OpenCount > HotSlotThreshold
+		out = append(out, *g)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Slot < out[j].Slot })
+	return out
+}
+
+// emitBySlot renders the slot-grouped view, either as JSON for harness
+// consumption or as a plain-text table that names the serialization
+// rule explicitly so an operator reading the warning does not have to
+// know ADR 0023/0028 to act on it.
+func emitBySlot(w io.Writer, groups []slotGroup, asJSON bool) error {
+	if asJSON {
+		payload := struct {
+			Slots     []slotGroup `json:"slots"`
+			Threshold int         `json:"hot_threshold"`
+		}{
+			Slots:     groups,
+			Threshold: HotSlotThreshold,
+		}
+		data, err := json.Marshal(payload)
+		if err != nil {
+			return fmt.Errorf("marshal by-slot: %w", err)
+		}
+		data = append(data, '\n')
+		_, err = w.Write(data)
+		return err
+	}
+	// Plain-text rendering. The caption is the serialization rule
+	// surfaced inline — operators must not have to read ADRs to
+	// understand why the count matters.
+	if _, err := fmt.Fprintf(w,
+		"bones runs one leaf per slot at a time; tasks sharing a slot "+
+			"serialize. Slots with >%d open tasks are flagged HOT — "+
+			"likely a planner packing mistake.\n",
+		HotSlotThreshold); err != nil {
+		return err
+	}
+	if len(groups) == 0 {
+		_, err := fmt.Fprintln(w, "(no open tasks)")
+		return err
+	}
+	for _, g := range groups {
+		marker := "    "
+		if g.Hot {
+			marker = "HOT "
+		}
+		if _, err := fmt.Fprintf(w, "%s%-24s %3d open\n",
+			marker, g.Slot, g.OpenCount); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// countOpenInSlot returns the number of non-closed tasks whose
+// Context["slot"] equals slot. Empty slot is a no-op (returns 0) — the
+// hot-slot warning is opt-in via --slot at create time. Used by both
+// `tasks create`'s post-mutation warning (issue #214 fix C) and any
+// other caller that needs the depth without re-deriving from a list.
+func countOpenInSlot(in []tasks.Task, slot string) int {
+	if slot == "" {
+		return 0
+	}
+	n := 0
+	for _, t := range in {
+		if t.Status == tasks.StatusClosed {
+			continue
+		}
+		if t.Context["slot"] == slot {
+			n++
+		}
+	}
+	return n
+}
+
+// maybeWarnHotSlot writes a one-line advisory to w when the
+// post-mutation depth crosses HotSlotThreshold. Empty slot is a no-op
+// (the feature is slot-scoped). The wording names the slot, the new
+// depth, and the consequence so the operator can correlate the warning
+// to ADR 0023/0028 without reading the ADRs. Issue #214 explicitly
+// requires the warning to be advisory only — the caller does not
+// inspect the return value, the mutation must still succeed, and the
+// exit code does not change. Re-warning every time growth lands in
+// the hot range is intentional: each create that adds to a hot slot
+// is a packing mistake to surface, not just the first crossing.
+func maybeWarnHotSlot(w io.Writer, slot string, newDepth int) {
+	if slot == "" || newDepth <= HotSlotThreshold {
+		return
+	}
+	_, _ = fmt.Fprintf(w,
+		"warning: slot %q now has %d open tasks (>%d); "+
+			"bones runs one leaf per slot, so these will serialize. "+
+			"Spread tasks across distinct slots to recover parallelism. "+
+			"Inspect with: bones tasks list --by-slot\n",
+		slot, newDepth, HotSlotThreshold)
+}

--- a/cli/templates/orchestrator/AGENTS.md
+++ b/cli/templates/orchestrator/AGENTS.md
@@ -42,6 +42,20 @@ Some harnesses (browser-based agents, simple chat UIs) have no programmatic hook
 
 The mechanical enforcement Claude Code provides via hooks downgrades to "agent must follow this directive" for everyone else. The substance is identical.
 
+## One leaf per slot (serialization rule)
+
+Bones runs at most one `coord.Leaf` per slot at a time (ADR 0023's slot disjointness contract; ADR 0028's architectural invariant 1: "Per-slot leaf process — each active slot owns exactly one `coord.Leaf`"). The substrate enforces this — the surface a plan author works with does not.
+
+The practical consequence: **N tasks sharing one slot run serially, regardless of file-disjointness or task-graph independence.** Parallelism in bones comes from N distinct slots, not from packing tasks into one slot. A 22-task plan with 10 tasks in slot `frontend` runs those 10 tasks serially even though the orchestrator dispatched them as one fan-out.
+
+When authoring a plan or creating tasks by hand, audit slot distribution before dispatch:
+
+```
+bones tasks list --by-slot
+```
+
+Slots with more than 4 open tasks are flagged `HOT` — almost always a planner packing mistake. `bones tasks create --slot=<name>` also prints a one-line stderr warning when the slot's open count crosses that threshold; the create still succeeds (the threshold is advisory, not a refusal), but the warning is the cue to spread tasks across more slots.
+
 ## Orchestrator workflow
 
 When the user runs a plan that contains `[slot: name]` task annotations and asks for parallel execution, you are the orchestrator. Your job is to validate the plan, dispatch one subagent per slot, monitor progress, dispatch a Phase 2 integration agent to wire the slots together, and surface completion state.


### PR DESCRIPTION
## Summary

Plan authors had no surface that named the per-slot leaf-serialization rule, so plans pack hot slots and silently lose parallelism. This PR surfaces the rule at the three points the issue calls out:

- **`bones tasks list --by-slot`** groups open tasks by `Context["slot"]`, flags slots with >4 open tasks as `HOT`, and names the serialization rule inline. JSON output exposes `{slot, open_count, hot, task_ids}` for harness consumption.
- **`bones tasks create --slot=<name>`** writes a one-line stderr advisory when the post-create depth exceeds the threshold. Mutation succeeds, exit code unchanged, stdout untouched. Closed tasks free the slot — never trigger the warning.
- **AGENTS.md template** gains a "One leaf per slot (serialization rule)" section that teaches the rule and points at `--by-slot`. Template-only — not backported into existing workspaces.

The threshold is a single named constant (`HotSlotThreshold = 4`) in `cli/tasks_slot.go` — not a flag, not workspace-configurable, per the issue's foot-gun guidance.

Authority for the rule: ADR 0023 (slot disjointness, per-slot leaf topology) and ADR 0028 architectural invariant 1 ("Per-slot leaf process — each active slot owns exactly one `coord.Leaf`"). No substrate change — surfacing only.

## Test plan

- [x] `make check` (fmt-check, vet, lint, race, todo-check) passes
- [x] `go test -tags=otel -short ./...` passes
- [x] Unit tests cover groupBySlot, emitBySlot (text + JSON), countOpenInSlot, maybeWarnHotSlot, AGENTS.md template content

Closes #214