### PR TITLE
fix(cli): passive WAL checkpoint hub.fossil before vanilla fossil

### DIFF
--- a/cli/apply.go
+++ b/cli/apply.go
@@ -258,6 +258,10 @@ func runApplyPreflight(cwd string) (*applyPreflight, error) {
 				"install via `brew install fossil` (or apt) and re-run",
 		)
 	}
+	// Vanilla fossil rejects hub.fossil when its WAL is un-checkpointed
+	// (bones #211 / #212). Run a passive checkpoint best-effort before
+	// apply shells to `fossil` for trunk manifest / open / merge.
+	passiveCheckpointHubFossil(hubRepo)
 	return &applyPreflight{
 		WorkspaceDir: root,
 		HubFossil:    hubRepo,

--- a/cli/fossil_checkpoint.go
+++ b/cli/fossil_checkpoint.go
@@ -1,0 +1,62 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/danmestas/libfossil"
+)
+
+// passiveCheckpointHubFossil runs `PRAGMA wal_checkpoint(PASSIVE)` against
+// the bones-managed hub fossil so vanilla fossil tooling (e.g. `fossil ui`,
+// `fossil timeline`, `fossil leaves`) sees a self-contained main file
+// instead of a 4 KiB stub plus a multi-hundred-KiB unmerged WAL.
+//
+// Why this is needed:
+//
+// libfossil opens the hub repo in WAL mode and writes a stub-plus-WAL on
+// every `bones up` / `bones hub start`. Until SQLite checkpoints the WAL
+// (which only happens on graceful close, manual checkpoint, or auto-
+// checkpoint after enough page churn), the main `.bones/hub.fossil` file
+// has too few pages for vanilla fossil's validity probe — `fossil` then
+// rejects it with `not a valid repository` and exits 1. See bones #211 /
+// #212.
+//
+// The PASSIVE mode is deliberate: it never blocks readers or writers, so
+// it is safe to call while the hub is running. It only checkpoints frames
+// that no other connection is reading. That's enough to fatten the main
+// file past vanilla fossil's threshold even on a live workspace.
+//
+// This is a bones-side workaround. The durable fix is upstream in
+// libfossil/EdgeSync's hub close path (the WAL should be checkpointed
+// when the hub stops cleanly). Until that lands, every shell-out from
+// bones to vanilla fossil against `hub.fossil` MUST call this helper
+// first.
+//
+// Errors are logged to stderr but never returned: a failed checkpoint
+// degrades into "vanilla fossil might fail," which is the same surface
+// callers already handle. We never want a checkpoint failure to mask
+// the vanilla-fossil command the user actually asked for.
+func passiveCheckpointHubFossil(hubRepoPath string) {
+	repo, err := libfossil.Open(hubRepoPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr,
+			"warning: passive WAL checkpoint skipped (open %s: %v); "+
+				"vanilla fossil may reject the repo if WAL is unmerged\n",
+			hubRepoPath, err)
+		return
+	}
+	defer func() { _ = repo.Close() }()
+
+	// PRAGMA wal_checkpoint returns three columns: busy, log frames,
+	// frames checkpointed. We don't care about the values — we only
+	// care that the call ran without error.
+	var busy, logFrames, ckptFrames int
+	row := repo.DB().QueryRow("PRAGMA wal_checkpoint(PASSIVE)")
+	if err := row.Scan(&busy, &logFrames, &ckptFrames); err != nil {
+		fmt.Fprintf(os.Stderr,
+			"warning: passive WAL checkpoint of %s failed: %v "+
+				"(vanilla fossil may reject the repo)\n",
+			hubRepoPath, err)
+	}
+}

--- a/cli/fossil_checkpoint_test.go
+++ b/cli/fossil_checkpoint_test.go
@@ -1,0 +1,117 @@
+package cli
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/danmestas/libfossil"
+	_ "github.com/danmestas/libfossil/db/driver/modernc"
+)
+
+// TestPassiveCheckpoint_MakesHubVanillaFossilReadable is the regression
+// test for bones #211 / #212. It builds a bones-style hub.fossil that
+// libfossil has just written (so the WAL is un-checkpointed and the
+// main file is the 4 KiB stub vanilla fossil chokes on), confirms
+// vanilla fossil DOES reject it, runs passiveCheckpointHubFossil,
+// then confirms vanilla fossil now accepts it.
+//
+// Without the fix this test fails at the post-checkpoint assertion:
+// the main file stays at 4 KiB and `fossil info` still prints
+// `not a valid repository`.
+func TestPassiveCheckpoint_MakesHubVanillaFossilReadable(t *testing.T) {
+	fossilBin, err := exec.LookPath("fossil")
+	if err != nil {
+		t.Skip("vanilla fossil binary not on PATH; regression test requires it")
+	}
+
+	dir := t.TempDir()
+	hubPath := filepath.Join(dir, "hub.fossil")
+
+	// Build the fixture exactly the way bones builds hub.fossil in real
+	// workspaces: libfossil.Create + an initial commit. Keep the repo
+	// handle open for the rest of the test so the scenario mirrors a
+	// running `bones hub` (file open, WAL un-checkpointed, hub still
+	// holding write locks). PASSIVE checkpoint must work in this state.
+	repo, err := libfossil.Create(hubPath, libfossil.CreateOpts{User: "hub"})
+	if err != nil {
+		t.Fatalf("libfossil.Create: %v", err)
+	}
+	t.Cleanup(func() { _ = repo.Close() })
+
+	if _, _, err := repo.Commit(libfossil.CommitOpts{
+		Files:   []libfossil.FileToCommit{{Name: "seed.txt", Content: []byte("seed\n")}},
+		Comment: "init",
+		User:    "hub",
+	}); err != nil {
+		t.Fatalf("repo.Commit: %v", err)
+	}
+
+	// Sanity check: the bug surface must actually be present pre-fix.
+	// hub.fossil should be a 4 KiB stub with bulk content sitting in
+	// the WAL sidecar. If this assertion ever stops holding, libfossil
+	// or modernc/sqlite changed their default journaling and the
+	// regression test no longer exercises the original bug — fail
+	// loudly so a human looks.
+	mainStat, err := os.Stat(hubPath)
+	if err != nil {
+		t.Fatalf("stat hub.fossil: %v", err)
+	}
+	if mainStat.Size() > 16*1024 {
+		t.Fatalf("expected hub.fossil to be a small WAL stub (<=16KiB), "+
+			"got %d bytes — fixture no longer reproduces #211", mainStat.Size())
+	}
+	walStat, err := os.Stat(hubPath + "-wal")
+	if err != nil || walStat.Size() == 0 {
+		t.Fatalf("expected non-empty hub.fossil-wal sidecar, got err=%v size=%d", err, walStat)
+	}
+
+	// Confirm the bug: vanilla fossil rejects the un-checkpointed file.
+	out, _ := exec.Command(fossilBin, "info", "-R", hubPath).CombinedOutput()
+	if !containsNotValid(string(out)) {
+		t.Fatalf("expected vanilla fossil to reject hub.fossil before "+
+			"checkpoint, got: %q", string(out))
+	}
+
+	// Apply the fix.
+	passiveCheckpointHubFossil(hubPath)
+
+	// Vanilla fossil must now accept the file.
+	out, err = exec.Command(fossilBin, "info", "-R", hubPath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("after PASSIVE checkpoint, vanilla fossil still failed: "+
+			"err=%v output=%q", err, string(out))
+	}
+	if containsNotValid(string(out)) {
+		t.Fatalf("after PASSIVE checkpoint, vanilla fossil still says "+
+			"`not a valid repository`: %q", string(out))
+	}
+}
+
+// TestPassiveCheckpoint_MissingFile_FailsSoft documents the contract
+// that a missing/unreadable hub.fossil must NOT crash the caller.
+// Callers (peek, status, swarm fan-in, apply) treat checkpoint as
+// best-effort and proceed to the vanilla-fossil shell-out regardless;
+// that contract is what makes it safe to drop this helper into every
+// shell-out path.
+func TestPassiveCheckpoint_MissingFile_FailsSoft(t *testing.T) {
+	// Should not panic and should not block — just emits a warning.
+	passiveCheckpointHubFossil(filepath.Join(t.TempDir(), "does-not-exist.fossil"))
+}
+
+// containsNotValid checks for the vanilla-fossil rejection signature.
+// Kept narrow so a future fossil version that reworks the message
+// surfaces as a test failure (and a prompt to revisit this fix).
+func containsNotValid(s string) bool {
+	return len(s) > 0 && (indexOf(s, "not a valid repository") >= 0)
+}
+
+func indexOf(haystack, needle string) int {
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return i
+		}
+	}
+	return -1
+}

--- a/cli/peek.go
+++ b/cli/peek.go
@@ -67,6 +67,12 @@ func (c *PeekCmd) Run(g *repocli.Globals) error {
 		return nil
 	}
 
+	// Vanilla fossil rejects hub.fossil when the WAL is un-checkpointed
+	// (bones #211 / #212). Run a passive checkpoint best-effort so the
+	// shell-out below sees a self-contained main file. Safe to call
+	// while the hub is running — PASSIVE never blocks readers/writers.
+	passiveCheckpointHubFossil(hubRepo)
+
 	port := c.Port
 	if port == 0 {
 		port = pickPeekPort()

--- a/cli/status.go
+++ b/cli/status.go
@@ -221,6 +221,12 @@ func gatherStatus(ctx context.Context, info workspace.Info) (statusReport, error
 	if _, statErr := os.Stat(hubRepo); statErr == nil && lookErr == nil {
 		rep.HubAvailable = true
 		rep.HubRepoPath = hubRepo
+		// Vanilla fossil rejects hub.fossil when its WAL is un-
+		// checkpointed (bones #211 / #212). Run a passive checkpoint
+		// best-effort before the `fossil leaves` and `fossil timeline`
+		// shell-outs below; otherwise status silently drops the
+		// "open leaves" and "recent activity" sections on a busy hub.
+		passiveCheckpointHubFossil(hubRepo)
 		leaves, _ := openLeavesOnTrunk(fossilBin, hubRepo)
 		rep.OpenLeaves = leaves
 		if len(leaves) > 0 {

--- a/cli/swarm_fanin.go
+++ b/cli/swarm_fanin.go
@@ -86,6 +86,11 @@ func (c *SwarmFanInCmd) resolvePrereqs() (string, string, error) {
 				"`brew install fossil` (or apt) and re-run",
 		)
 	}
+	// Vanilla fossil rejects hub.fossil when its WAL is un-checkpointed
+	// (bones #211 / #212). Run a passive checkpoint best-effort before
+	// any of fan-in's downstream `fossil open / merge / commit` calls
+	// shell out against this repo.
+	passiveCheckpointHubFossil(hubRepo)
 	return hubRepo, fossilBin, nil
 }
 


### PR DESCRIPTION
## Summary

- Vanilla fossil rejects bones-managed `hub.fossil` with "not a valid repository" whenever its WAL sidecar hasn't been checkpointed. libfossil opens the hub in WAL mode and leaves a 4 KiB stub plus a multi-hundred-KiB WAL; `fossil ui` / `fossil info` stat the main file before joining the WAL and bail out. This breaks `bones peek` on every fresh workspace and silently degrades `bones status`, `bones apply`, and `bones swarm fan-in`.
- Adds `passiveCheckpointHubFossil` in `cli/`: opens `hub.fossil` via libfossil, runs `PRAGMA wal_checkpoint(PASSIVE)`, fail-soft. PASSIVE is non-blocking and safe to call while the hub is running.
- Wires it into all four vanilla-fossil shell-out sites: `peek.go`, `status.go`, `apply.go`, `swarm_fanin.go`.

This is a bones-side workaround. The durable fix lives upstream in libfossil / EdgeSync's hub close path (the WAL should checkpoint when the hub stops cleanly); will be filed separately.

## Test plan

- [x] Regression test (`TestPassiveCheckpoint_MakesHubVanillaFossilReadable`) builds the bug surface (libfossil.Create + Commit, repo handle held open), confirms vanilla `fossil info` rejects the file pre-checkpoint, then verifies it accepts post-checkpoint. Verified the test FAILS without the fix and PASSES with it.
- [x] `TestPassiveCheckpoint_MissingFile_FailsSoft` pins the fail-soft contract.
- [x] `make check` clean (fmt-check, vet, lint, race, todo-check).
- [x] `go test -tags=otel -short ./...` clean.
- [x] End-to-end smoke: `bones peek --port 8889` against a fresh workspace's un-checkpointed `hub.fossil` — fossil ui starts cleanly, `/timeline` returns HTTP 200, hub.fossil grows from 4 KiB to ~240 KiB on the passive checkpoint pass.

Closes #211
Closes #212