### PR TITLE
fix(hub): rename --fossil-port → --repo-port, --nats-port → --coord-port

### DIFF
--- a/cli/hub.go
+++ b/cli/hub.go
@@ -47,8 +47,8 @@ type HubStartCmd struct {
 	// the resolved URL at .bones/hub-{fossil,nats}-url so a
 	// second workspace can run concurrently on its own free ports.
 	// Pass an explicit non-zero port to pin.
-	FossilPort int `name:"fossil-port" default:"0" help:"Fossil HTTP port (0 = per-ws)"`
-	NATSPort   int `name:"nats-port" default:"0" help:"NATS client port (0 = per-ws)"`
+	RepoPort  int `name:"repo-port" default:"0" help:"repo HTTP port (0 = per-ws)"`
+	CoordPort int `name:"coord-port" default:"0" help:"coord client port (0 = per-ws)"`
 	// DrainTimeout bounds NATS/Fossil drain on shutdown before
 	// runForeground returns errDrainTimeout (non-zero exit). See #158.
 	DrainTimeout time.Duration `name:"drain-timeout" default:"30s" help:"max drain wait"` //nolint:lll
@@ -67,8 +67,8 @@ func (c *HubStartCmd) Run(g *repocli.Globals) error {
 	defer stop()
 
 	return hub.Start(ctx, cwd,
-		hub.WithFossilPort(c.FossilPort),
-		hub.WithNATSPort(c.NATSPort),
+		hub.WithRepoPort(c.RepoPort),
+		hub.WithCoordPort(c.CoordPort),
 		hub.WithDetach(c.Detach),
 		hub.WithDrainTimeout(c.DrainTimeout),
 	)

--- a/internal/hub/hub.go
+++ b/internal/hub/hub.go
@@ -277,8 +277,8 @@ func openAndSeedHub(
 		RepoPath:       p.hubRepo,
 		BootstrapUser:  "orchestrator",
 		NATSStoreDir:   p.natsStore,
-		FossilHTTPPort: o.fossilPort,
-		NATSClientPort: o.natsPort,
+		FossilHTTPPort: o.repoPort,
+		NATSClientPort: o.coordPort,
 	})
 	if err != nil {
 		removeRepoAndSidecars(p)
@@ -375,8 +375,8 @@ func spawnDetachedChild(p paths, o opts) error {
 	defer func() { _ = hubLog.Close() }()
 
 	cmd := exec.Command(exe, "hub", "start",
-		"--fossil-port", strconv.Itoa(o.fossilPort),
-		"--nats-port", strconv.Itoa(o.natsPort),
+		"--repo-port", strconv.Itoa(o.repoPort),
+		"--coord-port", strconv.Itoa(o.coordPort),
 		"--drain-timeout", effectiveDrainTimeout(o.drainTimeout).String(),
 	)
 	cmd.Dir = p.root
@@ -397,8 +397,8 @@ func spawnDetachedChild(p paths, o opts) error {
 	// attaches "fossil child not ready: timeout" with no hint at the
 	// real cause (#127), which is typically a seed failure logged in
 	// hub.log only.
-	fossilAddr := fmt.Sprintf("127.0.0.1:%d", o.fossilPort)
-	natsAddr := fmt.Sprintf("127.0.0.1:%d", o.natsPort)
+	fossilAddr := fmt.Sprintf("127.0.0.1:%d", o.repoPort)
+	natsAddr := fmt.Sprintf("127.0.0.1:%d", o.coordPort)
 	if err := waitForTCP(fossilAddr, readyTimeout); err != nil {
 		_ = cmd.Process.Kill()
 		return fmt.Errorf("hub: fossil child not ready: %w%s",
@@ -413,7 +413,7 @@ func spawnDetachedChild(p paths, o opts) error {
 	// False-positive readiness defense (#138 item 1): the TCP probes
 	// above pass when SOMETHING responds on the configured ports, not
 	// when our child is the responder. If another process already
-	// owned fossilPort/natsPort, our child's bind failed, our child
+	// owned repoPort/coordPort, our child's bind failed, our child
 	// exited, but the probes succeeded against the unrelated process.
 	// Without this check, joinLogic would proceed thinking the hub is
 	// up, then every verb downstream fails mysteriously against the
@@ -445,7 +445,7 @@ func spawnDetachedChild(p paths, o opts) error {
 	}
 
 	fmt.Printf("hub: fossil at http://127.0.0.1:%d, nats at nats://127.0.0.1:%d (pid=%d)\n",
-		o.fossilPort, o.natsPort, pid)
+		o.repoPort, o.coordPort, pid)
 	return nil
 }
 

--- a/internal/hub/hub_test.go
+++ b/internal/hub/hub_test.go
@@ -42,7 +42,7 @@ func TestStartStopRoundTrip(t *testing.T) {
 	// issue #180.
 	t.Setenv("HOME", t.TempDir())
 	root := newGitRepoWithFile(t)
-	fossilPort, natsPort := freePort(t), freePort(t)
+	repoPort, coordPort := freePort(t), freePort(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 
@@ -53,18 +53,18 @@ func TestStartStopRoundTrip(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		startErr = Start(ctx, root,
-			WithFossilPort(fossilPort),
-			WithNATSPort(natsPort),
+			WithRepoPort(repoPort),
+			WithCoordPort(coordPort),
 		)
 	}()
 
 	// Wait for both servers to become reachable.
-	if err := waitForTCP("127.0.0.1:"+strconv.Itoa(fossilPort), 5*time.Second); err != nil {
+	if err := waitForTCP("127.0.0.1:"+strconv.Itoa(repoPort), 5*time.Second); err != nil {
 		cancel()
 		wg.Wait()
 		t.Fatalf("fossil never bound: %v", err)
 	}
-	if err := waitForTCP("127.0.0.1:"+strconv.Itoa(natsPort), 5*time.Second); err != nil {
+	if err := waitForTCP("127.0.0.1:"+strconv.Itoa(coordPort), 5*time.Second); err != nil {
 		cancel()
 		wg.Wait()
 		t.Fatalf("nats never bound: %v", err)
@@ -85,8 +85,8 @@ func TestStartStopRoundTrip(t *testing.T) {
 	// Idempotency: a second Start with both pids live returns nil
 	// without re-binding.
 	if err := Start(context.Background(), root,
-		WithFossilPort(fossilPort),
-		WithNATSPort(natsPort),
+		WithRepoPort(repoPort),
+		WithCoordPort(coordPort),
 	); err != nil {
 		cancel()
 		wg.Wait()
@@ -134,10 +134,10 @@ func TestStartNoGitTrackedFiles(t *testing.T) {
 		"git", "-c", "user.email=t@t", "-c", "user.name=t",
 		"commit", "--allow-empty", "-q", "-m", "init")
 
-	fossilPort, natsPort := freePort(t), freePort(t)
+	repoPort, coordPort := freePort(t), freePort(t)
 	err := Start(context.Background(), root,
-		WithFossilPort(fossilPort),
-		WithNATSPort(natsPort),
+		WithRepoPort(repoPort),
+		WithCoordPort(coordPort),
 	)
 	if err == nil {
 		t.Fatal("expected error from empty git tree, got nil")
@@ -161,7 +161,7 @@ func TestStartWritesRegistry(t *testing.T) {
 
 	t.Setenv("HOME", t.TempDir())
 	root := newGitRepoWithFile(t)
-	fossilPort, natsPort := freePort(t), freePort(t)
+	repoPort, coordPort := freePort(t), freePort(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 
@@ -171,18 +171,18 @@ func TestStartWritesRegistry(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		startErr = Start(ctx, root,
-			WithFossilPort(fossilPort),
-			WithNATSPort(natsPort),
+			WithRepoPort(repoPort),
+			WithCoordPort(coordPort),
 		)
 	}()
 
 	// Wait for both servers to be reachable before checking registry.
-	if err := waitForTCP("127.0.0.1:"+strconv.Itoa(fossilPort), 5*time.Second); err != nil {
+	if err := waitForTCP("127.0.0.1:"+strconv.Itoa(repoPort), 5*time.Second); err != nil {
 		cancel()
 		wg.Wait()
 		t.Fatalf("fossil never bound: %v", err)
 	}
-	if err := waitForTCP("127.0.0.1:"+strconv.Itoa(natsPort), 5*time.Second); err != nil {
+	if err := waitForTCP("127.0.0.1:"+strconv.Itoa(coordPort), 5*time.Second); err != nil {
 		cancel()
 		wg.Wait()
 		t.Fatalf("nats never bound: %v", err)

--- a/internal/hub/options.go
+++ b/internal/hub/options.go
@@ -24,8 +24,8 @@ type Option func(*opts)
 // opts holds tunable behavior for Start. The exported Option constructors
 // are the only way to mutate this struct from outside the package.
 type opts struct {
-	fossilPort   int
-	natsPort     int
+	repoPort     int
+	coordPort    int
 	detach       bool
 	drainTimeout time.Duration
 }
@@ -33,23 +33,23 @@ type opts struct {
 // defaults returns the production defaults: ports left zero so
 // resolvePorts allocates per-workspace, foreground (Start blocks on
 // ctx.Done()). A zero port means "look up the workspace's recorded URL
-// or pick a free port"; passing WithFossilPort(N) or WithNATSPort(N)
+// or pick a free port"; passing WithRepoPort(N) or WithCoordPort(N)
 // pins to N.
 func defaults() opts {
 	return opts{
-		fossilPort:   0,
-		natsPort:     0,
+		repoPort:     0,
+		coordPort:    0,
 		drainTimeout: defaultDrainTimeout,
 	}
 }
 
-// WithFossilPort pins the Fossil HTTP port. Zero means "let the hub
+// WithRepoPort pins the repo HTTP port. Zero means "let the hub
 // allocate per-workspace" (default behavior).
-func WithFossilPort(p int) Option { return func(o *opts) { o.fossilPort = p } }
+func WithRepoPort(p int) Option { return func(o *opts) { o.repoPort = p } }
 
-// WithNATSPort pins the NATS client port. Zero means "let the hub
+// WithCoordPort pins the coord client port. Zero means "let the hub
 // allocate per-workspace" (default behavior).
-func WithNATSPort(p int) Option { return func(o *opts) { o.natsPort = p } }
+func WithCoordPort(p int) Option { return func(o *opts) { o.coordPort = p } }
 
 // WithDetach controls Start's blocking behavior. When true, Start returns
 // as soon as both readiness probes succeed; the servers continue running

--- a/internal/hub/port_collision_test.go
+++ b/internal/hub/port_collision_test.go
@@ -14,12 +14,12 @@ import (
 // TestSpawnDetachedChild_DetectsPortCollision pins #138 item 1's
 // remaining gap (after commit 0f6ec3c added hubLogTail surfacing for
 // the seed-error case): when an unrelated process is already bound
-// to fossilPort, the child's startFossil fails, the child exits, but
+// to repoPort, the child's startFossil fails, the child exits, but
 // the parent's TCP probe succeeds because the foreign service
 // responds. Pre-fix, hub.Start would return nil — joinLogic then
 // thinks the hub is up and downstream verbs hit the foreign service.
 //
-// This test stands up a local TCP listener on fossilPort BEFORE
+// This test stands up a local TCP listener on repoPort BEFORE
 // calling Start with that port pinned. The child crashes on bind;
 // the parent's TCP probe passes (the listener responds). Without the
 // pid-vs-recorded-pid check, Start returns nil. With the check,
@@ -61,14 +61,14 @@ func TestSpawnDetachedChild_DetectsPortCollision(t *testing.T) {
 		t.Fatalf("listen fossil: %v", err)
 	}
 	t.Cleanup(func() { _ = fossilLis.Close() })
-	fossilPort := fossilLis.Addr().(*net.TCPAddr).Port
+	repoPort := fossilLis.Addr().(*net.TCPAddr).Port
 
 	natsLis, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("listen nats: %v", err)
 	}
 	t.Cleanup(func() { _ = natsLis.Close() })
-	natsPort := natsLis.Addr().(*net.TCPAddr).Port
+	coordPort := natsLis.Addr().(*net.TCPAddr).Port
 
 	// Bound the call so a regression (no pid check → false positive)
 	// returns nil quickly without leaving us waiting on a real
@@ -79,8 +79,8 @@ func TestSpawnDetachedChild_DetectsPortCollision(t *testing.T) {
 	go func() {
 		ch <- result{Start(context.Background(), root,
 			WithDetach(true),
-			WithFossilPort(fossilPort),
-			WithNATSPort(natsPort))}
+			WithRepoPort(repoPort),
+			WithCoordPort(coordPort))}
 	}()
 
 	select {

--- a/internal/hub/url.go
+++ b/internal/hub/url.go
@@ -48,26 +48,26 @@ func readURLFile(path string) string {
 // After resolution, the URL files are (re)written so consumers always
 // see the live hub's URLs — even when the caller passed explicit ports.
 func resolvePorts(p paths, o *opts) error {
-	if o.fossilPort == 0 {
+	if o.repoPort == 0 {
 		if recorded := portFromURL(readURLFile(p.fossilURL)); recorded != 0 {
-			o.fossilPort = recorded
+			o.repoPort = recorded
 		} else {
 			port, err := pickFreePort()
 			if err != nil {
 				return fmt.Errorf("hub: pick fossil port: %w", err)
 			}
-			o.fossilPort = port
+			o.repoPort = port
 		}
 	}
-	if o.natsPort == 0 {
+	if o.coordPort == 0 {
 		if recorded := portFromURL(readURLFile(p.natsURL)); recorded != 0 {
-			o.natsPort = recorded
+			o.coordPort = recorded
 		} else {
 			port, err := pickFreePort()
 			if err != nil {
 				return fmt.Errorf("hub: pick nats port: %w", err)
 			}
-			o.natsPort = port
+			o.coordPort = port
 		}
 	}
 	return writeURLFiles(p, *o)
@@ -76,8 +76,8 @@ func resolvePorts(p paths, o *opts) error {
 // writeURLFiles records the hub's fully-resolved URLs so consumers can
 // discover them without knowing the port allocation policy.
 func writeURLFiles(p paths, o opts) error {
-	fossilURL := fmt.Sprintf("http://127.0.0.1:%d", o.fossilPort)
-	natsURL := fmt.Sprintf("nats://127.0.0.1:%d", o.natsPort)
+	fossilURL := fmt.Sprintf("http://127.0.0.1:%d", o.repoPort)
+	natsURL := fmt.Sprintf("nats://127.0.0.1:%d", o.coordPort)
 	if err := os.WriteFile(p.fossilURL, []byte(fossilURL+"\n"), 0o644); err != nil {
 		return fmt.Errorf("hub: write fossil-url: %w", err)
 	}

--- a/internal/hub/url_test.go
+++ b/internal/hub/url_test.go
@@ -45,15 +45,15 @@ func TestResolvePorts_AllocatesFreeWhenZero(t *testing.T) {
 	if err := os.MkdirAll(p.orchDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	o := opts{fossilPort: 0, natsPort: 0}
+	o := opts{repoPort: 0, coordPort: 0}
 	if err := resolvePorts(p, &o); err != nil {
 		t.Fatal(err)
 	}
-	if o.fossilPort == 0 || o.natsPort == 0 {
+	if o.repoPort == 0 || o.coordPort == 0 {
 		t.Errorf("ports not assigned: %+v", o)
 	}
-	if o.fossilPort == o.natsPort {
-		t.Errorf("collision: both ports = %d", o.fossilPort)
+	if o.repoPort == o.coordPort {
+		t.Errorf("collision: both ports = %d", o.repoPort)
 	}
 	if FossilURL(dir) == "" {
 		t.Errorf("fossil URL file not written")
@@ -81,15 +81,15 @@ func TestResolvePorts_ReadsRecordedURL(t *testing.T) {
 		[]byte("nats://127.0.0.1:9002\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	o := opts{fossilPort: 0, natsPort: 0}
+	o := opts{repoPort: 0, coordPort: 0}
 	if err := resolvePorts(p, &o); err != nil {
 		t.Fatal(err)
 	}
-	if o.fossilPort != 9001 {
-		t.Errorf("fossilPort = %d, want 9001 (recorded)", o.fossilPort)
+	if o.repoPort != 9001 {
+		t.Errorf("repoPort = %d, want 9001 (recorded)", o.repoPort)
 	}
-	if o.natsPort != 9002 {
-		t.Errorf("natsPort = %d, want 9002 (recorded)", o.natsPort)
+	if o.coordPort != 9002 {
+		t.Errorf("coordPort = %d, want 9002 (recorded)", o.coordPort)
 	}
 }
 
@@ -102,11 +102,11 @@ func TestResolvePorts_PreservesExplicitPort(t *testing.T) {
 	if err := os.MkdirAll(p.orchDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	o := opts{fossilPort: 7777, natsPort: 7778}
+	o := opts{repoPort: 7777, coordPort: 7778}
 	if err := resolvePorts(p, &o); err != nil {
 		t.Fatal(err)
 	}
-	if o.fossilPort != 7777 || o.natsPort != 7778 {
+	if o.repoPort != 7777 || o.coordPort != 7778 {
 		t.Errorf("explicit ports clobbered: %+v", o)
 	}
 	// URL files should still reflect the explicit port.
@@ -163,7 +163,7 @@ func TestStartWritesURLFilesStopPreserves(t *testing.T) {
 	if err := os.MkdirAll(p.orchDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	o := opts{fossilPort: 0, natsPort: 0}
+	o := opts{repoPort: 0, coordPort: 0}
 	if err := resolvePorts(p, &o); err != nil {
 		t.Fatal(err)
 	}
@@ -173,7 +173,7 @@ func TestStartWritesURLFilesStopPreserves(t *testing.T) {
 				filepath.Base(path), err)
 		}
 	}
-	want := fmt.Sprintf("http://127.0.0.1:%d", o.fossilPort)
+	want := fmt.Sprintf("http://127.0.0.1:%d", o.repoPort)
 	if got := FossilURL(root); got != want {
 		t.Errorf("FossilURL = %q, want %q", got, want)
 	}


### PR DESCRIPTION
## Summary

- `--fossil-port` → `--repo-port`, `--nats-port` → `--coord-port`. Cleans up substrate vocab in `ps`/`htop`/`lsof` output.
- Internal field names + helper constructors renamed in lockstep (`FossilPort` → `RepoPort`, `WithFossilPort` → `WithRepoPort`, etc.).
- Substrate-internal names (URLs, file basenames, EdgeSync API types, third-party binaries) stay — rename is operator-facing only.

Closes #255

## Test plan

- [x] `make check` passes
- [x] `go test -tags=otel -short ./...` passes
- [x] Grep for old patterns (`fossil-port`, `nats-port`, `FossilPort`, `NATSPort`, `WithFossilPort`, `WithNATSPort`, lowercase variants) returns zero in `cli/` and `internal/`

## Notes

- Likely conflicts with #273 (`fix/254-single-hub-pid`) on `internal/hub/hub.go` and `internal/hub/hub_test.go`. Conflicts are mechanical — different identifiers within overlapping line ranges. Merge `#273` first; this rebases cleanly.
- Names intentionally NOT renamed:
  - `FossilHTTPPort` / `NATSClientPort` on `edgehub.Config` (upstream EdgeSync API surface)
  - `fossilURL` / `natsURL` (URL field names — the rename is for ports, not URLs)
  - `fossilLis` / `natsLis` (test fixture listener vars)
  - `nats.Conn`, `nats-server` (third-party SDK and binary)
  - `.bones/hub-{fossil,nats}-url` filename references (those files are separate concerns; if they need renaming, that's a different issue)
