### PR TITLE
fix(swarm): make --no-artifact structured boolean (#233)

### DIFF
--- a/cli/swarm_close.go
+++ b/cli/swarm_close.go
@@ -38,7 +38,7 @@ type SwarmCloseCmd struct {
 	// these markers are bones-side observations.
 	SubstrateError string `name:"substrate-error" help:"free-text substrate failure (#159)"`
 	SubstrateFault string `name:"substrate-fault" help:"substrate fault category (#159)"`
-	NoArtifact     string `name:"no-artifact" help:"reason for closing success without a commit"`
+	NoArtifact     bool   `name:"no-artifact" help:"acknowledge an intentional empty close"`
 	KeepWT         bool   `name:"keep-wt" help:"retain wt dir on success (default: remove)"`
 }
 
@@ -91,11 +91,13 @@ func (c *SwarmCloseCmd) Run(g *repocli.Globals) error {
 		"result":  c.Result,
 		"summary": c.Summary,
 	}
-	// Per b61574e, the no-artifact reason must appear in the audit trail
-	// so post-hoc inspection can distinguish legitimate artifact-free closes
-	// from silent precondition violations.
-	if c.NoArtifact != "" {
-		closeFields["no_artifact"] = c.NoArtifact
+	// Per #233, no_artifact is a structured boolean — true when the
+	// caller explicitly acknowledged an intentional empty close, absent
+	// otherwise. The bool shape replaces the prior free-form reason
+	// string (b61574e) so a hallucinated rationale ("harness blocked
+	// file write") cannot leak into the audit trail.
+	if c.NoArtifact {
+		closeFields["no_artifact"] = true
 	}
 	appendSlotEvent(info.WorkspaceDir, lease.Slot(), logwriter.Event{
 		Timestamp: timeNow(),

--- a/cmd/bones/integration/swarm_test.go
+++ b/cmd/bones/integration/swarm_test.go
@@ -622,3 +622,221 @@ func TestCLI_SwarmAutoDiscover(t *testing.T) {
 		t.Fatalf("swarm close exit=%d stderr=%s", code, stderr)
 	}
 }
+
+// TestCLI_SwarmClose_FailLoudWithoutCommit pins the #233 fix: a slot
+// that joined but never committed must NOT silently close success.
+// `bones swarm close --result=success` exits non-zero with a
+// diagnostic naming the precondition and pointing at --no-artifact
+// for the legitimate-empty-close path. Subagents that hallucinate the
+// "no Write" policy from #233 will surface this error to the
+// orchestrator instead of writing a bogus reason string.
+func TestCLI_SwarmClose_FailLoudWithoutCommit(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip in -short: integration test")
+	}
+	requireBinaries(t)
+	dir := setupSwarmWorkspace(t)
+	if resolved, err := filepath.EvalSymlinks(dir); err == nil {
+		dir = resolved
+	}
+	httpPort, natsPort := pickPortPair(t)
+	startSwarmHub(t, dir, httpPort, natsPort)
+	hubURL := fmt.Sprintf("http://127.0.0.1:%d", httpPort)
+
+	slot := "rendering"
+	taskID := createSwarmTaskNoFiles(t, dir, slot, "[slot: rendering] no-commit task")
+
+	if _, stderr, code := runCmd(t, bonesBin, dir,
+		"swarm", "join",
+		"--slot="+slot, "--task-id="+taskID,
+		"--hub-url="+hubURL,
+	); code != 0 {
+		t.Fatalf("swarm join exit=%d stderr=%s", code, stderr)
+	}
+
+	// No commit. Close should refuse with non-zero exit and a message
+	// that names the precondition + --no-artifact escape hatch.
+	stdout, stderr, code := runCmd(t, bonesBin, dir,
+		"swarm", "close",
+		"--slot="+slot, "--result=success",
+		"--summary=should be refused",
+		"--hub-url="+hubURL,
+	)
+	if code == 0 {
+		t.Fatalf("swarm close unexpectedly succeeded: stdout=%s stderr=%s",
+			stdout, stderr)
+	}
+	combined := stderr + stdout
+	if !strings.Contains(combined, "no work committed") {
+		t.Errorf("error missing precondition mention: %s", combined)
+	}
+	if !strings.Contains(combined, "--no-artifact") {
+		t.Errorf("error missing --no-artifact escape hatch: %s", combined)
+	}
+
+	// Session must still exist (close was refused before any state
+	// mutation), so a follow-up close --no-artifact can converge.
+	statusOut, _, _ := runCmd(t, bonesBin, dir, "swarm", "status", "--json")
+	if !strings.Contains(statusOut, slot) {
+		t.Errorf("session evaporated after refused close: %s", statusOut)
+	}
+}
+
+// TestCLI_SwarmClose_NoArtifactBypass pins the legitimate-empty-close
+// path: when an operator (or a research subagent that genuinely has
+// nothing to commit) explicitly opts in via --no-artifact, swarm close
+// succeeds. The per-slot log records `no_artifact: true` as a structured
+// boolean — NOT a free-form reason string. The boolean shape is the
+// fix shape for #233: a flag that flips, not a reason string an agent
+// can hallucinate.
+func TestCLI_SwarmClose_NoArtifactBypass(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip in -short: integration test")
+	}
+	requireBinaries(t)
+	dir := setupSwarmWorkspace(t)
+	if resolved, err := filepath.EvalSymlinks(dir); err == nil {
+		dir = resolved
+	}
+	httpPort, natsPort := pickPortPair(t)
+	startSwarmHub(t, dir, httpPort, natsPort)
+	hubURL := fmt.Sprintf("http://127.0.0.1:%d", httpPort)
+
+	slot := "rendering"
+	taskID := createSwarmTaskNoFiles(t, dir, slot, "[slot: rendering] research-only task")
+
+	if _, stderr, code := runCmd(t, bonesBin, dir,
+		"swarm", "join",
+		"--slot="+slot, "--task-id="+taskID,
+		"--hub-url="+hubURL,
+	); code != 0 {
+		t.Fatalf("swarm join exit=%d stderr=%s", code, stderr)
+	}
+
+	if _, stderr, code := runCmd(t, bonesBin, dir,
+		"swarm", "close",
+		"--slot="+slot, "--result=success",
+		"--summary=research returned inline",
+		"--no-artifact",
+		"--hub-url="+hubURL,
+	); code != 0 {
+		t.Fatalf("swarm close --no-artifact exit=%d stderr=%s", code, stderr)
+	}
+
+	logBytes, err := os.ReadFile(filepath.Join(dir, ".bones", "swarm", slot, "log"))
+	if err != nil {
+		t.Fatalf("read slot log: %v", err)
+	}
+	var closeLine map[string]interface{}
+	for _, line := range strings.Split(strings.TrimSpace(string(logBytes)), "\n") {
+		if line == "" {
+			continue
+		}
+		var row map[string]interface{}
+		if err := json.Unmarshal([]byte(line), &row); err != nil {
+			t.Fatalf("parse slot log line %q: %v", line, err)
+		}
+		if row["event"] == "close" {
+			closeLine = row
+		}
+	}
+	if closeLine == nil {
+		t.Fatalf("no close event in slot log:\n%s", logBytes)
+	}
+	got, ok := closeLine["no_artifact"]
+	if !ok {
+		t.Fatalf("close event missing no_artifact field: %v", closeLine)
+	}
+	gotBool, isBool := got.(bool)
+	if !isBool {
+		t.Fatalf("no_artifact must be a structured boolean, got %T = %v",
+			got, got)
+	}
+	if !gotBool {
+		t.Errorf("no_artifact: want true, got false")
+	}
+}
+
+// TestCLI_SwarmClose_HappyPathRegression is the regression guard:
+// after a normal join + commit + close --result=success cycle, the
+// per-slot log records the close WITHOUT a no_artifact field. The fix
+// for #233 must not regress this shape — operators reading the log
+// expect no_artifact to appear only on the explicit-empty-close path.
+func TestCLI_SwarmClose_HappyPathRegression(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip in -short: integration test")
+	}
+	requireBinaries(t)
+	dir := setupSwarmWorkspace(t)
+	if resolved, err := filepath.EvalSymlinks(dir); err == nil {
+		dir = resolved
+	}
+	httpPort, natsPort := pickPortPair(t)
+	startSwarmHub(t, dir, httpPort, natsPort)
+	hubURL := fmt.Sprintf("http://127.0.0.1:%d", httpPort)
+
+	relFile := "rendering/normal.txt"
+	absFile := filepath.Join(dir, relFile)
+	taskID := createSwarmTask(t, dir, absFile, "[slot: rendering] normal task")
+	slot := "rendering"
+
+	if _, stderr, code := runCmd(t, bonesBin, dir,
+		"swarm", "join",
+		"--slot="+slot, "--task-id="+taskID,
+		"--hub-url="+hubURL,
+	); code != 0 {
+		t.Fatalf("swarm join exit=%d stderr=%s", code, stderr)
+	}
+
+	wt := filepath.Join(dir, ".bones", "swarm", slot, "wt")
+	filePath := filepath.Join(wt, "rendering", "normal.txt")
+	if err := os.MkdirAll(filepath.Dir(filePath), 0o755); err != nil {
+		t.Fatalf("mkdir wt subdir: %v", err)
+	}
+	if err := os.WriteFile(filePath, []byte("hello\n"), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	if _, stderr, code := runCmd(t, bonesBin, dir,
+		"swarm", "commit",
+		"--slot="+slot, "-m=normal commit",
+		"--hub-url="+hubURL,
+		"rendering/normal.txt",
+	); code != 0 {
+		t.Fatalf("swarm commit exit=%d stderr=%s", code, stderr)
+	}
+
+	if _, stderr, code := runCmd(t, bonesBin, dir,
+		"swarm", "close",
+		"--slot="+slot, "--result=success", "--summary=done",
+		"--hub-url="+hubURL,
+	); code != 0 {
+		t.Fatalf("swarm close exit=%d stderr=%s", code, stderr)
+	}
+
+	logBytes, err := os.ReadFile(filepath.Join(dir, ".bones", "swarm", slot, "log"))
+	if err != nil {
+		t.Fatalf("read slot log: %v", err)
+	}
+	var closeLine map[string]interface{}
+	for _, line := range strings.Split(strings.TrimSpace(string(logBytes)), "\n") {
+		if line == "" {
+			continue
+		}
+		var row map[string]interface{}
+		if err := json.Unmarshal([]byte(line), &row); err != nil {
+			t.Fatalf("parse slot log line %q: %v", line, err)
+		}
+		if row["event"] == "close" {
+			closeLine = row
+		}
+	}
+	if closeLine == nil {
+		t.Fatalf("no close event in slot log:\n%s", logBytes)
+	}
+	if _, present := closeLine["no_artifact"]; present {
+		t.Errorf("happy path must not record no_artifact field: %v", closeLine)
+	}
+	if closeLine["result"] != "success" {
+		t.Errorf("close result: want success, got %v", closeLine["result"])
+	}
+}

--- a/internal/swarm/events.go
+++ b/internal/swarm/events.go
@@ -61,7 +61,7 @@ type Event struct {
 	AgentID    string    `json:"agent_id,omitempty"`
 	Host       string    `json:"host,omitempty"`
 	Result     string    `json:"result,omitempty"`
-	NoArtifact string    `json:"no_artifact,omitempty"`
+	NoArtifact bool      `json:"no_artifact,omitempty"`
 	CommitUUID string    `json:"commit_uuid,omitempty"`
 }
 

--- a/internal/swarm/lease.go
+++ b/internal/swarm/lease.go
@@ -97,12 +97,13 @@ var ErrCrossHostOperation = errors.New(
 // without producing an artifact severs the audit trail bones is
 // supposed to preserve. Callers that have a legitimate reason to
 // close success without a commit (e.g. a research subagent that
-// returned findings inline) must pass CloseOpts.NoArtifact with an
-// explicit reason; the reason is recorded so the post-mortem question
-// "why did this slot leave no commit?" has a documented answer.
+// returned findings inline) must opt in via CloseOpts.NoArtifact;
+// per #233 this is a boolean opt-in (not a free-form reason string)
+// so a hallucinated rationale cannot leak into the audit trail.
 var ErrCloseRequiresArtifact = errors.New(
-	"swarm: close --result=success refused — no commit landed since join; " +
-		"either commit the slot's artifact first or pass --no-artifact=<reason>",
+	"swarm: close --result=success refused — slot was joined but no work " +
+		"committed; either run `bones swarm commit` first, or pass " +
+		"--no-artifact to acknowledge an intentional empty close",
 )
 
 // AcquireOpts tunes Acquire and Resume. Zero-value defaults are
@@ -182,14 +183,14 @@ type CloseOpts struct {
 	// and fork leave it false.
 	CloseTaskOnSuccess bool
 
-	// NoArtifact, when non-empty, bypasses the
-	// "success requires a commit since join" precondition. The
-	// string is the operator's reason (e.g. "inline-only research
-	// findings") and is recorded in the lifecycle event log so the
-	// audit trail has a documented explanation for the missing
-	// artifact. Ignored when CloseTaskOnSuccess is false (fail and
-	// fork results have no artifact requirement).
-	NoArtifact string
+	// NoArtifact, when true, bypasses the "success requires a commit
+	// since join" precondition. Per #233 this is a structured boolean
+	// opt-in (not a free-form reason string) so a hallucinated
+	// rationale cannot leak into the audit trail; the lifecycle event
+	// records `no_artifact: true` when set. Ignored when
+	// CloseTaskOnSuccess is false (fail and fork results have no
+	// artifact requirement).
+	NoArtifact bool
 
 	// Reaped, when true, tags the emitted lifecycle event as
 	// EventSlotReap rather than EventSlotClose. Set by the
@@ -730,7 +731,7 @@ func (l *ResumedLease) Close(ctx context.Context, opts CloseOpts) error {
 // converges idempotently — the missing record itself implies the
 // caller already closed and we have nothing to refuse).
 func (l *ResumedLease) checkArtifactPrecondition(ctx context.Context, opts CloseOpts) error {
-	if !opts.CloseTaskOnSuccess || opts.NoArtifact != "" {
+	if !opts.CloseTaskOnSuccess || opts.NoArtifact {
 		return nil
 	}
 	if l.sessions == nil {

--- a/internal/swarm/lease_test.go
+++ b/internal/swarm/lease_test.go
@@ -374,7 +374,7 @@ func TestClose_DeletesRecordAndPidFile(t *testing.T) {
 	// cleanup path is what's exercised.
 	if err := resumed.Close(ctx, CloseOpts{
 		CloseTaskOnSuccess: true,
-		NoArtifact:         "test: covers cleanup path",
+		NoArtifact:         true,
 	}); err != nil {
 		t.Fatalf("Close: %v", err)
 	}
@@ -602,7 +602,7 @@ func TestClose_RefusesSuccessWithoutCommit(t *testing.T) {
 	// caller's recovery path is to commit, then retry close.
 	if err := resumed.Close(ctx, CloseOpts{
 		CloseTaskOnSuccess: true,
-		NoArtifact:         "test-bypass",
+		NoArtifact:         true,
 	}); err != nil {
 		t.Fatalf("Close with NoArtifact bypass: %v", err)
 	}
@@ -639,7 +639,7 @@ func TestClose_RemovesWTOnSuccess(t *testing.T) {
 	}
 	if err := resumed.Close(ctx, CloseOpts{
 		CloseTaskOnSuccess: true,
-		NoArtifact:         "test: covers wt-removal path",
+		NoArtifact:         true,
 	}); err != nil {
 		t.Fatalf("Close: %v", err)
 	}
@@ -704,7 +704,7 @@ func TestClose_KeepWTOnSuccess(t *testing.T) {
 	}
 	if err := resumed.Close(ctx, CloseOpts{
 		CloseTaskOnSuccess: true,
-		NoArtifact:         "test: covers keep-wt path",
+		NoArtifact:         true,
 		KeepWT:             true,
 	}); err != nil {
 		t.Fatalf("Close: %v", err)
@@ -746,7 +746,7 @@ func TestClose_IdempotentMissingWT(t *testing.T) {
 	}
 	if err := resumed.Close(ctx, CloseOpts{
 		CloseTaskOnSuccess: true,
-		NoArtifact:         "test: covers idempotent missing-wt",
+		NoArtifact:         true,
 	}); err != nil {
 		t.Fatalf("Close (wt already missing): %v", err)
 	}


### PR DESCRIPTION
## Summary

Option 2 (fail-loud middle) fix for #233. Subagents in fan-out are hallucinating
reasons for the existing free-form `--no-artifact=<reason>` flag. Live spy
evidence: 3 of 5 subagents in a single fan-out drifted, inventing rationales
like `"harness blocked file write"` and `"findings returned to orchestrator as
text per parent agent policy"` — actual harness tool-error count was zero.
The orchestrator's synthesis prompt was already firefighting the misconception
inline (*"Two earlier subagents wrongly inferred such a policy"*).

- `--no-artifact` becomes a boolean opt-in (was: string reason).
- Per-slot log records `no_artifact: true` only when the flag is set;
  free-form invented strings can no longer leak into the audit trail.
- Existing `ErrCloseRequiresArtifact` precondition (b61574e) unchanged —
  this is purely a shape change. Error message updated to surface the
  `--no-artifact` (no value) path to the operator/agent.
- `swarm.Event.NoArtifact` (`internal/swarm/events.go`) string -> bool with
  the same `omitempty` JSON tag; no downstream consumers existed.

Full #209 Layer A (bones-bundled subagent definitions) remains a separate
effort. Per scope decision, no new ADR — this is a behavioral refinement of
ADR 0028.

## Test plan

- [x] `make check` — clean.
- [x] `go test -tags=otel -short ./...` — clean.
- [x] New integration tests: `TestCLI_SwarmClose_FailLoudWithoutCommit`,
  `TestCLI_SwarmClose_NoArtifactBypass` (asserts boolean log shape),
  `TestCLI_SwarmClose_HappyPathRegression` (asserts no_artifact absent on
  normal close).
- [x] Existing `TestCLI_Swarm`, `TestCLI_SwarmReap` still green.
- [x] Existing `internal/swarm` lease tests updated to bool, all pass.
- [ ] Reviewer to confirm the bool-flag shape addresses #233 vs requiring
  Layer A bundling.

Closes #233