### PR TITLE
fix(scaffold): strip preserves user trailing newlines (#236)

### DIFF
--- a/cli/orchestrator.go
+++ b/cli/orchestrator.go
@@ -322,10 +322,10 @@ func upsertManagedBlock(path, body string) error {
 
 // stripManagedBlock removes the bones-managed section (markers and
 // body) from the file at path. User content outside the markers is
-// preserved byte-for-byte. The blank-line separator that
-// upsertManagedBlock added between user content and the BEGIN marker
-// is collapsed back to a single trailing newline so a strip-then-
-// upsert cycle round-trips cleanly.
+// preserved byte-for-byte (issue #236): the strip removes only the
+// bytes upsertManagedBlock added — the single separator '\n' before
+// BEGIN, the markers, the body, and the single trailing '\n' after
+// END — leaving the user's original trailing-whitespace shape intact.
 //
 // Nested marker pairs in the body are handled by findManagedBlock —
 // only the outer block is removed, even when the body itself contains
@@ -354,18 +354,16 @@ func stripManagedBlock(path string) error {
 		end++
 	}
 
-	// Collapse trailing newlines on the prefix (including the blank
-	// separator we added on upsert) so we restore exactly one trailing
-	// newline — matching the user's original "ends with \n" shape.
+	// Consume exactly the single '\n' separator that upsertManagedBlock
+	// inserts before BEGIN (see upsert: it adds one '\n' to the user
+	// prefix). Do NOT collapse multiple trailing newlines: that would
+	// eat the user's own blank-line trailers and break the byte-for-
+	// byte invariant (issue #236).
 	trimEnd := begin
-	for trimEnd > 0 && s[trimEnd-1] == '\n' {
+	if trimEnd > 0 && s[trimEnd-1] == '\n' {
 		trimEnd--
 	}
-	prefix := s[:trimEnd]
-	if prefix != "" {
-		prefix += "\n"
-	}
-	out := prefix + s[end:]
+	out := s[:trimEnd] + s[end:]
 
 	if out == "" {
 		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {

--- a/cli/orchestrator_test.go
+++ b/cli/orchestrator_test.go
@@ -1286,6 +1286,54 @@ func TestStripManagedBlock_PreservesContentAfterBlock(t *testing.T) {
 	}
 }
 
+// TestStripManagedBlock_ByteForByteRoundTrip pins issue #236: an
+// upsert+strip cycle must restore the user's original AGENTS.md
+// byte-for-byte. The earlier strip implementation collapsed every
+// trailing newline before the BEGIN marker and then re-added a single
+// '\n', which silently dropped one byte whenever the user's file
+// already ended in a blank line ("\n\n"). The contract documented in
+// cli/templates/orchestrator/AGENTS.md is that user content is "left
+// byte-for-byte unchanged" — this test pins that invariant for every
+// trailing-whitespace shape that round-trips cleanly.
+func TestStripManagedBlock_ByteForByteRoundTrip(t *testing.T) {
+	cases := []struct {
+		name string
+		user string
+	}{
+		{"single-trailing-newline", "# My agents file\n"},
+		{"blank-line-trailing", "# Hello\n\n"},
+		{"mid-content-blank-and-trailing", "# Title\n\nBody.\n"},
+		{"two-blank-lines-trailing", "# Title\n\n\n"},
+		{"single-line-trailing", "Line1\nLine2\n"},
+		{"only-newline", "\n"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "AGENTS.md")
+			if err := os.WriteFile(path, []byte(tc.user), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if err := upsertManagedBlock(path, "bones body"); err != nil {
+				t.Fatalf("upsert: %v", err)
+			}
+			if err := stripManagedBlock(path); err != nil {
+				t.Fatalf("strip: %v", err)
+			}
+			got, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("read post-strip: %v", err)
+			}
+			if string(got) != tc.user {
+				t.Errorf("byte-for-byte round-trip violated:\n"+
+					"want (%d bytes): %q\n"+
+					"got  (%d bytes): %q",
+					len(tc.user), tc.user, len(got), got)
+			}
+		})
+	}
+}
+
 // TestHasManagedBlock_RejectsBareSubstring pins that hasManagedBlock
 // returns true only for files that contain a real outer block — a
 // file that mentions the marker strings in user prose (no actual


### PR DESCRIPTION
## Summary

- `stripManagedBlock` collapsed every trailing newline before the BEGIN marker and re-added a single `\n`, silently dropping one byte whenever the user's AGENTS.md / CLAUDE.md ended in a blank line (`\n\n`). This violated the documented byte-for-byte contract.
- Strip now consumes exactly the single `\n` separator that `upsertManagedBlock` inserts — no more, no less — so any trailing-whitespace shape round-trips cleanly.
- Added `TestStripManagedBlock_ByteForByteRoundTrip` covering single-trailing-newline, blank-line-trailing, two-blank-lines-trailing, mid-content blank, single-line, and only-newline fixtures.

## Repro (pre-fix)

```
mkdir /tmp/byte-test && cd /tmp/byte-test && git init -q
printf '# Hello\n\n' > AGENTS.md      # 9 bytes
bones up && bones down -y
wc -c AGENTS.md                        # 8 (was 9) — bug
```

Post-fix: 9 bytes; sha256 matches; `git status` clean.

## Test plan

- [x] `TestStripManagedBlock_ByteForByteRoundTrip` fails before fix, passes after
- [x] All existing strip/upsert tests still pass (`TestStripManagedBlock_*`, `TestUpsertManagedBlock_*`)
- [x] `make check` green
- [x] `go test -tags=otel -short ./...` green
- [x] End-to-end binary repro: pre-up sha256 == post-down sha256

Closes #236