### PR TITLE
feat(apply): --slot=<name> --to=<dir> materializes slot artifacts

### DIFF
--- a/cli/apply.go
+++ b/cli/apply.go
@@ -18,19 +18,32 @@ import (
 	"github.com/danmestas/bones/internal/workspace"
 )
 
-// ApplyCmd materializes the hub fossil's trunk tip into the
-// project-root git working tree and stages the changes for the user
-// to review and commit. See
-// docs/superpowers/specs/2026-04-30-bones-apply-design.md.
+// ApplyCmd materializes fossil-resident work into a target directory.
+// Two modes share the same verb (issue #234, ADR 0037):
 //
-// bones apply never runs `git commit`. It writes files and stages with
+//  1. Default (trunk fan-in): with no flags, reads the hub fossil's
+//     trunk tip and stages the changes into the project-root git
+//     working tree for the user to review and commit. See
+//     docs/superpowers/specs/2026-04-30-bones-apply-design.md.
+//  2. Slot mode (--slot=<name> --to=<dir>): copies the slot's most
+//     recent committed-artifacts tree from `.bones/recovery/<slot>-*`
+//     into <dir>. The timestamped path scheme is hidden — the
+//     operator passes only the slot name. (#234)
+//
+// bones apply never runs `git commit`. In trunk mode it stages with
 // `git add -A` within fossil's tracked-paths set; the user owns the
-// commit message and the commit author identity.
+// commit message and the commit author identity. In slot mode it
+// writes files and stops — the operator decides what to do next.
 type ApplyCmd struct {
-	DryRun bool `name:"dry-run" help:"show planned changes without writing or staging"`
+	DryRun bool   `name:"dry-run" help:"show planned changes without writing or staging"`
+	Slot   string `name:"slot" help:"materialize this slot's committed artifacts; requires --to"`
+	To     string `name:"to" help:"target directory for --slot mode; created if missing"`
 }
 
 func (c *ApplyCmd) Run(g *repocli.Globals) (err error) {
+	if c.Slot != "" || c.To != "" {
+		return c.runSlotMode()
+	}
 	outcome := &applyOutcome{DryRun: c.DryRun}
 	_, end := telemetry.RecordCommand(context.Background(), "apply",
 		telemetry.Bool("dry_run", c.DryRun),
@@ -51,6 +64,142 @@ func (c *ApplyCmd) Run(g *repocli.Globals) (err error) {
 	}
 	defer cleanup()
 	return c.applyFromCheckout(pre, tempDir, outcome)
+}
+
+// runSlotMode handles `bones apply --slot=<name> --to=<dir>`. It
+// resolves the slot's most-recent recovery dir under
+// `.bones/recovery/<slot>-*`, copies its contents structure-preserving
+// into <dir>, and creates <dir> if missing. The timestamped path
+// scheme is intentionally hidden — operators pass only the slot name.
+//
+// Per #234, this verb exists so orchestrators don't have to grep
+// `.bones/recovery/` to retrieve committed slot work after
+// `bones swarm close`.
+func (c *ApplyCmd) runSlotMode() (err error) {
+	_, end := telemetry.RecordCommand(context.Background(), "apply",
+		telemetry.String("mode", "slot"),
+		telemetry.String("slot", c.Slot),
+	)
+	defer func() { end(err) }()
+
+	if c.Slot == "" {
+		return errors.New(
+			"bones apply: --to=<dir> requires --slot=<name>")
+	}
+	if c.To == "" {
+		return errors.New(
+			"bones apply: --slot requires --to=<dir> to materialize")
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("cwd: %w", err)
+	}
+	root, err := workspace.FindRoot(cwd)
+	if err != nil {
+		return fmt.Errorf(
+			"bones apply: workspace not found — run `bones init` or `bones up` first (%w)",
+			err)
+	}
+	srcDir, err := latestSlotRecoveryDir(root, c.Slot)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(c.To, 0o755); err != nil {
+		return fmt.Errorf("mkdir target: %w", err)
+	}
+	if err := copyRecoveryTree(srcDir, c.To); err != nil {
+		return fmt.Errorf("copy recovery tree: %w", err)
+	}
+	fmt.Fprintf(os.Stderr,
+		"bones apply: materialized slot %q → %s\n", c.Slot, c.To)
+	return nil
+}
+
+// latestSlotRecoveryDir scans `.bones/recovery/` for entries matching
+// `<slot>-<unix-ts>` and returns the absolute path of the
+// most-recent-by-mtime. Returns the documented "no committed
+// artifacts" error when none exist.
+//
+// The mtime tiebreaker (rather than parsing the unix-ts suffix) is
+// deliberate: it survives clock skew between the writer and reader,
+// and matches what `ls -t` would do for a human inspecting by hand.
+func latestSlotRecoveryDir(workspaceDir, slot string) (string, error) {
+	recoveryRoot := filepath.Join(workspaceDir, ".bones", "recovery")
+	entries, err := os.ReadDir(recoveryRoot)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", fmt.Errorf(
+				"slot %s has no committed artifacts (recovery dir missing)",
+				slot)
+		}
+		return "", fmt.Errorf("read recovery: %w", err)
+	}
+	prefix := slot + "-"
+	var best string
+	var bestMtime time.Time
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		if !strings.HasPrefix(e.Name(), prefix) {
+			continue
+		}
+		full := filepath.Join(recoveryRoot, e.Name())
+		info, err := os.Stat(full)
+		if err != nil {
+			continue
+		}
+		if best == "" || info.ModTime().After(bestMtime) {
+			best = full
+			bestMtime = info.ModTime()
+		}
+	}
+	if best == "" {
+		return "", fmt.Errorf(
+			"slot %s has no committed artifacts (recovery dir missing)",
+			slot)
+	}
+	return best, nil
+}
+
+// copyRecoveryTree mirrors src into dst, creating subdirectories and
+// copying regular files. Existing files in dst are overwritten — the
+// spec says "operator's responsibility." Symlinks and other
+// non-regular entries are skipped, matching the (intentionally
+// conservative) recovery-write policy in
+// internal/swarm/lease.go::copyTree.
+func copyRecoveryTree(src, dst string) error {
+	return filepath.WalkDir(src, func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		if rel == "." {
+			return nil
+		}
+		target := filepath.Join(dst, rel)
+		if d.IsDir() {
+			return os.MkdirAll(target, 0o755)
+		}
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		if !info.Mode().IsRegular() {
+			return nil
+		}
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			return err
+		}
+		data, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		return os.WriteFile(target, data, info.Mode().Perm())
+	})
 }
 
 // applyOutcome carries the post-hoc attributes the telemetry span needs,

--- a/cli/apply_slot_test.go
+++ b/cli/apply_slot_test.go
@@ -1,0 +1,208 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	libfossilcli "github.com/danmestas/libfossil/cli"
+)
+
+// TestApplySlot_MaterializesLatestRecovery verifies that
+// `bones apply --slot=<name> --to=<dir>` copies the latest recovery
+// dir's contents into <dir>, preserving the relative path layout but
+// hiding the timestamped scheme from the operator.
+func TestApplySlot_MaterializesLatestRecovery(t *testing.T) {
+	dir := buildSlotRecoveryFixture(t, "alpha", map[string]string{
+		"research/alpha/findings.md": "alpha findings\n",
+		"research/alpha/SUMMARY.md":  "alpha summary\n",
+	}, time.Now())
+
+	target := filepath.Join(dir, "out")
+	cmd := &ApplyCmd{Slot: "alpha", To: target}
+	if err := cmd.Run(&libfossilcli.Globals{}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	for rel, want := range map[string]string{
+		"research/alpha/findings.md": "alpha findings\n",
+		"research/alpha/SUMMARY.md":  "alpha summary\n",
+	} {
+		got, err := os.ReadFile(filepath.Join(target, rel))
+		if err != nil {
+			t.Errorf("read %s: %v", rel, err)
+			continue
+		}
+		if string(got) != want {
+			t.Errorf("%s = %q, want %q", rel, got, want)
+		}
+	}
+}
+
+// TestApplySlot_NoRecoveryDir verifies the documented error when no
+// recovery dir exists for the slot.
+func TestApplySlot_NoRecoveryDir(t *testing.T) {
+	dir := t.TempDir()
+	must(t, os.MkdirAll(filepath.Join(dir, ".bones"), 0o755))
+	must(t, os.WriteFile(filepath.Join(dir, ".bones", "agent.id"),
+		[]byte("slot-test-agent\n"), 0o644))
+
+	t.Chdir(dir)
+	cmd := &ApplyCmd{Slot: "ghost", To: filepath.Join(dir, "out")}
+	err := cmd.Run(&libfossilcli.Globals{})
+	if err == nil ||
+		!strings.Contains(err.Error(), "slot ghost has no committed artifacts") {
+		t.Fatalf("expected 'no committed artifacts' error, got %v", err)
+	}
+}
+
+// TestApplySlot_PicksMostRecentByMtime verifies the multi-recovery
+// tiebreaker: when several recovery dirs exist for the same slot
+// (multiple sessions), pick the most-recent-by-mtime.
+func TestApplySlot_PicksMostRecentByMtime(t *testing.T) {
+	now := time.Now()
+	dir := t.TempDir()
+	must(t, os.MkdirAll(filepath.Join(dir, ".bones"), 0o755))
+	must(t, os.WriteFile(filepath.Join(dir, ".bones", "agent.id"),
+		[]byte("slot-test-agent\n"), 0o644))
+
+	older := filepath.Join(dir, ".bones", "recovery", "beta-100")
+	newer := filepath.Join(dir, ".bones", "recovery", "beta-200")
+	must(t, os.MkdirAll(older, 0o755))
+	must(t, os.MkdirAll(newer, 0o755))
+	must(t, os.WriteFile(filepath.Join(older, "marker.txt"),
+		[]byte("OLD\n"), 0o644))
+	must(t, os.WriteFile(filepath.Join(newer, "marker.txt"),
+		[]byte("NEW\n"), 0o644))
+	// Force older's mtime to be in the past so the tie-breaker is
+	// unambiguous (mkdir order is not enough on filesystems with
+	// coarse mtime resolution).
+	past := now.Add(-2 * time.Hour)
+	must(t, os.Chtimes(older, past, past))
+	future := now.Add(1 * time.Hour)
+	must(t, os.Chtimes(newer, future, future))
+
+	t.Chdir(dir)
+	target := filepath.Join(dir, "out")
+	cmd := &ApplyCmd{Slot: "beta", To: target}
+	if err := cmd.Run(&libfossilcli.Globals{}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(target, "marker.txt"))
+	if err != nil {
+		t.Fatalf("read marker: %v", err)
+	}
+	if strings.TrimSpace(string(got)) != "NEW" {
+		t.Errorf("marker = %q, want NEW (newer recovery dir)", got)
+	}
+}
+
+// TestApplySlot_WithoutToFlagErrors verifies that --slot without --to
+// is a usage error.
+func TestApplySlot_WithoutToFlagErrors(t *testing.T) {
+	dir := t.TempDir()
+	must(t, os.MkdirAll(filepath.Join(dir, ".bones"), 0o755))
+	must(t, os.WriteFile(filepath.Join(dir, ".bones", "agent.id"),
+		[]byte("slot-test-agent\n"), 0o644))
+
+	t.Chdir(dir)
+	cmd := &ApplyCmd{Slot: "alpha"}
+	err := cmd.Run(&libfossilcli.Globals{})
+	if err == nil || !strings.Contains(err.Error(), "--to=<dir>") {
+		t.Fatalf("expected '--to=<dir>' usage error, got %v", err)
+	}
+}
+
+// TestApplySlot_OverwritesExistingFiles verifies that pre-existing
+// files in the target dir get overwritten silently — operator's
+// responsibility, per spec.
+func TestApplySlot_OverwritesExistingFiles(t *testing.T) {
+	dir := buildSlotRecoveryFixture(t, "gamma", map[string]string{
+		"a.txt": "from-recovery\n",
+	}, time.Now())
+
+	target := filepath.Join(dir, "out")
+	must(t, os.MkdirAll(target, 0o755))
+	must(t, os.WriteFile(filepath.Join(target, "a.txt"),
+		[]byte("stale-content\n"), 0o644))
+
+	cmd := &ApplyCmd{Slot: "gamma", To: target}
+	if err := cmd.Run(&libfossilcli.Globals{}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(target, "a.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "from-recovery\n" {
+		t.Errorf("a.txt = %q, want overwritten with recovery content", got)
+	}
+}
+
+// TestApplySlot_CreatesTargetDir verifies the target dir is created
+// if it doesn't already exist.
+func TestApplySlot_CreatesTargetDir(t *testing.T) {
+	dir := buildSlotRecoveryFixture(t, "delta", map[string]string{
+		"x.md": "x\n",
+	}, time.Now())
+
+	target := filepath.Join(dir, "nested", "deeper", "out")
+	cmd := &ApplyCmd{Slot: "delta", To: target}
+	if err := cmd.Run(&libfossilcli.Globals{}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(target, "x.md")); err != nil {
+		t.Errorf("target dir not created or file missing: %v", err)
+	}
+}
+
+// buildSlotRecoveryFixture creates a minimal bones workspace with one
+// recovery dir for `slot` populated with `files` (rel-path → content).
+// `now` controls the recovery dir's timestamp suffix and is also used
+// to force consistent mtimes for tiebreaker tests. Chdirs to the
+// workspace dir.
+func buildSlotRecoveryFixture(
+	t *testing.T, slot string, files map[string]string, now time.Time,
+) string {
+	t.Helper()
+	dir := t.TempDir()
+	must(t, os.MkdirAll(filepath.Join(dir, ".bones"), 0o755))
+	must(t, os.WriteFile(filepath.Join(dir, ".bones", "agent.id"),
+		[]byte("slot-test-agent\n"), 0o644))
+
+	recoveryName := slot + "-" + itoa(now.Unix())
+	recoveryDir := filepath.Join(dir, ".bones", "recovery", recoveryName)
+	must(t, os.MkdirAll(recoveryDir, 0o755))
+	for rel, content := range files {
+		full := filepath.Join(recoveryDir, rel)
+		must(t, os.MkdirAll(filepath.Dir(full), 0o755))
+		must(t, os.WriteFile(full, []byte(content), 0o644))
+	}
+	t.Chdir(dir)
+	return dir
+}
+
+// itoa is a tiny stdlib-free int64→string helper to keep the fixture
+// helper free of strconv churn.
+func itoa(n int64) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
+}

--- a/cli/templates/orchestrator/AGENTS.md
+++ b/cli/templates/orchestrator/AGENTS.md
@@ -116,6 +116,8 @@ When all Phase 1 subagents return DONE, **dispatch one more subagent** to wire t
 3. Print a summary: slots completed, tasks per slot, integration commits, peek URL.
 4. Tell the user: "Swarm complete. Browse the timeline with `bones peek`, review changes with `git diff`, stage with `git add`, then `git commit`."
 
+Use `bones apply --slot=<X> --to=<dir>` to materialize committed slot work outside the trunk fan-in path.
+
 The hub stays running across the session — your harness's session-end hook (or manual `bones hub stop`) tears it down.
 
 ## Subagent workflow

--- a/internal/swarm/lease.go
+++ b/internal/swarm/lease.go
@@ -695,6 +695,12 @@ func (l *ResumedLease) Close(ctx context.Context, opts CloseOpts) error {
 			fmt.Fprintf(os.Stderr,
 				"swarm.ResumedLease.Close: preserved %d file(s) at %s (#156)\n",
 				count, path)
+			// Discoverability hint (#234): point operators at the
+			// `bones apply --slot --to` verb so they don't have to
+			// grep `.bones/recovery/` to retrieve committed slot work.
+			fmt.Fprintf(os.Stderr,
+				"artifacts available via: bones apply --slot=%s --to=<dir>\n",
+				l.slot)
 		}
 		// Best-effort idempotent removal: missing wt is fine. A
 		// permission-style error would propagate via os.RemoveAll's


### PR DESCRIPTION
## Summary

Extends `bones apply` with `--slot=<name> --to=<dir>` so operators can
extract committed slot work without grepping `.bones/recovery/`.
Reuses the existing verb's design space (deep module per Ousterhout
and ADR 0037) — `bones apply` is already "materialize fossil-resident
work into a target," and slot extraction is just another point in
that space. No new verbs, no new persistence surface.

- Resolves the latest `.bones/recovery/<slot>-*` dir by mtime
  (tiebreaker survives clock skew between writer/reader and matches
  what `ls -t` would do).
- Copies the tree structure-preserving into `<dir>`; creates `<dir>`
  if missing; overwrites pre-existing files silently per spec.
- The timestamped path scheme stays hidden — operators pass only
  the slot name.
- Existing trunk fan-in path is untouched when neither flag is set.

Discoverability hooks land alongside:

- `bones swarm close` appends a one-line hint
  `artifacts available via: bones apply --slot=<name> --to=<dir>`
  after the existing "preserved N file(s)" notice (only when files
  were actually preserved — no noise on empty closes).
- `cli/templates/orchestrator/AGENTS.md` gets a one-sentence pointer
  in Step 7 / completion.

## Test plan

- [x] New tests in `cli/apply_slot_test.go` cover: latest-recovery
  copy, missing-recovery error, mtime tiebreaker across multiple
  recovery dirs, `--slot` without `--to` usage error, target-dir
  creation, and silent overwrite of existing files.
- [x] `make check` passes (fmt-check, vet, lint, race, todo-check).
- [x] `go test -tags=otel -short ./...` passes.
- [x] Existing apply / swarm-close tests unchanged and green.

Closes #234