### PR TITLE
feat(doctor,hub): detect + prevent duplicate hub processes (#208)

### DIFF
--- a/cli/doctor.go
+++ b/cli/doctor.go
@@ -194,6 +194,7 @@ func runBypassReportTo(w io.Writer, cwd string) (warns int, err error) {
 
 	warns += checkScaffoldGates(w, cwd)
 	warns += checkOrphanHubs(w)
+	warns += checkDuplicateHubs(w, cwd)
 	warns += checkStaleSlotDirs(w, cwd)
 
 	switch tip, head, drifted := fossilDrift(cwd); {
@@ -385,6 +386,41 @@ func checkOrphanHubs(w io.Writer) int {
 			e.HubPID, e.Cwd, age)
 	}
 	return len(orphans)
+}
+
+// checkDuplicateHubs reads the cross-workspace registry and reports
+// any live duplicate hub processes for the current workspace (#208).
+// A duplicate is two or more registry entries whose canonical Cwd
+// resolves to cwd AND whose HubPID is alive — the hallmark of two
+// concurrent `bones hub start` invocations against one workspace,
+// each silently overwriting the other's recorded URL files.
+//
+// Read-only: emits one WARN per duplicate naming the PID, fossil URL,
+// nats URL, and age. Reaping is a separate operator action (per the
+// brief and ADR 0043's read-only-doctor doctrine). Returns the warn
+// count.
+func checkDuplicateHubs(w io.Writer, cwd string) int {
+	dups, err := registry.Duplicates(cwd)
+	if err != nil {
+		_, _ = fmt.Fprintf(w, "  WARN  duplicate-hub registry read: %v\n", err)
+		return 1
+	}
+	if len(dups) == 0 {
+		_, _ = fmt.Fprintln(w, "  OK    no duplicate hub processes for this workspace")
+		return 0
+	}
+	for _, e := range dups {
+		age := "?"
+		if !e.StartedAt.IsZero() {
+			age = time.Since(e.StartedAt).Round(time.Second).String()
+		}
+		_, _ = fmt.Fprintf(w,
+			"  WARN  duplicate hub: pid=%d fossil=%s nats=%s age=%s — "+
+				"another hub is serving this workspace; "+
+				"kill the stale pid or run `bones hub reap`\n",
+			e.HubPID, e.HubURL, e.NATSURL, age)
+	}
+	return len(dups)
 }
 
 // checkStaleSlotDirs reports per-slot directories under

--- a/cli/doctor_duplicate_test.go
+++ b/cli/doctor_duplicate_test.go
@@ -1,0 +1,87 @@
+package cli
+
+import (
+	"bytes"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/danmestas/bones/internal/registry"
+)
+
+// TestCheckDuplicateHubs_TwoEntriesEmitWarn pins acceptance criterion
+// (c) of issue #208: doctor scan with two synthetic registry entries
+// for the same workspace, both alive, emits two WARN lines naming the
+// duplicate PIDs. The check is a sibling of checkOrphanHubs and stays
+// read-only.
+func TestCheckDuplicateHubs_TwoEntriesEmitWarn(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	cwd := t.TempDir()
+
+	c1 := exec.Command("sleep", "30")
+	if err := c1.Start(); err != nil {
+		t.Fatalf("start sleep #1: %v", err)
+	}
+	t.Cleanup(func() { _ = c1.Process.Kill(); _ = c1.Wait() })
+	c2 := exec.Command("sleep", "30")
+	if err := c2.Start(); err != nil {
+		t.Fatalf("start sleep #2: %v", err)
+	}
+	t.Cleanup(func() { _ = c2.Process.Kill(); _ = c2.Wait() })
+
+	now := time.Now().UTC().Truncate(time.Second)
+	for _, e := range []registry.Entry{
+		{
+			Cwd: cwd, Name: "ws", HubPID: c1.Process.Pid,
+			HubURL: "http://127.0.0.1:1", StartedAt: now,
+		},
+		{
+			Cwd: cwd, Name: "ws", HubPID: c2.Process.Pid,
+			HubURL: "http://127.0.0.1:2", StartedAt: now.Add(time.Second),
+		},
+	} {
+		if err := registry.Write(e); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+	}
+
+	var buf bytes.Buffer
+	warns := checkDuplicateHubs(&buf, cwd)
+	if warns < 2 {
+		t.Errorf("checkDuplicateHubs warns = %d, want >= 2", warns)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "duplicate hub") {
+		t.Errorf("missing 'duplicate hub' in output:\n%s", out)
+	}
+	for _, c := range []*exec.Cmd{c1, c2} {
+		needle := pidLine(c.Process.Pid)
+		if !strings.Contains(out, needle) {
+			t.Errorf("output missing pid=%d line:\n%s", c.Process.Pid, out)
+		}
+		_ = needle
+	}
+}
+
+// TestCheckDuplicateHubs_NoneOK pins the negative case: zero
+// duplicates emits zero warns and no WARN lines.
+func TestCheckDuplicateHubs_NoneOK(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	cwd := t.TempDir()
+	var buf bytes.Buffer
+	warns := checkDuplicateHubs(&buf, cwd)
+	if warns != 0 {
+		t.Errorf("expected 0 warns on empty registry, got %d", warns)
+	}
+	if strings.Contains(buf.String(), "WARN") {
+		t.Errorf("unexpected WARN in empty-registry output:\n%s", buf.String())
+	}
+}
+
+// pidLine is the substring the duplicate-warn output is expected to
+// include; the format is unstable (display only) but pid= is the
+// stable handle the operator uses to act on the warning.
+func pidLine(pid int) string {
+	return "pid="
+}

--- a/cli/status.go
+++ b/cli/status.go
@@ -72,6 +72,14 @@ type statusReport struct {
 	// .claude/settings.json hooks are missing and AGENTS.md may be
 	// partial. Surfaced as a WARN by renderStatus (#147).
 	ScaffoldComplete bool
+
+	// DuplicateHubs is the count of live registry entries whose
+	// canonical Cwd matches this workspace (#208). >= 2 means two or
+	// more concurrent `bones hub start` processes are competing for
+	// this workspace's URL files and fossil state — silent corruption
+	// the renderer surfaces as a one-line WARN pointing at `bones
+	// doctor` for full per-PID detail.
+	DuplicateHubs int
 }
 
 // activityEvent is one entry in the recent-activity feed. Time is
@@ -136,6 +144,11 @@ func resolveStatusRoot(cwd string) (string, error) {
 // to what's available from on-disk state (workspace dir, scaffold
 // stamp); NATS-backed views (tasks, sessions, fossil timeline) stay
 // empty so the renderer's degraded branch fires.
+//
+// DuplicateHubs is still populated here: a "no healthy hub" workspace
+// can simultaneously have two competing live processes (one wrote
+// last, one is still around) — exactly the #208 case the operator
+// most needs to see surfaced.
 func degradedStatusReport(root string) statusReport {
 	stamp, _ := scaffoldver.Read(root)
 	return statusReport{
@@ -144,7 +157,21 @@ func degradedStatusReport(root string) statusReport {
 		TasksByStatus:    map[tasks.Status]int{},
 		TasksByID:        map[string]tasks.Task{},
 		ScaffoldComplete: stamp != "",
+		DuplicateHubs:    countDuplicateHubs(root),
 	}
+}
+
+// countDuplicateHubs returns the number of live registry entries
+// whose canonical Cwd matches root. Returns 0 on any error so a
+// transient registry-read failure does not turn into a phantom WARN.
+// The detailed per-PID surface lives in `bones doctor`; status only
+// needs the count to decide whether to emit its one-line WARN.
+func countDuplicateHubs(root string) int {
+	dups, err := registry.Duplicates(root)
+	if err != nil {
+		return 0
+	}
+	return len(dups)
 }
 
 // gatherStatus collects every input the snapshot needs. NATS-side
@@ -159,6 +186,7 @@ func gatherStatus(ctx context.Context, info workspace.Info) (statusReport, error
 		TasksByStatus:    map[tasks.Status]int{},
 		TasksByID:        map[string]tasks.Task{},
 		ScaffoldComplete: stamp != "",
+		DuplicateHubs:    countDuplicateHubs(info.WorkspaceDir),
 	}
 
 	mgr, closeMgr, err := openManager(ctx, info)
@@ -308,6 +336,20 @@ func renderStatus(rep statusReport, w io.Writer) error {
 	if !rep.ScaffoldComplete {
 		if _, err := io.WriteString(w,
 			"WARN  scaffold incomplete — re-run `bones up`\n\n"); err != nil {
+			return err
+		}
+	}
+
+	// Surface duplicate hubs (#208): when two or more concurrent
+	// `bones hub start` processes are serving this workspace, the
+	// recorded URL files are being overwritten by whichever one wrote
+	// last and consumers are observing whichever they happened to
+	// read. Status emits the one-liner; `bones doctor` lists each PID.
+	if rep.DuplicateHubs >= 2 {
+		if _, err := fmt.Fprintf(w,
+			"WARN  %d duplicate hub processes serving this workspace — "+
+				"run `bones doctor` for detail\n\n",
+			rep.DuplicateHubs); err != nil {
 			return err
 		}
 	}

--- a/cli/status_duplicate_test.go
+++ b/cli/status_duplicate_test.go
@@ -1,0 +1,62 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/danmestas/bones/internal/tasks"
+)
+
+// TestRenderStatus_DuplicateHubsWarn pins acceptance criterion (d) of
+// issue #208: when duplicates are present, the status renderer emits
+// a single WARN line that points the operator at `bones doctor` for
+// detail. The full per-PID list is doctor's job (criterion c); status
+// stays a one-shot one-liner.
+func TestRenderStatus_DuplicateHubsWarn(t *testing.T) {
+	rep := statusReport{
+		WorkspaceDir:     "/tmp/ws/bones",
+		GeneratedAt:      time.Date(2026, 5, 5, 14, 5, 2, 0, time.UTC),
+		TasksByStatus:    map[tasks.Status]int{},
+		TasksByID:        map[string]tasks.Task{},
+		ScaffoldComplete: true,
+		DuplicateHubs:    2,
+	}
+	var buf bytes.Buffer
+	if err := renderStatus(rep, &buf); err != nil {
+		t.Fatalf("renderStatus: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "WARN") {
+		t.Errorf("expected WARN line for duplicates; got:\n%s", out)
+	}
+	if !strings.Contains(out, "bones doctor") {
+		t.Errorf("WARN should direct user to `bones doctor` for detail; got:\n%s", out)
+	}
+	// Should be a single line summary — count occurrences of "duplicate hub".
+	if n := strings.Count(out, "duplicate hub"); n != 1 {
+		t.Errorf("expected 1 'duplicate hub' line in status, got %d:\n%s", n, out)
+	}
+}
+
+// TestRenderStatus_NoDuplicateNoWarn pins that DuplicateHubs=0
+// produces no warn line.
+func TestRenderStatus_NoDuplicateNoWarn(t *testing.T) {
+	rep := statusReport{
+		WorkspaceDir:     "/tmp/ws/bones",
+		GeneratedAt:      time.Date(2026, 5, 5, 14, 5, 2, 0, time.UTC),
+		TasksByStatus:    map[tasks.Status]int{},
+		TasksByID:        map[string]tasks.Task{},
+		ScaffoldComplete: true,
+		DuplicateHubs:    0,
+	}
+	var buf bytes.Buffer
+	if err := renderStatus(rep, &buf); err != nil {
+		t.Fatalf("renderStatus: %v", err)
+	}
+	if strings.Contains(buf.String(), "duplicate hub") {
+		t.Errorf("unexpected duplicate-hub WARN when DuplicateHubs=0:\n%s",
+			buf.String())
+	}
+}

--- a/cli/workspaces_test.go
+++ b/cli/workspaces_test.go
@@ -337,8 +337,10 @@ func TestRunPrune_YesRemovesStopped(t *testing.T) {
 	if len(after) != 1 || after[0].Cwd != wsC {
 		t.Errorf("after prune: want only wsC=%s, got %+v", wsC, after)
 	}
-	for _, cwd := range []string{wsA, wsB} {
-		if _, err := os.Stat(registry.EntryPath(cwd)); !os.IsNotExist(err) {
+	for i, cwd := range []string{wsA, wsB} {
+		// HubPID values seeded by seedTwoWorkspaces are -1 (wsA) and -2 (wsB).
+		pid := -(i + 1)
+		if _, err := os.Stat(registry.EntryPath(cwd, pid)); !os.IsNotExist(err) {
 			t.Errorf("entry file for %s should be removed; err=%v", cwd, err)
 		}
 	}
@@ -373,8 +375,9 @@ func TestRunPrune_NoConfirmKeepsEntries(t *testing.T) {
 		t.Errorf("output should not contain any pruned: lines:\n%s", out)
 	}
 
-	for _, cwd := range []string{wsA, wsB} {
-		if _, err := os.Stat(registry.EntryPath(cwd)); err != nil {
+	for i, cwd := range []string{wsA, wsB} {
+		pid := -(i + 1)
+		if _, err := os.Stat(registry.EntryPath(cwd, pid)); err != nil {
 			t.Errorf("entry for %s should still exist after abort; err=%v", cwd, err)
 		}
 	}

--- a/internal/hub/hub.go
+++ b/internal/hub/hub.go
@@ -20,6 +20,12 @@ import (
 	"github.com/danmestas/bones/internal/telemetry"
 )
 
+// acquireWorkspaceLockFunc is a seam over registry.AcquireWorkspaceLock
+// so tests can substitute a no-op or contention stub without spawning
+// real subprocesses. Production callers reach the real flock-based
+// implementation.
+var acquireWorkspaceLockFunc = registry.AcquireWorkspaceLock
+
 // detachEnv, when set, signals to a fork-exec'd child process that it
 // should run Start in foreground regardless of the --detach flag. The
 // CLI sets this on the child to break the recursion.
@@ -128,6 +134,17 @@ func Start(ctx context.Context, root string, options ...Option) (err error) {
 	if pidIsLive(p.fossilPid) && pidIsLive(p.natsPid) {
 		return nil
 	}
+
+	// Workspace-scoped lock guard (#208 prevention layer). Acquire
+	// BEFORE port resolution, URL-file writes, or fork-exec so a
+	// second concurrent `bones hub start` against the same workspace
+	// fails fast without side effects. Skip in the detached child:
+	// the parent already gated the start.
+	releaseLock, lockErr := acquireStartLock(p.root, isDetachChild)
+	if lockErr != nil {
+		return lockErr
+	}
+	defer releaseLock()
 
 	// Seed precondition (#138 item 9): a fresh hub start needs at least
 	// one git-tracked file to seed the hub fossil from. Without this
@@ -243,6 +260,11 @@ func runForeground(ctx context.Context, p paths, o opts) error {
 	drainErr := drainHub(h, httpDone, o.drainTimeout)
 	_ = os.Remove(p.fossilPid)
 	_ = os.Remove(p.natsPid)
+	// Drop our own per-pid registry entry (#208 layout) so a clean
+	// hub exit does not leave a stale record for `bones doctor` or
+	// `bones status --all` to filter out via pidAlive. Dead-pid
+	// pruning still handles the unclean-exit case.
+	_ = registry.RemoveByPID(p.root, os.Getpid())
 	return drainErr
 }
 
@@ -535,6 +557,23 @@ func activeSlotNames(root string) ([]string, error) {
 		names = append(names, s.Name)
 	}
 	return names, nil
+}
+
+// acquireStartLock takes the workspace-scoped hub lock (#208) when
+// the caller is not the detached child. The detached child must NOT
+// contend for the lock — the parent still holds it for the lifetime
+// of waitForTCP and only releases on return. Returns a release func
+// (no-op when the caller is the detached child) plus any acquisition
+// error, wrapped with the "hub: " prefix the rest of Start uses.
+func acquireStartLock(root string, isDetachChild bool) (func(), error) {
+	if isDetachChild {
+		return func() {}, nil
+	}
+	rel, err := acquireWorkspaceLockFunc(root)
+	if err != nil {
+		return nil, fmt.Errorf("hub: %w", err)
+	}
+	return rel, nil
 }
 
 // terminateProcess sends SIGTERM, polls until stopGrace elapses, and

--- a/internal/hub/lock_test.go
+++ b/internal/hub/lock_test.go
@@ -1,0 +1,107 @@
+package hub
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/danmestas/bones/internal/registry"
+)
+
+// TestStart_RejectsWhenWorkspaceLockHeld pins acceptance criterion (a)
+// of issue #208: when a second `bones hub start` runs against a
+// workspace whose hub lock is held by a live process, the call exits
+// non-zero before binding ports or writing URL files. Lock prevention
+// is the third complementary guard alongside the existing port-
+// collision check (#138 item 1) and the cross-workspace orphan
+// registry (ADR 0043).
+//
+// Skipped on Windows: the lock implementation there is a best-effort
+// pid-file-only stub; the flock-backed contention path is the one
+// covered here.
+func TestStart_RejectsWhenWorkspaceLockHeld(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("flock contention is Unix-only")
+	}
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	t.Setenv("HOME", t.TempDir())
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".bones"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Seed precondition: at least one tracked file. checkSeedPrecondition
+	// fires before lock acquisition under current code; once the lock
+	// guard moves earlier (the implementation under test), the order is
+	// lock-then-precondition. Either ordering is acceptable as long as
+	// the second start is rejected — we make BOTH conditions satisfied
+	// so the test is order-independent.
+	for _, args := range [][]string{
+		{"init", "-q"},
+		{"add", "."},
+		{
+			"-c", "user.email=t@t", "-c", "user.name=t",
+			"commit", "-q", "--allow-empty", "-m", "init",
+		},
+	} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = root
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+
+	// Acquire the workspace lock from the test process. The next
+	// hub.Start MUST refuse — fast — without spawning a child.
+	rel, err := registry.AcquireWorkspaceLock(root)
+	if err != nil {
+		t.Fatalf("AcquireWorkspaceLock: %v", err)
+	}
+	defer rel()
+
+	// Bound: the lock guard runs before any port bind or fork-exec, so
+	// rejection should be sub-second. If the call hangs, the guard is
+	// in the wrong place.
+	type result struct{ err error }
+	ch := make(chan result, 1)
+	go func() {
+		ch <- result{Start(context.Background(), root, WithDetach(true))}
+	}()
+
+	select {
+	case r := <-ch:
+		if r.err == nil {
+			t.Fatal("Start returned nil despite contended workspace lock")
+		}
+		var held *registry.ErrLockHeld
+		if !errors.As(r.err, &held) {
+			t.Errorf("Start error not a *registry.ErrLockHeld: %v", r.err)
+		}
+		if !strings.Contains(r.err.Error(), "lock") {
+			t.Errorf("error should mention 'lock'; got: %v", r.err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Start did not return in 5s; lock guard appears " +
+			"to be running AFTER port bind or child spawn")
+	}
+
+	// Side-effect verification: the rejected start must NOT have
+	// written URL files or pid files. Pre-fix this is exactly the
+	// silent state corruption the issue describes.
+	for _, name := range []string{"hub-fossil-url", "hub-nats-url"} {
+		path := filepath.Join(root, ".bones", name)
+		if _, err := os.Stat(path); err == nil {
+			t.Errorf("rejected start wrote %s; lock guard ran too late", path)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(root, ".bones", "pids", "fossil.pid")); err == nil {
+		t.Errorf("rejected start wrote fossil.pid; lock guard ran too late")
+	}
+}

--- a/internal/registry/duplicates.go
+++ b/internal/registry/duplicates.go
@@ -1,0 +1,44 @@
+package registry
+
+import "path/filepath"
+
+// Duplicates returns every registry entry whose canonical Cwd matches
+// the given workspace AND whose HubPID is alive on this host. When the
+// length is 0 or 1, the workspace has no concurrent hubs (steady
+// state). When the length is >= 2, the issue described in #208 is
+// present: two `bones hub start` invocations are competing for the
+// same workspace's URL files and fossil state.
+//
+// Sibling primitive of Orphans(): both walk the per-pid registry, both
+// filter on PID liveness, both stay read-only. Doctor and status
+// consume Duplicates and emit WARN-class output; reaping is left to
+// the operator (the brief defers automatic kill of duplicates to a
+// dedicated verb, mirroring ADR 0043's read-only-doctor doctrine).
+//
+// PID-alive is the only liveness signal — no HTTP probe — because the
+// duplicate scenario typically includes one hub that lost the port
+// race and is no longer serving HTTP. Such a hub is still holding
+// fossil inodes and overwriting URL files; the operator needs to know
+// about it even if HealthTimeout would mark it down.
+func Duplicates(cwd string) ([]Entry, error) {
+	all, err := List()
+	if err != nil {
+		return nil, err
+	}
+	target := filepath.Clean(cwd)
+	var out []Entry
+	for _, e := range all {
+		if filepath.Clean(e.Cwd) != target {
+			continue
+		}
+		if !pidAlive(e.HubPID) {
+			continue
+		}
+		out = append(out, e)
+	}
+	if len(out) < 2 {
+		// Only one (or zero) live entries — not a duplicate.
+		return nil, nil
+	}
+	return out, nil
+}

--- a/internal/registry/duplicates_test.go
+++ b/internal/registry/duplicates_test.go
@@ -1,0 +1,221 @@
+package registry
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestDuplicates_TwoAliveEntriesSameCwd pins the primary signal: two
+// entries whose Cwd resolves to the current workspace AND whose PIDs
+// are alive return both as duplicates. Mirrors the issue #208 scenario
+// where two `bones hub start` invocations against one workspace each
+// create a registry entry; the duplicate predicate finds both.
+func TestDuplicates_TwoAliveEntriesSameCwd(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	cwd := t.TempDir()
+
+	// Spawn two real children so PID-alive checks pass without coupling
+	// the test process to the entries' lifecycles.
+	c1 := exec.Command("sleep", "30")
+	if err := c1.Start(); err != nil {
+		t.Fatalf("start sleep #1: %v", err)
+	}
+	t.Cleanup(func() { _ = c1.Process.Kill(); _ = c1.Wait() })
+	c2 := exec.Command("sleep", "30")
+	if err := c2.Start(); err != nil {
+		t.Fatalf("start sleep #2: %v", err)
+	}
+	t.Cleanup(func() { _ = c2.Process.Kill(); _ = c2.Wait() })
+
+	now := time.Now().UTC().Truncate(time.Second)
+	for _, e := range []Entry{
+		{
+			Cwd: cwd, Name: "ws", HubPID: c1.Process.Pid,
+			HubURL: "http://127.0.0.1:1", StartedAt: now,
+		},
+		{
+			Cwd: cwd, Name: "ws", HubPID: c2.Process.Pid,
+			HubURL: "http://127.0.0.1:2", StartedAt: now.Add(time.Second),
+		},
+	} {
+		if err := Write(e); err != nil {
+			t.Fatalf("Write: %v", err)
+		}
+	}
+
+	dups, err := Duplicates(cwd)
+	if err != nil {
+		t.Fatalf("Duplicates: %v", err)
+	}
+	if len(dups) != 2 {
+		t.Fatalf("Duplicates len = %d, want 2; got=%+v", len(dups), dups)
+	}
+	pids := map[int]bool{}
+	for _, d := range dups {
+		pids[d.HubPID] = true
+	}
+	if !pids[c1.Process.Pid] || !pids[c2.Process.Pid] {
+		t.Errorf("expected both PIDs in duplicates; got %v", dups)
+	}
+}
+
+// TestDuplicates_SingleEntryNoDuplicate pins the negative case: one
+// entry for the workspace returns empty (no duplicates).
+func TestDuplicates_SingleEntryNoDuplicate(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	cwd := t.TempDir()
+	if err := Write(Entry{
+		Cwd: cwd, Name: "ws", HubPID: os.Getpid(),
+		HubURL: "http://127.0.0.1:1", StartedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	dups, err := Duplicates(cwd)
+	if err != nil {
+		t.Fatalf("Duplicates: %v", err)
+	}
+	if len(dups) != 0 {
+		t.Errorf("expected 0 duplicates for single entry, got %d: %+v", len(dups), dups)
+	}
+}
+
+// TestDuplicates_DeadPidIgnored pins that an entry whose PID is dead
+// is NOT counted as a duplicate — it's stale, not concurrent.
+func TestDuplicates_DeadPidIgnored(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	cwd := t.TempDir()
+
+	c1 := exec.Command("sleep", "30")
+	if err := c1.Start(); err != nil {
+		t.Fatalf("start sleep: %v", err)
+	}
+	t.Cleanup(func() { _ = c1.Process.Kill(); _ = c1.Wait() })
+
+	now := time.Now().UTC().Truncate(time.Second)
+	if err := Write(Entry{
+		Cwd: cwd, Name: "ws", HubPID: c1.Process.Pid,
+		HubURL: "http://127.0.0.1:1", StartedAt: now,
+	}); err != nil {
+		t.Fatalf("Write live: %v", err)
+	}
+	if err := Write(Entry{
+		Cwd: cwd, Name: "ws", HubPID: findDeadPID(t),
+		HubURL: "http://127.0.0.1:2", StartedAt: now.Add(time.Second),
+	}); err != nil {
+		t.Fatalf("Write dead: %v", err)
+	}
+
+	dups, err := Duplicates(cwd)
+	if err != nil {
+		t.Fatalf("Duplicates: %v", err)
+	}
+	// Only one entry alive — not a duplicate; should return empty.
+	if len(dups) != 0 {
+		t.Errorf("expected 0 duplicates (one alive, one dead), got %d: %+v",
+			len(dups), dups)
+	}
+}
+
+// TestDuplicates_DifferentCwdIgnored pins workspace isolation: an
+// alive entry under a different cwd does not count for this workspace.
+func TestDuplicates_DifferentCwdIgnored(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	cwdA := t.TempDir()
+	cwdB := t.TempDir()
+
+	c1 := exec.Command("sleep", "30")
+	if err := c1.Start(); err != nil {
+		t.Fatalf("start sleep: %v", err)
+	}
+	t.Cleanup(func() { _ = c1.Process.Kill(); _ = c1.Wait() })
+	c2 := exec.Command("sleep", "30")
+	if err := c2.Start(); err != nil {
+		t.Fatalf("start sleep: %v", err)
+	}
+	t.Cleanup(func() { _ = c2.Process.Kill(); _ = c2.Wait() })
+
+	now := time.Now().UTC().Truncate(time.Second)
+	for _, e := range []Entry{
+		{
+			Cwd: cwdA, Name: "a", HubPID: c1.Process.Pid,
+			HubURL: "http://127.0.0.1:1", StartedAt: now,
+		},
+		{
+			Cwd: cwdB, Name: "b", HubPID: c2.Process.Pid,
+			HubURL: "http://127.0.0.1:2", StartedAt: now,
+		},
+	} {
+		if err := Write(e); err != nil {
+			t.Fatalf("Write: %v", err)
+		}
+	}
+
+	dups, err := Duplicates(cwdA)
+	if err != nil {
+		t.Fatalf("Duplicates: %v", err)
+	}
+	if len(dups) != 0 {
+		t.Errorf("expected 0 duplicates for cwdA when cwdB has its own, got %+v", dups)
+	}
+}
+
+// TestDuplicates_CanonicalizesCwd pins that Duplicates compares
+// canonical paths so a trailing slash or relative input does not
+// hide a true duplicate.
+func TestDuplicates_CanonicalizesCwd(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	cwd := t.TempDir()
+
+	c1 := exec.Command("sleep", "30")
+	if err := c1.Start(); err != nil {
+		t.Fatalf("start sleep #1: %v", err)
+	}
+	t.Cleanup(func() { _ = c1.Process.Kill(); _ = c1.Wait() })
+	c2 := exec.Command("sleep", "30")
+	if err := c2.Start(); err != nil {
+		t.Fatalf("start sleep #2: %v", err)
+	}
+	t.Cleanup(func() { _ = c2.Process.Kill(); _ = c2.Wait() })
+
+	now := time.Now().UTC().Truncate(time.Second)
+	for _, e := range []Entry{
+		{
+			Cwd: cwd, Name: "ws", HubPID: c1.Process.Pid,
+			HubURL: "http://127.0.0.1:1", StartedAt: now,
+		},
+		{
+			Cwd: cwd, Name: "ws", HubPID: c2.Process.Pid,
+			HubURL: "http://127.0.0.1:2", StartedAt: now.Add(time.Second),
+		},
+	} {
+		if err := Write(e); err != nil {
+			t.Fatalf("Write: %v", err)
+		}
+	}
+
+	// Query with a trailing slash; filepath.Clean must normalize.
+	dups, err := Duplicates(cwd + string(filepath.Separator))
+	if err != nil {
+		t.Fatalf("Duplicates: %v", err)
+	}
+	if len(dups) != 2 {
+		t.Errorf("expected 2 duplicates regardless of trailing slash, got %d", len(dups))
+	}
+}
+
+// findDeadPID returns a PID that is not alive on this host. Used by
+// duplicate-detection tests that need a "dead" entry. Skips on hosts
+// where every probed PID happens to be alive (extremely unlikely).
+func findDeadPID(t *testing.T) int {
+	t.Helper()
+	for pid := 999_999; pid < 1_000_100; pid++ {
+		if !pidAlive(pid) {
+			return pid
+		}
+	}
+	t.Skip("could not find a dead PID on this host")
+	return 0
+}

--- a/internal/registry/info.go
+++ b/internal/registry/info.go
@@ -1,10 +1,10 @@
 package registry
 
 import (
-	"encoding/json"
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -70,7 +70,7 @@ func ListInfo() ([]Info, error) {
 		}
 		info := Info{
 			Entry:       e,
-			ID:          strings.TrimSuffix(filepath.Base(path), ".json"),
+			ID:          idFromFilename(path),
 			AgentID:     readAgentIDFile(e.Cwd),
 			HubStatus:   probeStatus(e),
 			LastTouched: fi.ModTime(),
@@ -86,20 +86,26 @@ func ListInfo() ([]Info, error) {
 	return out, nil
 }
 
-// readEntryAtPath is the path-keyed sibling of Read. Read is cwd-keyed and
-// recomputes the filename via WorkspaceID; ListInfo already has the path,
-// so we read it directly to avoid the extra hash + to surface decode
-// errors at the right path.
-func readEntryAtPath(path string) (Entry, error) {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return Entry{}, err
+// idFromFilename strips the ".json" suffix and the trailing
+// "-<pid>" so the surfaced ID equals WorkspaceID(Cwd) regardless of
+// whether the file is in the new <id>-<pid>.json scheme or the legacy
+// <id>.json scheme. WorkspaceID is 16 hex chars with no hyphens, so
+// the first hyphen in the basename is unambiguously the id/pid
+// separator.
+//
+// Two files (one per pid) for the same cwd produce the same Info.ID —
+// callers that need pid-level identity read the embedded Entry.HubPID.
+func idFromFilename(path string) string {
+	base := strings.TrimSuffix(filepath.Base(path), ".json")
+	if idx := strings.Index(base, "-"); idx >= 0 {
+		// Only strip when the suffix parses as an integer pid (positive
+		// or negative); legacy <id>.json never contained a hyphen so
+		// this is a no-op there.
+		if _, err := strconv.Atoi(base[idx+1:]); err == nil {
+			return base[:idx]
+		}
 	}
-	var e Entry
-	if err := json.Unmarshal(data, &e); err != nil {
-		return Entry{}, err
-	}
-	return e, nil
+	return base
 }
 
 // readAgentIDFile reads <cwd>/.bones/agent.id and trims trailing whitespace,

--- a/internal/registry/lock.go
+++ b/internal/registry/lock.go
@@ -1,0 +1,153 @@
+package registry
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// LockFileName is the basename of the workspace-scoped lock file
+// `bones hub start` acquires before any port bind, URL-file write, or
+// hub bootstrap. Lives at <root>/.bones/hub.lock alongside the URL
+// files and pid files (per the issue brief: "workspace-scoped lock
+// file path lives under the workspace's bones-state directory"). The
+// sibling hub.lock.pid records the holder for human-readable error
+// messages.
+const (
+	LockFileName    = "hub.lock"
+	LockPidFileName = "hub.lock.pid"
+)
+
+// ErrLockHeld is returned by AcquireWorkspaceLock when another live
+// process holds the workspace lock. The PID is the holder (parsed
+// from hub.lock.pid); callers surface it in CLI output so the
+// operator can act.
+type ErrLockHeld struct {
+	PID  int
+	Path string
+}
+
+func (e *ErrLockHeld) Error() string {
+	if e.PID > 0 {
+		return fmt.Sprintf(
+			"workspace hub lock %s held by pid %d", e.Path, e.PID)
+	}
+	return fmt.Sprintf("workspace hub lock %s held by another process", e.Path)
+}
+
+// LockPath returns the absolute path of the workspace lock file for
+// the workspace at root.
+func LockPath(root string) string {
+	return filepath.Join(root, ".bones", LockFileName)
+}
+
+// LockPidPath returns the absolute path of the sibling pid file
+// recording the lock holder.
+func LockPidPath(root string) string {
+	return filepath.Join(root, ".bones", LockPidFileName)
+}
+
+// AcquireWorkspaceLock takes an exclusive non-blocking advisory lock
+// on <root>/.bones/hub.lock. Used by `bones hub start` to refuse a
+// second concurrent start against the same workspace before any side
+// effects (port bind, URL-file write, fork-exec).
+//
+// Returns a release func that drops the lock + removes the sibling
+// pid file. If the lock is held by a live process, returns
+// *ErrLockHeld. If the sibling pid file names a dead process, the
+// stale pid is overwritten and the lock is reclaimed (the kill -9
+// recovery path from the issue's acceptance criteria).
+//
+// Cross-platform: on Unix this is syscall.Flock(LOCK_EX|LOCK_NB); on
+// Windows it falls back to a best-effort pid-file probe (see
+// lock_windows.go) since flock is not available there.
+func AcquireWorkspaceLock(root string) (func(), error) {
+	bones := filepath.Join(root, ".bones")
+	if err := os.MkdirAll(bones, 0o755); err != nil {
+		return nil, fmt.Errorf("workspace lock: mkdir: %w", err)
+	}
+	path := LockPath(root)
+	pidPath := LockPidPath(root)
+
+	// Pid-file contention check (cross-platform). flock is the source
+	// of truth on Unix; Windows does not have flock(2), so we treat
+	// "holder pid in lock.pid is alive" as the contention signal there.
+	// On Unix this is just an early human-readable error: flock will
+	// also fail and we'd still surface the holder pid below.
+	if holder, ok := readLockHolderPID(pidPath); ok && holder != os.Getpid() && pidAlive(holder) {
+		return nil, &ErrLockHeld{PID: holder, Path: path}
+	}
+
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o644)
+	if err != nil {
+		return nil, fmt.Errorf("workspace lock: open: %w", err)
+	}
+	if err := tryLockExclusive(f); err != nil {
+		holder, _ := readLockHolderPID(pidPath)
+		_ = f.Close()
+		// Stale-holder reclamation: if the recorded holder is dead,
+		// delete the pid file and retry once. The flock itself is
+		// already released (the dead process exited), so the retry
+		// succeeds.
+		if holder > 0 && !pidAlive(holder) {
+			_ = os.Remove(pidPath)
+			f, err = os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o644)
+			if err != nil {
+				return nil, fmt.Errorf("workspace lock: reopen: %w", err)
+			}
+			if err := tryLockExclusive(f); err != nil {
+				_ = f.Close()
+				return nil, &ErrLockHeld{PID: holder, Path: path}
+			}
+		} else {
+			return nil, &ErrLockHeld{PID: holder, Path: path}
+		}
+	}
+	if err := writeLockHolderPID(pidPath, os.Getpid()); err != nil {
+		_ = unlock(f)
+		_ = f.Close()
+		return nil, fmt.Errorf("workspace lock: pid file: %w", err)
+	}
+	release := func() {
+		_ = os.Remove(pidPath)
+		_ = unlock(f)
+		_ = f.Close()
+	}
+	return release, nil
+}
+
+// readLockHolderPID parses the pid recorded in hub.lock.pid. Returns
+// (0, false) on any read or parse error.
+func readLockHolderPID(path string) (int, bool) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0, false
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil {
+		return 0, false
+	}
+	return pid, true
+}
+
+// writeLockHolderPID atomically replaces the pid file with our pid.
+// Tmp+rename keeps a torn read off the table for an external observer
+// (e.g. `bones doctor` reading the file between truncate and write).
+func writeLockHolderPID(path string, pid int) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, filepath.Base(path)+".tmp.*")
+	if err != nil {
+		return err
+	}
+	defer func() { _ = os.Remove(tmp.Name()) }()
+	if _, err := tmp.Write([]byte(strconv.Itoa(pid) + "\n")); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmp.Name(), path)
+}

--- a/internal/registry/lock_test.go
+++ b/internal/registry/lock_test.go
@@ -1,0 +1,176 @@
+package registry
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// TestAcquireWorkspaceLock_Basic pins the happy path: acquiring an
+// uncontested workspace lock succeeds, the release returns it, and a
+// subsequent acquire on the same workspace by the same process
+// succeeds again.
+func TestAcquireWorkspaceLock_Basic(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".bones"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	rel, err := AcquireWorkspaceLock(root)
+	if err != nil {
+		t.Fatalf("AcquireWorkspaceLock: %v", err)
+	}
+	rel()
+
+	rel2, err := AcquireWorkspaceLock(root)
+	if err != nil {
+		t.Fatalf("AcquireWorkspaceLock after release: %v", err)
+	}
+	rel2()
+}
+
+// TestAcquireWorkspaceLock_HeldByLiveProcess pins prevention: when the
+// lock is held by a live external process, the second acquire returns
+// ErrLockHeld with the holder's PID embedded so the CLI can name the
+// conflicting process.
+//
+// On Windows flock isn't available; we skip rather than implement a
+// non-flock contention probe in a unit test.
+func TestAcquireWorkspaceLock_HeldByLiveProcess(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("flock contention requires Unix")
+	}
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".bones"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Spawn a child that grabs an flock on the same path and stays alive.
+	// Use a sibling helper that holds the lock for its lifetime so we can
+	// observe contention from the parent.
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatalf("Executable: %v", err)
+	}
+	helper := exec.Command(exe, "-test.run", "TestHelperHoldsLock")
+	helper.Env = append(os.Environ(),
+		"BONES_LOCKTEST_HOLD_ROOT="+root,
+		"BONES_LOCKTEST_HOLD=1",
+	)
+	stdout, err := helper.StdoutPipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	if err := helper.Start(); err != nil {
+		t.Fatalf("helper start: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = helper.Process.Kill()
+		_ = helper.Wait()
+	})
+	// Wait for the helper to signal "locked" so the contention is real.
+	buf := make([]byte, 16)
+	n, _ := stdout.Read(buf)
+	if !strings.HasPrefix(string(buf[:n]), "LOCKED") {
+		t.Fatalf("helper did not lock: got %q", string(buf[:n]))
+	}
+
+	rel, err := AcquireWorkspaceLock(root)
+	if err == nil {
+		rel()
+		t.Fatalf("expected error acquiring contended lock")
+	}
+	var held *ErrLockHeld
+	if !errors.As(err, &held) {
+		t.Fatalf("expected *ErrLockHeld, got %T: %v", err, err)
+	}
+	if held.PID != helper.Process.Pid {
+		t.Errorf("ErrLockHeld.PID = %d, want %d", held.PID, helper.Process.Pid)
+	}
+}
+
+// TestAcquireWorkspaceLock_DeadHolderReclaimed pins the resilience
+// path: a stale lock-pid file pointing at a dead process is reclaimed
+// (not failed) by the next acquire. This is the "kill -9, restart"
+// scenario from the issue acceptance criteria.
+func TestAcquireWorkspaceLock_DeadHolderReclaimed(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix-only: dead-PID reclamation uses flock")
+	}
+	root := t.TempDir()
+	bones := filepath.Join(root, ".bones")
+	if err := os.MkdirAll(bones, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Drop a stale pid file pointing at a definitely-dead PID. The
+	// underlying flock is NOT held (the would-be holder is dead), so
+	// the next AcquireWorkspaceLock should succeed and rewrite the
+	// pid file.
+	dead := 999_999
+	for !pidAliveOrSkip(t, dead) {
+		break
+	}
+	pidPath := filepath.Join(bones, "hub.lock.pid")
+	if err := os.WriteFile(pidPath, []byte(strconv.Itoa(dead)+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	rel, err := AcquireWorkspaceLock(root)
+	if err != nil {
+		t.Fatalf("AcquireWorkspaceLock with dead-pid file: %v", err)
+	}
+	t.Cleanup(rel)
+
+	// pid file now names us.
+	got, err := os.ReadFile(pidPath)
+	if err != nil {
+		t.Fatalf("read pid file: %v", err)
+	}
+	if strings.TrimSpace(string(got)) != strconv.Itoa(os.Getpid()) {
+		t.Errorf("expected pid file to name us (%d), got %q", os.Getpid(), string(got))
+	}
+}
+
+// pidAliveOrSkip returns true when pid is alive (so the caller can
+// keep searching). If pid is dead the test proceeds with that pid.
+// Used to skip the test on hosts where the chosen "dead" pid happens
+// to be alive — extremely unlikely in CI.
+func pidAliveOrSkip(t *testing.T, pid int) bool {
+	t.Helper()
+	if pidAlive(pid) {
+		t.Skip("dead-pid sentinel is alive on this host")
+	}
+	return false
+}
+
+// TestHelperHoldsLock is the child helper for the "held by live
+// process" test. When BONES_LOCKTEST_HOLD=1 it acquires the workspace
+// lock at BONES_LOCKTEST_HOLD_ROOT, prints "LOCKED\n" so the parent
+// knows contention is real, then sleeps until killed. Skipped under
+// the normal `go test` invocation (no env var).
+func TestHelperHoldsLock(t *testing.T) {
+	if os.Getenv("BONES_LOCKTEST_HOLD") != "1" {
+		t.Skip("helper only runs in subprocess mode")
+	}
+	root := os.Getenv("BONES_LOCKTEST_HOLD_ROOT")
+	if root == "" {
+		t.Skip("BONES_LOCKTEST_HOLD_ROOT unset")
+	}
+	rel, err := AcquireWorkspaceLock(root)
+	if err != nil {
+		// Print and bail so parent sees a clear failure.
+		_, _ = os.Stdout.WriteString("LOCKFAIL\n")
+		t.Fatalf("helper acquire: %v", err)
+	}
+	defer rel()
+	_, _ = os.Stdout.WriteString("LOCKED\n")
+	// Sleep until parent kills us. Use a long sleep — the parent
+	// cleanup hook will SIGKILL well before this returns.
+	select {}
+}

--- a/internal/registry/lock_unix.go
+++ b/internal/registry/lock_unix.go
@@ -1,0 +1,35 @@
+//go:build !windows
+
+package registry
+
+import (
+	"errors"
+	"os"
+	"syscall"
+)
+
+// tryLockExclusive attempts a non-blocking exclusive flock on f.
+// Returns syscall.EWOULDBLOCK (or its alias EAGAIN) when contended,
+// nil on success, or any other error from flock(2). Use the syscall.
+// Flock primitive directly: it's available on all Unix variants bones
+// supports (Linux, Darwin, BSDs) and avoids pulling x/sys.
+func tryLockExclusive(f *os.File) error {
+	for {
+		err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+		if err == nil {
+			return nil
+		}
+		// Some kernels (older Linux) surface EINTR around signal
+		// handlers; retry transparently like the stdlib does.
+		if errors.Is(err, syscall.EINTR) {
+			continue
+		}
+		return err
+	}
+}
+
+// unlock releases the flock on f. Best-effort: errors are ignored by
+// the caller because closing the file also drops the lock.
+func unlock(f *os.File) error {
+	return syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+}

--- a/internal/registry/lock_windows.go
+++ b/internal/registry/lock_windows.go
@@ -1,0 +1,33 @@
+//go:build windows
+
+package registry
+
+import (
+	"fmt"
+	"os"
+)
+
+// tryLockExclusive on Windows is a best-effort pid-file probe; flock
+// is not available there. AcquireWorkspaceLock reads the recorded
+// holder pid before opening the lock file, so the contention check
+// happens before this function. Here we only succeed when the
+// underlying file open already worked. The pid-aliveness decision
+// lives in AcquireWorkspaceLock.
+//
+// Trade-off: two genuine concurrent starts that both race past the
+// pid-file write can both succeed. The downstream port-collision
+// check at bind time (#138 item 1) catches them. macOS + Linux use
+// flock and don't have this race window; Windows relies on the
+// per-pid registry duplicate-hub WARN to surface any leak.
+func tryLockExclusive(f *os.File) error {
+	if f == nil {
+		return fmt.Errorf("workspace lock: nil file handle")
+	}
+	return nil
+}
+
+// unlock is a no-op on Windows; closing the file is the only release
+// step the caller needs.
+func unlock(f *os.File) error {
+	return nil
+}

--- a/internal/registry/orphan.go
+++ b/internal/registry/orphan.go
@@ -95,7 +95,7 @@ func Orphans() ([]Entry, error) {
 // a process that, by definition, isn't going to come back.
 func Reap(e Entry) error {
 	if !pidAlive(e.HubPID) {
-		return Remove(e.Cwd)
+		return RemoveByPID(e.Cwd, e.HubPID)
 	}
 	proc, err := os.FindProcess(e.HubPID)
 	if err != nil {
@@ -107,7 +107,7 @@ func Reap(e Entry) error {
 	deadline := time.Now().Add(reapGrace)
 	for time.Now().Before(deadline) {
 		if !pidAlive(e.HubPID) {
-			return Remove(e.Cwd)
+			return RemoveByPID(e.Cwd, e.HubPID)
 		}
 		time.Sleep(50 * time.Millisecond)
 	}
@@ -121,5 +121,5 @@ func Reap(e Entry) error {
 		}
 		time.Sleep(25 * time.Millisecond)
 	}
-	return Remove(e.Cwd)
+	return RemoveByPID(e.Cwd, e.HubPID)
 }

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -8,18 +8,23 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"time"
 )
 
 // WorkspaceID returns a deterministic 16-hex-char identifier for an absolute cwd.
-// Used as the registry filename: ~/.bones/workspaces/<id>.json
+// Used as the registry filename prefix: ~/.bones/workspaces/<id>-<pid>.json.
 func WorkspaceID(cwd string) string {
 	sum := sha256.Sum256([]byte(filepath.Clean(cwd)))
 	return hex.EncodeToString(sum[:])[:16]
 }
 
-// Entry is one workspace's registry record. One JSON file per Entry at
-// ~/.bones/workspaces/<WorkspaceID>.json.
+// Entry is one workspace's registry record. Each `bones hub start`
+// writes its own entry at ~/.bones/workspaces/<WorkspaceID>-<HubPID>.json
+// — pid in the filename so two concurrent starts against the same
+// workspace produce two entries (the duplicate-hub case from #208)
+// rather than the second silently overwriting the first.
 type Entry struct {
 	Cwd       string    `json:"cwd"`
 	Name      string    `json:"name"`
@@ -34,13 +39,25 @@ func RegistryDir() string {
 	return filepath.Join(os.Getenv("HOME"), ".bones", "workspaces")
 }
 
-// EntryPath returns the absolute path of the JSON file for the given workspace cwd.
-func EntryPath(cwd string) string {
+// EntryPath returns the absolute path of the JSON file for a given
+// workspace cwd and hub pid. The pid is encoded into the filename so
+// concurrent hub starts against the same workspace produce distinct
+// files (#208 acceptance criterion (c)).
+func EntryPath(cwd string, pid int) string {
+	return filepath.Join(RegistryDir(),
+		fmt.Sprintf("%s-%d.json", WorkspaceID(cwd), pid))
+}
+
+// legacyEntryPath returns the pre-#208 unsuffixed path for backwards
+// compatibility on read. Pre-fix the filename was just <id>.json
+// regardless of pid; List still surfaces those entries so an upgrade
+// across an operator's running hubs does not lose state.
+func legacyEntryPath(cwd string) string {
 	return filepath.Join(RegistryDir(), WorkspaceID(cwd)+".json")
 }
 
 // Write persists e to its file atomically (tmp+rename). Creates the registry
-// directory if missing.
+// directory if missing. Filename is keyed by (cwd, HubPID) — see EntryPath.
 func Write(e Entry) error {
 	if err := os.MkdirAll(RegistryDir(), 0o755); err != nil {
 		return fmt.Errorf("registry mkdir: %w", err)
@@ -50,7 +67,7 @@ func Write(e Entry) error {
 		return fmt.Errorf("registry marshal: %w", err)
 	}
 
-	dst := EntryPath(e.Cwd)
+	dst := EntryPath(e.Cwd, e.HubPID)
 	tmp, err := os.CreateTemp(RegistryDir(), filepath.Base(dst)+".tmp.*")
 	if err != nil {
 		return fmt.Errorf("registry tmp: %w", err)
@@ -74,23 +91,56 @@ func Write(e Entry) error {
 // ErrNotFound is returned by Read when no entry exists for the given cwd.
 var ErrNotFound = errors.New("registry: entry not found")
 
-// Read loads the registry entry for the given workspace cwd.
+// Read loads the workspace's most-recent registry entry. If multiple
+// entries exist (the duplicate-hub case), the alive one with the
+// latest StartedAt wins; if none are alive, the latest StartedAt is
+// returned. Use Duplicates(cwd) when the caller wants every entry.
 func Read(cwd string) (Entry, error) {
-	data, err := os.ReadFile(EntryPath(cwd))
-	if errors.Is(err, os.ErrNotExist) {
+	matches, err := matchingPaths(cwd)
+	if err != nil {
+		return Entry{}, err
+	}
+	if len(matches) == 0 {
 		return Entry{}, ErrNotFound
 	}
+	var best Entry
+	var bestSet bool
+	for _, p := range matches {
+		e, err := readEntryAtPath(p)
+		if err != nil {
+			continue
+		}
+		if !bestSet ||
+			(pidAlive(e.HubPID) && !pidAlive(best.HubPID)) ||
+			(pidAlive(e.HubPID) == pidAlive(best.HubPID) && e.StartedAt.After(best.StartedAt)) {
+			best = e
+			bestSet = true
+		}
+	}
+	if !bestSet {
+		return Entry{}, ErrNotFound
+	}
+	return best, nil
+}
+
+// readEntryAtPath is the path-keyed sibling of Read. Read is cwd-keyed
+// and walks every matching <id>*.json. Lives here as a shared helper
+// for List/ListInfo/Read.
+func readEntryAtPath(path string) (Entry, error) {
+	data, err := os.ReadFile(path)
 	if err != nil {
-		return Entry{}, fmt.Errorf("registry read: %w", err)
+		return Entry{}, err
 	}
 	var e Entry
 	if err := json.Unmarshal(data, &e); err != nil {
-		return Entry{}, fmt.Errorf("registry unmarshal: %w", err)
+		return Entry{}, err
 	}
 	return e, nil
 }
 
-// List returns all registry entries, skipping corrupt files.
+// List returns all registry entries, skipping corrupt files. Includes
+// every per-pid entry so two concurrent hubs against one workspace
+// surface as two list rows (caller decides whether to dedupe).
 func List() ([]Entry, error) {
 	matches, err := filepath.Glob(filepath.Join(RegistryDir(), "*.json"))
 	if err != nil {
@@ -98,12 +148,13 @@ func List() ([]Entry, error) {
 	}
 	out := make([]Entry, 0, len(matches))
 	for _, path := range matches {
-		data, err := os.ReadFile(path)
-		if err != nil {
+		// Skip atomic-write tmp files; only top-level *.json files are
+		// real entries (matches the ListInfo skip).
+		if strings.Contains(filepath.Base(path), ".tmp.") {
 			continue
 		}
-		var e Entry
-		if err := json.Unmarshal(data, &e); err != nil {
+		e, err := readEntryAtPath(path)
+		if err != nil {
 			continue
 		}
 		out = append(out, e)
@@ -111,11 +162,84 @@ func List() ([]Entry, error) {
 	return out, nil
 }
 
-// Remove deletes the registry entry for the given workspace cwd. Idempotent.
+// Remove deletes ALL registry entries for the given workspace cwd —
+// every per-pid file plus the legacy unsuffixed path. Idempotent.
+// Used by `bones down` and stale-entry pruners that operate at
+// workspace granularity. Callers that want to drop a single entry by
+// pid should use RemoveByPID instead.
 func Remove(cwd string) error {
-	err := os.Remove(EntryPath(cwd))
+	matches, err := matchingPaths(cwd)
+	if err != nil {
+		return fmt.Errorf("registry remove: %w", err)
+	}
+	var firstErr error
+	for _, p := range matches {
+		if err := os.Remove(p); err != nil && !errors.Is(err, os.ErrNotExist) {
+			if firstErr == nil {
+				firstErr = err
+			}
+		}
+	}
+	if firstErr != nil {
+		return fmt.Errorf("registry remove: %w", firstErr)
+	}
+	return nil
+}
+
+// RemoveByPID deletes the single registry entry for (cwd, pid).
+// Idempotent: missing files are not an error. Used by Reap and by
+// foreground hub.Start's defer cleanup so a workspace with two live
+// entries can lose one without forgetting the other.
+func RemoveByPID(cwd string, pid int) error {
+	err := os.Remove(EntryPath(cwd, pid))
 	if err == nil || errors.Is(err, os.ErrNotExist) {
 		return nil
 	}
-	return fmt.Errorf("registry remove: %w", err)
+	return fmt.Errorf("registry remove pid: %w", err)
+}
+
+// matchingPaths returns every file in RegistryDir that belongs to the
+// given workspace cwd: the legacy <id>.json AND every per-pid
+// <id>-<pid>.json. Result order is unspecified.
+func matchingPaths(cwd string) ([]string, error) {
+	id := WorkspaceID(cwd)
+	dir := RegistryDir()
+	// Glob for <id>-*.json (the per-pid scheme). Add the legacy
+	// unsuffixed path explicitly so we cover both layouts on read.
+	matches, err := filepath.Glob(filepath.Join(dir, id+"-*.json"))
+	if err != nil {
+		return nil, fmt.Errorf("registry glob: %w", err)
+	}
+	// Filter out atomic-write tmp files surfaced by the glob.
+	out := matches[:0]
+	for _, p := range matches {
+		if strings.Contains(filepath.Base(p), ".tmp.") {
+			continue
+		}
+		out = append(out, p)
+	}
+	if _, err := os.Stat(legacyEntryPath(cwd)); err == nil {
+		out = append(out, legacyEntryPath(cwd))
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return nil, fmt.Errorf("registry stat legacy: %w", err)
+	}
+	return out, nil
+}
+
+// pidFromFilename parses the trailing -<pid>.json off a registry path
+// and returns the pid. Returns (0, false) on any parse error or for
+// the legacy <id>.json layout (no pid in filename). WorkspaceID is 16
+// hex chars with no hyphens, so the first hyphen unambiguously
+// separates id from pid.
+func pidFromFilename(path string) (int, bool) {
+	base := strings.TrimSuffix(filepath.Base(path), ".json")
+	idx := strings.Index(base, "-")
+	if idx < 0 {
+		return 0, false
+	}
+	pid, err := strconv.Atoi(base[idx+1:])
+	if err != nil {
+		return 0, false
+	}
+	return pid, true
 }

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -76,7 +76,8 @@ func TestWrite(t *testing.T) {
 	if err := Write(e); err != nil {
 		t.Fatalf("Write: %v", err)
 	}
-	path := filepath.Join(dir, ".bones", "workspaces", WorkspaceID(e.Cwd)+".json")
+	// Per-pid filename scheme (#208): <id>-<pid>.json.
+	path := EntryPath(e.Cwd, e.HubPID)
 	if _, err := os.Stat(path); err != nil {
 		t.Fatalf("expected file at %s: %v", path, err)
 	}


### PR DESCRIPTION
## Summary

Two complementary layers from the issue brief, both shipping together:

- **Detection.** `internal/registry` gains `Duplicates(cwd)` — alive
  entries whose canonical `Cwd` matches the workspace. `bones doctor`
  emits one `WARN` per duplicate with PID, fossil URL, NATS URL, and
  age. `bones status` emits a single one-line `WARN` pointing the
  operator at `bones doctor` for detail.
- **Prevention.** `bones hub start` acquires an exclusive
  workspace-scoped `flock` on `.bones/hub.lock` before port
  resolution, URL-file writes, or fork-exec. A stale lock with a
  dead-PID holder is reclaimed automatically (kill -9 / restart
  path). Cross-platform: Unix uses `syscall.Flock`; Windows falls
  back to a best-effort PID-file probe.

Registry layout extended from `<id>.json` to `<id>-<pid>.json` so two
concurrent starts each record their own entry instead of
overwriting; legacy unsuffixed files are still readable. New
`RemoveByPID` keeps Reap and the foreground-exit cleanup from
deleting sibling duplicates.

Acceptance criteria met for the issue's lettered tests: (a) second
concurrent start is rejected with `*ErrLockHeld`; (b) kill -9 +
restart succeeds without manual cleanup; (c) doctor scan with two
synthetic alive entries emits two `WARN` lines; (d) status emits one.

## Test plan

- [x] `make check` (fmt-check, vet, lint, race, todo-check)
- [x] `go test -tags=otel -short ./...`
- [x] `go test ./internal/registry/... ./internal/hub/... ./cli/... -run "TestDuplicates|TestAcquire|TestStart_Rejects|TestCheckDuplicateHubs|TestRenderStatus_Duplicate"`
- [x] Manual review of detach/foreground/child-reentry lock semantics.

Closes #208