### PR TITLE
feat(manifest): extend bones-manifest to cover .bones/ state + hooks

### DIFF
--- a/cli/doctor.go
+++ b/cli/doctor.go
@@ -206,6 +206,7 @@ func runBypassReportTo(w io.Writer, cwd string) (warns int, err error) {
 	}
 
 	warns += checkScaffoldGates(w, cwd)
+	warns += checkManifestIntegrity(w, cwd)
 	warns += checkOrphanHubs(w)
 	warns += checkDuplicateHubs(w, cwd)
 	warns += checkStaleSlotDirs(w, cwd)
@@ -404,6 +405,105 @@ func checkDuplicateHubs(w io.Writer, cwd string) int {
 			e.HubPID, e.HubURL, e.NATSURL, age)
 	}
 	return len(dups)
+}
+
+// checkManifestIntegrity reads .claude/skills/.bones-manifest.json
+// and verifies the non-skill scaffold footprint it records (issue
+// #262). Three drift modes:
+//
+//   - tamper: a file in Scaffolded has a different sha256 on disk
+//   - partial: a file in Scaffolded is missing on disk entirely
+//   - mid-version drift: manifest.Version != current binary version
+//
+// The bones-owned hook subset of .claude/settings.json is also
+// hashed (manifest.SettingsHooksSHA256) and compared against the
+// current on-disk hash. Divergence here means somebody has hand-
+// edited or deleted bones's hook entries since `bones up`; doctor
+// surfaces it as a WARN so the operator can re-run `bones up` to
+// restore the canonical set.
+//
+// Read-only and silent on workspaces without a manifest (legacy
+// pre-issue-#262 installs and pre-`bones up` directories).
+//
+// Returns the count of WARN-class findings emitted.
+func checkManifestIntegrity(w io.Writer, cwd string) int {
+	manifest, err := readManifest(cwd)
+	if err != nil {
+		_, _ = fmt.Fprintf(w, "  WARN  read bones manifest: %v\n", err)
+		return 1
+	}
+	if manifest == nil {
+		// No manifest at all — either a fresh workspace before
+		// `bones up`, or a legacy install whose manifest predates
+		// issue #262. Either way, nothing to verify against.
+		return 0
+	}
+
+	var warns int
+
+	// Mid-version drift: manifest stamped by an older bones than
+	// the current binary. scaffoldver already surfaces stamp drift
+	// against `.bones/scaffold_version`; the manifest's Version
+	// field is a second witness — useful when the stamp file got
+	// nuked but the manifest survived.
+	if manifest.Version != "" {
+		bin := version.Get()
+		if scaffoldver.Drifted(manifest.Version, bin) {
+			_, _ = fmt.Fprintf(w,
+				"  WARN  bones manifest v%s, binary v%s — run `bones up` to refresh\n",
+				manifest.Version, bin)
+			warns++
+		}
+	}
+
+	// Per-file tamper / missing checks for the non-skill entries.
+	for _, sf := range manifest.Scaffolded {
+		full := filepath.Join(cwd, filepath.FromSlash(sf.Path))
+		data, err := os.ReadFile(full)
+		if errors.Is(err, fs.ErrNotExist) {
+			_, _ = fmt.Fprintf(w,
+				"  WARN  bones manifest claims %s but it is missing — "+
+					"partial scaffold; run `bones up`\n",
+				sf.Path)
+			warns++
+			continue
+		}
+		if err != nil {
+			_, _ = fmt.Fprintf(w,
+				"  WARN  read %s: %v\n", sf.Path, err)
+			warns++
+			continue
+		}
+		if got := hashHex(data); got != sf.SHA256 {
+			_, _ = fmt.Fprintf(w,
+				"  WARN  bones manifest tamper: %s sha256 drift (manifest=%s on-disk=%s)\n",
+				sf.Path, short(sf.SHA256), short(got))
+			warns++
+		}
+	}
+
+	// Bones-owned hook subset of .claude/settings.json. Empty
+	// recorded value means a legacy manifest from a pre-#262
+	// binary — skip silently rather than false-positive.
+	if manifest.SettingsHooksSHA256 != "" {
+		got, herr := bonesOwnedHooksHashFromDisk(cwd)
+		if herr != nil {
+			_, _ = fmt.Fprintf(w,
+				"  WARN  read bones-owned hooks: %v\n", herr)
+			warns++
+		} else if got != manifest.SettingsHooksSHA256 {
+			_, _ = fmt.Fprintf(w,
+				"  WARN  bones manifest tamper: .claude/settings.json bones-owned hooks "+
+					"sha256 drift (manifest=%s on-disk=%s) — run `bones up` to restore\n",
+				short(manifest.SettingsHooksSHA256), short(got))
+			warns++
+		}
+	}
+
+	if warns == 0 && len(manifest.Scaffolded) > 0 {
+		_, _ = fmt.Fprintln(w, "  OK    bones manifest matches on-disk scaffold")
+	}
+	return warns
 }
 
 // checkStaleSlotDirs reports per-slot directories under

--- a/cli/manifest_test.go
+++ b/cli/manifest_test.go
@@ -1,0 +1,434 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/danmestas/bones/internal/version"
+)
+
+// TestWriteManifest_StampsScaffoldedEntries pins issue #262: after a
+// fresh scaffoldOrchestrator pass, the manifest's Scaffolded field
+// records .bones/agent.id and .bones/scaffold_version with sha256 +
+// size, and SettingsHooksSHA256 is non-empty (covering the
+// bones-owned hook subset of .claude/settings.json).
+func TestWriteManifest_StampsScaffoldedEntries(t *testing.T) {
+	dir := t.TempDir()
+	// Write agent.id so writeManifest has something to stamp for it.
+	// scaffoldOrchestrator does NOT write agent.id itself — that's
+	// workspace.Init's job, which runs before scaffoldOrchestrator in
+	// `bones up`. Tests that drive scaffoldOrchestrator directly need
+	// to seed the file.
+	bones := filepath.Join(dir, ".bones")
+	if err := os.MkdirAll(bones, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(bones, "agent.id"),
+		[]byte("test-agent-1234"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := scaffoldOrchestrator(dir); err != nil {
+		t.Fatalf("scaffoldOrchestrator: %v", err)
+	}
+
+	m, err := readManifest(dir)
+	if err != nil {
+		t.Fatalf("readManifest: %v", err)
+	}
+	if m == nil {
+		t.Fatal("manifest absent after scaffold")
+	}
+
+	// Scaffolded entries: both agent.id and scaffold_version present.
+	wantPaths := map[string]bool{
+		".bones/agent.id":         false,
+		".bones/scaffold_version": false,
+	}
+	for _, sf := range m.Scaffolded {
+		if _, ok := wantPaths[sf.Path]; !ok {
+			t.Errorf("unexpected scaffolded entry: %s", sf.Path)
+			continue
+		}
+		wantPaths[sf.Path] = true
+		if sf.SHA256 == "" {
+			t.Errorf("%s sha256 empty", sf.Path)
+		}
+		if sf.Size <= 0 {
+			t.Errorf("%s size %d, want > 0", sf.Path, sf.Size)
+		}
+		// Size must match on-disk byte length.
+		data, _ := os.ReadFile(filepath.Join(dir, filepath.FromSlash(sf.Path)))
+		if int64(len(data)) != sf.Size {
+			t.Errorf("%s size mismatch: manifest=%d on-disk=%d",
+				sf.Path, sf.Size, len(data))
+		}
+		if hashHex(data) != sf.SHA256 {
+			t.Errorf("%s sha256 mismatch: manifest=%s on-disk=%s",
+				sf.Path, sf.SHA256, hashHex(data))
+		}
+	}
+	for p, seen := range wantPaths {
+		if !seen {
+			t.Errorf("scaffolded missing entry: %s", p)
+		}
+	}
+
+	// Settings.json bones-owned hook subset: hash present.
+	if m.SettingsHooksSHA256 == "" {
+		t.Errorf("SettingsHooksSHA256 empty after fresh scaffold")
+	}
+}
+
+// TestWriteManifest_OmitsRollingFiles pins the scope decision in
+// issue #262: rolling/lifecycle files (.bones/up.log, .bones/hub.pid)
+// are NOT recorded in the manifest because their content changes
+// outside `bones up`'s control and would false-positive every doctor
+// run.
+func TestWriteManifest_OmitsRollingFiles(t *testing.T) {
+	dir := t.TempDir()
+	// Pre-create up.log and hub.pid so they exist when writeManifest
+	// scans .bones/. If the manifest were to include them, they would
+	// show up in Scaffolded.
+	bones := filepath.Join(dir, ".bones")
+	if err := os.MkdirAll(bones, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(bones, "up.log"),
+		[]byte("INFO up\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(bones, "hub.pid"),
+		[]byte("12345"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(bones, "agent.id"),
+		[]byte("aid"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := scaffoldOrchestrator(dir); err != nil {
+		t.Fatal(err)
+	}
+	m, err := readManifest(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, sf := range m.Scaffolded {
+		switch sf.Path {
+		case ".bones/up.log":
+			t.Errorf(".bones/up.log must not be in manifest (rolling content)")
+		case ".bones/hub.pid":
+			t.Errorf(".bones/hub.pid must not be in manifest (lifecycle artifact)")
+		}
+	}
+}
+
+// TestHashBonesOwnedHooks_IgnoresUserHooks pins that adding a
+// non-bones hook to settings.json does NOT change the recorded
+// SettingsHooksSHA256. The hash is computed over the bones-owned
+// subset only.
+func TestHashBonesOwnedHooks_IgnoresUserHooks(t *testing.T) {
+	bonesOnly := map[string]any{
+		"SessionStart": []any{
+			map[string]any{
+				"matcher": "",
+				"hooks": []any{
+					map[string]any{"command": "bones tasks prime --json", "type": "command"},
+					map[string]any{"command": "bones hub start", "type": "command"},
+				},
+			},
+		},
+		"PreCompact": []any{
+			map[string]any{
+				"matcher": "",
+				"hooks": []any{
+					map[string]any{"command": "bones tasks prime --json", "type": "command"},
+				},
+			},
+		},
+	}
+	bonesPlusUser := map[string]any{
+		"SessionStart": []any{
+			map[string]any{
+				"matcher": "",
+				"hooks": []any{
+					map[string]any{"command": "bones tasks prime --json", "type": "command"},
+					map[string]any{"command": "bones hub start", "type": "command"},
+					map[string]any{"command": "user-thing", "type": "command"},
+				},
+			},
+		},
+		"PreCompact": []any{
+			map[string]any{
+				"matcher": "",
+				"hooks": []any{
+					map[string]any{"command": "bones tasks prime --json", "type": "command"},
+				},
+			},
+		},
+		"Stop": []any{
+			map[string]any{
+				"matcher": "",
+				"hooks": []any{
+					map[string]any{"command": "user-cleanup", "type": "command"},
+				},
+			},
+		},
+	}
+	a := hashBonesOwnedHooks(bonesOnly)
+	b := hashBonesOwnedHooks(bonesPlusUser)
+	if a == "" {
+		t.Fatalf("hash empty on bones-only hooks")
+	}
+	if a != b {
+		t.Errorf("user hooks influenced bones-owned subset hash:\nbones-only=%s\nbones+user=%s",
+			a, b)
+	}
+}
+
+// TestHashBonesOwnedHooks_DetectsMissingBonesHook pins that REMOVING
+// a bones-owned hook entry changes the hash — that's the tamper
+// signal doctor uses to flag a hand-edited settings.json.
+func TestHashBonesOwnedHooks_DetectsMissingBonesHook(t *testing.T) {
+	full := map[string]any{
+		"SessionStart": []any{
+			map[string]any{
+				"matcher": "",
+				"hooks": []any{
+					map[string]any{"command": "bones tasks prime --json", "type": "command"},
+					map[string]any{"command": "bones hub start", "type": "command"},
+				},
+			},
+		},
+		"PreCompact": []any{
+			map[string]any{
+				"matcher": "",
+				"hooks": []any{
+					map[string]any{"command": "bones tasks prime --json", "type": "command"},
+				},
+			},
+		},
+	}
+	missingHubStart := map[string]any{
+		"SessionStart": []any{
+			map[string]any{
+				"matcher": "",
+				"hooks": []any{
+					map[string]any{"command": "bones tasks prime --json", "type": "command"},
+				},
+			},
+		},
+		"PreCompact": []any{
+			map[string]any{
+				"matcher": "",
+				"hooks": []any{
+					map[string]any{"command": "bones tasks prime --json", "type": "command"},
+				},
+			},
+		},
+	}
+	if hashBonesOwnedHooks(full) == hashBonesOwnedHooks(missingHubStart) {
+		t.Errorf("hash unchanged when a bones-owned hook was removed")
+	}
+}
+
+// TestCheckManifestIntegrity_Clean pins that a clean fresh-scaffold
+// workspace produces zero WARN-class findings from the manifest
+// integrity check.
+func TestCheckManifestIntegrity_Clean(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".bones"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".bones", "agent.id"),
+		[]byte("aid"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := scaffoldOrchestrator(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	got := checkManifestIntegrity(&buf, dir)
+	if got != 0 {
+		t.Errorf("warns=%d on clean workspace; output:\n%s", got, buf.String())
+	}
+	if !strings.Contains(buf.String(), "OK") {
+		t.Errorf("expected OK line; got:\n%s", buf.String())
+	}
+}
+
+// TestCheckManifestIntegrity_TamperedScaffoldedFile detects content
+// drift on a manifest-tracked non-skill file. Hand-edit
+// .bones/scaffold_version after the manifest was stamped → doctor
+// must surface a tamper WARN.
+func TestCheckManifestIntegrity_TamperedScaffoldedFile(t *testing.T) {
+	dir := setupCleanScaffold(t)
+	// Tamper: rewrite scaffold_version. The manifest already recorded
+	// the original hash; doctor should flag the mismatch.
+	stamp := filepath.Join(dir, ".bones", "scaffold_version")
+	if err := os.WriteFile(stamp, []byte("99.99.99-tampered\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	warns := checkManifestIntegrity(&buf, dir)
+	out := buf.String()
+	if warns < 1 {
+		t.Errorf("expected at least 1 WARN, got %d; output:\n%s", warns, out)
+	}
+	if !strings.Contains(out, "tamper") {
+		t.Errorf("expected tamper finding in output:\n%s", out)
+	}
+	if !strings.Contains(out, "scaffold_version") {
+		t.Errorf("tamper output should name the drifted file:\n%s", out)
+	}
+}
+
+// TestCheckManifestIntegrity_PartialScaffold detects a manifest
+// entry whose corresponding file is missing on disk — the
+// signature of a partial scaffold or operator-driven `rm`.
+func TestCheckManifestIntegrity_PartialScaffold(t *testing.T) {
+	dir := setupCleanScaffold(t)
+	if err := os.Remove(filepath.Join(dir, ".bones", "agent.id")); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	warns := checkManifestIntegrity(&buf, dir)
+	out := buf.String()
+	if warns < 1 {
+		t.Errorf("expected at least 1 WARN, got %d; output:\n%s", warns, out)
+	}
+	if !strings.Contains(out, "missing") {
+		t.Errorf("expected partial-scaffold finding (missing) in output:\n%s", out)
+	}
+	if !strings.Contains(out, "agent.id") {
+		t.Errorf("partial output should name the missing file:\n%s", out)
+	}
+}
+
+// TestCheckManifestIntegrity_VersionDrift detects a manifest stamped
+// by an older bones than the current binary.
+func TestCheckManifestIntegrity_VersionDrift(t *testing.T) {
+	dir := setupCleanScaffold(t)
+	// Rewrite the manifest's Version field to simulate an older
+	// install. Use a concrete version (NOT "dev") so scaffoldver.Drifted
+	// fires; bonesVersion under test defaults to "dev" which Drifted
+	// suppresses.
+	bumpManifestVersion(t, dir, "0.0.1-stale", "9.9.9-current")
+
+	var buf bytes.Buffer
+	warns := checkManifestIntegrity(&buf, dir)
+	out := buf.String()
+	if warns < 1 {
+		t.Errorf("expected at least 1 WARN, got %d; output:\n%s", warns, out)
+	}
+	if !strings.Contains(out, "manifest v0.0.1-stale") {
+		t.Errorf("expected manifest version in output:\n%s", out)
+	}
+}
+
+// TestCheckManifestIntegrity_TamperedSettingsHooks detects a hand-
+// edit that removes a bones-owned hook from .claude/settings.json
+// after `bones up` stamped the manifest.
+func TestCheckManifestIntegrity_TamperedSettingsHooks(t *testing.T) {
+	dir := setupCleanScaffold(t)
+	// Hand-edit settings.json to drop the `bones hub start` entry.
+	settingsPath := filepath.Join(dir, ".claude", "settings.json")
+	data, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var settings map[string]any
+	if err := json.Unmarshal(data, &settings); err != nil {
+		t.Fatal(err)
+	}
+	hooks := settings["hooks"].(map[string]any)
+	pruneCommandFromEvent(hooks, "SessionStart", "bones hub start")
+	out, _ := json.MarshalIndent(settings, "", "  ")
+	if err := os.WriteFile(settingsPath, append(out, '\n'), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	warns := checkManifestIntegrity(&buf, dir)
+	output := buf.String()
+	if warns < 1 {
+		t.Errorf("expected at least 1 WARN, got %d; output:\n%s", warns, output)
+	}
+	if !strings.Contains(output, "settings.json") {
+		t.Errorf("expected settings.json finding:\n%s", output)
+	}
+	if !strings.Contains(output, "tamper") {
+		t.Errorf("expected tamper label in output:\n%s", output)
+	}
+}
+
+// TestCheckManifestIntegrity_NoManifest is silent (zero warns) for
+// workspaces without a manifest — covers fresh dirs before
+// `bones up` and legacy pre-#262 installs.
+func TestCheckManifestIntegrity_NoManifest(t *testing.T) {
+	dir := t.TempDir()
+	var buf bytes.Buffer
+	warns := checkManifestIntegrity(&buf, dir)
+	if warns != 0 {
+		t.Errorf("warns=%d on workspace without manifest; output:\n%s",
+			warns, buf.String())
+	}
+	if buf.Len() != 0 {
+		t.Errorf("expected silent on missing manifest; got:\n%s", buf.String())
+	}
+}
+
+// setupCleanScaffold runs scaffoldOrchestrator on a fresh temp dir
+// (with a seeded agent.id, since workspace.Init normally writes that
+// before scaffoldOrchestrator in the real `bones up` flow). Returns
+// the workspace root.
+func setupCleanScaffold(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".bones"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".bones", "agent.id"),
+		[]byte("test-agent-id"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := scaffoldOrchestrator(dir); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// bumpManifestVersion rewrites manifest.Version to stale and bumps
+// the running binary version to current for the duration of the
+// test. Restores the original on cleanup. Doctor reads the binary
+// version through internal/version, so the override has to land
+// there — bonesVersion in cli is only consulted at manifest write
+// time.
+func bumpManifestVersion(t *testing.T, dir, stale, current string) {
+	t.Helper()
+	mPath := filepath.Join(dir, filepath.FromSlash(manifestRel))
+	data, err := os.ReadFile(mPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var m skillManifest
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatal(err)
+	}
+	m.Version = stale
+	out, _ := json.MarshalIndent(m, "", "  ")
+	if err := os.WriteFile(mPath, append(out, '\n'), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	prev := version.Get()
+	version.Set(current)
+	t.Cleanup(func() { version.Set(prev) })
+}

--- a/cli/orchestrator.go
+++ b/cli/orchestrator.go
@@ -86,6 +86,14 @@ func scaffoldOrchestrator(root string) (scaffoldFootprint, error) {
 	if err := scaffoldver.Write(root, version.Get()); err != nil {
 		return fp, fmt.Errorf("scaffold version stamp: %w", err)
 	}
+	// Manifest writes last (issue #262): every other scaffold step has
+	// finished, so the manifest captures the final hashes of
+	// .bones/scaffold_version, .bones/agent.id, and the bones-owned
+	// hook subset of .claude/settings.json. doctor uses these to
+	// detect tamper / partial-scaffold drift in `bones doctor`.
+	if err := writeManifest(root); err != nil {
+		return fp, fmt.Errorf("manifest: %w", err)
+	}
 	return fp, nil
 }
 

--- a/cli/skills.go
+++ b/cli/skills.go
@@ -48,6 +48,19 @@ var bonesOwnedSkills = []string{
 	"using-bones-swarm",
 }
 
+// scaffoldFile records a single bones-written file outside the skills
+// tree (e.g. .bones/agent.id, .bones/scaffold_version). Path is the
+// workspace-relative slash-separated path; SHA256 is hex of the bytes
+// bones observed when stamping the manifest; Size is the byte length
+// of those same bytes. These three together are what `bones doctor`
+// uses to detect tamper / partial-scaffold drift on the non-skill
+// scaffold footprint (issue #262).
+type scaffoldFile struct {
+	Path   string `json:"path"`
+	SHA256 string `json:"sha256"`
+	Size   int64  `json:"size"`
+}
+
 // skillManifest is the on-disk schema for manifestRel. Keys in Files
 // are workspace-relative paths (always forward-slash separated, even
 // on Windows, so a manifest written on one host is portable).
@@ -55,6 +68,14 @@ var bonesOwnedSkills = []string{
 // This is the load-bearing data structure for issue #210: install
 // stamps the bytes it wrote, uninstall trusts that stamp regardless
 // of how the embedded bundle has evolved between the two events.
+//
+// Issue #262 extended this manifest to also cover bones-written files
+// outside the skills tree (.bones/agent.id, .bones/scaffold_version)
+// and the bones-owned hook subset of .claude/settings.json. The
+// non-skill entries live in Scaffolded (with size + sha256) and
+// SettingsHooksSHA256 — sibling fields rather than crammed into
+// Files because removeBonesSkills's per-file remove logic keys off
+// Files entries existing iff they were skill files.
 type skillManifest struct {
 	// Version is the bones binary version that wrote the manifest.
 	// Diagnostic only — not used in the remove decision.
@@ -65,6 +86,33 @@ type skillManifest struct {
 	// against this map: match → bones-owned + unedited (remove);
 	// mismatch → user-edited (preserve + warn).
 	Files map[string]string `json:"files"`
+
+	// Scaffolded records non-skill files bones writes during `bones
+	// up` (.bones/agent.id, .bones/scaffold_version). doctor uses
+	// these entries to detect tamper (sha256 drift) and partial
+	// scaffold (file missing on disk). Empty on legacy manifests
+	// written by pre-#262 binaries.
+	Scaffolded []scaffoldFile `json:"scaffolded,omitempty"`
+
+	// SettingsHooksSHA256 is the SHA-256 hex of the canonical-JSON
+	// rendering of the bones-owned hook subset of
+	// .claude/settings.json — only the hook entries bones installs
+	// (per bonesOwnedHookCommands). User-added hooks alongside
+	// bones's are NOT tamper-detected (they aren't bones's to claim).
+	// Empty on legacy manifests.
+	SettingsHooksSHA256 string `json:"settings_hooks_sha256,omitempty"`
+}
+
+// bonesOwnedHookCommands lists the (event, command) pairs bones
+// installs into .claude/settings.json. The integrity hash recorded in
+// the manifest is computed over a canonical rendering of just these
+// entries — not the whole settings.json, because the user is free to
+// add their own hooks alongside bones's, and the manifest must not
+// false-positive on those.
+var bonesOwnedHookCommands = []struct{ Event, Command string }{
+	{"SessionStart", "bones tasks prime --json"},
+	{"SessionStart", "bones hub start"},
+	{"PreCompact", "bones tasks prime --json"},
 }
 
 // writeBonesSkills materializes the embedded skill bundle into
@@ -79,16 +127,17 @@ type skillManifest struct {
 // New files written are tracked in fp.FilesWritten using their
 // workspace-relative path so the up summary can render them.
 //
-// After all files are processed, writeManifest stamps the install-time
-// provenance record (manifestRel) so `bones down` can recognize this
-// install's bones-owned files even after a binary upgrade swaps the
-// embedded bundle out from under us (issue #210).
+// Stamping the install-time manifest is now the responsibility of
+// scaffoldOrchestrator (issue #262) — it runs after every scaffold
+// step finishes so the manifest can record .bones/scaffold_version,
+// .bones/agent.id, and the bones-owned hook subset of
+// .claude/settings.json alongside the skill files.
 func writeBonesSkills(root string, fp *scaffoldFootprint) error {
 	skillsDir := filepath.Join(root, ".claude", "skills")
 	if err := os.MkdirAll(skillsDir, 0o755); err != nil {
 		return fmt.Errorf("mkdir skills: %w", err)
 	}
-	if err := fs.WalkDir(skillsFS, skillsRoot, func(path string, d fs.DirEntry, err error) error {
+	return fs.WalkDir(skillsFS, skillsRoot, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
@@ -101,10 +150,7 @@ func writeBonesSkills(root string, fp *scaffoldFootprint) error {
 		}
 		dst := filepath.Join(skillsDir, rel)
 		return materializeSkillFile(skillsFS, path, dst, root, fp)
-	}); err != nil {
-		return err
-	}
-	return writeManifest(root)
+	})
 }
 
 // writeManifest stamps the install-time provenance record at
@@ -134,8 +180,6 @@ func writeBonesSkills(root string, fp *scaffoldFootprint) error {
 //
 // The manifest itself is excluded from its own contents.
 func writeManifest(root string) error {
-	skillsDir := filepath.Join(root, ".claude", "skills")
-
 	prev, err := readManifest(root)
 	if err != nil {
 		return err
@@ -145,61 +189,25 @@ func writeManifest(root string) error {
 		previousHashes = prev.Files
 	}
 
-	// Build the embed-side hash table once so the per-file decision
-	// below is a constant-time lookup rather than re-reading the
-	// embed FS for every on-disk file.
-	embedHashes, err := buildEmbedHashes()
+	files, err := buildSkillFileHashes(root, previousHashes)
 	if err != nil {
 		return err
 	}
-
+	scaff, err := buildScaffoldedEntries(root)
+	if err != nil {
+		return err
+	}
+	hooksHash, err := bonesOwnedHooksHashFromDisk(root)
+	if err != nil {
+		return err
+	}
 	m := skillManifest{
-		Version: bonesVersion(),
-		Files:   map[string]string{},
+		Version:             bonesVersion(),
+		Files:               files,
+		Scaffolded:          scaff,
+		SettingsHooksSHA256: hooksHash,
 	}
-	for _, name := range bonesOwnedSkills {
-		dir := filepath.Join(skillsDir, name)
-		err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
-			if err != nil {
-				if errors.Is(err, fs.ErrNotExist) {
-					return fs.SkipDir
-				}
-				return err
-			}
-			if d.IsDir() {
-				return nil
-			}
-			rel, rerr := filepath.Rel(root, path)
-			if rerr != nil {
-				return fmt.Errorf("rel %s: %w", path, rerr)
-			}
-			relSlash := filepath.ToSlash(rel)
 
-			// Sticky-ownership branch: previously claimed → keep
-			// the previous hash. Even if the user has since edited
-			// the file (bytes diverge), the manifest tracks what
-			// bones installed so down can detect the divergence.
-			if h, ok := previousHashes[relSlash]; ok {
-				m.Files[relSlash] = h
-				return nil
-			}
-
-			data, rerr := os.ReadFile(path)
-			if rerr != nil {
-				return fmt.Errorf("read %s: %w", path, rerr)
-			}
-			cur := hashHex(data)
-			embedRel := strings.TrimPrefix(relSlash, ".claude/skills/")
-			if want, ok := embedHashes[embedRel]; ok && cur == want {
-				m.Files[relSlash] = cur
-			}
-			// else: user-pre-existing, not bones-owned, skip.
-			return nil
-		})
-		if err != nil && !errors.Is(err, fs.ErrNotExist) {
-			return err
-		}
-	}
 	out, err := json.MarshalIndent(m, "", "  ")
 	if err != nil {
 		return fmt.Errorf("marshal manifest: %w", err)
@@ -209,6 +217,177 @@ func writeManifest(root string) error {
 		return fmt.Errorf("mkdir manifest dir: %w", err)
 	}
 	return os.WriteFile(path, append(out, '\n'), 0o644)
+}
+
+// buildSkillFileHashes walks the bones-owned skill dirs under
+// .claude/skills/<bones-owned skill>/ and returns the path → hash
+// map that goes into manifest.Files. The selection rule (sticky
+// previous-manifest entry, else current-embed match, else skip) is
+// the issue-#210 contract carried verbatim from the prior inline
+// implementation.
+func buildSkillFileHashes(
+	root string, previousHashes map[string]string,
+) (map[string]string, error) {
+	skillsDir := filepath.Join(root, ".claude", "skills")
+	embedHashes, err := buildEmbedHashes()
+	if err != nil {
+		return nil, err
+	}
+	out := map[string]string{}
+	for _, name := range bonesOwnedSkills {
+		dir := filepath.Join(skillsDir, name)
+		err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+			return walkSkillFile(path, d, err, root, previousHashes, embedHashes, out)
+		})
+		if err != nil && !errors.Is(err, fs.ErrNotExist) {
+			return nil, err
+		}
+	}
+	return out, nil
+}
+
+// walkSkillFile is the per-file decision body for buildSkillFileHashes.
+// Extracted from the WalkDir callback to keep buildSkillFileHashes
+// under the funlen cap.
+func walkSkillFile(
+	path string, d fs.DirEntry, err error,
+	root string,
+	previousHashes, embedHashes, out map[string]string,
+) error {
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return fs.SkipDir
+		}
+		return err
+	}
+	if d.IsDir() {
+		return nil
+	}
+	rel, rerr := filepath.Rel(root, path)
+	if rerr != nil {
+		return fmt.Errorf("rel %s: %w", path, rerr)
+	}
+	relSlash := filepath.ToSlash(rel)
+
+	// Sticky-ownership branch: previously claimed → keep the
+	// previous hash. Even if the user has since edited the file
+	// (bytes diverge), the manifest tracks what bones installed so
+	// down can detect the divergence.
+	if h, ok := previousHashes[relSlash]; ok {
+		out[relSlash] = h
+		return nil
+	}
+
+	data, rerr := os.ReadFile(path)
+	if rerr != nil {
+		return fmt.Errorf("read %s: %w", path, rerr)
+	}
+	cur := hashHex(data)
+	embedRel := strings.TrimPrefix(relSlash, ".claude/skills/")
+	if want, ok := embedHashes[embedRel]; ok && cur == want {
+		out[relSlash] = cur
+	}
+	// else: user-pre-existing, not bones-owned, skip.
+	return nil
+}
+
+// scaffoldedTrackedPaths is the canonical list of non-skill files
+// `bones up` writes outside .claude/skills/. Adding a path here
+// extends doctor's tamper / partial-scaffold detection (issue #262)
+// to that file. Paths must be slash-separated workspace-relative.
+//
+// Excluded by design:
+//   - .bones/up.log (rolling audit log, content changes every run)
+//   - .bones/hub.pid (lifecycle artifact, only present while hub is
+//     running)
+//   - .claude/settings.json (whole file is user+bones territory; the
+//     bones-owned hook subset is hashed separately as
+//     SettingsHooksSHA256)
+var scaffoldedTrackedPaths = []string{
+	".bones/agent.id",
+	".bones/scaffold_version",
+}
+
+// buildScaffoldedEntries hashes each path in scaffoldedTrackedPaths
+// and returns the resulting scaffoldFile slice. Files that don't
+// exist on disk yet (e.g. the manifest is being stamped before that
+// step ran) are silently omitted — the manifest will simply be
+// missing the entry and doctor will flag the absence on next read.
+// Hard read errors propagate so callers can surface them.
+func buildScaffoldedEntries(root string) ([]scaffoldFile, error) {
+	var out []scaffoldFile
+	for _, rel := range scaffoldedTrackedPaths {
+		full := filepath.Join(root, filepath.FromSlash(rel))
+		data, err := os.ReadFile(full)
+		if errors.Is(err, fs.ErrNotExist) {
+			continue
+		}
+		if err != nil {
+			return nil, fmt.Errorf("read %s: %w", rel, err)
+		}
+		out = append(out, scaffoldFile{
+			Path:   rel,
+			SHA256: hashHex(data),
+			Size:   int64(len(data)),
+		})
+	}
+	return out, nil
+}
+
+// bonesOwnedHooksHashFromDisk reads .claude/settings.json, extracts
+// the bones-owned hook subset (per bonesOwnedHookCommands), and
+// returns the SHA-256 hex of its canonical rendering. Returns an
+// empty string + nil error when settings.json is absent — that
+// matches a workspace where mergeSettings has not yet run.
+func bonesOwnedHooksHashFromDisk(root string) (string, error) {
+	path := filepath.Join(root, ".claude", "settings.json")
+	data, err := os.ReadFile(path)
+	if errors.Is(err, fs.ErrNotExist) {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("read settings.json: %w", err)
+	}
+	var settings map[string]any
+	if len(data) > 0 {
+		if err := json.Unmarshal(data, &settings); err != nil {
+			return "", fmt.Errorf("parse settings.json: %w", err)
+		}
+	}
+	hooks, _ := settings["hooks"].(map[string]any)
+	return hashBonesOwnedHooks(hooks), nil
+}
+
+// hashBonesOwnedHooks computes the canonical SHA-256 hex of the
+// bones-owned hook subset. The canonical form is JSON-serialized as
+// a stable []map{event, command} list, sorted by (event, command),
+// so two manifests with semantically equivalent hooks produce the
+// same hash regardless of map iteration order. Hooks bones doesn't
+// claim are ignored — the subset never includes user-added entries.
+//
+// The function returns the empty string only when zero bones-owned
+// hook commands are present on disk (e.g. user hand-pruned them).
+// In that case doctor compares "" against the manifest's recorded
+// hash and surfaces the divergence as a tamper finding.
+func hashBonesOwnedHooks(hooks map[string]any) string {
+	type entry struct {
+		Event   string `json:"event"`
+		Command string `json:"command"`
+	}
+	var present []entry
+	for _, want := range bonesOwnedHookCommands {
+		if hookCommandPresent(hooks, want.Event, want.Command) {
+			present = append(present, entry{Event: want.Event, Command: want.Command})
+		}
+	}
+	sort.Slice(present, func(i, j int) bool {
+		if present[i].Event != present[j].Event {
+			return present[i].Event < present[j].Event
+		}
+		return present[i].Command < present[j].Command
+	})
+	out, _ := json.Marshal(present)
+	return hashHex(out)
 }
 
 // buildEmbedHashes returns a map from skill-relative path (e.g.


### PR DESCRIPTION
## Summary

- Extend the existing `.claude/skills/.bones-manifest.json` schema (no new file) with sibling fields: `scaffolded[]` for `.bones/` state, `settings_hooks_sha256` for the bones-owned hook subset of `.claude/settings.json`.
- `bones doctor` reads the manifest and reports tamper / partial scaffold / version drift / hooks tamper. Silent on legacy/missing manifests so older workspaces don't false-positive.
- 12 new tests covering schema, hooks-hashing edge cases, and the four doctor detection paths.

Closes #262

## Schema decision

Sibling fields rather than cramming everything into the existing `Files[]`. `removeBonesSkills` keys off `Files` to determine which skill files to delete; co-mingling non-skill entries would have required reworking that contract for no gain.

## What's tracked vs not

| Path | Tracked | Reason |
|---|---|---|
| `.bones/agent.id` | ✅ sha256 + size | stable |
| `.bones/scaffold_version` | ✅ sha256 + size | version-bound |
| `.claude/settings.json` (bones-owned hooks subset) | ✅ content hash | tamper detection on the subset bones owns; user-added hooks don't false-positive |
| `.claude/skills/*` | ✅ already covered | unchanged |
| `.bones/up.log` | ❌ | rolling audit log, content changes every run |
| `.bones/hub.pid` | ❌ | lifecycle file, only present when hub is running |

## Test plan

- [x] `make check` passes
- [x] `go test -tags=otel -short ./...` passes
- [x] End-to-end smoke: fresh `bones up` produces manifest with expected `scaffolded[]` + non-empty `settings_hooks_sha256`

## Doctor integration

Extended `runBypassReportTo` rather than adding a new helper. Reads via existing `readManifest`. Emits one OK line on clean, named entries on each detection class.

## Notes

- Manifest path stays at `.claude/skills/.bones-manifest.json` per locked scope.
- Refactored `writeManifest` to satisfy lint (extracted helpers).
- `scaffoldOrchestrator` now writes manifest as the final step, after skills + settings.json merge + `scaffoldver.Write`, so all tracked files exist when hashed.
