### PR TITLE
fix(hub): consolidate to single .bones/hub.pid

### DIFF
--- a/cli/doctor.go
+++ b/cli/doctor.go
@@ -547,7 +547,7 @@ func short(h string) string {
 // Per #228, this resolves the workspace via workspace.FindRoot
 // (read-only) and probes hub liveness with workspace.HubIsHealthy
 // rather than going through workspace.Join. Join lazy-starts the hub
-// (writes .bones/pids/, hub-fossil-url, hub-nats-url) on every doctor
+// (writes .bones/hub.pid, hub-fossil-url, hub-nats-url) on every doctor
 // invocation, which violates the read-only contract of doctor and
 // contradicts the lazy-hub promise printed by `bones up`. When no
 // healthy hub is available, this short-circuits with a single INFO

--- a/cli/doctor_test.go
+++ b/cli/doctor_test.go
@@ -183,7 +183,7 @@ func TestDoctorCmdAllPathInvokesRender(t *testing.T) {
 // TestRunSwarmReport_DoesNotAutoStartHub pins #228: when no hub is
 // running, runSwarmReport must NOT route through workspace.Join (which
 // lazy-starts the hub) — that violates doctor's read-only contract and
-// silently writes .bones/pids/ + URL files on every doctor invocation.
+// silently writes .bones/hub.pid + URL files on every doctor invocation.
 //
 // Mirrors TestResolveStatusRoot_DoesNotAutoStartHub from #207. After
 // the fix, runSwarmReport resolves the workspace via workspace.FindRoot
@@ -223,8 +223,8 @@ func TestRunSwarmReport_DoesNotAutoStartHub(t *testing.T) {
 			t.Errorf("runSwarmReport created %s; #228 says it must not write hub state", path)
 		}
 	}
-	if _, err := os.Stat(filepath.Join(root, ".bones", "pids")); err == nil {
-		t.Errorf("runSwarmReport created .bones/pids/; #228 says it must not write hub state")
+	if _, err := os.Stat(filepath.Join(root, ".bones", "hub.pid")); err == nil {
+		t.Errorf("runSwarmReport created .bones/hub.pid; #228 says it must not write hub state")
 	}
 }
 

--- a/cli/down.go
+++ b/cli/down.go
@@ -339,7 +339,7 @@ func planStopHub(root string, c *DownCmd) []downAction {
 	// (no-op when hub isn't running), so unconditional inclusion is
 	// both correct and self-documenting in the dry-run output.
 	return []downAction{{
-		description: "stop hub (.bones/pids/{fossil,nats}.pid)",
+		description: "stop hub (.bones/hub.pid)",
 		do: func() error {
 			// Best-effort: an already-stopped hub must not fail down.
 			// WithForce so the active-slot guard (#157) doesn't block

--- a/cli/status.go
+++ b/cli/status.go
@@ -111,7 +111,7 @@ func (c *StatusCmd) Run(g *repocli.Globals) error {
 	// the existing degraded-mode branch (HubAvailable=false) without
 	// touching workspace.Join — Join would lazy-start the hub via
 	// hubStartFunc, contradicting the lazy-hub promise printed by
-	// `bones up` and silently writing .bones/pids/ + URL files on
+	// `bones up` and silently writing .bones/hub.pid + URL files on
 	// every `bones status` invocation.
 	if !workspace.HubIsHealthy(root) {
 		return renderStatus(degradedStatusReport(root), os.Stdout)

--- a/cli/status_test.go
+++ b/cli/status_test.go
@@ -296,10 +296,10 @@ func TestResolveStatusRoot_DoesNotAutoStartHub(t *testing.T) {
 			t.Errorf("stat %s: unexpected error: %v", path, err)
 		}
 	}
-	// pids dir is hub.Start's first side effect; presence indicates
+	// hub.pid is hub.Start's first side effect; presence indicates
 	// the auto-start branch ran.
-	if _, err := os.Stat(filepath.Join(root, ".bones", "pids")); err == nil {
-		t.Errorf("resolveStatusRoot created .bones/pids/; hub auto-start ran (#207)")
+	if _, err := os.Stat(filepath.Join(root, ".bones", "hub.pid")); err == nil {
+		t.Errorf("resolveStatusRoot created .bones/hub.pid; hub auto-start ran (#207)")
 	}
 }
 
@@ -358,8 +358,8 @@ func TestStatusRun_NoHub_DoesNotStartOne(t *testing.T) {
 			t.Errorf("status created %s; #207 says it must not write hub state", path)
 		}
 	}
-	if _, err := os.Stat(filepath.Join(root, ".bones", "pids")); err == nil {
-		t.Errorf("status created .bones/pids/; #207 says it must not write hub state")
+	if _, err := os.Stat(filepath.Join(root, ".bones", "hub.pid")); err == nil {
+		t.Errorf("status created .bones/hub.pid; #207 says it must not write hub state")
 	}
 }
 

--- a/cli/tasks_status.go
+++ b/cli/tasks_status.go
@@ -31,10 +31,10 @@ func (c *TasksStatusCmd) Run(g *repocli.Globals) error {
 	}
 	defer stop()
 
-	// Hub liveness: read the fossil-server PID. workspace.Join already
+	// Hub liveness: read the hub PID. workspace.Join already
 	// guarantees the hub is up by this point (auto-start fired if not),
 	// so a read failure here is unexpected and worth surfacing.
-	pidPath := filepath.Join(info.WorkspaceDir, ".bones", "pids", "fossil.pid")
+	pidPath := filepath.Join(info.WorkspaceDir, ".bones", "hub.pid")
 	pidStr, err := os.ReadFile(pidPath)
 	if err != nil {
 		fmt.Fprintln(os.Stderr,

--- a/cli/templates/orchestrator/AGENTS.md
+++ b/cli/templates/orchestrator/AGENTS.md
@@ -73,8 +73,7 @@ Non-zero exit → print violations and stop. The validator's slot-dir derivation
 The `SessionStart` hook should have started it. Sanity-check:
 
 ```
-test -f .bones/pids/fossil.pid && \
-  test -f .bones/pids/nats.pid && \
+test -f .bones/hub.pid && \
   curl -fsS -X POST "$(cat .bones/hub-fossil-url)/xfer" >/dev/null
 ```
 

--- a/cli/up_test.go
+++ b/cli/up_test.go
@@ -37,7 +37,7 @@ func TestPrintHubStatus_FreshScaffold(t *testing.T) {
 func TestPrintHubStatus_HubRunning(t *testing.T) {
 	root := t.TempDir()
 	bones := filepath.Join(root, ".bones")
-	if err := os.MkdirAll(filepath.Join(bones, "pids"), 0o755); err != nil {
+	if err := os.MkdirAll(bones, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(bones, "hub-fossil-url"),
@@ -49,11 +49,9 @@ func TestPrintHubStatus_HubRunning(t *testing.T) {
 		t.Fatal(err)
 	}
 	live := strconv.Itoa(os.Getpid())
-	for _, name := range []string{"fossil.pid", "nats.pid"} {
-		if err := os.WriteFile(filepath.Join(bones, "pids", name),
-			[]byte(live+"\n"), 0o644); err != nil {
-			t.Fatal(err)
-		}
+	if err := os.WriteFile(filepath.Join(bones, "hub.pid"),
+		[]byte(live+"\n"), 0o644); err != nil {
+		t.Fatal(err)
 	}
 
 	var buf bytes.Buffer
@@ -81,7 +79,7 @@ func TestPrintHubStatus_HubRunning(t *testing.T) {
 func TestPrintHubStatus_StaleURLs(t *testing.T) {
 	root := t.TempDir()
 	bones := filepath.Join(root, ".bones")
-	if err := os.MkdirAll(filepath.Join(bones, "pids"), 0o755); err != nil {
+	if err := os.MkdirAll(bones, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(bones, "hub-fossil-url"),
@@ -93,11 +91,9 @@ func TestPrintHubStatus_StaleURLs(t *testing.T) {
 		t.Fatal(err)
 	}
 	// 999999 is a high pid that will not be in use on a normal host.
-	for _, name := range []string{"fossil.pid", "nats.pid"} {
-		if err := os.WriteFile(filepath.Join(bones, "pids", name),
-			[]byte("999999\n"), 0o644); err != nil {
-			t.Fatal(err)
-		}
+	if err := os.WriteFile(filepath.Join(bones, "hub.pid"),
+		[]byte("999999\n"), 0o644); err != nil {
+		t.Fatal(err)
 	}
 
 	var buf bytes.Buffer

--- a/docs/site/content/docs/reference/skills.md
+++ b/docs/site/content/docs/reference/skills.md
@@ -14,7 +14,7 @@ Skills are auto-discovered by the harness when it scans the workspace's `.claude
 Triggered when the user invokes a slot-annotated plan or asks to "run plan in parallel" / "orchestrate this plan" / "dispatch agents from plan". The skill drives a four-step flow:
 
 1. **Validate** — `bones validate-plan <plan-path>`. Stops on non-zero exit and surfaces the violations.
-2. **Verify hub** — checks `.bones/pids/{fossil,nats}.pid` and the hub's `/xfer` endpoint; runs `bones hub start` if anything's missing (the verb is idempotent).
+2. **Verify hub** — checks `.bones/hub.pid` and the hub's `/xfer` endpoint; runs `bones hub start` if anything's missing (the verb is idempotent).
 3. **Extract slots** — `bones validate-plan --list-slots <plan-path>` emits a JSON slot→tasks mapping; the orchestrator uses it to build dispatch prompts without re-parsing the plan.
 4. **Dispatch** — invokes the Task tool once per slot, passing the slot's task list and environment values (`AGENT_ID`, `SLOT_ID`, `HUB_URL`, `NATS_URL`, `WORKDIR`) inline.
 

--- a/internal/hub/hub.go
+++ b/internal/hub/hub.go
@@ -80,18 +80,18 @@ var errDrainTimeout = errors.New("hub: drain timeout exceeded")
 // .bones/hub.fossil seeded from git-tracked files, a Fossil HTTP
 // server on the chosen port, and an embedded NATS JetStream server.
 //
-// Idempotent: if both pid files exist and the recorded processes are
-// alive, Start returns nil immediately.
+// Idempotent: if hub.pid exists and the recorded process is alive,
+// Start returns nil immediately.
 //
 // With WithDetach(true) the calling process fork-execs itself in
 // "foreground" mode, waits for both servers to become reachable, and
-// returns. The child outlives the caller and owns the servers; pid
-// files reference the child. This is what `bones hub start --detach`
+// returns. The child outlives the caller and owns the servers;
+// hub.pid references the child. This is what `bones hub start --detach`
 // uses so a shell can fire-and-forget the hub.
 //
 // Without detach, Start blocks on ctx.Done(): the calling process is
-// the hub. Pid files reference the calling process. On cancellation,
-// both servers shut down cleanly and pid files are removed.
+// the hub. hub.pid references the calling process. On cancellation,
+// both servers shut down cleanly and hub.pid is removed.
 func Start(ctx context.Context, root string, options ...Option) (err error) {
 	o := defaults()
 	for _, fn := range options {
@@ -123,15 +123,19 @@ func Start(ctx context.Context, root string, options ...Option) (err error) {
 		defer func() { end(err) }()
 	}
 
-	if err := os.MkdirAll(p.pidDir, 0o755); err != nil {
-		return fmt.Errorf("hub: pids dir: %w", err)
-	}
 	if err := os.MkdirAll(p.logDir, 0o755); err != nil {
 		return fmt.Errorf("hub: logs dir: %w", err)
 	}
 
-	// Idempotency: if both pid files point at live processes, we're done.
-	if pidIsLive(p.fossilPid) && pidIsLive(p.natsPid) {
+	// One-time migration (#254): the legacy .bones/pids/ subdir held
+	// fossil.pid and nats.pid for the same supervisor process. Remove
+	// it on first Start after upgrade so stale pid files don't confuse
+	// any external tooling that still scans the legacy path. Best-
+	// effort: a permission failure here must not block hub start.
+	_ = os.RemoveAll(filepath.Join(p.orchDir, "pids"))
+
+	// Idempotency: if hub.pid points at a live process, we're done.
+	if pidIsLive(p.hubPid) {
 		return nil
 	}
 
@@ -199,34 +203,30 @@ func Start(ctx context.Context, root string, options ...Option) (err error) {
 // shells can detect liveness, and Stop in this same process is
 // equivalent to canceling ctx.
 func runForeground(ctx context.Context, p paths, o opts) error {
-	// Fresh-start detection (ADR 0023): if no fossil PID is alive,
+	// Fresh-start detection (ADR 0023): if hub.pid is not alive,
 	// wipe stale checkout state so each session starts from a clean
 	// substrate. Working-tree files are untouched. SQLite -shm and -wal
 	// sidecars are part of stale state — without removing them, the
 	// next bootstrap hits SQLITE_IOERR_SHORT_READ (522). See #138.
-	if !pidIsLive(p.fossilPid) {
+	if !pidIsLive(p.hubPid) {
 		removeRepoAndSidecars(p)
 	}
 	if err := os.MkdirAll(p.natsStore, 0o755); err != nil {
 		return fmt.Errorf("hub: nats store dir: %w", err)
 	}
-	// Write pid files BEFORE NewHub binds the HTTP listener. edgehub.NewHub
+	// Write hub.pid BEFORE NewHub binds the HTTP listener. edgehub.NewHub
 	// calls net.Listen at construction (the HTTP socket is up before
 	// ServeHTTP runs), and the kernel SYN-ACKs connections to a bound-but-
 	// unaccepted socket — so the detach parent's waitForTCP probe succeeds
-	// the moment NewHub returns. If we wrote pids after NewHub, the
+	// the moment NewHub returns. If we wrote hub.pid after NewHub, the
 	// parent's port-collision check (readPid against cmd.Process.Pid)
 	// would race ahead of the pid write and fire a false-positive
-	// "fossil port responded but pids/fossil.pid does not name our child
-	// (recorded 0)" error on every detach start. Pid files name the
+	// "fossil port responded but hub.pid does not name our child
+	// (recorded 0)" error on every detach start. The pid file names the
 	// foreground process either way (os.Getpid() is stable across the
-	// NewHub call), so writing them first is correct.
-	if err := writePid(p.fossilPid, os.Getpid()); err != nil {
-		return fmt.Errorf("hub: write fossil.pid: %w", err)
-	}
-	if err := writePid(p.natsPid, os.Getpid()); err != nil {
-		_ = os.Remove(p.fossilPid)
-		return fmt.Errorf("hub: write nats.pid: %w", err)
+	// NewHub call), so writing it first is correct.
+	if err := writePid(p.hubPid, os.Getpid()); err != nil {
+		return fmt.Errorf("hub: write hub.pid: %w", err)
 	}
 	freshSeed := false
 	if _, err := os.Stat(p.hubRepo); errors.Is(err, os.ErrNotExist) {
@@ -234,8 +234,7 @@ func runForeground(ctx context.Context, p paths, o opts) error {
 	}
 	h, err := openAndSeedHub(ctx, p, o, freshSeed)
 	if err != nil {
-		_ = os.Remove(p.fossilPid)
-		_ = os.Remove(p.natsPid)
+		_ = os.Remove(p.hubPid)
 		return err
 	}
 	httpDone := make(chan struct{})
@@ -258,8 +257,7 @@ func runForeground(ctx context.Context, p paths, o opts) error {
 	<-ctx.Done()
 	httpCancel()
 	drainErr := drainHub(h, httpDone, o.drainTimeout)
-	_ = os.Remove(p.fossilPid)
-	_ = os.Remove(p.natsPid)
+	_ = os.Remove(p.hubPid)
 	// Drop our own per-pid registry entry (#208 layout) so a clean
 	// hub exit does not leave a stale record for `bones doctor` or
 	// `bones status --all` to filter out via pidAlive. Dead-pid
@@ -419,17 +417,16 @@ func spawnDetachedChild(p paths, o opts) error {
 	// up, then every verb downstream fails mysteriously against the
 	// foreign service.
 	//
-	// Verify the recorded fossil pid matches our child. The child
-	// writes p.fossilPid as part of startFossil, so by the time the
-	// fossil port responds, the file should exist with the child's
-	// pid. Mismatch (or missing) means port collision or a crashed
-	// child that never wrote the file.
-	if recorded, ok := readPid(p.fossilPid); !ok || recorded != cmd.Process.Pid {
+	// Verify the recorded hub pid matches our child. The child writes
+	// p.hubPid before NewHub, so by the time the fossil port responds,
+	// the file should exist with the child's pid. Mismatch (or missing)
+	// means port collision or a crashed child that never wrote the file.
+	if recorded, ok := readPid(p.hubPid); !ok || recorded != cmd.Process.Pid {
 		_ = cmd.Process.Kill()
 		return fmt.Errorf("hub: fossil port %s responded but %s does not "+
 			"name our child (pid %d, recorded %d) — likely port "+
 			"collision; another service is bound to the port%s",
-			fossilAddr, p.fossilPid, cmd.Process.Pid, recorded,
+			fossilAddr, p.hubPid, cmd.Process.Pid, recorded,
 			hubLogTail(p))
 	}
 
@@ -473,14 +470,14 @@ func WithForce(force bool) StopOption {
 // tearing the hub down (#157). Use WithForce to override.
 var ErrActiveSlots = errors.New("hub: active swarm slots present")
 
-// Stop terminates the processes recorded in the pid files written by
-// Start and removes those pid files. SIGTERM first; if the process is
-// still alive after stopGrace, SIGKILL. Pid files are only removed
-// once the process is confirmed dead so a follow-up Start cannot
-// mistake an orphan-still-alive for "nothing to clean up" (#138).
+// Stop terminates the process recorded in hub.pid (written by Start)
+// and removes the pid file. SIGTERM first; if the process is still
+// alive after stopGrace, SIGKILL. The pid file is only removed once
+// the process is confirmed dead so a follow-up Start cannot mistake
+// an orphan-still-alive for "nothing to clean up" (#138).
 //
-// Missing pid files or stale pids are not an error: Stop is idempotent
-// so callers can shut down without first checking whether Start ran.
+// A missing or stale hub.pid is not an error: Stop is idempotent so
+// callers can shut down without first checking whether Start ran.
 //
 // As a safety, Stop will not signal the calling process. If the
 // recorded pid matches os.Getpid(), Stop only removes the pid file.
@@ -526,20 +523,10 @@ func Stop(root string, options ...StopOption) (err error) {
 	}
 
 	self := os.Getpid()
-	// Both servers share a single child process in the detached model,
-	// so the two pid files typically reference the same pid. Dedup so
-	// we only signal once.
-	handled := make(map[int]struct{})
-	for _, pidFile := range []string{p.fossilPid, p.natsPid} {
-		pid, ok := readPid(pidFile)
-		if ok && pid != self {
-			if _, done := handled[pid]; !done {
-				terminateProcess(pid)
-				handled[pid] = struct{}{}
-			}
-		}
-		_ = os.Remove(pidFile)
+	if pid, ok := readPid(p.hubPid); ok && pid != self {
+		terminateProcess(pid)
 	}
+	_ = os.Remove(p.hubPid)
 	return nil
 }
 
@@ -612,11 +599,9 @@ func terminateProcess(pid int) {
 type paths struct {
 	root        string
 	orchDir     string
-	pidDir      string
 	logDir      string
 	hubRepo     string
-	fossilPid   string
-	natsPid     string
+	hubPid      string
 	fossilURL   string
 	natsURL     string
 	fossilLog   string
@@ -634,8 +619,8 @@ func HubFossilPath(root string) string {
 }
 
 // IsRunning reports whether a hub for the workspace at root is
-// currently running. Returns (pid, true) when both fossil.pid and
-// nats.pid exist and name live processes; (0, false) otherwise.
+// currently running. Returns (pid, true) when hub.pid exists and
+// names a live process; (0, false) otherwise.
 //
 // Read-only. Used by cli/up to print accurate post-scaffold status
 // without spawning anything (per ADR 0041 the hub is started lazily
@@ -645,11 +630,8 @@ func IsRunning(root string) (int, bool) {
 	if err != nil {
 		return 0, false
 	}
-	pid, ok := readPid(p.fossilPid)
+	pid, ok := readPid(p.hubPid)
 	if !ok || !pidIntIsLive(pid) {
-		return 0, false
-	}
-	if !pidIsLive(p.natsPid) {
 		return 0, false
 	}
 	return pid, true
@@ -671,11 +653,9 @@ func newPaths(root string) (paths, error) {
 	return paths{
 		root:        abs,
 		orchDir:     orch,
-		pidDir:      filepath.Join(orch, "pids"),
 		logDir:      orch,
 		hubRepo:     filepath.Join(orch, "hub.fossil"),
-		fossilPid:   filepath.Join(orch, "pids", "fossil.pid"),
-		natsPid:     filepath.Join(orch, "pids", "nats.pid"),
+		hubPid:      filepath.Join(orch, "hub.pid"),
 		fossilURL:   filepath.Join(orch, "hub-fossil-url"),
 		natsURL:     filepath.Join(orch, "hub-nats-url"),
 		fossilLog:   filepath.Join(orch, "fossil.log"),

--- a/internal/hub/hub_test.go
+++ b/internal/hub/hub_test.go
@@ -70,15 +70,15 @@ func TestStartStopRoundTrip(t *testing.T) {
 		t.Fatalf("nats never bound: %v", err)
 	}
 
-	// Pid files exist and reference live processes. There is a brief
+	// hub.pid exists and references a live process. There is a brief
 	// window between port-bind and pid-file write inside the
 	// foreground Start, so poll up to readyTimeout before failing.
-	for _, name := range []string{"fossil.pid", "nats.pid"} {
-		pidFile := filepath.Join(root, markerDirName, "pids", name)
+	{
+		pidFile := filepath.Join(root, markerDirName, "hub.pid")
 		if !waitForPidLive(pidFile, 5*time.Second) {
 			cancel()
 			wg.Wait()
-			t.Fatalf("%s: pid not live within timeout", name)
+			t.Fatalf("hub.pid: pid not live within timeout")
 		}
 	}
 
@@ -100,12 +100,12 @@ func TestStartStopRoundTrip(t *testing.T) {
 		wg.Wait()
 		t.Fatalf("Stop: %v", err)
 	}
-	for _, name := range []string{"fossil.pid", "nats.pid"} {
-		pidFile := filepath.Join(root, markerDirName, "pids", name)
+	{
+		pidFile := filepath.Join(root, markerDirName, "hub.pid")
 		if _, err := os.Stat(pidFile); !os.IsNotExist(err) {
 			cancel()
 			wg.Wait()
-			t.Fatalf("%s: pid file still present after Stop", name)
+			t.Fatalf("hub.pid: pid file still present after Stop")
 		}
 	}
 

--- a/internal/hub/lock_test.go
+++ b/internal/hub/lock_test.go
@@ -101,7 +101,7 @@ func TestStart_RejectsWhenWorkspaceLockHeld(t *testing.T) {
 			t.Errorf("rejected start wrote %s; lock guard ran too late", path)
 		}
 	}
-	if _, err := os.Stat(filepath.Join(root, ".bones", "pids", "fossil.pid")); err == nil {
-		t.Errorf("rejected start wrote fossil.pid; lock guard ran too late")
+	if _, err := os.Stat(filepath.Join(root, ".bones", "hub.pid")); err == nil {
+		t.Errorf("rejected start wrote hub.pid; lock guard ran too late")
 	}
 }

--- a/internal/hub/precondition_test.go
+++ b/internal/hub/precondition_test.go
@@ -56,7 +56,7 @@ func TestStart_FailsFastOnEmptyGitRepo(t *testing.T) {
 			"the spawn-and-wait path (#138 item 9)")
 	}
 
-	// Side-effect assertion: no hub.fossil and no .bones/pids/* should
+	// Side-effect assertion: no hub.fossil and no .bones/hub.pid should
 	// have been created. The precondition fires before any of those
 	// would be touched.
 	if _, err := exec.LookPath("git"); err == nil {

--- a/internal/hub/runforeground_test.go
+++ b/internal/hub/runforeground_test.go
@@ -69,15 +69,14 @@ func TestWaitOrTimeout_ZeroFallsBackToDefault(t *testing.T) {
 // detach pid-race regression introduced by the libfossil-exit migration.
 // edgehub.NewHub binds the HTTP listener at construction (the kernel
 // SYN-ACKs on the bound socket immediately), so the detach parent's
-// waitForTCP would race ahead of the child's writePid if pid writes
-// happened post-NewHub. Verifies fossil.pid + nats.pid both name the
-// foreground process by the time openAndSeedHub is invoked. Runs a
-// synthetic seed-failure to keep the test fast: we only need to assert
-// pid files are present on entry into the seed step, not that the full
-// hub bring-up succeeds.
+// waitForTCP would race ahead of the child's writePid if the pid write
+// happened post-NewHub. Verifies hub.pid names the foreground process
+// by the time openAndSeedHub is invoked. Runs a synthetic seed-failure
+// to keep the test fast: we only need to assert hub.pid is present on
+// entry into the seed step, not that the full hub bring-up succeeds.
 func TestRunForeground_PidsWrittenBeforeHubOpen(t *testing.T) {
 	root := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(root, ".bones", "pids"), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Join(root, ".bones"), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	p, err := newPaths(root)
@@ -87,25 +86,20 @@ func TestRunForeground_PidsWrittenBeforeHubOpen(t *testing.T) {
 
 	orig := seedHubRepoFunc
 	defer func() { seedHubRepoFunc = orig }()
-	var fossilPidAtSeed, natsPidAtSeed int
+	var hubPidAtSeed int
 	seedHubRepoFunc = func(_ context.Context, _ *edgehub.Hub, p paths) error {
-		// Read pid files at the moment seedHubRepo runs — well after
-		// runForeground's writePid calls completed but before any of
-		// the post-NewHub return paths could clean them up.
-		fossilPidAtSeed, _ = readPid(p.fossilPid)
-		natsPidAtSeed, _ = readPid(p.natsPid)
+		// Read hub.pid at the moment seedHubRepo runs — well after
+		// runForeground's writePid call completed but before any of
+		// the post-NewHub return paths could clean it up.
+		hubPidAtSeed, _ = readPid(p.hubPid)
 		return errors.New("synthetic seed failure to short-circuit")
 	}
 
 	_ = runForeground(context.Background(), p, opts{})
 
-	if fossilPidAtSeed != os.Getpid() {
-		t.Errorf("fossil.pid at seed time: got %d, want %d (foreground process)",
-			fossilPidAtSeed, os.Getpid())
-	}
-	if natsPidAtSeed != os.Getpid() {
-		t.Errorf("nats.pid at seed time: got %d, want %d (foreground process)",
-			natsPidAtSeed, os.Getpid())
+	if hubPidAtSeed != os.Getpid() {
+		t.Errorf("hub.pid at seed time: got %d, want %d (foreground process)",
+			hubPidAtSeed, os.Getpid())
 	}
 }
 
@@ -118,7 +112,7 @@ func TestRunForeground_PidsWrittenBeforeHubOpen(t *testing.T) {
 // or freshly-recreated parent file. See issue #138.
 func TestRunForeground_SeedFailureCleansSidecars(t *testing.T) {
 	root := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(root, ".bones", "pids"), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Join(root, ".bones"), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	p, err := newPaths(root)
@@ -159,13 +153,13 @@ func TestRunForeground_SeedFailureCleansSidecars(t *testing.T) {
 // TestRunForeground_FreshStartCleansStaleSidecars asserts that stale
 // SQLite sidecars from a prior crashed run don't poison the next
 // startup with SQLITE_IOERR_SHORT_READ (522). runForeground's
-// pre-NewHub cleanup (removeRepoAndSidecars when fossil.pid is dead)
+// pre-NewHub cleanup (removeRepoAndSidecars when hub.pid is dead)
 // removes them before edgehub.NewHub opens the repo, so NewHub
 // succeeds and the synthetic seed-failure path runs cleanly.
 // See issue #138.
 func TestRunForeground_FreshStartCleansStaleSidecars(t *testing.T) {
 	root := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(root, ".bones", "pids"), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Join(root, ".bones"), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	p, err := newPaths(root)
@@ -173,7 +167,7 @@ func TestRunForeground_FreshStartCleansStaleSidecars(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Plant stale sidecars from a prior failed run. No fossil.pid → the
+	// Plant stale sidecars from a prior failed run. No hub.pid → the
 	// fresh-start branch should fire and wipe them before NewHub runs.
 	for _, suffix := range []string{"-shm", "-wal"} {
 		if err := os.WriteFile(p.hubRepo+suffix, []byte("stale"), 0o644); err != nil {

--- a/internal/hub/stop_escalation_test.go
+++ b/internal/hub/stop_escalation_test.go
@@ -23,7 +23,7 @@ func TestStop_EscalatesToSIGKILLOnTermResistant(t *testing.T) {
 		t.Skip("posix-only: Windows lacks SIGTERM/SIGKILL semantics")
 	}
 	root := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(root, ".bones", "pids"), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Join(root, ".bones"), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	p, err := newPaths(root)
@@ -93,7 +93,7 @@ func TestStop_EscalatesToSIGKILLOnTermResistant(t *testing.T) {
 		close(done)
 	}()
 
-	if err := writePid(p.fossilPid, pid); err != nil {
+	if err := writePid(p.hubPid, pid); err != nil {
 		t.Fatalf("writePid: %v", err)
 	}
 

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -232,20 +232,16 @@ func joinLogic(ctx context.Context, cwd string) (Info, error) {
 	}, nil
 }
 
-// HubIsHealthy returns true when both the fossil and nats pid files
-// resolve to live processes and a /healthz GET succeeds within 500ms.
-// False on any failure — caller responds by calling hubStartFunc, or
-// (for read-only verbs) by rendering degraded-mode output.
+// HubIsHealthy returns true when hub.pid resolves to a live process
+// and a /healthz GET succeeds within 500ms. False on any failure —
+// caller responds by calling hubStartFunc, or (for read-only verbs)
+// by rendering degraded-mode output.
 //
 // Exported so read-only verbs (e.g. `bones status`, #207) can probe
 // hub liveness without going through Join, whose auto-start branch
 // would contradict the lazy-hub promise printed by `bones up`.
 func HubIsHealthy(workspaceDir string) bool {
-	pidsDir := filepath.Join(workspaceDir, markerDirName, "pids")
-	if !pidFileLive(filepath.Join(pidsDir, "fossil.pid")) {
-		return false
-	}
-	if !pidFileLive(filepath.Join(pidsDir, "nats.pid")) {
+	if !pidFileLive(filepath.Join(workspaceDir, markerDirName, "hub.pid")) {
 		return false
 	}
 	url := hub.FossilURL(workspaceDir)

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -243,15 +243,13 @@ func TestJoin_NoOpWhenHubHealthy(t *testing.T) {
 		t.Fatalf("Init: %v", err)
 	}
 	bones := filepath.Join(dir, markerDirName)
-	if err := os.MkdirAll(filepath.Join(bones, "pids"), 0o755); err != nil {
-		t.Fatalf("mkdir pids: %v", err)
+	if err := os.MkdirAll(bones, 0o755); err != nil {
+		t.Fatalf("mkdir bones: %v", err)
 	}
 	livePID := strconv.Itoa(os.Getpid())
-	for _, name := range []string{"fossil.pid", "nats.pid"} {
-		if err := os.WriteFile(filepath.Join(bones, "pids", name),
-			[]byte(livePID), 0o644); err != nil {
-			t.Fatalf("write %s: %v", name, err)
-		}
+	if err := os.WriteFile(filepath.Join(bones, "hub.pid"),
+		[]byte(livePID), 0o644); err != nil {
+		t.Fatalf("write hub.pid: %v", err)
 	}
 	// Stand up a tiny healthz server so HubIsHealthy's GET succeeds.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary

- Consolidate `.bones/pids/fossil.pid` + `.bones/pids/nats.pid` into a single `.bones/hub.pid` at the `.bones/` top-level. Both old files held the same supervisor PID; two-file representation misled liveness scripts and leaked substrate vocabulary.
- Drop `.bones/pids/` subdir entirely. One-time best-effort cleanup on first hub start handles existing operators.
- Substrate-vocabulary cleanup (`#B-3` / `#B-10` family per the issue brief).

Closes #254

## Test plan

- [x] `make check` — fmt-check, vet, lint, race, todo-check all pass
- [x] `go test -tags=otel -short ./...` — full CI-parity test pass
- [x] `paths` struct (internal/hub/hub.go): `fossilPid`, `natsPid`, `pidDir` fields collapsed to single `hubPid`. `newPaths` writes `hub.pid` directly under `orch`.
- [x] `Start`: single `writePid(p.hubPid, ...)` instead of two; one-time `os.RemoveAll(.bones/pids)` migration near top of Start.
- [x] `Stop`, `IsRunning`, `HubIsHealthy`: collapsed to single pid check.
- [x] Tests across `internal/hub/`, `internal/workspace/`, `cli/` updated. Scaffolded AGENTS.md verify-hub snippet + docs-site skills reference updated to match new path.

## Notes

- Pre-ADR-0041 legacy-layout migration (`internal/workspace/migrate.go`) still references `fossil.pid`/`nats.pid` under `.orchestrator/` — that's the separate workspace-shape detector, intentionally untouched.
- Historical references in `docs/adr/0043` and audit docs left intact (historical record).
