### PR TITLE
fix(doctor): bundle of read-only contract + label fixes

### DIFF
--- a/cli/doctor.go
+++ b/cli/doctor.go
@@ -159,11 +159,12 @@ func runBypassReportTo(w io.Writer, cwd string) (warns int, err error) {
 			_, _ = fmt.Fprintf(w, "  WARN  hook read failed: %v\n", hookErr)
 			warns++
 		case !installed:
-			_, _ = fmt.Fprintln(w, "  WARN  pre-commit hook missing — run `bones up` to reinstall")
+			_, _ = fmt.Fprintln(w,
+				"  WARN  bones substrate pre-commit hook missing — run `bones up` to reinstall")
 			printFix(w, FixForMissingHook())
 			warns++
 		default:
-			_, _ = fmt.Fprintln(w, "  OK    pre-commit hook installed")
+			_, _ = fmt.Fprintln(w, "  OK    bones substrate pre-commit hook installed")
 		}
 	}
 

--- a/cli/doctor.go
+++ b/cli/doctor.go
@@ -218,10 +218,18 @@ func runBypassReportTo(w io.Writer, cwd string) (warns int, err error) {
 	return warns, nil
 }
 
-// checkAgentsMD reports on AGENTS.md state per ADR 0042: when the
-// scaffold version stamp says bones up has run, AGENTS.md must exist,
-// be bones-managed (first line marker), and carry the required Agent
-// Setup section. Returns true if a WARN was emitted.
+// checkAgentsMD reports on AGENTS.md state per ADR 0042 + ADR 0045
+// (four-shape contract). Three states are recognized for an existing
+// file:
+//
+//  1. Whole file is bones-owned (first-line marker, e.g. CLAUDE.md
+//     symlink target) — verify the required Agent Setup section.
+//  2. User-authored file with a `<!-- BONES:BEGIN --> … <!-- BONES:END -->`
+//     marker block — bones IS managing the block; report OK (#230).
+//  3. User-authored file with no bones content — informational, out
+//     of bones' scope.
+//
+// Returns true if a WARN was emitted.
 func checkAgentsMD(w io.Writer, cwd string) bool {
 	path := filepath.Join(cwd, "AGENTS.md")
 	data, err := os.ReadFile(path)
@@ -239,18 +247,22 @@ func checkAgentsMD(w io.Writer, cwd string) bool {
 		_, _ = fmt.Fprintf(w, "  WARN  AGENTS.md read: %v\n", err)
 		return true
 	}
-	if !bonesOwnedAgentsMD(data) {
-		_, _ = fmt.Fprintln(w,
-			"  INFO  AGENTS.md present but not bones-managed — bones content out of scope")
+	if bonesOwnedAgentsMD(data) {
+		if !strings.Contains(string(data), "## Agent Setup (REQUIRED)") {
+			_, _ = fmt.Fprintln(w,
+				"  WARN  AGENTS.md missing required `## Agent Setup (REQUIRED)` section — "+
+					"run `bones up` to refresh")
+			return true
+		}
+		_, _ = fmt.Fprintln(w, "  OK    AGENTS.md scaffolded with bones-required sections")
 		return false
 	}
-	if !strings.Contains(string(data), "## Agent Setup (REQUIRED)") {
-		_, _ = fmt.Fprintln(w,
-			"  WARN  AGENTS.md missing required `## Agent Setup (REQUIRED)` section — "+
-				"run `bones up` to refresh")
-		return true
+	if hasManagedBlock(data) {
+		_, _ = fmt.Fprintln(w, "  OK    AGENTS.md has bones-managed marker block")
+		return false
 	}
-	_, _ = fmt.Fprintln(w, "  OK    AGENTS.md scaffolded with bones-required sections")
+	_, _ = fmt.Fprintln(w,
+		"  INFO  AGENTS.md present but not bones-managed — bones content out of scope")
 	return false
 }
 

--- a/cli/doctor.go
+++ b/cli/doctor.go
@@ -69,7 +69,18 @@ func (c *DoctorCmd) Run(g *repocli.Globals) (err error) {
 	// The EdgeSync side returns an error on failed checks; surface
 	// that error AFTER our additional report so operators see the
 	// swarm picture even when an upstream check failed.
-	baseErr := c.DoctorCmd.Run(g)
+	//
+	// Per #232, the EdgeSync delegation is gated on actually being
+	// inside an EdgeSync workspace (`.fossil` file or `.fslckout`
+	// checkout DB at cwd or any parent). Outside one, EdgeSync's
+	// doctor surfaces irrelevant warnings (missing `.fossil`, NATS
+	// at :4222 unreachable) since bones uses ephemeral NATS on a
+	// hub-assigned port.
+	var baseErr error
+	cwd, _ := os.Getwd()
+	if isEdgeSyncWorkspace(cwd) {
+		baseErr = c.DoctorCmd.Run(g)
+	}
 	baseFailed = baseErr != nil
 	swarmErr := c.runSwarmReport()
 	swarmFailed = swarmErr != nil
@@ -623,6 +634,44 @@ func classifySwarmSession(s swarm.Session, host string) string {
 	staleSec := int64(time.Since(s.LastRenewed).Seconds())
 	return classifyState(s, host, staleSec)
 }
+
+// isEdgeSyncWorkspace reports whether cwd is inside an EdgeSync
+// workspace (a directory tree containing a `.fossil` repo file or a
+// `.fslckout` checkout database). Mirrors libfossil's findRepo walk:
+// from cwd, ascend to the filesystem root, returning true on the
+// first hit. Outside an EdgeSync workspace, `bones doctor` skips the
+// edgesync-doctor delegation per #232 so its EdgeSync-specific checks
+// (`.fossil` presence, external NATS at :4222) don't surface as
+// irrelevant warnings on plain bones workspaces.
+func isEdgeSyncWorkspace(cwd string) bool {
+	if cwd == "" {
+		return false
+	}
+	dir, err := filepath.Abs(cwd)
+	if err != nil {
+		return false
+	}
+	for range maxEdgeSyncWalkDepth {
+		if _, err := os.Stat(filepath.Join(dir, ".fslckout")); err == nil {
+			return true
+		}
+		matches, _ := filepath.Glob(filepath.Join(dir, "*.fossil"))
+		if len(matches) > 0 {
+			return true
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return false
+		}
+		dir = parent
+	}
+	return false
+}
+
+// maxEdgeSyncWalkDepth caps the upward walk in isEdgeSyncWorkspace.
+// 64 levels is preposterous for any real filesystem; the cap defends
+// against a runtime anomaly that would otherwise loop indefinitely.
+const maxEdgeSyncWalkDepth = 64
 
 func labelFor(state string) string {
 	switch state {

--- a/cli/doctor.go
+++ b/cli/doctor.go
@@ -17,6 +17,7 @@ import (
 	repocli "github.com/danmestas/EdgeSync/cli/repo"
 
 	"github.com/danmestas/bones/internal/githook"
+	"github.com/danmestas/bones/internal/hub"
 	"github.com/danmestas/bones/internal/registry"
 	"github.com/danmestas/bones/internal/scaffoldver"
 	"github.com/danmestas/bones/internal/slotgc"
@@ -512,6 +513,15 @@ func short(h string) string {
 // Errors connecting to NATS surface as warnings rather than fail
 // the whole doctor — `bones doctor` is meant to be informational
 // even on a half-broken setup.
+//
+// Per #228, this resolves the workspace via workspace.FindRoot
+// (read-only) and probes hub liveness with workspace.HubIsHealthy
+// rather than going through workspace.Join. Join lazy-starts the hub
+// (writes .bones/pids/, hub-fossil-url, hub-nats-url) on every doctor
+// invocation, which violates the read-only contract of doctor and
+// contradicts the lazy-hub promise printed by `bones up`. When no
+// healthy hub is available, this short-circuits with a single INFO
+// line instead of dialing NATS.
 func (c *DoctorCmd) runSwarmReport() error {
 	fmt.Println()
 	fmt.Println("=== bones swarm sessions ===")
@@ -520,13 +530,28 @@ func (c *DoctorCmd) runSwarmReport() error {
 		fmt.Printf("  WARN  cwd: %v\n", err)
 		return nil
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	info, err := workspace.Join(ctx, cwd)
+	root, err := workspace.FindRoot(cwd)
 	if err != nil {
 		fmt.Printf("  INFO  not in a bones workspace (%v)\n", err)
 		return nil
 	}
+	if !workspace.HubIsHealthy(root) {
+		fmt.Println("  INFO  hub not running — no sessions to inspect")
+		return nil
+	}
+	natsURL := hub.NATSURL(root)
+	fossilURL := hub.FossilURL(root)
+	if natsURL == "" || fossilURL == "" {
+		fmt.Println("  INFO  hub URLs not recorded — no sessions to inspect")
+		return nil
+	}
+	info := workspace.Info{
+		WorkspaceDir: root,
+		NATSURL:      natsURL,
+		LeafHTTPURL:  fossilURL,
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
 	sess, closer, err := openSwarmSessions(ctx, info)
 	if err != nil {
 		fmt.Printf("  WARN  open swarm sessions: %v\n", err)

--- a/cli/doctor_test.go
+++ b/cli/doctor_test.go
@@ -227,3 +227,59 @@ func TestRunSwarmReport_DoesNotAutoStartHub(t *testing.T) {
 		t.Errorf("runSwarmReport created .bones/pids/; #228 says it must not write hub state")
 	}
 }
+
+// TestCheckAgentsMD_MarkerBlock pins #230: an AGENTS.md authored by
+// the user (no first-line marker) but carrying a bones-managed
+// `<!-- BONES:BEGIN --> … <!-- BONES:END -->` block IS bones-managed.
+// The check must report OK rather than the misleading "present but
+// not bones-managed" INFO that pre-fix bones doctor emitted against
+// every workspace where bones up appended its marker block to a
+// pre-existing AGENTS.md.
+func TestCheckAgentsMD_MarkerBlock(t *testing.T) {
+	cases := []struct {
+		name    string
+		content string
+		wantOK  string
+		wantNot string
+	}{
+		{
+			name: "whole-file-bones-owned",
+			content: agentsMDMarker + "\n\n## Agent Setup (REQUIRED)\n" +
+				"body\n",
+			wantOK:  "OK    AGENTS.md scaffolded with bones-required sections",
+			wantNot: "not bones-managed",
+		},
+		{
+			name: "user-authored-with-marker-block",
+			content: "# My Project\n\nUser content here.\n\n" +
+				bonesBlockBegin + "\nbones-managed body\n" + bonesBlockEnd + "\n",
+			wantOK:  "OK    AGENTS.md has bones-managed marker block",
+			wantNot: "not bones-managed",
+		},
+		{
+			name: "user-only-no-bones-content",
+			content: "# My Project\n\nNot bones-managed content.\n" +
+				"Nothing to see here.\n",
+			wantOK:  "INFO  AGENTS.md present but not bones-managed",
+			wantNot: "marker block",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cwd := t.TempDir()
+			if err := os.WriteFile(filepath.Join(cwd, "AGENTS.md"),
+				[]byte(tc.content), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			var buf bytes.Buffer
+			_ = checkAgentsMD(&buf, cwd)
+			out := buf.String()
+			if !strings.Contains(out, tc.wantOK) {
+				t.Errorf("expected %q in output, got:\n%s", tc.wantOK, out)
+			}
+			if strings.Contains(out, tc.wantNot) {
+				t.Errorf("did not expect %q in output, got:\n%s", tc.wantNot, out)
+			}
+		})
+	}
+}

--- a/cli/doctor_test.go
+++ b/cli/doctor_test.go
@@ -307,3 +307,68 @@ func TestPreCommitHookLabel_Disambiguated(t *testing.T) {
 			"label, got:\n%s", out)
 	}
 }
+
+// TestIsEdgeSyncWorkspace pins #232: detection must be true when a
+// `.fossil` repo or `.fslckout` checkout marker is present at cwd or
+// any parent, and false on a plain bones workspace whose only fossil
+// state is the nested `.bones/hub.fossil` (which lives under .bones/
+// and is invisible to a glob over the root level).
+func TestIsEdgeSyncWorkspace(t *testing.T) {
+	t.Run("plain-bones-workspace-no-edgesync", func(t *testing.T) {
+		root := t.TempDir()
+		// Bones workspace shape: .bones/agent.id + .bones/hub.fossil.
+		// The nested .fossil at .bones/hub.fossil must NOT be treated
+		// as an EdgeSync repo (it lives below the root level glob).
+		if err := os.MkdirAll(filepath.Join(root, ".bones"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(root, ".bones", "agent.id"),
+			[]byte("test-agent-id\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(root, ".bones", "hub.fossil"),
+			[]byte("placeholder\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if isEdgeSyncWorkspace(root) {
+			t.Error("plain bones workspace mis-detected as EdgeSync")
+		}
+	})
+
+	t.Run("edgesync-workspace-with-fossil-file", func(t *testing.T) {
+		root := t.TempDir()
+		if err := os.WriteFile(filepath.Join(root, "myrepo.fossil"),
+			[]byte("placeholder\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if !isEdgeSyncWorkspace(root) {
+			t.Error("workspace with .fossil at root not detected as EdgeSync")
+		}
+	})
+
+	t.Run("edgesync-workspace-with-fslckout", func(t *testing.T) {
+		root := t.TempDir()
+		if err := os.WriteFile(filepath.Join(root, ".fslckout"),
+			[]byte("placeholder\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if !isEdgeSyncWorkspace(root) {
+			t.Error("workspace with .fslckout not detected as EdgeSync")
+		}
+	})
+
+	t.Run("nested-cwd-walks-up-to-edgesync-root", func(t *testing.T) {
+		root := t.TempDir()
+		if err := os.WriteFile(filepath.Join(root, "myrepo.fossil"),
+			[]byte("placeholder\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		nested := filepath.Join(root, "sub", "deep")
+		if err := os.MkdirAll(nested, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if !isEdgeSyncWorkspace(nested) {
+			t.Error("walk-up from nested cwd did not find EdgeSync root")
+		}
+	})
+}

--- a/cli/doctor_test.go
+++ b/cli/doctor_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -177,4 +178,52 @@ func TestDoctorCmdAllPathInvokesRender(t *testing.T) {
 	})
 	// Error is expected (hub at :1 is down → issues found), not a crash.
 	_ = c.runAll(nil)
+}
+
+// TestRunSwarmReport_DoesNotAutoStartHub pins #228: when no hub is
+// running, runSwarmReport must NOT route through workspace.Join (which
+// lazy-starts the hub) — that violates doctor's read-only contract and
+// silently writes .bones/pids/ + URL files on every doctor invocation.
+//
+// Mirrors TestResolveStatusRoot_DoesNotAutoStartHub from #207. After
+// the fix, runSwarmReport resolves the workspace via workspace.FindRoot
+// + workspace.HubIsHealthy and short-circuits to "hub not running" when
+// no healthy hub exists.
+func TestRunSwarmReport_DoesNotAutoStartHub(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".bones"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".bones", "agent.id"),
+		[]byte("test-agent-id\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(root)
+
+	stdout, finish := captureStdout(t)
+	c := &DoctorCmd{}
+	if err := c.runSwarmReport(); err != nil {
+		t.Fatalf("runSwarmReport: %v", err)
+	}
+	finish()
+
+	out := stdout.String()
+	if !strings.Contains(out, "hub not running") {
+		t.Errorf("expected 'hub not running' INFO line, got:\n%s", out)
+	}
+	if strings.Contains(out, "starting hub for workspace") {
+		t.Errorf("doctor auto-started hub (#228); output:\n%s", out)
+	}
+	// Hub state files must NOT have been created. workspace.Join would
+	// have written hub-fossil-url and hub-nats-url and started a leaf;
+	// FindRoot writes nothing.
+	for _, name := range []string{"hub-fossil-url", "hub-nats-url"} {
+		path := filepath.Join(root, ".bones", name)
+		if _, err := os.Stat(path); err == nil {
+			t.Errorf("runSwarmReport created %s; #228 says it must not write hub state", path)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(root, ".bones", "pids")); err == nil {
+		t.Errorf("runSwarmReport created .bones/pids/; #228 says it must not write hub state")
+	}
 }

--- a/cli/doctor_test.go
+++ b/cli/doctor_test.go
@@ -283,3 +283,27 @@ func TestCheckAgentsMD_MarkerBlock(t *testing.T) {
 		})
 	}
 }
+
+// TestPreCommitHookLabel_Disambiguated pins #231: bones substrate
+// pre-commit hook check must use a label distinct from EdgeSync's
+// "pre-commit hook" label. Without disambiguation, `bones doctor`
+// emits two contradictory lines under identical labels.
+func TestPreCommitHookLabel_Disambiguated(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	tmp := t.TempDir()
+	// Make .git so the hook check fires (vs the no-git INFO branch).
+	if err := os.MkdirAll(filepath.Join(tmp, ".git", "hooks"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	_, _ = runBypassReportTo(&buf, tmp)
+	out := buf.String()
+	// The bones substrate gates emit a "bones substrate pre-commit hook"
+	// label. EdgeSync's doctor uses the bare "pre-commit hook" label;
+	// the two must not collide. Either WARN (missing) or OK (installed)
+	// path satisfies — both go through the disambiguated label.
+	if !strings.Contains(out, "bones substrate pre-commit hook") {
+		t.Errorf("expected disambiguated 'bones substrate pre-commit hook' "+
+			"label, got:\n%s", out)
+	}
+}


### PR DESCRIPTION
## Summary

Four small fixes to `bones doctor`, all in `cli/doctor.go`.

- **#228** — `runSwarmReport` routed through `workspace.Join`, which lazy-starts the hub and writes `.bones/pids/`, `hub-fossil-url`, `hub-nats-url` on every doctor invocation. Same fix shape as #207's status fix: resolve via `workspace.FindRoot` (read-only walk-up) and probe with `workspace.HubIsHealthy`. When no hub is healthy, short-circuit to `INFO  hub not running — no sessions to inspect`.

- **#230** — `checkAgentsMD` reported `INFO  AGENTS.md present but not bones-managed` even when bones was managing a `<!-- BONES:BEGIN --> … <!-- BONES:END -->` block in a user-authored file. Now uses the same `bonesOwnedAgentsMD` + `hasManagedBlock` helpers `bones down` uses, with three-state output: whole-file owned (existing OK), marker block (new `OK  AGENTS.md has bones-managed marker block`), no bones content (existing INFO).

- **#231** — Two `pre-commit hook` labels collided in a single doctor run (one WARN from EdgeSync's delegation, one OK from bones substrate gates). Renames the bones substrate label to `bones substrate pre-commit hook`. The EdgeSync side is in upstream code we can't edit; #232's gating eliminates the collision in non-EdgeSync workspaces.

- **#232** — `c.DoctorCmd.Run(g)` (the EdgeSync delegation) ran unconditionally, surfacing `WARN  repository: no .fossil file found` and `WARN  nats connectivity: nats://localhost:4222 unreachable` on plain bones workspaces. Adds `isEdgeSyncWorkspace(cwd)` — a walk-up that mirrors libfossil's `findRepo` (looks for `.fossil` or `.fslckout`) — and gates the delegation on it.

## Test plan

- [x] `make check` (fmt-check, vet, lint, race, todo-check) — green
- [x] `go test -tags=otel -short ./...` — green
- [x] New regression tests pass: `TestRunSwarmReport_DoesNotAutoStartHub`, `TestCheckAgentsMD_MarkerBlock` (3 sub-cases), `TestPreCommitHookLabel_Disambiguated`, `TestIsEdgeSyncWorkspace` (4 sub-cases)
- [ ] Manual: `cd <fresh-bones-up-workspace>; bones doctor` — confirm no `bones: starting hub for workspace` line, no new `.bones/pids/` or `hub-*-url` files

Closes #228
Closes #230
Closes #231
Closes #232