### PR TITLE
fix(status): drop "%d leaves open" from header — substrate leak

### DIFF
--- a/cli/status.go
+++ b/cli/status.go
@@ -53,7 +53,6 @@ type statusReport struct {
 	// than failing the whole command.
 	HubAvailable bool
 	HubRepoPath  string
-	OpenLeaves   []string
 	TrunkHead    string // short hash, blank when no commits yet
 
 	Sessions []swarm.Session
@@ -222,7 +221,6 @@ func gatherStatus(ctx context.Context, info workspace.Info) (statusReport, error
 		rep.HubAvailable = true
 		rep.HubRepoPath = hubRepo
 		leaves, _ := openLeavesOnTrunk(fossilBin, hubRepo)
-		rep.OpenLeaves = leaves
 		if len(leaves) > 0 {
 			rep.TrunkHead = shortHash(leaves[0])
 		}
@@ -318,10 +316,13 @@ func splitTimeAndRest(line string) (time.Time, string, bool) {
 }
 
 func renderStatus(rep statusReport, w io.Writer) error {
-	header := fmt.Sprintf("bones · workspace: %s · trunk: %s · %d leaves open · as of %s\n\n",
+	// Per #259: don't surface "leaves open" — it's a NATS-substrate
+	// concept (a "leaf" here is a hub instance), and operators only
+	// need to see swarm-session counts (rendered in the body table
+	// via renderSlotTable). Header stays in operator vocabulary.
+	header := fmt.Sprintf("bones · workspace: %s · trunk: %s · as of %s\n\n",
 		filepath.Base(rep.WorkspaceDir),
 		hubField(rep.TrunkHead, rep.HubAvailable),
-		len(rep.OpenLeaves),
 		rep.GeneratedAt.Format("15:04:05"),
 	)
 	if _, err := io.WriteString(w, header); err != nil {

--- a/cli/status_test.go
+++ b/cli/status_test.go
@@ -81,7 +81,6 @@ func TestRenderStatus_WithSessionsAndTasks(t *testing.T) {
 		GeneratedAt:  now,
 		HubAvailable: true,
 		TrunkHead:    "002e31b7",
-		OpenLeaves:   []string{"002e31b7aa", "55a80c53ec"},
 		Sessions: []swarm.Session{
 			{
 				Slot:        "ui",
@@ -125,7 +124,7 @@ func TestRenderStatus_WithSessionsAndTasks(t *testing.T) {
 	out := buf.String()
 
 	for _, want := range []string{
-		"trunk: 002e31b7", "2 leaves open",
+		"trunk: 002e31b7",
 		"SLOT", "TASK", "STATE", "LAST",
 		"ui", "3a4b1c2d", "claimed", "2m ago",
 		"backend", "—", "19m ago",


### PR DESCRIPTION
## Summary

- Drop `· %d leaves open` from the status header. "Leaves" here is the NATS-substrate concept (a "leaf" = a hub instance), overloaded with EdgeSync's worker-session "leaf" the body already shows.
- Operator vocabulary only in the header. Swarm-session count is already rendered in the body via `renderSlotTable`.
- Drop `OpenLeaves []string` from `statusReport` — no longer read by anything. `openLeavesOnTrunk` is still called for `TrunkHead` derivation; just don't store its slice on the struct.

New header reads: `bones · workspace: gonvex · trunk: e3e4a9b8 · as of 14:05:02`

Closes #259

## Test plan

- [x] `make check` — fmt-check, vet, lint, race, todo-check all pass
- [x] `go test -tags=otel -short ./cli/...` passes
- [x] `TestRenderStatus_WithSessionsAndTasks` updated: drops `"2 leaves open"` from `wants` and `OpenLeaves` from the fixture.

## Notes

- Vocabulary policy per the issue: bones never surfaces "NATS leaf" or "EdgeSync leaf" to operators — internally they're substrate concepts; externally the operator only knows "hub" and "swarm session". This was a P2 substrate leak in the most-visible operator surface.
- Companion substrate-rename work (#246, #254, #255) touches `internal/hub/hub.go` and is intentionally bundled separately.
