### PR TITLE
fix(registry): self-prune dead-pid and missing-cwd entries on read

### DIFF
--- a/cli/doctor.go
+++ b/cli/doctor.go
@@ -363,9 +363,15 @@ func workspaceMarkerPresent(root string) bool {
 }
 
 // checkOrphanHubs reads the cross-workspace registry and reports
-// any orphan hub processes — alive PIDs whose workspace directory
-// no longer exists or has been trashed (per ADR 0043). Returns the
-// number of WARN-class findings emitted (one per orphan).
+// any orphan hub processes — alive PIDs whose workspace marker has
+// been scrubbed or whose cwd resolves into the user's Trash (per ADR
+// 0043). Returns the number of WARN-class findings emitted (one per
+// orphan).
+//
+// Since #229 the registry self-prunes entries whose cwd no longer
+// exists at all (and entries with dead pids), so this report only
+// surfaces orphans the operator can still action — not the stale
+// crud that pre-#229 accumulated indefinitely.
 func checkOrphanHubs(w io.Writer) int {
 	orphans, err := registry.Orphans()
 	if err != nil {

--- a/cli/down_test.go
+++ b/cli/down_test.go
@@ -750,9 +750,12 @@ func TestPlanReapOrphans_QueuesCrossWorkspaceOrphans(t *testing.T) {
 		t.Fatalf("seed alive: %v", err)
 	}
 
-	// One orphan: registry entry, child pid alive, but workspace dir
-	// missing (the IsOrphan signal). Must be queued for reap.
-	orphanWS := filepath.Join(t.TempDir(), "deleted-out-from-under")
+	// One orphan: registry entry, child pid alive, workspace dir
+	// exists but its .bones/agent.id marker has been scrubbed (the
+	// surviving IsOrphan signal post-#229). Must be queued for reap.
+	// Pre-#229 this test used a wholly-missing cwd; the registry's
+	// read-time self-prune now removes those silently.
+	orphanWS := t.TempDir()
 	if err := registry.Write(registry.Entry{
 		Cwd: orphanWS, Name: "orphan", HubPID: childPID,
 		StartedAt: time.Now().UTC(),
@@ -779,10 +782,13 @@ func TestPlanReapOrphans_QueuesCrossWorkspaceOrphans(t *testing.T) {
 // under os.Getpid() routinely, and the guard is cheap insurance.
 func TestPlanReapOrphans_SkipsSelfPID(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
-	// Plant a self-pid orphan: workspace dir doesn't exist (orphan
-	// signal #1), pid is alive (we're alive), would normally reap.
+	// Plant a self-pid orphan: workspace dir exists but its
+	// .bones/agent.id marker is missing (the surviving orphan signal
+	// post-#229), pid is alive (we're alive), would normally reap.
+	// Pre-#229 this test used a vanished-cwd path; that signal is now
+	// silently pruned by the registry's read-time scan.
 	if err := registry.Write(registry.Entry{
-		Cwd:       filepath.Join(t.TempDir(), "vanished-ws"),
+		Cwd:       t.TempDir(),
 		Name:      "self-pid-orphan",
 		HubPID:    os.Getpid(),
 		StartedAt: time.Now().UTC(),

--- a/cli/hub_reap_test.go
+++ b/cli/hub_reap_test.go
@@ -25,8 +25,14 @@ func TestRunHubReap_NoOrphans(t *testing.T) {
 }
 
 // TestRunHubReap_ReapsOrphan: spawn a real subprocess, register it
-// pointing at a vanished cwd, run reap with --yes, confirm both the
-// process is gone and the registry entry is removed.
+// pointing at a workspace whose .bones/agent.id marker is absent, run
+// reap with --yes, confirm both the process is gone and the registry
+// entry is removed.
+//
+// Pre-#229 this test used a non-existent cwd as the orphan signal;
+// the read-time self-prune now removes such entries silently before
+// Orphans() sees them. Marker-missing remains an actionable orphan
+// (live PID, dir on disk, no .bones/agent.id) so reap still surfaces it.
 func TestRunHubReap_ReapsOrphan(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 
@@ -41,9 +47,9 @@ func TestRunHubReap_ReapsOrphan(t *testing.T) {
 		}
 	})
 
-	// Register pointing at a path that doesn't exist — qualifies as orphan.
+	orphanCwd := t.TempDir() // exists, but no .bones/agent.id marker
 	e := registry.Entry{
-		Cwd:       "/definitely/does/not/exist/orphan-test",
+		Cwd:       orphanCwd,
 		Name:      "orphan-test",
 		HubURL:    "http://127.0.0.1:1",
 		NATSURL:   "nats://127.0.0.1:1",
@@ -73,10 +79,13 @@ func TestRunHubReap_ReapsOrphan(t *testing.T) {
 func TestRunHubReap_DryRun(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 
-	// Register a fake orphan whose PID is alive (use os.Getpid()) and
-	// whose cwd doesn't exist. We'll only do a dry-run, so no reaping.
+	// Marker-missing orphan: cwd exists but no .bones/agent.id. Live
+	// PID via os.Getpid(). Pre-#229 used a non-existent cwd; that path
+	// is now silently pruned by the read-time scan rather than
+	// surfaced as an actionable orphan.
+	orphanCwd := t.TempDir()
 	e := registry.Entry{
-		Cwd:       "/definitely/does/not/exist/dryrun-test",
+		Cwd:       orphanCwd,
 		Name:      "dryrun-test",
 		HubURL:    "http://127.0.0.1:1",
 		HubPID:    os.Getpid(), // self — alive

--- a/cli/status_test.go
+++ b/cli/status_test.go
@@ -217,9 +217,14 @@ func TestStatusAllRendersTable(t *testing.T) {
 
 	now := time.Now().UTC()
 	pid := os.Getpid()
+	// Real cwds so the registry's read-time self-prune (#229) keeps
+	// the entries; pre-#229 placeholder paths like /Users/dan/foo
+	// passed because List() didn't check existence.
+	cwdFoo := t.TempDir()
+	cwdBar := t.TempDir()
 	for _, e := range []registry.Entry{
-		{Cwd: "/Users/dan/foo", Name: "foo", HubURL: srv.URL, HubPID: pid, StartedAt: now},
-		{Cwd: "/Users/dan/bar", Name: "bar", HubURL: srv.URL, HubPID: pid, StartedAt: now},
+		{Cwd: cwdFoo, Name: "foo", HubURL: srv.URL, HubPID: pid, StartedAt: now},
+		{Cwd: cwdBar, Name: "bar", HubURL: srv.URL, HubPID: pid, StartedAt: now},
 	} {
 		if err := registry.Write(e); err != nil {
 			t.Fatalf("seed: %v", err)
@@ -393,8 +398,9 @@ func TestStatusAllJSON(t *testing.T) {
 		w.WriteHeader(200)
 	}))
 	defer srv.Close()
+	cwd := t.TempDir() // real path so #229 self-prune keeps the entry
 	if err := registry.Write(registry.Entry{
-		Cwd: "/x", Name: "x", HubURL: srv.URL, HubPID: os.Getpid(), StartedAt: time.Now().UTC(),
+		Cwd: cwd, Name: "x", HubURL: srv.URL, HubPID: os.Getpid(), StartedAt: time.Now().UTC(),
 	}); err != nil {
 		t.Fatalf("seed: %v", err)
 	}

--- a/cli/workspaces_test.go
+++ b/cli/workspaces_test.go
@@ -22,7 +22,10 @@ func mkBonesDir(t *testing.T, root string) {
 }
 
 // seedTwoWorkspaces writes two registry entries (each with its own
-// .bones/agent.id) and returns the resolved cwds.
+// .bones/agent.id) and returns the resolved cwds. Uses os.Getpid() as
+// HubPID so the registry's read-time self-prune (#229) keeps the
+// entries; the URL probe still resolves to HubStopped because
+// 127.0.0.1:1/:2 are not bound.
 func seedTwoWorkspaces(t *testing.T) (string, string) {
 	t.Helper()
 	t.Setenv("HOME", t.TempDir())
@@ -34,11 +37,12 @@ func seedTwoWorkspaces(t *testing.T) (string, string) {
 	writeAgentIDForTest(t, wsB)
 
 	now := time.Now().UTC().Truncate(time.Second)
+	pid := os.Getpid()
 	if err := registry.Write(registry.Entry{
 		Cwd: wsA, Name: "alpha",
 		HubURL:    "http://127.0.0.1:1",
 		NATSURL:   "nats://127.0.0.1:1",
-		HubPID:    -1,
+		HubPID:    pid,
 		StartedAt: now,
 	}); err != nil {
 		t.Fatal(err)
@@ -47,7 +51,7 @@ func seedTwoWorkspaces(t *testing.T) (string, string) {
 		Cwd: wsB, Name: "beta",
 		HubURL:    "http://127.0.0.1:2",
 		NATSURL:   "nats://127.0.0.1:2",
-		HubPID:    -2,
+		HubPID:    pid,
 		StartedAt: now,
 	}); err != nil {
 		t.Fatal(err)
@@ -192,9 +196,11 @@ func TestWorkspacesShowAmbiguous(t *testing.T) {
 	writeAgentIDForTest(t, wsB)
 	now := time.Now().UTC().Truncate(time.Second)
 	for _, cwd := range []string{wsA, wsB} {
+		// os.Getpid() since #229 — the read-time self-prune drops
+		// entries with HubPID<=0 before this assertion runs.
 		if err := registry.Write(registry.Entry{
 			Cwd: cwd, Name: "twin",
-			HubURL: "http://127.0.0.1:0", HubPID: -1,
+			HubURL: "http://127.0.0.1:0", HubPID: os.Getpid(),
 			StartedAt: now,
 		}); err != nil {
 			t.Fatal(err)
@@ -300,9 +306,14 @@ func TestRunPrune_YesRemovesStopped(t *testing.T) {
 	wsC := t.TempDir()
 	mkBonesDir(t, wsC)
 	writeAgentIDForTest(t, wsC)
+	// Empty HubURL → probeStatus returns HubUnknown. Pre-#229 we used
+	// HubPID=0 here, but the registry's read-time self-prune now drops
+	// HubPID<=0 entries as crud before ListInfo sees them. A live pid
+	// + empty URL exercises the same "unknown" code path without
+	// tripping the prune.
 	if err := registry.Write(registry.Entry{
 		Cwd: wsC, Name: "unknown",
-		HubURL: "", NATSURL: "", HubPID: 0,
+		HubURL: "", NATSURL: "", HubPID: os.Getpid(),
 		StartedAt: time.Now().UTC().Truncate(time.Second),
 	}); err != nil {
 		t.Fatal(err)
@@ -337,10 +348,10 @@ func TestRunPrune_YesRemovesStopped(t *testing.T) {
 	if len(after) != 1 || after[0].Cwd != wsC {
 		t.Errorf("after prune: want only wsC=%s, got %+v", wsC, after)
 	}
-	for i, cwd := range []string{wsA, wsB} {
-		// HubPID values seeded by seedTwoWorkspaces are -1 (wsA) and -2 (wsB).
-		pid := -(i + 1)
-		if _, err := os.Stat(registry.EntryPath(cwd, pid)); !os.IsNotExist(err) {
+	for _, cwd := range []string{wsA, wsB} {
+		// seedTwoWorkspaces uses os.Getpid() since #229 (read-time
+		// self-prune required live pids to keep entries on disk).
+		if _, err := os.Stat(registry.EntryPath(cwd, os.Getpid())); !os.IsNotExist(err) {
 			t.Errorf("entry file for %s should be removed; err=%v", cwd, err)
 		}
 	}
@@ -375,9 +386,8 @@ func TestRunPrune_NoConfirmKeepsEntries(t *testing.T) {
 		t.Errorf("output should not contain any pruned: lines:\n%s", out)
 	}
 
-	for i, cwd := range []string{wsA, wsB} {
-		pid := -(i + 1)
-		if _, err := os.Stat(registry.EntryPath(cwd, pid)); err != nil {
+	for _, cwd := range []string{wsA, wsB} {
+		if _, err := os.Stat(registry.EntryPath(cwd, os.Getpid())); err != nil {
 			t.Errorf("entry for %s should still exist after abort; err=%v", cwd, err)
 		}
 	}

--- a/internal/registry/info.go
+++ b/internal/registry/info.go
@@ -45,27 +45,24 @@ type Info struct {
 // hub-status probe runs IsAlive on each entry; callers that want to skip
 // the probe (e.g. for fast paths) should use List + their own enrichment.
 //
+// Self-prunes stale entries on read (#229) — same predicate as List(): a
+// dead HubPID or a missing Cwd both qualify the entry as crud and the
+// file is removed before this function returns.
+//
 // Results are sorted by Name, then Cwd, for stable output across calls.
 func ListInfo() ([]Info, error) {
-	matches, err := filepath.Glob(filepath.Join(RegistryDir(), "*.json"))
+	paths, entries, err := pruneStale()
 	if err != nil {
 		return nil, err
 	}
-	out := make([]Info, 0, len(matches))
-	for _, path := range matches {
-		// Skip atomic-write tmp files (".tmp.*"); only top-level *.json
-		// files are real entries.
-		if strings.Contains(filepath.Base(path), ".tmp.") {
-			continue
-		}
+	out := make([]Info, 0, len(entries))
+	for i, e := range entries {
+		path := paths[i]
 		fi, err := os.Stat(path)
 		if err != nil {
-			continue
-		}
-		// Read the entry payload via the canonical Read seam so any
-		// future migrations land here too.
-		e, err := readEntryAtPath(path)
-		if err != nil {
+			// File vanished between prune and stat — skip rather
+			// than fail the listing. Behavior matches the pre-#229
+			// best-effort skip-on-stat-error path.
 			continue
 		}
 		info := Info{

--- a/internal/registry/info_test.go
+++ b/internal/registry/info_test.go
@@ -25,19 +25,23 @@ func TestListInfoEnumerates(t *testing.T) {
 	mustWriteAgentID(t, wsB, "agent-b")
 
 	now := time.Now().UTC().Truncate(time.Second)
+	// Use the test's own pid for HubPID — alive on this host, so the
+	// read-time prune (#229) keeps the entries. The probeStatus call
+	// still resolves to HubStopped because the URL is unreachable.
+	pid := os.Getpid()
 	entries := []Entry{
 		{
 			Cwd: wsA, Name: "alpha",
 			HubURL:    "http://127.0.0.1:1", // unreachable
 			NATSURL:   "nats://127.0.0.1:1",
-			HubPID:    -1, // pidAlive returns false on pid<=0
+			HubPID:    pid,
 			StartedAt: now,
 		},
 		{
 			Cwd: wsB, Name: "beta",
 			HubURL:    "http://127.0.0.1:2",
 			NATSURL:   "nats://127.0.0.1:2",
-			HubPID:    -2,
+			HubPID:    pid,
 			StartedAt: now,
 		},
 	}
@@ -107,7 +111,7 @@ func TestListInfoSkipsCorrupt(t *testing.T) {
 	mustWriteAgentID(t, good, "good")
 	if err := Write(Entry{
 		Cwd: good, Name: "good",
-		HubURL: "http://127.0.0.1:0", HubPID: -1,
+		HubURL: "http://127.0.0.1:0", HubPID: os.Getpid(),
 		StartedAt: time.Now().UTC().Truncate(time.Second),
 	}); err != nil {
 		t.Fatalf("Write: %v", err)
@@ -125,15 +129,19 @@ func TestListInfoSkipsCorrupt(t *testing.T) {
 	}
 }
 
-// TestListInfoMissingAgentID: registry entry whose cwd no longer has a
-// .bones/agent.id (workspace removed underneath us) reports AgentID="".
+// TestListInfoMissingAgentID: registry entry whose cwd exists but
+// has no .bones/agent.id (workspace marker scrubbed underneath us)
+// reports AgentID="". Pre-#229 this test used a non-existent cwd
+// path; #229's read-time self-prune now removes such entries (cwd
+// gone == registry crud), so the test uses an existing-but-marker-
+// less directory to preserve the original intent.
 func TestListInfoMissingAgentID(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
-	gone := filepath.Join(t.TempDir(), "gone") // never created
+	bare := t.TempDir() // exists, no .bones/agent.id marker
 	if err := Write(Entry{
-		Cwd: gone, Name: "gone",
-		HubURL: "http://127.0.0.1:0", HubPID: -1,
+		Cwd: bare, Name: "bare",
+		HubURL: "http://127.0.0.1:0", HubPID: os.Getpid(),
 		StartedAt: time.Now().UTC().Truncate(time.Second),
 	}); err != nil {
 		t.Fatalf("Write: %v", err)

--- a/internal/registry/orphan.go
+++ b/internal/registry/orphan.go
@@ -25,8 +25,14 @@ var reapGrace = 2 * time.Second
 //     XDG-Trash equivalent on Linux)
 //
 // The PID-alive check is the same one IsAlive uses; an entry whose
-// PID is dead is not an orphan (it's a stale entry awaiting prune)
-// and will be reported by IsAlive returning false.
+// PID is dead is not an orphan (it's a stale entry that the read-
+// time prune will delete; see prune.go).
+//
+// Since #229's read-time self-prune, signal (1) and the dead-PID
+// case are removed at the registry layer before IsOrphan is reached.
+// IsOrphan still tests them defensively in case a new caller routes
+// around List/Orphans, but in practice this function returns true
+// only for the marker-missing or trashed-cwd signals.
 func IsOrphan(e Entry) bool {
 	if !pidAlive(e.HubPID) {
 		return false

--- a/internal/registry/prune.go
+++ b/internal/registry/prune.go
@@ -1,0 +1,86 @@
+package registry
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// pruneStale walks every <id>-<pid>.json (and legacy <id>.json) in the
+// registry directory, deletes any entry whose process is not alive on
+// this host OR whose recorded Cwd no longer exists, and returns the
+// surviving entries paired with their on-disk paths.
+//
+// This is the read-time self-prune from issue #229: pre-fix the
+// registry only filtered stale entries in memory and they accumulated
+// indefinitely (PR #199-era reaper required manual `bones hub reap`).
+// Per ADR 0043 the registry should self-clean — pidAlive == false and
+// missing-cwd are both "this entry is meaningless" signals — so a
+// single read pass is the right place to act.
+//
+// The doctor's "orphan" report (live PID + workspace marker missing
+// or trashed) is preserved as actionable: those entries still have an
+// existing Cwd directory and a live PID, so they fall through the
+// prune and surface via Orphans(). Only the silent-crud cases (dead
+// PID, vanished cwd) get deleted.
+//
+// Errors deleting individual files are swallowed — the goal is
+// best-effort cleanup, not a transactional sweep. A file that survives
+// (permissions glitch, race with another reader) just shows up on the
+// next call. Returns parallel slices: paths[i] is the on-disk path of
+// entries[i]. Callers that don't need paths can ignore the first
+// return value.
+func pruneStale() ([]string, []Entry, error) {
+	matches, err := filepath.Glob(filepath.Join(RegistryDir(), "*.json"))
+	if err != nil {
+		return nil, nil, err
+	}
+	paths := make([]string, 0, len(matches))
+	entries := make([]Entry, 0, len(matches))
+	for _, path := range matches {
+		// Skip atomic-write tmp files surfaced by the glob.
+		if strings.Contains(filepath.Base(path), ".tmp.") {
+			continue
+		}
+		e, err := readEntryAtPath(path)
+		if err != nil {
+			// Corrupt files are not stale-by-pid; leave them so
+			// existing List behavior (skip-on-error) is preserved.
+			// A separate corruption-prune verb is out of scope for #229.
+			continue
+		}
+		if isStaleEntry(e) {
+			_ = os.Remove(path)
+			continue
+		}
+		paths = append(paths, path)
+		entries = append(entries, e)
+	}
+	return paths, entries, nil
+}
+
+// isStaleEntry reports whether e is registry crud that the read-path
+// scan should delete. Two signals qualify:
+//
+//  1. e.HubPID is not alive on this host (dead PID, never-existed PID,
+//     or recycled-to-other-process PID we don't have permission to
+//     signal). The original hub is gone; nothing this entry points to
+//     still exists.
+//  2. e.Cwd does not exist on disk (ENOENT). The workspace was rm
+//     -rf'd; even if the PID happens to be alive (recycled to an
+//     unrelated process, or a true orphan), the entry has no
+//     reachable workspace to act against.
+//
+// Live PID + cwd-exists-but-marker-missing-or-trashed entries are
+// left alone — those are doctor-actionable orphans (ADR 0043) that
+// the operator should resolve via `bones hub reap`.
+func isStaleEntry(e Entry) bool {
+	if !pidAlive(e.HubPID) {
+		return true
+	}
+	if _, err := os.Stat(e.Cwd); errors.Is(err, os.ErrNotExist) {
+		return true
+	}
+	return false
+}

--- a/internal/registry/prune_test.go
+++ b/internal/registry/prune_test.go
@@ -1,0 +1,210 @@
+package registry
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// writeWorkspaceMarker creates <dir>/.bones/agent.id so dir reads as
+// a valid bones workspace.
+func writeWorkspaceMarker(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(dir, ".bones"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".bones", "agent.id"),
+		[]byte("test"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestPruneStale_DeletesDeadPidEntry pins #229's primary signal: an
+// entry whose recorded HubPID is dead is removed from disk on the next
+// registry scan, no operator intervention required.
+func TestPruneStale_DeletesDeadPidEntry(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	cwd := t.TempDir()
+	writeWorkspaceMarker(t, cwd)
+
+	dead := findDeadPID(t)
+	stale := Entry{
+		Cwd: cwd, Name: "stale", HubURL: "http://127.0.0.1:1",
+		HubPID: dead, StartedAt: time.Now().UTC(),
+	}
+	if err := Write(stale); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	staleFile := EntryPath(cwd, dead)
+	if _, err := os.Stat(staleFile); err != nil {
+		t.Fatalf("setup: file not written: %v", err)
+	}
+
+	// List() is a registry read path; per the fix it must self-prune
+	// entries whose pid is dead before returning.
+	got, err := List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("List returned %d entries, want 0 (dead-pid entry should be pruned)", len(got))
+	}
+	if _, err := os.Stat(staleFile); !os.IsNotExist(err) {
+		t.Errorf("expected stale file %s to be deleted, stat err = %v", staleFile, err)
+	}
+}
+
+// TestPruneStale_DeletesMissingCwdEntry pins #229's second signal: an
+// entry whose recorded Cwd no longer exists on disk is pruned from the
+// registry, even if the PID happens to be alive (the recycled-pid case
+// observed in the spy evidence — pids 51824 and 16499 surfaced 5+
+// hours after their cwds were rm -rf'd).
+func TestPruneStale_DeletesMissingCwdEntry(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	gone := filepath.Join(t.TempDir(), "deleted-workspace")
+	// Don't create gone; it must not exist for this test.
+
+	stale := Entry{
+		Cwd: gone, Name: "vanished", HubURL: "http://127.0.0.1:1",
+		HubPID:    os.Getpid(), // self — alive
+		StartedAt: time.Now().UTC(),
+	}
+	if err := Write(stale); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	staleFile := EntryPath(gone, os.Getpid())
+	if _, err := os.Stat(staleFile); err != nil {
+		t.Fatalf("setup: file not written: %v", err)
+	}
+
+	got, err := List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("List returned %d entries, want 0 (missing-cwd entry should be pruned)", len(got))
+	}
+	if _, err := os.Stat(staleFile); !os.IsNotExist(err) {
+		t.Errorf("expected stale file %s to be deleted, stat err = %v", staleFile, err)
+	}
+}
+
+// TestPruneStale_KeepsLiveEntry pins the control: an entry whose pid
+// is alive AND cwd exists must survive the prune. Without this, the
+// fix would drop ALL entries and break every other registry consumer.
+func TestPruneStale_KeepsLiveEntry(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	cwd := t.TempDir()
+	writeWorkspaceMarker(t, cwd)
+
+	live := Entry{
+		Cwd: cwd, Name: "live", HubURL: "http://127.0.0.1:1",
+		HubPID: os.Getpid(), StartedAt: time.Now().UTC(),
+	}
+	if err := Write(live); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	livePath := EntryPath(cwd, os.Getpid())
+
+	got, err := List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("List len = %d, want 1", len(got))
+	}
+	if got[0].Cwd != cwd {
+		t.Errorf("got cwd %q, want %q", got[0].Cwd, cwd)
+	}
+	if _, err := os.Stat(livePath); err != nil {
+		t.Errorf("live entry file deleted: %v", err)
+	}
+}
+
+// TestPruneStale_MixedEntries pins behavior under a realistic registry
+// state — one live entry alongside two stale ones (one dead-pid, one
+// missing-cwd). After a single read pass, only the live entry remains.
+func TestPruneStale_MixedEntries(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	liveCwd := t.TempDir()
+	writeWorkspaceMarker(t, liveCwd)
+
+	deadPidCwd := t.TempDir()
+	writeWorkspaceMarker(t, deadPidCwd)
+	dead := findDeadPID(t)
+
+	missingCwd := filepath.Join(t.TempDir(), "vanished")
+	// missingCwd intentionally not created.
+
+	live := Entry{Cwd: liveCwd, Name: "live", HubPID: os.Getpid(), HubURL: "http://127.0.0.1:1"}
+	deadEntry := Entry{Cwd: deadPidCwd, Name: "dead", HubPID: dead, HubURL: "http://127.0.0.1:2"}
+	gone := Entry{Cwd: missingCwd, Name: "gone", HubPID: os.Getpid(), HubURL: "http://127.0.0.1:3"}
+
+	for _, e := range []Entry{live, deadEntry, gone} {
+		if err := Write(e); err != nil {
+			t.Fatalf("Write %s: %v", e.Name, err)
+		}
+	}
+
+	got, err := List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("List len = %d, want 1 (only live should survive). got = %+v", len(got), got)
+	}
+	if got[0].Name != "live" {
+		t.Errorf("survivor = %q, want %q", got[0].Name, "live")
+	}
+	// Dead-pid file gone.
+	if _, err := os.Stat(EntryPath(deadPidCwd, dead)); !os.IsNotExist(err) {
+		t.Errorf("dead-pid file should be removed; stat err = %v", err)
+	}
+	// Missing-cwd file gone.
+	if _, err := os.Stat(EntryPath(missingCwd, os.Getpid())); !os.IsNotExist(err) {
+		t.Errorf("missing-cwd file should be removed; stat err = %v", err)
+	}
+}
+
+// TestPruneStale_OrphansSurfacesActionable pins the doctor UX after
+// self-prune: Orphans() reports only the *actionable* case — live
+// process whose workspace marker is missing or whose cwd was trashed
+// — not the silently-pruned dead-pid / missing-cwd crud. This is
+// option (a) from issue #229's fix brief.
+func TestPruneStale_OrphansSurfacesActionable(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	// Stale entry that should be pruned silently (dead pid + extant cwd).
+	stale := t.TempDir()
+	writeWorkspaceMarker(t, stale)
+	dead := findDeadPID(t)
+	if err := Write(Entry{Cwd: stale, Name: "stale", HubPID: dead}); err != nil {
+		t.Fatalf("Write stale: %v", err)
+	}
+
+	// Actionable orphan: live pid + cwd exists but marker is missing.
+	orphanCwd := t.TempDir() // exists, no .bones/agent.id marker
+	if err := Write(Entry{
+		Cwd: orphanCwd, Name: "orphan", HubPID: os.Getpid(),
+		HubURL: "http://127.0.0.1:1",
+	}); err != nil {
+		t.Fatalf("Write orphan: %v", err)
+	}
+
+	got, err := Orphans()
+	if err != nil {
+		t.Fatalf("Orphans: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("Orphans len = %d, want 1 (actionable only). got = %+v", len(got), got)
+	}
+	if got[0].Name != "orphan" {
+		t.Errorf("Orphans()[0].Name = %q, want %q", got[0].Name, "orphan")
+	}
+	// Stale file should have been pruned by the read-path scan.
+	if _, err := os.Stat(EntryPath(stale, dead)); !os.IsNotExist(err) {
+		t.Errorf("stale file should be removed; stat err = %v", err)
+	}
+}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -95,6 +95,11 @@ var ErrNotFound = errors.New("registry: entry not found")
 // entries exist (the duplicate-hub case), the alive one with the
 // latest StartedAt wins; if none are alive, the latest StartedAt is
 // returned. Use Duplicates(cwd) when the caller wants every entry.
+//
+// Self-prunes the cwd-scoped entries on read (#229): any matched file
+// whose HubPID is dead OR whose Cwd no longer exists is removed
+// before the survivors compete for "best." Returns ErrNotFound when
+// every entry was crud (or none existed to start).
 func Read(cwd string) (Entry, error) {
 	matches, err := matchingPaths(cwd)
 	if err != nil {
@@ -108,6 +113,10 @@ func Read(cwd string) (Entry, error) {
 	for _, p := range matches {
 		e, err := readEntryAtPath(p)
 		if err != nil {
+			continue
+		}
+		if isStaleEntry(e) {
+			_ = os.Remove(p)
 			continue
 		}
 		if !bestSet ||
@@ -141,25 +150,18 @@ func readEntryAtPath(path string) (Entry, error) {
 // List returns all registry entries, skipping corrupt files. Includes
 // every per-pid entry so two concurrent hubs against one workspace
 // surface as two list rows (caller decides whether to dedupe).
+//
+// Self-prunes stale entries on read (#229): any entry whose HubPID is
+// not alive on this host OR whose Cwd no longer exists is deleted from
+// disk before the surviving set is returned. ADR 0043 promises the
+// registry "prunes on read"; pre-#229 only the in-memory filter
+// honored that — the on-disk files accumulated indefinitely.
 func List() ([]Entry, error) {
-	matches, err := filepath.Glob(filepath.Join(RegistryDir(), "*.json"))
+	_, entries, err := pruneStale()
 	if err != nil {
 		return nil, fmt.Errorf("registry glob: %w", err)
 	}
-	out := make([]Entry, 0, len(matches))
-	for _, path := range matches {
-		// Skip atomic-write tmp files; only top-level *.json files are
-		// real entries (matches the ListInfo skip).
-		if strings.Contains(filepath.Base(path), ".tmp.") {
-			continue
-		}
-		e, err := readEntryAtPath(path)
-		if err != nil {
-			continue
-		}
-		out = append(out, e)
-	}
-	return out, nil
+	return entries, nil
 }
 
 // Remove deletes ALL registry entries for the given workspace cwd —

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -90,8 +90,13 @@ func TestWrite(t *testing.T) {
 func TestRead(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("HOME", dir)
+	// Use a real (existing) cwd and a live pid so the read-time
+	// self-prune (#229) doesn't drop our entry on the floor. Pre-#229
+	// this test passed with cwd=/x and pid=1; that combo now reads as
+	// stale registry crud and is pruned by Read().
+	cwd := t.TempDir()
 	want := Entry{
-		Cwd: "/x", Name: "x", HubURL: "u", HubPID: 1,
+		Cwd: cwd, Name: "x", HubURL: "u", HubPID: os.Getpid(),
 		StartedAt: time.Now().UTC().Truncate(time.Second),
 	}
 	if err := Write(want); err != nil {
@@ -112,9 +117,15 @@ func TestRead(t *testing.T) {
 func TestList(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("HOME", dir)
+	// Real cwds + live pid so List's self-prune (#229) leaves these
+	// entries in place. Pre-#229 this test got away with placeholder
+	// cwds (/a, /b) because List didn't check existence on read.
+	cwdA := t.TempDir()
+	cwdB := t.TempDir()
+	now := time.Now().UTC().Truncate(time.Second)
 	entries := []Entry{
-		{Cwd: "/a", Name: "a", HubPID: 1, StartedAt: time.Now().UTC().Truncate(time.Second)},
-		{Cwd: "/b", Name: "b", HubPID: 2, StartedAt: time.Now().UTC().Truncate(time.Second)},
+		{Cwd: cwdA, Name: "a", HubPID: os.Getpid(), StartedAt: now},
+		{Cwd: cwdB, Name: "b", HubPID: os.Getpid(), StartedAt: now},
 	}
 	for _, e := range entries {
 		if err := Write(e); err != nil {


### PR DESCRIPTION
## Summary

- The orphan-hub registry under `~/.bones/workspaces/` never deleted stale entries: `pidAlive()` and `IsOrphan()` filtered in memory but the on-disk `<id>-<pid>.json` files persisted indefinitely. Spy evidence: `bones doctor` surfaced the same `WARN orphan hub` lines for 5+ hours after the operator killed the process and `rm -rf`'d the cwd.
- Adds `pruneStale()` to the registry package and wires it into `List`, `ListInfo`, and `Read`. Any entry whose `HubPID` is dead OR whose `Cwd` no longer exists is removed from disk on the way out, then the survivors are returned. Matches ADR 0043's "registry prunes on read" contract that pre-fix only the in-memory filter honored.
- Doctor's orphan report now surfaces only **actionable** orphans (live PID + workspace marker missing or trashed cwd). Silent-crud cases (dead pid, vanished cwd) get pruned without the operator running `bones hub reap`.

## Test plan

- [x] `make check` (fmt, vet, lint, race, todo-check) — green
- [x] `go test -tags=otel -short ./...` — green (matches CI)
- [x] New `internal/registry/prune_test.go` covers: dead-pid → pruned, missing-cwd → pruned, live entry → kept, mixed registry → only live survives, `Orphans()` surfaces only actionable
- [x] Existing seed paths that used `HubPID=-1/-2` or placeholder cwds (`/x`, `/Users/dan/foo`) updated to `os.Getpid()` + `t.TempDir()`; pre-fix they passed because reads didn't check liveness, post-fix they'd be pruned mid-test
- [x] `IsOrphan` doc updated to note the cwd-doesn't-exist branch is dead code post-prune; left in defensively
- [x] `cli/doctor.go` `checkOrphanHubs` doc updated to note the report is "actionable orphans only" since #229

Closes #229