### PR TITLE
docs(skills): scrub substrate vocabulary from scaffolded skills

### DIFF
--- a/cli/templates/skills/finishing-a-bones-leaf/SKILL.md
+++ b/cli/templates/skills/finishing-a-bones-leaf/SKILL.md
@@ -16,7 +16,7 @@ Your swarm session has closed (`bones swarm close --result=success`), but the le
 
 ## Requirements
 
-- A bones workspace (`.bones/repo.fossil` exists in cwd; required for all options)
+- A bones workspace (`.bones/` directory exists in cwd; required for all options)
 - For the optional push-to-git tail (Option 1's follow-up):
   - The workspace is also a git repo (`.git/` exists at the same root)
   - `bones apply` subcommand available (bones v0.X+ — calibrate against the bones release that ships it)
@@ -47,7 +47,7 @@ bones swarm fan-in --dry-run -m "merge <leaves> to trunk"
 bones swarm fan-in -m "merge <leaves> to trunk"
 ```
 
-**On conflict** (semantics not yet empirically verified — see spec § 11 — but the defensive flow is canonical given fossil's conflict model):
+**On conflict** (semantics not yet empirically verified — see spec § 11 — but the defensive flow below is canonical):
 
 If `fan-in` reports a non-zero exit code, conflicts likely exist. Enumerate and resolve:
 
@@ -110,7 +110,7 @@ Answering `y`/`Y`/`yes` (case-insensitive) runs the flow below. Anything else fi
 bones apply
 ```
 
-This is the bones-side checkout-equivalent: it copies fossil-trunk's tip state onto the git working tree. After this, `git status` shows the swarmed changes as unstaged.
+This is the bones-side checkout-equivalent: it copies trunk's tip state onto the git working tree. After this, `git status` shows the swarmed changes as unstaged.
 
 `bones apply` is invoked with no arguments — assumes the default behavior is "materialize trunk tip into cwd's git worktree". If the actual `bones apply` CLI requires explicit args when the bones release ships, adjust this skill's invocation.
 

--- a/cli/templates/skills/using-bones-powers/SKILL.md
+++ b/cli/templates/skills/using-bones-powers/SKILL.md
@@ -42,8 +42,8 @@ bones-powers skills assume you understand these concepts. If any are unfamiliar,
 
 | Term | Meaning |
 |---|---|
-| **workspace** | A directory bootstrapped by `bones up`. Marker: `.bones/repo.fossil`. |
-| **hub** | The Fossil repo at the center of the workspace. Holds trunk and all leaves. |
+| **workspace** | A directory bootstrapped by `bones up`. Marker: a `.bones/` directory at the root. |
+| **hub** | The repo at the center of the workspace. Holds trunk and all leaves. |
 | **trunk** | The mainline branch in the hub. Equivalent to git's `main`. |
 | **slot** | A named worker role (e.g. `alpha`, `frontend`, `infra`). Tasks are routed by slot. |
 | **leaf** | A slot's working session — a worktree + claimed task + open hub branch. Created by `bones swarm join`. |

--- a/cli/templates/skills/using-bones-swarm/SKILL.md
+++ b/cli/templates/skills/using-bones-swarm/SKILL.md
@@ -13,7 +13,7 @@ category:
 
 `bones swarm` is the slot-scoped session primitive. One swarm session = one leaf = one worktree + one claimed task + one open hub branch. This skill walks you through the 5-step lifecycle.
 
-**Prerequisite**: a bones workspace (`.bones/repo.fossil` exists in cwd or a parent). If missing, run `bones up` first.
+**Prerequisite**: a bones workspace (`.bones/` directory exists in cwd or a parent). If missing, run `bones up` first.
 
 ## The lifecycle
 


### PR DESCRIPTION
## Summary

- Scrub substrate vocabulary (`fossil`, `libfossil`, `edgesync`, `nats`, `jetstream`) from scaffolded SKILL.md files.
- Update glossary marker reference from stale `.bones/repo.fossil` (never existed) to `.bones/` directory presence.
- Use only bones vocabulary (hub, trunk, leaf, slot, swarm, coord, repo).

Closes #253

## Files

- `cli/templates/skills/using-bones-powers/SKILL.md` — glossary
- `cli/templates/skills/using-bones-swarm/SKILL.md` — prerequisite line
- `cli/templates/skills/finishing-a-bones-leaf/SKILL.md` — three edits

## Test plan

- [x] `make check` passes
- [x] `go test -tags=otel -short ./...` passes
- [x] `grep -rn 'fossil\|libfossil\|edgesync\|nats\|jetstream' cli/templates/skills/` returns empty

## Notes

- Pure docs change. No code paths affected.
- ADRs in `docs/adr/` intentionally left alone — architectural record.
