### PR TITLE
feat(hub): structured lifecycle logging in .bones/hub.log

### DIFF
--- a/internal/hub/hub.go
+++ b/internal/hub/hub.go
@@ -203,6 +203,14 @@ func Start(ctx context.Context, root string, options ...Option) (err error) {
 // shells can detect liveness, and Stop in this same process is
 // equivalent to canceling ctx.
 func runForeground(ctx context.Context, p paths, o opts) error {
+	// Open the lifecycle log first so `hub: starting` is the first
+	// thing we write — diagnosing a crashed-hub workspace begins with
+	// hub.log, and every event after this point lands here too (#247).
+	hl := openHubLog(p)
+	defer hl.Close()
+	hl.Infof("hub: starting (pid=%d, repo-port=%d, coord-port=%d)",
+		os.Getpid(), o.repoPort, o.coordPort)
+
 	// Fresh-start detection (ADR 0023): if hub.pid is not alive,
 	// wipe stale checkout state so each session starts from a clean
 	// substrate. Working-tree files are untouched. SQLite -shm and -wal
@@ -212,6 +220,7 @@ func runForeground(ctx context.Context, p paths, o opts) error {
 		removeRepoAndSidecars(p)
 	}
 	if err := os.MkdirAll(p.coordStore, 0o755); err != nil {
+		hl.Errorf("hub: failed to create coord store dir: %v", err)
 		return fmt.Errorf("hub: coord store dir: %w", err)
 	}
 	// Write hub.pid BEFORE NewHub binds the HTTP listener. edgehub.NewHub
@@ -226,6 +235,7 @@ func runForeground(ctx context.Context, p paths, o opts) error {
 	// foreground process either way (os.Getpid() is stable across the
 	// NewHub call), so writing it first is correct.
 	if err := writePid(p.hubPid, os.Getpid()); err != nil {
+		hl.Errorf("hub: write hub.pid failed: %v", err)
 		return fmt.Errorf("hub: write hub.pid: %w", err)
 	}
 	freshSeed := false
@@ -235,6 +245,7 @@ func runForeground(ctx context.Context, p paths, o opts) error {
 	h, err := openAndSeedHub(ctx, p, o, freshSeed)
 	if err != nil {
 		_ = os.Remove(p.hubPid)
+		hl.Errorf("hub: bring-up failed: %v", err)
 		return err
 	}
 	httpDone := make(chan struct{})
@@ -252,9 +263,12 @@ func runForeground(ctx context.Context, p paths, o opts) error {
 		HubPID:    os.Getpid(),
 		StartedAt: time.Now().UTC(),
 	}); err != nil {
+		hl.Warnf("hub: registry write failed (non-fatal): %v", err)
 		fmt.Fprintf(os.Stderr, "hub: registry write failed (non-fatal): %v\n", err)
 	}
+	hl.Infof("hub: ready")
 	<-ctx.Done()
+	hl.Infof("hub: stopping")
 	httpCancel()
 	drainErr := drainHub(h, httpDone, o.drainTimeout)
 	_ = os.Remove(p.hubPid)
@@ -263,6 +277,11 @@ func runForeground(ctx context.Context, p paths, o opts) error {
 	// `bones status --all` to filter out via pidAlive. Dead-pid
 	// pruning still handles the unclean-exit case.
 	_ = registry.RemoveByPID(p.root, os.Getpid())
+	if drainErr != nil {
+		hl.Errorf("hub: stopped with drain error: %v", drainErr)
+	} else {
+		hl.Infof("hub: stopped")
+	}
 	return drainErr
 }
 
@@ -397,13 +416,17 @@ func spawnDetachedChild(p paths, o opts) error {
 	// hub.log only.
 	fossilAddr := fmt.Sprintf("127.0.0.1:%d", o.repoPort)
 	natsAddr := fmt.Sprintf("127.0.0.1:%d", o.coordPort)
+	parentLog := openHubLog(p)
+	defer parentLog.Close()
 	if err := waitForTCP(fossilAddr, readyTimeout); err != nil {
 		_ = cmd.Process.Kill()
+		parentLog.Errorf("hub: child exited before repo port ready: %v", err)
 		return fmt.Errorf("hub: fossil child not ready: %w%s",
 			err, hubLogTail(p))
 	}
 	if err := waitForTCP(natsAddr, readyTimeout); err != nil {
 		_ = cmd.Process.Kill()
+		parentLog.Errorf("hub: child exited before coord port ready: %v", err)
 		return fmt.Errorf("hub: nats child not ready: %w%s",
 			err, hubLogTail(p))
 	}
@@ -423,6 +446,8 @@ func spawnDetachedChild(p paths, o opts) error {
 	// means port collision or a crashed child that never wrote the file.
 	if recorded, ok := readPid(p.hubPid); !ok || recorded != cmd.Process.Pid {
 		_ = cmd.Process.Kill()
+		parentLog.Errorf("hub: repo port collision (recorded pid=%d, child pid=%d)",
+			recorded, cmd.Process.Pid)
 		return fmt.Errorf("hub: fossil port %s responded but %s does not "+
 			"name our child (pid %d, recorded %d) — likely port "+
 			"collision; another service is bound to the port%s",

--- a/internal/hub/hub_log.go
+++ b/internal/hub/hub_log.go
@@ -1,0 +1,86 @@
+package hub
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+// hubLogger appends structured lifecycle events to .bones/hub.log so a
+// crashed-hub workspace has a navigable audit trail rather than the
+// 63-byte banner the legacy code wrote (#247). Events use bones
+// vocabulary only — `hub:`, `coord:`, `repo:` — so an operator
+// reading the log isn't asked to translate `fossil` / `nats` /
+// `jetstream` substrate words back into bones concepts.
+//
+// Append-only: operators auditing a crashed workspace need the full
+// history, not just the last run. spawnDetachedChild also opens
+// hub.log in append mode for the child's stdout/stderr stream, so the
+// two writers cooperate without truncation.
+//
+// A nil logger is safe — every method is a no-op so callers don't
+// branch on open errors.
+type hubLogger struct {
+	mu   sync.Mutex
+	file *os.File
+	path string
+}
+
+// openHubLog opens (or creates, append-mode) <root>/.bones/hub.log.
+// Returns a usable logger even on open failure (file pointer nil,
+// methods degrade to no-ops) so a write-protected workspace cannot
+// break hub start.
+func openHubLog(p paths) *hubLogger {
+	_ = os.MkdirAll(p.orchDir, 0o755)
+	path := filepath.Join(p.orchDir, "hub.log")
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	l := &hubLogger{path: path}
+	if err == nil {
+		l.file = f
+	}
+	return l
+}
+
+// Close flushes and closes the underlying file. Safe on nil or on a
+// logger whose file failed to open.
+func (l *hubLogger) Close() {
+	if l == nil || l.file == nil {
+		return
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	_ = l.file.Close()
+	l.file = nil
+}
+
+// Infof writes one INFO-level lifecycle event.
+func (l *hubLogger) Infof(format string, args ...any) {
+	l.appendLine("INFO", fmt.Sprintf(format, args...))
+}
+
+// Warnf writes one WARN-level lifecycle event.
+func (l *hubLogger) Warnf(format string, args ...any) {
+	l.appendLine("WARN", fmt.Sprintf(format, args...))
+}
+
+// Errorf writes one ERROR-level lifecycle event.
+func (l *hubLogger) Errorf(format string, args ...any) {
+	l.appendLine("ERROR", fmt.Sprintf(format, args...))
+}
+
+// appendLine emits one timestamped line. ISO-8601 UTC keeps the file
+// machine-grep-friendly across timezones; the level field is padded so
+// `grep -E '^\S+ ERROR'` lines up regardless of whether the level is
+// INFO / WARN / ERROR. Errors writing to disk are dropped — bones must
+// not abort hub bring-up because the log file became unwritable.
+func (l *hubLogger) appendLine(level, msg string) {
+	if l == nil || l.file == nil {
+		return
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	_, _ = fmt.Fprintf(l.file, "%s %-5s %s\n",
+		time.Now().UTC().Format(time.RFC3339), level, msg)
+}

--- a/internal/hub/hub_log_test.go
+++ b/internal/hub/hub_log_test.go
@@ -1,0 +1,269 @@
+package hub
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestHubLog_StartingLineFormat asserts the starting line shape. The
+// log file accumulates a timestamped INFO line naming pid, repo-port,
+// and coord-port — so an operator opening hub.log in a crashed
+// workspace can pin the exact ports the hub tried to bind. Uses
+// operator vocabulary (hub:, repo-port=, coord-port=) per #247.
+func TestHubLog_StartingLineFormat(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip in -short: spawns subprocess servers, port-bind sensitive")
+	}
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	t.Setenv("HOME", t.TempDir())
+	root := newGitRepoWithFile(t)
+	fossilPort, natsPort := freePort(t), freePort(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var startErr error
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		startErr = Start(ctx, root,
+			WithRepoPort(fossilPort),
+			WithCoordPort(natsPort),
+		)
+	}()
+	defer func() {
+		cancel()
+		wg.Wait()
+		if startErr != nil {
+			t.Logf("foreground Start exit (post-test): %v", startErr)
+		}
+	}()
+
+	// Wait until hub.log has the starting + ready lines so we know
+	// the foreground process has crossed the post-bind log point.
+	waitForHubLogContains(t, root, "hub: ready", 5*time.Second)
+
+	logPath := filepath.Join(root, ".bones", "hub.log")
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read hub.log: %v", err)
+	}
+	got := string(data)
+
+	// Pin the starting line: ISO-8601 timestamp + INFO + structured
+	// fields. Regex is permissive on the exact timestamp shape but
+	// strict on the operator-facing token order.
+	re := regexp.MustCompile(
+		`\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z INFO\s+hub: starting ` +
+			`\(pid=\d+, repo-port=` + strconv.Itoa(fossilPort) +
+			`, coord-port=` + strconv.Itoa(natsPort) + `\)`,
+	)
+	if !re.MatchString(got) {
+		t.Errorf("hub.log missing well-formed starting line.\nlog:\n%s", got)
+	}
+	if !strings.Contains(got, "hub: ready") {
+		t.Errorf("hub.log missing ready line.\nlog:\n%s", got)
+	}
+}
+
+// TestHubLog_StoppingThenStopped asserts the ordered shutdown pair:
+// `hub: stopping` followed by `hub: stopped` (or a stopped-with-drain-
+// error variant). Without ordering, an operator scanning hub.log
+// can't tell whether ctx-cancel reached drainHub.
+func TestHubLog_StoppingThenStopped(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip in -short: spawns subprocess servers")
+	}
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	t.Setenv("HOME", t.TempDir())
+	root := newGitRepoWithFile(t)
+	fossilPort, natsPort := freePort(t), freePort(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var startErr error
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		startErr = Start(ctx, root,
+			WithRepoPort(fossilPort),
+			WithCoordPort(natsPort),
+		)
+	}()
+
+	waitForHubLogContains(t, root, "hub: ready", 5*time.Second)
+	cancel()
+	wg.Wait()
+	if startErr != nil {
+		t.Logf("foreground Start returned: %v", startErr)
+	}
+
+	logPath := filepath.Join(root, ".bones", "hub.log")
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read hub.log: %v", err)
+	}
+	got := string(data)
+
+	stoppingIdx := strings.Index(got, "hub: stopping")
+	stoppedIdx := strings.Index(got, "hub: stopped")
+	if stoppingIdx < 0 {
+		t.Fatalf("hub.log missing stopping line.\nlog:\n%s", got)
+	}
+	if stoppedIdx < 0 {
+		t.Fatalf("hub.log missing stopped line.\nlog:\n%s", got)
+	}
+	if stoppedIdx <= stoppingIdx {
+		t.Fatalf("hub: stopped should come after hub: stopping.\nlog:\n%s", got)
+	}
+}
+
+// TestHubLog_AppendAcrossCycles asserts hub.log accumulates across
+// repeated start/stop cycles instead of truncating each run. An
+// operator auditing a workspace that has crashed-and-restarted needs
+// the full timeline.
+func TestHubLog_AppendAcrossCycles(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip in -short: spawns subprocess servers")
+	}
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	t.Setenv("HOME", t.TempDir())
+	root := newGitRepoWithFile(t)
+	fossilPort, natsPort := freePort(t), freePort(t)
+
+	for cycle := range 2 {
+		ctx, cancel := context.WithCancel(context.Background())
+		var startErr error
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			startErr = Start(ctx, root,
+				WithRepoPort(fossilPort),
+				WithCoordPort(natsPort),
+			)
+		}()
+		waitForHubLogContains(t, root, "hub: ready", 5*time.Second)
+		cancel()
+		wg.Wait()
+		if startErr != nil {
+			t.Logf("cycle %d Start returned: %v", cycle, startErr)
+		}
+	}
+
+	logPath := filepath.Join(root, ".bones", "hub.log")
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read hub.log: %v", err)
+	}
+	got := string(data)
+
+	// Two cycles → at least two starting lines, two ready lines, two
+	// stopping lines, two stopped lines.
+	if n := strings.Count(got, "hub: starting"); n < 2 {
+		t.Errorf("expected >=2 starting lines across cycles, got %d.\nlog:\n%s", n, got)
+	}
+	if n := strings.Count(got, "hub: ready"); n < 2 {
+		t.Errorf("expected >=2 ready lines across cycles, got %d.\nlog:\n%s", n, got)
+	}
+	if n := strings.Count(got, "hub: stopping"); n < 2 {
+		t.Errorf("expected >=2 stopping lines across cycles, got %d.\nlog:\n%s", n, got)
+	}
+}
+
+// TestHubLog_NoSubstrateVocabulary asserts lifecycle events use bones
+// vocabulary only — no `fossil`, `nats`, or `jetstream`. Substrate
+// names leak abstraction across the bones boundary; operators reading
+// hub.log should see hub:/repo:/coord: only (#247).
+func TestHubLog_NoSubstrateVocabulary(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip in -short: spawns subprocess servers")
+	}
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	t.Setenv("HOME", t.TempDir())
+	root := newGitRepoWithFile(t)
+	fossilPort, natsPort := freePort(t), freePort(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var startErr error
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		startErr = Start(ctx, root,
+			WithRepoPort(fossilPort),
+			WithCoordPort(natsPort),
+		)
+	}()
+
+	waitForHubLogContains(t, root, "hub: ready", 5*time.Second)
+	cancel()
+	wg.Wait()
+	if startErr != nil {
+		t.Logf("foreground Start returned: %v", startErr)
+	}
+
+	logPath := filepath.Join(root, ".bones", "hub.log")
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read hub.log: %v", err)
+	}
+	got := strings.ToLower(string(data))
+
+	// Whitelist the lifecycle line prefixes we add; only THOSE lines
+	// must be substrate-free. Substrate words elsewhere in hub.log
+	// (e.g., legacy "hub: fossil at ..." stdout banner that lands here
+	// in the detached child path) are out of scope for this issue.
+	for _, line := range strings.Split(got, "\n") {
+		// Match lines emitted by hubLogger only — they have the
+		// "<ts> <LEVEL> hub:" shape with the level field padded.
+		if !strings.Contains(line, " hub: starting") &&
+			!strings.Contains(line, " hub: ready") &&
+			!strings.Contains(line, " hub: stopping") &&
+			!strings.Contains(line, " hub: stopped") &&
+			!strings.Contains(line, " hub: child exited") {
+			continue
+		}
+		for _, banned := range []string{"fossil", "nats", "jetstream"} {
+			if strings.Contains(line, banned) {
+				t.Errorf("lifecycle line contains substrate word %q: %q", banned, line)
+			}
+		}
+	}
+}
+
+// waitForHubLogContains polls .bones/hub.log until it contains needle,
+// or t.Fatalfs on timeout. Used to synchronize with async log writes
+// from the foreground hub goroutine.
+func waitForHubLogContains(t *testing.T, root, needle string, timeout time.Duration) {
+	t.Helper()
+	logPath := filepath.Join(root, ".bones", "hub.log")
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		data, err := os.ReadFile(logPath)
+		if err == nil && strings.Contains(string(data), needle) {
+			return
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	t.Fatalf("hub.log never contained %q within %s", needle, timeout)
+}


### PR DESCRIPTION
## Summary

- Add structured lifecycle logging to `.bones/hub.log` (`internal/hub/hub_log.go`).
- Hub start/ready/stop emit ISO-8601 timestamped events with operator-vocab prefixes (`hub:`, `repo-port`, `coord-port`). Bring-up errors land in the same log with ERROR level.
- Replaces the unhelpful single-line banner that made `hubLogTail`'s "tail on failure" path useless.

Closes #247

## Format

```
2026-05-06T09:42:42Z INFO  hub: starting (pid=92871, repo-port=50727, coord-port=50730)
2026-05-06T09:42:43Z INFO  hub: ready
2026-05-06T09:43:14Z INFO  hub: stopping
2026-05-06T09:43:14Z INFO  hub: stopped
```

Append-only — operators auditing a crashed-hub workspace see the full history.

## Vocabulary

Lifecycle lines use ONLY bones vocab: `hub:`, `repo-port`, `coord-port`. No `fossil`, `nats`, or `jetstream` words leak into operator-visible lifecycle events. Substrate-internal log lines from `startFossil` / `startNATS` keep their existing names — those are diagnostic detail, not operator surface.

## Tests

- `TestHubLog_StartingLineFormat` — regex-pins format
- `TestHubLog_StoppingThenStopped` — ordering
- `TestHubLog_AppendAcrossCycles` — append behavior across hub start/stop cycles
- `TestHubLog_NoSubstrateVocabulary` — scans lifecycle-prefix lines, fails on `fossil`/`nats`/`jetstream`

`make check` + `go test -tags=otel -short ./...` both green.

## Out of scope

- Lock-recovery on stale-PID (already in `internal/registry/lock.go`)
- `bones status` distinguishing crashed-vs-not-started — separate UX issue
- Crash-detection that prunes lock+pid+registry — out of scope

## Conflicts

May conflict with `#273` and `#275` on `internal/hub/hub.go`. Mechanical — different new lines added in adjacent regions.
