### PR TITLE
fix(down): symmetric cleanup of settings.json + .gitignore

### DIFF
--- a/cli/down.go
+++ b/cli/down.go
@@ -177,6 +177,8 @@ func planDown(root string, c *DownCmd) []downAction {
 	plan = append(plan, planRemoveAgentsMD(root)...)
 	plan = append(plan, planRemoveHooks(root, c)...)
 	plan = append(plan, planRemoveFossilMarkers(root)...)
+	plan = append(plan, planRemoveGitignoreEntries(root)...)
+	plan = append(plan, planRemoveEmptyClaudeDir(root, c)...)
 	return plan
 }
 
@@ -542,6 +544,15 @@ func planRemoveFossilMarkers(root string) []downAction {
 //
 // Other hooks are preserved verbatim. Empty hook groups and the
 // "hooks" top-level key are pruned when removal leaves them empty.
+//
+// Symmetric with `bones up` (#235): when stripping the bones-owned
+// hooks leaves the file with no remaining top-level keys, the file
+// is deleted entirely. Bones up only writes a "hooks" object, so an
+// empty post-strip object means the file is bones-owned end to end —
+// keeping a stub `{}` behind would leak a `.claude/settings.json` the
+// user never authored. User-authored keys (theme, env, permissions,
+// etc.) at the top level keep the file intact with those keys
+// preserved byte-for-byte.
 func removeBonesHooks(path string) error {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -551,29 +562,40 @@ func removeBonesHooks(path string) error {
 		return err
 	}
 	if len(data) == 0 {
-		return nil
+		// An empty file was not bones-authored (bones up always writes
+		// at least `{"hooks": {...}}`). Remove it for symmetry: an empty
+		// settings.json carries no information and survives only as
+		// noise. Issue #235.
+		return os.Remove(path)
 	}
 	var rootObj map[string]any
 	if err := json.Unmarshal(data, &rootObj); err != nil {
 		return fmt.Errorf("parse %s: %w", path, err)
 	}
 	hooks, _ := rootObj["hooks"].(map[string]any)
-	if hooks == nil {
-		return nil
+	if hooks != nil {
+		pruneHookEvent(hooks, "SessionStart", "hub-bootstrap.sh")         // legacy
+		pruneHookEvent(hooks, "SessionStart", "bones hub start")          // current (ADR 0041)
+		pruneHookEvent(hooks, "SessionStart", "bones tasks prime --json") // task priming
+		pruneHookEvent(hooks, "PreCompact", "bones tasks prime --json")   // task priming
+		// Current installs land under SessionEnd; the legacy Stop event
+		// is also pruned so workspaces installed before the migration
+		// are still cleaned up by `bones down`.
+		pruneHookEvent(hooks, "SessionEnd", "hub-shutdown.sh")
+		pruneHookEvent(hooks, "Stop", "hub-shutdown.sh")
+		if len(hooks) == 0 {
+			delete(rootObj, "hooks")
+		} else {
+			rootObj["hooks"] = hooks
+		}
 	}
-	pruneHookEvent(hooks, "SessionStart", "hub-bootstrap.sh")         // legacy
-	pruneHookEvent(hooks, "SessionStart", "bones hub start")          // current (ADR 0041)
-	pruneHookEvent(hooks, "SessionStart", "bones tasks prime --json") // task priming
-	pruneHookEvent(hooks, "PreCompact", "bones tasks prime --json")   // task priming
-	// Current installs land under SessionEnd; the legacy Stop event
-	// is also pruned so workspaces installed before the migration
-	// are still cleaned up by `bones down`.
-	pruneHookEvent(hooks, "SessionEnd", "hub-shutdown.sh")
-	pruneHookEvent(hooks, "Stop", "hub-shutdown.sh")
-	if len(hooks) == 0 {
-		delete(rootObj, "hooks")
-	} else {
-		rootObj["hooks"] = hooks
+	// Issue #235: if no top-level keys remain, the file held only
+	// bones-owned hooks. Delete it so post-down state matches pre-up.
+	// Any user-authored top-level key (theme, model, env, permissions,
+	// includeCoAuthoredBy, …) keeps the file alive and the keys are
+	// preserved verbatim.
+	if len(rootObj) == 0 {
+		return os.Remove(path)
 	}
 	out, err := json.MarshalIndent(rootObj, "", "  ")
 	if err != nil {
@@ -649,4 +671,193 @@ func fileExists(path string) bool {
 func dirExists(path string) bool {
 	fi, err := os.Stat(path)
 	return err == nil && fi.IsDir()
+}
+
+// planRemoveEmptyClaudeDir removes the workspace's `.claude/` directory
+// if it ends up empty after the rest of the down plan executes (i.e.
+// all bones-owned content under it — settings.json, skills/ — has
+// already been removed). Symmetric with `bones up` which creates the
+// directory on a fresh tree (#235).
+//
+// Skipped when --keep-skills or --keep-hooks is set: those flags
+// preserve content under `.claude/`, so the directory must stay too.
+//
+// The action's thunk re-checks emptiness at execution time. A no-op
+// when the directory still has user-authored content (anything bones
+// didn't install) ensures the user's pre-existing `.claude/` survives
+// teardown unchanged.
+func planRemoveEmptyClaudeDir(root string, c *DownCmd) []downAction {
+	if c.KeepSkills || c.KeepHooks {
+		return nil
+	}
+	dir := filepath.Join(root, ".claude")
+	if !dirExists(dir) {
+		return nil
+	}
+	return []downAction{{
+		description: "remove " + dir + " if empty",
+		do: func() error {
+			empty, err := dirIsEmpty(dir)
+			if err != nil || !empty {
+				// nil here when not empty: the directory has user
+				// content (custom skills, agent files, etc.) and
+				// must be preserved. Errors stat'ing fall through
+				// silently — the operator already saw the rest of
+				// the plan succeed.
+				return nil
+			}
+			return os.Remove(dir)
+		},
+	}}
+}
+
+// dirIsEmpty reports whether dir contains any entries. Returns false
+// on stat errors so callers default to the safe "leave it alone"
+// branch. The check is shallow — a `.claude/skills/.bones-manifest.json`
+// (the issue #210 manifest) parent directory still counts as non-empty
+// from this function's perspective, which is correct: if anything
+// under .claude/ survives the rest of the plan, .claude/ stays.
+func dirIsEmpty(dir string) (bool, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return false, err
+	}
+	return len(entries) == 0, nil
+}
+
+// bonesGitignoreEntries lists the lines `bones up` adds to the
+// project root's .gitignore via ensureGitignoreEntries (cli/orchestrator.go).
+// Kept in lockstep with that helper — drift means down asymmetric with up.
+var bonesGitignoreEntries = []string{
+	".fslckout",
+	".fossil-settings/",
+	".bones/",
+}
+
+// bonesGitignoreHeader is the comment line `bones up` writes above its
+// gitignore additions. Stripped exactly as written; a user who edited
+// the comment text will keep their edited version (which is the right
+// outcome — bones treats edited comments as user content).
+const bonesGitignoreHeader = "# Bones runtime + Fossil checkout-at-root (ADRs 0023, 0041)"
+
+// planRemoveGitignoreEntries removes the lines `bones up` appended to
+// the project's .gitignore (#237). Symmetric with up's auto-add: any
+// of the 3 bones-owned entries (.fslckout, .fossil-settings/, .bones/)
+// still present in the file is dropped, along with the bones header
+// comment if it survived unchanged. User-authored lines — including
+// bones-entries the user duplicated below their own comment block —
+// are removed by exact-line match too, which is the documented
+// behavior: a user who pre-existed `.bones/` in their gitignore had
+// the same line bones would have added, so the post-down state is
+// indistinguishable from "bones never touched it".
+//
+// The file is rewritten with:
+//   - bones-owned lines removed
+//   - the bones header line removed
+//   - a single trailing blank-line run between adjacent kept blocks
+//     collapsed (so removing a 4-line block in the middle doesn't
+//     leave a 3-line gap)
+//
+// If removal leaves the file empty (or whitespace-only) the file is
+// deleted — `bones up` creates .gitignore on a fresh tree, so an
+// empty post-down file is the same asymmetry as #235's empty
+// settings.json.
+func planRemoveGitignoreEntries(root string) []downAction {
+	path := filepath.Join(root, ".gitignore")
+	if !fileExists(path) {
+		return nil
+	}
+	return []downAction{{
+		description: "remove bones entries from " + path,
+		do:          func() error { return removeBonesGitignoreEntries(path) },
+	}}
+}
+
+// removeBonesGitignoreEntries does the actual rewrite. Pure file I/O,
+// extracted so the plan thunk stays a one-liner and the logic is
+// directly unit-testable without going through planDown.
+//
+// Algorithm:
+//  1. Read all lines.
+//  2. Drop lines that match (after TrimSpace) any bonesGitignoreEntries
+//     entry, or that match the bones header verbatim (TrimSpace).
+//  3. Collapse runs of 2+ blank lines down to 1 (the removal of a 4-line
+//     block sandwiched by blanks would otherwise produce a visible gap).
+//  4. If the result is empty/whitespace, delete the file.
+//  5. Otherwise, write back with a trailing newline if the original
+//     ended with one.
+func removeBonesGitignoreEntries(path string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+
+	bonesSet := map[string]bool{}
+	for _, e := range bonesGitignoreEntries {
+		bonesSet[e] = true
+	}
+
+	// Preserve the file's trailing-newline state: a gitignore that
+	// ends with "\n" should still end with "\n" after rewrite.
+	hadTrailingNewline := len(data) > 0 && data[len(data)-1] == '\n'
+
+	lines := strings.Split(string(data), "\n")
+	// strings.Split on "a\n" yields ["a", ""] — drop the trailing empty
+	// element so we don't double-count it as a blank line during
+	// collapse. We re-add the trailing newline at write time.
+	if hadTrailingNewline && len(lines) > 0 && lines[len(lines)-1] == "" {
+		lines = lines[:len(lines)-1]
+	}
+
+	var kept []string
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if bonesSet[trimmed] {
+			continue
+		}
+		if trimmed == bonesGitignoreHeader {
+			continue
+		}
+		kept = append(kept, line)
+	}
+
+	// Collapse 2+ consecutive blanks to 1. The bones header + 3 entries
+	// occupy 4 lines preceded by an inserted blank (header line in
+	// ensureGitignoreEntries starts with "\n"); after stripping, that
+	// inserted blank can sit next to the user's pre-existing trailing
+	// blank, giving a 2-line gap. Collapse keeps the file tidy.
+	var collapsed []string
+	prevBlank := false
+	for _, line := range kept {
+		isBlank := strings.TrimSpace(line) == ""
+		if isBlank && prevBlank {
+			continue
+		}
+		collapsed = append(collapsed, line)
+		prevBlank = isBlank
+	}
+	// Drop a single leading blank if present (the bones block was
+	// prefixed with one and the user's original gitignore didn't start
+	// with one).
+	for len(collapsed) > 0 && strings.TrimSpace(collapsed[0]) == "" {
+		collapsed = collapsed[1:]
+	}
+	// Drop any trailing blanks before deciding emptiness.
+	for len(collapsed) > 0 && strings.TrimSpace(collapsed[len(collapsed)-1]) == "" {
+		collapsed = collapsed[:len(collapsed)-1]
+	}
+
+	// If nothing survives, the file was bones-only. Delete it.
+	if len(collapsed) == 0 {
+		return os.Remove(path)
+	}
+
+	out := strings.Join(collapsed, "\n")
+	if hadTrailingNewline {
+		out += "\n"
+	}
+	return os.WriteFile(path, []byte(out), 0o644)
 }

--- a/cli/down_test.go
+++ b/cli/down_test.go
@@ -124,7 +124,8 @@ func TestRemoveBonesHooks_NoHooksKey(t *testing.T) {
 
 // TestRemoveBonesHooks_OnlyBonesHooks: when settings.json has only
 // the bones-installed hooks and no others, the entire hooks key is
-// removed (no empty container left behind).
+// removed AND the file itself is deleted (#235). A settings.json that
+// would be left as `{}` post-strip is bones-owned end to end.
 func TestRemoveBonesHooks_OnlyBonesHooks(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "settings.json")
@@ -158,15 +159,16 @@ func TestRemoveBonesHooks_OnlyBonesHooks(t *testing.T) {
 	if err := removeBonesHooks(path); err != nil {
 		t.Fatalf("removeBonesHooks: %v", err)
 	}
-	got := readJSON(t, path)
-	if _, ok := got["hooks"]; ok {
-		t.Errorf("hooks key should be removed; got %+v", got)
+	if _, err := os.Stat(path); !errors.Is(err, fs.ErrNotExist) {
+		t.Errorf("settings.json with only bones hooks should be deleted; "+
+			"stat err=%v", err)
 	}
 }
 
 // TestRemoveBonesHooks_LegacyStopHook: bones down on a workspace
 // installed before the SessionEnd migration must still clean up the
-// shim that lives under the old "Stop" event.
+// shim that lives under the old "Stop" event. Per #235 the resulting
+// empty settings.json is also removed.
 func TestRemoveBonesHooks_LegacyStopHook(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "settings.json")
@@ -189,9 +191,9 @@ func TestRemoveBonesHooks_LegacyStopHook(t *testing.T) {
 	if err := removeBonesHooks(path); err != nil {
 		t.Fatalf("removeBonesHooks: %v", err)
 	}
-	got := readJSON(t, path)
-	if _, ok := got["hooks"]; ok {
-		t.Errorf("legacy Stop hook should be cleaned up; got %+v", got)
+	if _, err := os.Stat(path); !errors.Is(err, fs.ErrNotExist) {
+		t.Errorf("legacy-Stop-only settings.json should be deleted; "+
+			"stat err=%v", err)
 	}
 }
 
@@ -200,6 +202,7 @@ func TestRemoveBonesHooks_LegacyStopHook(t *testing.T) {
 // `bones hub start`, `bones tasks prime --json` under SessionStart,
 // and `bones tasks prime --json` under PreCompact. User-authored
 // hooks at the same events are preserved (covered by a sibling test).
+// Per #235 the resulting empty settings.json is also removed.
 func TestRemoveBonesHooks_StripsAllBonesOwned(t *testing.T) {
 	dir := t.TempDir()
 	settings := filepath.Join(dir, "settings.json")
@@ -230,16 +233,8 @@ func TestRemoveBonesHooks_StripsAllBonesOwned(t *testing.T) {
 	if err := removeBonesHooks(settings); err != nil {
 		t.Fatalf("removeBonesHooks: %v", err)
 	}
-	got, err := os.ReadFile(settings)
-	if err != nil {
-		t.Fatalf("ReadFile: %v", err)
-	}
-	s := string(got)
-	if strings.Contains(s, "bones hub start") {
-		t.Errorf("settings still contains 'bones hub start':\n%s", s)
-	}
-	if strings.Contains(s, "bones tasks prime --json") {
-		t.Errorf("settings still contains 'bones tasks prime --json':\n%s", s)
+	if _, err := os.Stat(settings); !errors.Is(err, fs.ErrNotExist) {
+		t.Errorf("bones-only settings.json should be deleted; stat err=%v", err)
 	}
 }
 
@@ -1010,6 +1005,350 @@ func TestRemoveBonesSkills_BundleVersionSkew(t *testing.T) {
 	skillsDir := filepath.Join(dir, ".claude", "skills")
 	if _, err := os.Stat(skillsDir); !errors.Is(err, fs.ErrNotExist) {
 		t.Errorf("empty .claude/skills/ should be removed; err=%v", err)
+	}
+}
+
+// TestRemoveBonesHooks_DeletesEmptyFile pins issue #235: when stripping
+// bones-owned hooks leaves settings.json with no remaining top-level
+// keys, the file is deleted entirely. Bones up only writes a "hooks"
+// object on a fresh tree, so an empty post-strip object means the file
+// is bones-owned end to end — leaving `{}` behind leaks a settings.json
+// the user never authored.
+func TestRemoveBonesHooks_DeletesEmptyFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "settings.json")
+	writeJSON(t, path, map[string]any{
+		"hooks": map[string]any{
+			"SessionStart": []any{
+				map[string]any{
+					"matcher": "",
+					"hooks": []any{
+						map[string]any{
+							"command": "bones hub start",
+							"type":    "command",
+						},
+					},
+				},
+			},
+		},
+	})
+
+	if err := removeBonesHooks(path); err != nil {
+		t.Fatalf("removeBonesHooks: %v", err)
+	}
+	if _, err := os.Stat(path); !errors.Is(err, fs.ErrNotExist) {
+		t.Errorf("settings.json should be deleted when only bones hooks "+
+			"remained; stat err=%v", err)
+	}
+}
+
+// TestRemoveBonesHooks_PreservesUserKeys pins the non-clobber half of
+// #235: settings.json with non-hooks user keys (theme, env, …) survives
+// down with those keys preserved byte-for-byte. Only bones-owned hooks
+// are stripped.
+func TestRemoveBonesHooks_PreservesUserKeys(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "settings.json")
+	writeJSON(t, path, map[string]any{
+		"theme": "dark",
+		"env":   map[string]any{"FOO": "bar"},
+		"hooks": map[string]any{
+			"SessionStart": []any{
+				map[string]any{
+					"matcher": "",
+					"hooks": []any{
+						map[string]any{
+							"command": "bones hub start",
+							"type":    "command",
+						},
+					},
+				},
+			},
+		},
+	})
+
+	if err := removeBonesHooks(path); err != nil {
+		t.Fatalf("removeBonesHooks: %v", err)
+	}
+
+	// File must survive.
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("settings.json should be preserved with user keys: %v", err)
+	}
+	got := readJSON(t, path)
+	if got["theme"] != "dark" {
+		t.Errorf("theme: got %v, want dark", got["theme"])
+	}
+	envMap, _ := got["env"].(map[string]any)
+	if envMap["FOO"] != "bar" {
+		t.Errorf("env.FOO: got %v, want bar", envMap["FOO"])
+	}
+	if _, ok := got["hooks"]; ok {
+		t.Errorf("hooks key should be removed; got %+v", got["hooks"])
+	}
+}
+
+// TestRemoveBonesHooks_DeletesLiteralEmptyJSON pins the #235 edge case:
+// a settings.json that is already `{}` (no keys) is bones-owned by
+// definition and gets removed.
+func TestRemoveBonesHooks_DeletesLiteralEmptyJSON(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "settings.json")
+	if err := os.WriteFile(path, []byte("{}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := removeBonesHooks(path); err != nil {
+		t.Fatalf("removeBonesHooks: %v", err)
+	}
+	if _, err := os.Stat(path); !errors.Is(err, fs.ErrNotExist) {
+		t.Errorf("empty {} settings.json should be deleted; stat err=%v", err)
+	}
+}
+
+// TestRunDown_RemovesEmptyClaudeDir pins issue #235's symmetry
+// invariant end-to-end: on a workspace where bones up created
+// .claude/ (no pre-existing user content), bones down removes it
+// completely. settings.json gets stripped → file empty → deleted →
+// .claude/ now empty → directory removed.
+func TestRunDown_RemovesEmptyClaudeDir(t *testing.T) {
+	dir := t.TempDir()
+	mkdir(t, filepath.Join(dir, ".bones"))
+	mkdir(t, filepath.Join(dir, ".claude"))
+	// Bones-owned settings.json with only the bones hub-start hook.
+	writeFile(t, filepath.Join(dir, ".claude", "settings.json"), `{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {"command": "bones hub start", "type": "command", "timeout": 10}
+        ]
+      }
+    ]
+  }
+}`)
+
+	if err := runDown(dir, &DownCmd{Yes: true, KeepHub: true},
+		strings.NewReader("")); err != nil {
+		t.Fatalf("runDown: %v", err)
+	}
+
+	settingsPath := filepath.Join(dir, ".claude", "settings.json")
+	if _, err := os.Stat(settingsPath); !errors.Is(err, fs.ErrNotExist) {
+		t.Errorf("settings.json should be removed: %v", err)
+	}
+	claudeDir := filepath.Join(dir, ".claude")
+	if _, err := os.Stat(claudeDir); !errors.Is(err, fs.ErrNotExist) {
+		t.Errorf(".claude/ should be removed (was empty): %v", err)
+	}
+}
+
+// TestRunDown_PreservesNonEmptyClaudeDir pins the inverse invariant:
+// a .claude/ that still contains user files after bones-owned content
+// is stripped must survive. Down does not nuke user-authored agent
+// configs, custom skills, etc.
+func TestRunDown_PreservesNonEmptyClaudeDir(t *testing.T) {
+	dir := t.TempDir()
+	mkdir(t, filepath.Join(dir, ".bones"))
+	mkdir(t, filepath.Join(dir, ".claude"))
+	// User-authored file in .claude/. Bones never wrote this.
+	writeFile(t, filepath.Join(dir, ".claude", "user-notes.md"),
+		"my own notes\n")
+	// Bones-owned settings.json — gets removed.
+	writeFile(t, filepath.Join(dir, ".claude", "settings.json"), `{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {"command": "bones hub start", "type": "command", "timeout": 10}
+        ]
+      }
+    ]
+  }
+}`)
+
+	if err := runDown(dir, &DownCmd{Yes: true, KeepHub: true},
+		strings.NewReader("")); err != nil {
+		t.Fatalf("runDown: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, ".claude")); err != nil {
+		t.Errorf(".claude/ should be preserved (has user file): %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".claude", "user-notes.md")); err != nil {
+		t.Errorf("user file should be preserved: %v", err)
+	}
+}
+
+// TestPlanRemoveEmptyClaudeDir_KeepFlagsSuppress: --keep-skills or
+// --keep-hooks must suppress the empty-dir cleanup, since either flag
+// implies content under .claude/ is being kept and the directory must
+// stay too.
+func TestPlanRemoveEmptyClaudeDir_KeepFlagsSuppress(t *testing.T) {
+	dir := t.TempDir()
+	mkdir(t, filepath.Join(dir, ".claude"))
+
+	if plan := planRemoveEmptyClaudeDir(dir, &DownCmd{KeepSkills: true}); plan != nil {
+		t.Errorf("KeepSkills should suppress empty-claude cleanup; got %d actions",
+			len(plan))
+	}
+	if plan := planRemoveEmptyClaudeDir(dir, &DownCmd{KeepHooks: true}); plan != nil {
+		t.Errorf("KeepHooks should suppress empty-claude cleanup; got %d actions",
+			len(plan))
+	}
+}
+
+// TestRemoveBonesGitignoreEntries_RemovesAllThree pins issue #237: the
+// 3 lines bones up adds (.fslckout, .fossil-settings/, .bones/) plus
+// the bones header comment are all stripped on down. Symmetric with up.
+func TestRemoveBonesGitignoreEntries_RemovesAllThree(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".gitignore")
+	// Layout matches what ensureGitignoreEntries writes when starting
+	// from an empty file (or appending to a user-authored file).
+	body := "node_modules/\n*.log\n\n" +
+		"# Bones runtime + Fossil checkout-at-root (ADRs 0023, 0041)\n" +
+		".fslckout\n.fossil-settings/\n.bones/\n"
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := removeBonesGitignoreEntries(path); err != nil {
+		t.Fatalf("removeBonesGitignoreEntries: %v", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	for _, banned := range []string{
+		".fslckout", ".fossil-settings/", ".bones/",
+		"# Bones runtime",
+	} {
+		if strings.Contains(string(got), banned) {
+			t.Errorf(".gitignore still contains %q:\n%s", banned, got)
+		}
+	}
+	// User content survives.
+	if !strings.Contains(string(got), "node_modules/") {
+		t.Errorf("user line node_modules/ stripped:\n%s", got)
+	}
+	if !strings.Contains(string(got), "*.log") {
+		t.Errorf("user line *.log stripped:\n%s", got)
+	}
+}
+
+// TestRemoveBonesGitignoreEntries_DeletesEmptyFile pins the symmetric
+// case of #237: a .gitignore that bones up created on a fresh tree
+// (no pre-existing user content) is removed entirely on down.
+func TestRemoveBonesGitignoreEntries_DeletesEmptyFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".gitignore")
+	body := "\n# Bones runtime + Fossil checkout-at-root (ADRs 0023, 0041)\n" +
+		".fslckout\n.fossil-settings/\n.bones/\n"
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := removeBonesGitignoreEntries(path); err != nil {
+		t.Fatalf("removeBonesGitignoreEntries: %v", err)
+	}
+	if _, err := os.Stat(path); !errors.Is(err, fs.ErrNotExist) {
+		t.Errorf("bones-only .gitignore should be deleted; stat err=%v", err)
+	}
+}
+
+// TestRemoveBonesGitignoreEntries_UserDuplicatedEntry documents the
+// edge case noted in the issue brief: when the user has manually added
+// `.bones/` (or another bones-owned line) to their gitignore, exact-
+// match removal still drops it. This is correct: bones-owned line
+// content is bones-owned line content regardless of who typed it, and
+// the post-down state is indistinguishable from "bones never touched
+// the file" — which IS the byte-for-byte uninstall promise. A user who
+// wants `.bones/` ignored independently can re-add it after down.
+func TestRemoveBonesGitignoreEntries_UserDuplicatedEntry(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".gitignore")
+	// User had .bones/ themselves before bones up ran — it sits
+	// outside the bones header block. ensureGitignoreEntries skips
+	// duplicates so it won't appear under the header. After down,
+	// exact-match removal removes the user's line too.
+	body := "node_modules/\n.bones/\n*.log\n\n" +
+		"# Bones runtime + Fossil checkout-at-root (ADRs 0023, 0041)\n" +
+		".fslckout\n.fossil-settings/\n"
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := removeBonesGitignoreEntries(path); err != nil {
+		t.Fatalf("removeBonesGitignoreEntries: %v", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if strings.Contains(string(got), ".bones/") {
+		t.Errorf("user-duplicated .bones/ line should be removed; got:\n%s", got)
+	}
+	if !strings.Contains(string(got), "node_modules/") {
+		t.Errorf("user line node_modules/ stripped:\n%s", got)
+	}
+}
+
+// TestRemoveBonesGitignoreEntries_MissingFile is a no-op (idempotent
+// on a tree without a .gitignore).
+func TestRemoveBonesGitignoreEntries_MissingFile(t *testing.T) {
+	dir := t.TempDir()
+	if err := removeBonesGitignoreEntries(filepath.Join(dir, "missing")); err != nil {
+		t.Errorf("missing file should be no-op, got: %v", err)
+	}
+}
+
+// TestPlanRemoveGitignoreEntries_OmitsWhenAbsent: no .gitignore →
+// no plan action. The plan output reflects what's present on disk.
+func TestPlanRemoveGitignoreEntries_OmitsWhenAbsent(t *testing.T) {
+	dir := t.TempDir()
+	if plan := planRemoveGitignoreEntries(dir); plan != nil {
+		t.Errorf("expected nil plan for missing .gitignore; got %d actions",
+			len(plan))
+	}
+}
+
+// TestUpDown_GitignoreSymmetry pins the round-trip invariant: after
+// `bones up` adds entries to a .gitignore that previously held only
+// user content, `bones down` produces a file byte-identical to the
+// pre-up state. Catches drift between bonesGitignoreEntries (down) and
+// the entries ensureGitignoreEntries actually writes (up).
+func TestUpDown_GitignoreSymmetry(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".gitignore")
+	preUp := "node_modules/\n*.log\n"
+	if err := os.WriteFile(path, []byte(preUp), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ensureGitignoreEntries(dir, nil); err != nil {
+		t.Fatalf("ensureGitignoreEntries: %v", err)
+	}
+	// Sanity: up actually added something.
+	mid, _ := os.ReadFile(path)
+	if string(mid) == preUp {
+		t.Fatal("ensureGitignoreEntries was a no-op; test setup is wrong")
+	}
+
+	if err := removeBonesGitignoreEntries(path); err != nil {
+		t.Fatalf("removeBonesGitignoreEntries: %v", err)
+	}
+
+	postDown, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read post-down: %v", err)
+	}
+	if string(postDown) != preUp {
+		t.Errorf("up→down not symmetric:\npre-up:\n%q\npost-down:\n%q",
+			preUp, postDown)
 	}
 }
 


### PR DESCRIPTION
## Summary

- `bones down` now deletes `.claude/settings.json` when stripping bones-owned hooks leaves no other top-level keys, then removes `.claude/` if it is empty (#235). User-authored keys (theme, env, permissions, …) keep the file alive with byte-for-byte preservation.
- `bones down` now removes the 3 lines `bones up` writes to `.gitignore` (`.fslckout`, `.fossil-settings/`, `.bones/`) plus the bones header comment, collapses any blank-line gap left behind, and deletes the file if nothing user-authored survives (#237).
- Round-trip up→down symmetry test pins the invariant so future drift between `ensureGitignoreEntries` (up) and `bonesGitignoreEntries` (down) breaks CI.

## Notes on edge cases

- **Empty `{}` settings.json the user authored**: deleted. An empty JSON object carries no information; matching pre-up state on a fresh tree wins.
- **User-duplicated `.bones/` in `.gitignore`**: removed by exact-line match. The post-down state is indistinguishable from "bones never touched the file" — the documented uninstall promise. A user who wants `.bones/` ignored independently can re-add it after down.
- **`--keep-skills` / `--keep-hooks`**: suppress the empty-`.claude/` cleanup since either flag implies content under `.claude/` survives.

## Test plan

- [x] `make check` (fmt-check, vet, lint, race, todo-check, full test suite)
- [x] `go test -tags=otel -short ./...`
- [x] `go build -tags=otel ./...`
- [x] New tests cover: bones-only settings.json deletion, user-key preservation, literal `{}` deletion, end-to-end runDown empty/non-empty `.claude/` paths, `--keep-*` suppression, gitignore 3-line removal, gitignore-only file deletion, user-duplicated entry removal, missing-file no-ops, full up→down symmetry round-trip.

Closes #235
Closes #237