### PR TITLE
fix(hub): rename .nats-store/ → .bones/coord/

### DIFF
--- a/internal/coord/hub.go
+++ b/internal/coord/hub.go
@@ -58,7 +58,7 @@ func OpenHub(ctx context.Context, workdir, httpAddr string) (*Hub, error) {
 		RepoPath:       filepath.Join(workdir, "hub.fossil"),
 		BootstrapUser:  "hub",
 		NobodyCaps:     "gio",
-		NATSStoreDir:   filepath.Join(workdir, ".nats-store"),
+		NATSStoreDir:   filepath.Join(workdir, "coord"),
 		FossilHTTPPort: port,
 	})
 	if err != nil {

--- a/internal/hub/hub.go
+++ b/internal/hub/hub.go
@@ -211,8 +211,8 @@ func runForeground(ctx context.Context, p paths, o opts) error {
 	if !pidIsLive(p.hubPid) {
 		removeRepoAndSidecars(p)
 	}
-	if err := os.MkdirAll(p.natsStore, 0o755); err != nil {
-		return fmt.Errorf("hub: nats store dir: %w", err)
+	if err := os.MkdirAll(p.coordStore, 0o755); err != nil {
+		return fmt.Errorf("hub: coord store dir: %w", err)
 	}
 	// Write hub.pid BEFORE NewHub binds the HTTP listener. edgehub.NewHub
 	// calls net.Listen at construction (the HTTP socket is up before
@@ -274,7 +274,7 @@ func openAndSeedHub(
 	h, err := edgehub.NewHub(ctx, edgehub.Config{
 		RepoPath:       p.hubRepo,
 		BootstrapUser:  "orchestrator",
-		NATSStoreDir:   p.natsStore,
+		NATSStoreDir:   p.coordStore,
 		FossilHTTPPort: o.repoPort,
 		NATSClientPort: o.coordPort,
 	})
@@ -606,7 +606,7 @@ type paths struct {
 	natsURL     string
 	fossilLog   string
 	natsLog     string
-	natsStore   string
+	coordStore  string
 	fslckout    string
 	fslSettings string
 }
@@ -660,7 +660,7 @@ func newPaths(root string) (paths, error) {
 		natsURL:     filepath.Join(orch, "hub-nats-url"),
 		fossilLog:   filepath.Join(orch, "fossil.log"),
 		natsLog:     filepath.Join(orch, "nats.log"),
-		natsStore:   filepath.Join(orch, "nats-store"),
+		coordStore:  filepath.Join(orch, "coord"),
 		fslckout:    filepath.Join(abs, ".fslckout"),
 		fslSettings: filepath.Join(abs, ".fossil-settings"),
 	}, nil

--- a/internal/workspace/migrate.go
+++ b/internal/workspace/migrate.go
@@ -1,8 +1,10 @@
 // Workspace migration helpers.
 //
-// Two unrelated legacy formats are handled here:
+// Three unrelated legacy formats are handled here:
 //  1. .agent-infra/ → .bones/ (pre-rename marker; migrateLegacyMarker)
 //  2. .orchestrator/ → .bones/ (pre-ADR-0041 hub; migrateLegacyLayout)
+//  3. .bones/nats-store/ → .bones/coord/ (pre-#246 substrate-vocabulary
+//     leak; migrateNATSStoreToCoord)
 
 package workspace
 
@@ -133,7 +135,7 @@ func migrateLegacyLayout(workspaceDir string) error {
 		{filepath.Join(orch, "hub.fossil"), filepath.Join(bones, "hub.fossil")},
 		{filepath.Join(orch, "hub-fossil-url"), filepath.Join(bones, "hub-fossil-url")},
 		{filepath.Join(orch, "hub-nats-url"), filepath.Join(bones, "hub-nats-url")},
-		{filepath.Join(orch, "nats-store"), filepath.Join(bones, "nats-store")},
+		{filepath.Join(orch, "nats-store"), filepath.Join(bones, "coord")},
 		{filepath.Join(orch, "fossil.log"), filepath.Join(bones, "fossil.log")},
 		{filepath.Join(orch, "nats.log"), filepath.Join(bones, "nats.log")},
 		{filepath.Join(orch, "hub.log"), filepath.Join(bones, "hub.log")},
@@ -175,6 +177,44 @@ func migrateLegacyLayout(workspaceDir string) error {
 	}
 
 	fmt.Fprintln(os.Stderr, "migrated workspace to .bones/ layout (ADR 0041)")
+	return nil
+}
+
+// migrateNATSStoreToCoord renames .bones/nats-store/ to .bones/coord/ on
+// workspaces created before the substrate-vocabulary cleanup (#246). The
+// directory holds JetStream's on-disk state; renaming the parent is
+// safe because nats-server discovers streams via its own internal
+// catalog under <store_dir>/jetstream/$G/streams/, which is unaffected
+// by the parent rename.
+//
+// Idempotent and best-effort: returns nil if .bones/nats-store/ is
+// missing or .bones/coord/ already exists. On rename failure (e.g.
+// permissions, target half-populated) logs to stderr and returns nil
+// so a workspace with a rare layout edge-case still starts — the hub
+// will simply create a fresh .bones/coord/ alongside, and the next
+// `bones down` cycle will leave the operator a chance to inspect.
+func migrateNATSStoreToCoord(workspaceDir string) error {
+	bones := filepath.Join(workspaceDir, markerDirName)
+	src := filepath.Join(bones, "nats-store")
+	dst := filepath.Join(bones, "coord")
+	if _, err := os.Stat(src); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("stat .bones/nats-store: %w", err)
+	}
+	if _, err := os.Stat(dst); err == nil {
+		// .bones/coord/ already exists — assume migration already ran or
+		// the hub created a fresh coord/ alongside a stale nats-store/.
+		// Skip rather than clobber.
+		return nil
+	}
+	if err := os.Rename(src, dst); err != nil {
+		fmt.Fprintf(os.Stderr,
+			"workspace: best-effort migrate .bones/nats-store/ → .bones/coord/ failed: %v\n",
+			err)
+		return nil
+	}
 	return nil
 }
 

--- a/internal/workspace/migrate_internal_test.go
+++ b/internal/workspace/migrate_internal_test.go
@@ -63,6 +63,7 @@ func TestMigrateLegacyLayout_MovesFiles(t *testing.T) {
 	pidsDir := filepath.Join(orchDir, "pids")
 	for _, d := range []string{
 		pidsDir,
+		// legacy nats-store dirs preserved during move
 		filepath.Join(orchDir, "nats-store", "jetstream"),
 		filepath.Join(orchDir, "scripts"),
 		bonesDir, // pre-existing legacy workspace-leaf state
@@ -101,7 +102,7 @@ func TestMigrateLegacyLayout_MovesFiles(t *testing.T) {
 	for _, p := range []string{
 		"hub.fossil", "hub-fossil-url", "hub-nats-url",
 		"fossil.log", "nats.log", "hub.log",
-		filepath.Join("nats-store", "jetstream"),
+		filepath.Join("coord", "jetstream"),
 	} {
 		if _, err := os.Stat(filepath.Join(bonesDir, p)); err != nil {
 			t.Errorf(".bones/%s missing after migrate: %v", p, err)
@@ -140,6 +141,68 @@ func TestMigrateLegacyLayout_Idempotent(t *testing.T) {
 	// Second run: should be a no-op (legacyAbsent).
 	if err := migrateLegacyLayout(dir); err != nil {
 		t.Fatalf("second migrate: %v", err)
+	}
+}
+
+func TestMigrateNATSStoreToCoord_RenamesDir(t *testing.T) {
+	dir := t.TempDir()
+	bones := filepath.Join(dir, ".bones")
+	old := filepath.Join(bones, "nats-store", "jetstream", "$G", "streams")
+	if err := os.MkdirAll(old, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	canary := filepath.Join(bones, "nats-store", "marker")
+	if err := os.WriteFile(canary, []byte("hello"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	if err := migrateNATSStoreToCoord(dir); err != nil {
+		t.Fatalf("migrateNATSStoreToCoord: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(bones, "nats-store")); !os.IsNotExist(err) {
+		t.Errorf(".bones/nats-store/ still exists: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(bones, "coord", "jetstream", "$G", "streams")); err != nil {
+		t.Errorf(".bones/coord/jetstream/$G/streams missing: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(bones, "coord", "marker"))
+	if err != nil {
+		t.Fatalf("read marker: %v", err)
+	}
+	if string(got) != "hello" {
+		t.Errorf("marker = %q, want %q", got, "hello")
+	}
+}
+
+func TestMigrateNATSStoreToCoord_NoOpWhenAbsent(t *testing.T) {
+	dir := t.TempDir()
+	if err := migrateNATSStoreToCoord(dir); err != nil {
+		t.Fatalf("migrateNATSStoreToCoord on empty workspace: %v", err)
+	}
+}
+
+func TestMigrateNATSStoreToCoord_NoOpWhenCoordExists(t *testing.T) {
+	// Both .bones/nats-store/ and .bones/coord/ present — skip rather
+	// than clobber. The hub's MkdirAll will simply pick coord/ on the
+	// next start.
+	dir := t.TempDir()
+	bones := filepath.Join(dir, ".bones")
+	if err := os.MkdirAll(filepath.Join(bones, "nats-store"), 0o755); err != nil {
+		t.Fatalf("mkdir nats-store: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(bones, "coord"), 0o755); err != nil {
+		t.Fatalf("mkdir coord: %v", err)
+	}
+	if err := migrateNATSStoreToCoord(dir); err != nil {
+		t.Fatalf("migrateNATSStoreToCoord: %v", err)
+	}
+	// Both should still exist (no-op).
+	if _, err := os.Stat(filepath.Join(bones, "nats-store")); err != nil {
+		t.Errorf(".bones/nats-store/ removed unexpectedly: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(bones, "coord")); err != nil {
+		t.Errorf(".bones/coord/ removed unexpectedly: %v", err)
 	}
 }
 

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -137,6 +137,11 @@ func initLogic(ctx context.Context, cwd string) (Info, error) {
 		return Info{}, fmt.Errorf("mkdir .bones: %w", err)
 	}
 
+	// Best-effort: rename pre-#246 .bones/nats-store/ to .bones/coord/.
+	if err := migrateNATSStoreToCoord(cwd); err != nil {
+		return Info{}, err
+	}
+
 	// Idempotent: if agent.id already exists, reuse it; otherwise mint.
 	agentID, err := readAgentID(cwd)
 	if err != nil {
@@ -193,6 +198,11 @@ func joinLogic(ctx context.Context, cwd string) (Info, error) {
 		if err := migrateLegacyLayout(workspaceDir); err != nil {
 			return Info{}, err
 		}
+	}
+
+	// Best-effort: rename pre-#246 .bones/nats-store/ to .bones/coord/.
+	if err := migrateNATSStoreToCoord(workspaceDir); err != nil {
+		return Info{}, err
 	}
 
 	agentID, err := readAgentID(workspaceDir)


### PR DESCRIPTION
## Summary

- Rename `.bones/nats-store/` → `.bones/coord/`. Operator-visible substrate vocab leak in the path.
- Migration: `migrateNATSStoreToCoord` runs from `Init`/`Join` for existing operators (best-effort, idempotent rename of the dir). Pre-ADR-0041 migration also lands new-shape content in `coord/` directly.
- Stream names already use bones vocab (`KV_bones-*`) — left alone. Parent dirname is the only fix needed.

Closes #246

## Test plan

- [x] `make check` passes
- [x] `go test -tags=otel -short ./...` passes
- [x] 3 new tests for `migrateNATSStoreToCoord`: rename, absent no-op, both-present no-op

## Notes

- **`jetstream/$G/streams/` sublayer NOT flattened.** `nats-server` creates that layout under `server.Options{StoreDir: ...}` itself; `$G` is JetStream's global-account namespace, not freely configurable without upstream NATS account-model surgery. Per the issue brief that's allowed — `coord/` rename alone closes the operator-vocabulary leak.
- **`NATSStoreDir` on `edgehub.Config` left intentionally** — that's upstream EdgeSync API surface. Per CLAUDE.md upstream-fix policy, would need an EdgeSync PR; deferred as out of scope.
- Likely conflicts with `#273` (`fix/254-single-hub-pid`) on `internal/hub/hub.go`'s `paths` struct. Conflicts are mechanical — different field renames in adjacent lines. Merge `#273` first, then this rebases cleanly.
