### PR TITLE
feat(cleanup): bones cleanup verb + lease-TTL auto-reap

### DIFF
--- a/cli/cleanup.go
+++ b/cli/cleanup.go
@@ -1,0 +1,276 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	repocli "github.com/danmestas/EdgeSync/cli/repo"
+
+	"github.com/danmestas/bones/internal/swarm"
+	"github.com/danmestas/bones/internal/workspace"
+)
+
+// CleanupCmd is the prompt-cleanup verb that operators (or harness
+// `SubagentStop` recipes) invoke to reap a single slot or a legacy
+// `.claude/worktrees/agent-*/` dir without waiting for the hub's
+// lease-TTL watcher to converge.
+//
+// Three mutually-exclusive modes:
+//
+//   - --slot=<name>          drop the slot's session record and remove
+//     `.bones/swarm/<slot>/wt/`. Idempotent —
+//     a missing slot is a no-op (exit 0) so
+//     re-running after a SubagentStop hook
+//     already fired converges silently.
+//   - --worktree=<path>      remove a single legacy
+//     `.claude/worktrees/agent-*/` dir. Force-
+//     unlocks the git worktree first so a
+//     crashed-agent lock file does not block
+//     removal.
+//   - --all-worktrees        remove the entire `.claude/worktrees/`
+//     tree. Useful for the migration from
+//     pre-ADR-0050 isolation; the loud
+//     `bones up` refusal points operators here.
+//
+// Bones ships only the verb. The recipe for wiring this into Claude
+// Code's `SubagentStop` hook is documented at
+// `docs/recipes/claude-code-harness.md`; bones does NOT scaffold the
+// hook because it does not own `.claude/settings.json` wholesale
+// (#256, #260, ADR 0050).
+type CleanupCmd struct {
+	Slot         string `name:"slot" help:"reap a single slot (drops session record + removes wt)"`    //nolint:lll
+	Worktree     string `name:"worktree" help:"remove a single legacy .claude/worktrees/agent-*/ dir"` //nolint:lll
+	AllWorktrees bool   `name:"all-worktrees" help:"remove the entire .claude/worktrees/ tree"`        //nolint:lll
+}
+
+// Run dispatches on the chosen mode. Mutual exclusion is enforced
+// up front so a typo'd combination fails before any side effect.
+func (c *CleanupCmd) Run(g *repocli.Globals) error {
+	if err := c.validateFlags(); err != nil {
+		return err
+	}
+	if c.Slot != "" {
+		return c.runSlot(c.Slot)
+	}
+	if c.Worktree != "" {
+		return c.runWorktree(c.Worktree)
+	}
+	return c.runAllWorktrees()
+}
+
+// validateFlags enforces the mutual-exclusion invariant: exactly
+// one mode flag must be set. Two flags → user is confused, refuse
+// before either side effect lands. Zero flags → print a usage hint
+// (the verb does nothing safe by default).
+func (c *CleanupCmd) validateFlags() error {
+	count := 0
+	if c.Slot != "" {
+		count++
+	}
+	if c.Worktree != "" {
+		count++
+	}
+	if c.AllWorktrees {
+		count++
+	}
+	if count == 0 {
+		return errors.New(
+			"bones cleanup: pass exactly one of --slot=<name>, " +
+				"--worktree=<path>, or --all-worktrees",
+		)
+	}
+	if count > 1 {
+		return errors.New(
+			"bones cleanup: --slot, --worktree, and --all-worktrees " +
+				"are mutually exclusive",
+		)
+	}
+	return nil
+}
+
+// runSlot reaps one slot. The verb is idempotent: a missing
+// session record + missing wt directory is a no-op (exit 0). When
+// the workspace itself is unreachable (no .bones/, no live hub) the
+// verb falls back to filesystem-only cleanup so an operator can run
+// `bones cleanup --slot=X` even after `bones down` has torn the
+// hub state down.
+func (c *CleanupCmd) runSlot(slot string) error {
+	ctx, stop, info, err := joinWorkspace()
+	if err != nil {
+		// Workspace not joinable — surface the same shape as
+		// other verbs but make the no-op path explicit so the
+		// SubagentStop hook converges.
+		return fmt.Errorf("bones cleanup: %w", err)
+	}
+	defer stop()
+
+	sess, closeSess, openErr := openSwarmSessions(ctx, info)
+	if openErr != nil {
+		// NATS unreachable: do best-effort filesystem cleanup
+		// only. The session record will fall out of the bucket
+		// via JetStream KV TTL even without our delete.
+		fmt.Fprintf(os.Stderr,
+			"bones cleanup: warning: %v (filesystem-only cleanup)\n",
+			openErr,
+		)
+		return cleanupSlotFS(info.WorkspaceDir, slot)
+	}
+	defer closeSess()
+
+	wt := swarm.SlotWorktree(info.WorkspaceDir, slot)
+	hadWT := false
+	if st, statErr := os.Stat(wt); statErr == nil && st.IsDir() {
+		hadWT = true
+	}
+
+	existed, err := swarm.SlotCleanup(ctx, sess, info.WorkspaceDir, slot)
+	if err != nil {
+		return fmt.Errorf("bones cleanup: %w", err)
+	}
+	switch {
+	case existed:
+		fmt.Fprintf(os.Stderr, "bones cleanup: reaped slot %q\n", slot)
+	case hadWT:
+		// No KV record but a wt dir was sitting on disk — typical
+		// when an operator manually mkdir'd a slot dir or when the
+		// substrate already evicted the record but the host was
+		// offline when it happened. Still call it a successful
+		// removal (not a no-op).
+		fmt.Fprintf(os.Stderr,
+			"bones cleanup: removed slot %q wt dir (no live record)\n", slot)
+	default:
+		fmt.Fprintf(os.Stderr,
+			"bones cleanup: slot %q already clean (no-op)\n", slot)
+	}
+	return nil
+}
+
+// cleanupSlotFS is the substrate-unreachable fallback: remove the
+// slot's wt dir without touching KV. The TTL watcher (or the next
+// `bones up`) will reap the orphan record.
+func cleanupSlotFS(workspaceDir, slot string) error {
+	wt := swarm.SlotWorktree(workspaceDir, slot)
+	if err := os.RemoveAll(wt); err != nil {
+		return fmt.Errorf("remove %s: %w", wt, err)
+	}
+	fmt.Fprintf(os.Stderr,
+		"bones cleanup: removed %s (substrate offline; record may persist until TTL)\n",
+		wt,
+	)
+	return nil
+}
+
+// runWorktree removes one legacy `.claude/worktrees/agent-*/` dir.
+// Force-unlocks the git worktree first so a crashed-agent lock
+// file (`.git/worktrees/<name>/locked`) does not block removal.
+//
+// Errors loudly when path does not exist OR when path is not a
+// recognizable worktree dir — the operator should know they typo'd
+// the path before discovering nothing happened.
+func (c *CleanupCmd) runWorktree(path string) error {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return fmt.Errorf("bones cleanup: resolve %s: %w", path, err)
+	}
+	st, err := os.Stat(abs)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			// Idempotent: missing path is a no-op.
+			fmt.Fprintf(os.Stderr,
+				"bones cleanup: %s already gone (no-op)\n", abs)
+			return nil
+		}
+		return fmt.Errorf("bones cleanup: stat %s: %w", abs, err)
+	}
+	if !st.IsDir() {
+		return fmt.Errorf(
+			"bones cleanup: %s is not a directory — pass --all-worktrees "+
+				"to remove the entire .claude/worktrees/ tree, or use "+
+				"`git worktree remove --force` for non-worktree paths",
+			abs,
+		)
+	}
+	// Best-effort `git worktree remove --force`. If git is missing
+	// or the path is not registered as a git worktree (e.g. a stale
+	// dir whose owning repo has been garbage-collected), fall
+	// through to plain os.RemoveAll. The end state is the same
+	// (path gone) regardless of which path got us there.
+	tryGitWorktreeRemove(abs)
+	if err := os.RemoveAll(abs); err != nil {
+		return fmt.Errorf("bones cleanup: remove %s: %w", abs, err)
+	}
+	fmt.Fprintf(os.Stderr, "bones cleanup: removed worktree %s\n", abs)
+	return nil
+}
+
+// tryGitWorktreeRemove invokes `git worktree remove --force <path>`
+// from the parent of path, swallowing any error. The returned exit
+// code is irrelevant — the caller falls through to os.RemoveAll
+// either way. Pulled into a helper so runWorktree's flow reads
+// linearly.
+func tryGitWorktreeRemove(path string) {
+	if _, err := exec.LookPath("git"); err != nil {
+		return
+	}
+	parent := filepath.Dir(path)
+	cmd := exec.Command("git", "worktree", "remove", "--force", path)
+	cmd.Dir = parent
+	// Silence stderr/stdout: this is a best-effort assist, not the
+	// authoritative remove. The os.RemoveAll below is.
+	_ = cmd.Run()
+}
+
+// runAllWorktrees removes the entire `.claude/worktrees/` tree. No
+// per-worktree git remove — a `bones up` refusal pointed the
+// operator here, so the tree is by definition stale. Idempotent;
+// missing tree is exit 0.
+func (c *CleanupCmd) runAllWorktrees() error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("bones cleanup: cwd: %w", err)
+	}
+	root := findClaudeWorktreesRoot(cwd)
+	if root == "" {
+		fmt.Fprintln(os.Stderr,
+			"bones cleanup: no .claude/worktrees/ tree found (no-op)")
+		return nil
+	}
+	if err := os.RemoveAll(root); err != nil {
+		return fmt.Errorf("bones cleanup: remove %s: %w", root, err)
+	}
+	fmt.Fprintf(os.Stderr, "bones cleanup: removed %s\n", root)
+	return nil
+}
+
+// findClaudeWorktreesRoot walks up from start to locate
+// `<repo-root>/.claude/worktrees`. Returns "" when no such
+// directory exists at any ancestor. Uses workspace.FindRoot when
+// available (a bones workspace always has .bones/) and otherwise
+// falls back to a self-contained walk so the verb still works in
+// non-bones git repos that legacy .claude/worktrees/ dirs may live
+// under.
+func findClaudeWorktreesRoot(start string) string {
+	if root, err := workspace.FindRoot(start); err == nil {
+		candidate := filepath.Join(root, ".claude", "worktrees")
+		if st, err := os.Stat(candidate); err == nil && st.IsDir() {
+			return candidate
+		}
+	}
+	// Fallback: scan up until we hit `.claude/worktrees` or the
+	// filesystem root.
+	cur := start
+	for {
+		candidate := filepath.Join(cur, ".claude", "worktrees")
+		if st, err := os.Stat(candidate); err == nil && st.IsDir() {
+			return candidate
+		}
+		parent := filepath.Dir(cur)
+		if parent == cur {
+			return ""
+		}
+		cur = parent
+	}
+}

--- a/cli/cleanup_test.go
+++ b/cli/cleanup_test.go
@@ -1,0 +1,342 @@
+// Tests for `bones cleanup` (#265, ADR 0050). The verb has three
+// modes; coverage here pins each one against real substrate (slot
+// mode dials NATS via the in-process hub) and against pure
+// filesystem state (worktree / all-worktrees modes).
+package cli
+
+import (
+	"context"
+	"errors"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/danmestas/bones/internal/coord"
+	"github.com/danmestas/bones/internal/swarm"
+	"github.com/danmestas/bones/internal/workspace"
+)
+
+// cleanupFreePort returns an unused 127.0.0.1 TCP port for the
+// in-process hub. Local copy of the helper used in
+// tasks_close_test.go and internal/swarm/lease_test.go; the cli
+// package's tests duplicate rather than depend across packages.
+func cleanupFreePort(t *testing.T) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	addr := ln.Addr().String()
+	_ = ln.Close()
+	return addr
+}
+
+// cleanupFixture brings up a workspace dir with an in-process
+// libfossil + NATS hub. Tests acquire a slot against this fixture,
+// then run `bones cleanup --slot=...` to verify the session record
+// + wt directory both go away.
+type cleanupFixture struct {
+	dir  string
+	hub  *coord.Hub
+	info workspace.Info
+}
+
+func newCleanupFixture(t *testing.T) *cleanupFixture {
+	t.Helper()
+	dir := t.TempDir()
+	orch := filepath.Join(dir, ".bones")
+	if err := os.MkdirAll(orch, 0o755); err != nil {
+		t.Fatalf("mkdir .bones: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+	hub, err := coord.OpenHub(ctx, orch, cleanupFreePort(t))
+	if err != nil {
+		t.Fatalf("OpenHub: %v", err)
+	}
+	t.Cleanup(func() { _ = hub.Stop() })
+	return &cleanupFixture{
+		dir: dir,
+		hub: hub,
+		info: workspace.Info{
+			WorkspaceDir: dir,
+			NATSURL:      hub.NATSURL(),
+			AgentID:      "test-agent",
+		},
+	}
+}
+
+// createTask opens a fixture leaf and inserts an open task so an
+// Acquire has something to claim. Mirrors the helper in
+// tasks_close_test.go and internal/swarm/lease_test.go.
+func (f *cleanupFixture) createTask(t *testing.T, title, holdPath string) coord.TaskID {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	leaf, err := coord.OpenLeaf(ctx, coord.LeafConfig{
+		Hub:     f.hub,
+		Workdir: filepath.Join(f.dir, ".bones", "fixture"),
+		SlotID:  "fixture-" + title,
+	})
+	if err != nil {
+		t.Fatalf("fixture OpenLeaf: %v", err)
+	}
+	defer func() { _ = leaf.Stop() }()
+	tid, err := leaf.OpenTask(ctx, title, []string{holdPath})
+	if err != nil {
+		t.Fatalf("OpenTask: %v", err)
+	}
+	return tid
+}
+
+// acquireSlot is the minimal "create a session record + wt dir"
+// helper. Returns the slot name + a release func; callers run the
+// cleanup verb between Acquire and Release to verify reaping
+// behavior.
+func (f *cleanupFixture) acquireSlot(
+	t *testing.T, ctx context.Context, slot string,
+) {
+	t.Helper()
+	holdPath := filepath.Join(f.dir, slot, "x.txt")
+	taskID := string(f.createTask(t, slot+"-task", holdPath))
+	lease, err := swarm.Acquire(ctx, f.info, slot, taskID, swarm.AcquireOpts{
+		Hub: f.hub,
+	})
+	if err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	if err := lease.Release(ctx); err != nil {
+		t.Fatalf("Release: %v", err)
+	}
+}
+
+// runSlotCleanupViaSwarmHelper drives the cleanup logic against a
+// swarm.Sessions handle directly. The cli verb wraps this same
+// shape (open Sessions, call SlotCleanup); driving SlotCleanup
+// directly avoids needing to chdir/joinWorkspace in tests.
+func runSlotCleanupViaSwarmHelper(
+	t *testing.T, f *cleanupFixture, slot string,
+) (existed bool) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	sess, closeSess, err := openSwarmSessions(ctx, f.info)
+	if err != nil {
+		t.Fatalf("openSwarmSessions: %v", err)
+	}
+	defer closeSess()
+	existed, err = swarm.SlotCleanup(ctx, sess, f.info.WorkspaceDir, slot)
+	if err != nil {
+		t.Fatalf("SlotCleanup: %v", err)
+	}
+	return existed
+}
+
+// TestCleanup_Slot_RemovesSlotDir pins the wt-removal contract:
+// after `bones cleanup --slot=<name>`, the on-disk
+// .bones/swarm/<slot>/wt/ directory must be gone.
+func TestCleanup_Slot_RemovesSlotDir(t *testing.T) {
+	f := newCleanupFixture(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	f.acquireSlot(t, ctx, "agent-tdd")
+
+	wt := swarm.SlotWorktree(f.dir, "agent-tdd")
+	if _, err := os.Stat(wt); err != nil {
+		t.Fatalf("pre-cleanup wt missing (Acquire didn't open it?): %v", err)
+	}
+
+	if existed := runSlotCleanupViaSwarmHelper(t, f, "agent-tdd"); !existed {
+		t.Fatalf("SlotCleanup: existed=false; expected true (slot was just acquired)")
+	}
+	if _, err := os.Stat(wt); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("wt still present after cleanup: stat err=%v", err)
+	}
+}
+
+// TestCleanup_Slot_DropsSessionRecord pins the KV-side contract:
+// after cleanup, `swarm.Sessions.Get` for the slot must return
+// ErrNotFound.
+func TestCleanup_Slot_DropsSessionRecord(t *testing.T) {
+	f := newCleanupFixture(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	f.acquireSlot(t, ctx, "agent-kv")
+	runSlotCleanupViaSwarmHelper(t, f, "agent-kv")
+
+	sess, closeSess, err := openSwarmSessions(ctx, f.info)
+	if err != nil {
+		t.Fatalf("openSwarmSessions: %v", err)
+	}
+	defer closeSess()
+	_, _, err = sess.Get(ctx, "agent-kv")
+	if !errors.Is(err, swarm.ErrNotFound) {
+		t.Errorf("post-cleanup Get: want ErrNotFound, got %v", err)
+	}
+}
+
+// TestCleanup_Slot_Idempotent: re-running on an already-clean slot
+// must be a no-op (existed=false) and must not return an error.
+func TestCleanup_Slot_Idempotent(t *testing.T) {
+	f := newCleanupFixture(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	f.acquireSlot(t, ctx, "agent-idempo")
+	runSlotCleanupViaSwarmHelper(t, f, "agent-idempo")
+
+	// Second pass — the cleanup must not error and must report the
+	// slot is already clean (existed=false).
+	if existed := runSlotCleanupViaSwarmHelper(t, f, "agent-idempo"); existed {
+		t.Errorf("second SlotCleanup: existed=true; expected false on already-clean slot")
+	}
+}
+
+// TestCleanup_Slot_UnknownNameError is the negative-case for the
+// CLI verb: when --slot=<name> names a slot that has neither a
+// session record nor a wt dir, the verb's error / message path
+// reports a clean no-op (exit 0) rather than a substrate error.
+//
+// This pins the idempotence contract from the issue spec — a
+// SubagentStop hook already-fired won't trip a duplicate cleanup.
+func TestCleanup_Slot_UnknownNameError(t *testing.T) {
+	f := newCleanupFixture(t)
+
+	if existed := runSlotCleanupViaSwarmHelper(t, f, "ghost-slot-never-existed"); existed {
+		t.Errorf("SlotCleanup on unknown slot: existed=true; expected false (no record)")
+	}
+	wt := swarm.SlotWorktree(f.dir, "ghost-slot-never-existed")
+	if _, err := os.Stat(wt); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("wt unexpectedly present for unknown slot: %v", err)
+	}
+}
+
+// TestCleanup_Worktree_RemovesGitWorktree pins the legacy worktree
+// removal path: a `.claude/worktrees/agent-X/` dir created via
+// real `git worktree add` (when git is on PATH) must be removed
+// after `bones cleanup --worktree=<path>`. When git isn't
+// available we fall back to a plain dir + sentinel file (the
+// runWorktree helper's os.RemoveAll path covers both cases).
+func TestCleanup_Worktree_RemovesGitWorktree(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH; can't exercise git-worktree-remove path")
+	}
+	repoDir := t.TempDir()
+	// Initialize a git repo with one commit so `git worktree add`
+	// has a HEAD to point at.
+	mustRunGit(t, repoDir, "init", "-q", "-b", "main")
+	mustRunGit(t, repoDir, "config", "user.email", "test@example.com")
+	mustRunGit(t, repoDir, "config", "user.name", "Test User")
+	if err := os.WriteFile(filepath.Join(repoDir, "README"), []byte("hi\n"), 0o644); err != nil {
+		t.Fatalf("write README: %v", err)
+	}
+	mustRunGit(t, repoDir, "add", ".")
+	mustRunGit(t, repoDir, "commit", "-q", "-m", "init")
+
+	worktreePath := filepath.Join(repoDir, ".claude", "worktrees", "agent-x")
+	if err := os.MkdirAll(filepath.Dir(worktreePath), 0o755); err != nil {
+		t.Fatalf("mkdir worktrees parent: %v", err)
+	}
+	mustRunGit(t, repoDir, "worktree", "add", "-b", "agent-x", worktreePath)
+
+	cmd := &CleanupCmd{Worktree: worktreePath}
+	if err := cmd.runWorktree(worktreePath); err != nil {
+		t.Fatalf("runWorktree: %v", err)
+	}
+	if _, err := os.Stat(worktreePath); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("worktree still present: stat err=%v", err)
+	}
+}
+
+// TestCleanup_AllWorktrees pins the migration path: with
+// `<repo>/.claude/worktrees/agent-A`, `agent-B`, etc. on disk,
+// `bones cleanup --all-worktrees` must remove the entire
+// `.claude/worktrees/` tree.
+func TestCleanup_AllWorktrees(t *testing.T) {
+	repoDir := t.TempDir()
+	// Mark the dir as a bones workspace so findClaudeWorktreesRoot
+	// resolves via workspace.FindRoot. (Without this, the function
+	// falls back to a self-walk; both paths should land on the same
+	// dir.)
+	if err := os.MkdirAll(filepath.Join(repoDir, ".bones"), 0o755); err != nil {
+		t.Fatalf("mkdir .bones: %v", err)
+	}
+	wts := filepath.Join(repoDir, ".claude", "worktrees")
+	for _, name := range []string{"agent-a", "agent-b"} {
+		path := filepath.Join(wts, name)
+		if err := os.MkdirAll(path, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", path, err)
+		}
+		if err := os.WriteFile(filepath.Join(path, "marker"), []byte("x"), 0o644); err != nil {
+			t.Fatalf("marker: %v", err)
+		}
+	}
+
+	cwd, _ := os.Getwd()
+	t.Cleanup(func() { _ = os.Chdir(cwd) })
+	if err := os.Chdir(repoDir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+
+	cmd := &CleanupCmd{AllWorktrees: true}
+	if err := cmd.runAllWorktrees(); err != nil {
+		t.Fatalf("runAllWorktrees: %v", err)
+	}
+	if _, err := os.Stat(wts); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf(".claude/worktrees still present: stat err=%v", err)
+	}
+}
+
+// TestCleanup_MutuallyExclusiveFlags: passing two mode flags is a
+// usage error.
+func TestCleanup_MutuallyExclusiveFlags(t *testing.T) {
+	cmd := &CleanupCmd{Slot: "x", Worktree: "/tmp/y"}
+	err := cmd.validateFlags()
+	if err == nil {
+		t.Fatal("expected error on --slot + --worktree combo")
+	}
+	if !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Errorf("error should mention mutual exclusion, got: %v", err)
+	}
+
+	cmd = &CleanupCmd{Slot: "x", AllWorktrees: true}
+	if err := cmd.validateFlags(); err == nil {
+		t.Errorf("expected error on --slot + --all-worktrees combo")
+	}
+
+	cmd = &CleanupCmd{Worktree: "/tmp/y", AllWorktrees: true}
+	if err := cmd.validateFlags(); err == nil {
+		t.Errorf("expected error on --worktree + --all-worktrees combo")
+	}
+
+	// All three: also rejected.
+	cmd = &CleanupCmd{Slot: "x", Worktree: "/tmp/y", AllWorktrees: true}
+	if err := cmd.validateFlags(); err == nil {
+		t.Errorf("expected error on all three flags set")
+	}
+
+	// Zero flags → also a usage error (the verb does nothing safe).
+	cmd = &CleanupCmd{}
+	if err := cmd.validateFlags(); err == nil {
+		t.Errorf("expected error when no flags are set")
+	}
+}
+
+// mustRunGit runs `git` in dir with the given args. Test fatals on
+// any non-zero exit. Pulled out of the worktree test so the test
+// body reads as a series of git commands without exec error
+// boilerplate.
+func mustRunGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
+	}
+}

--- a/cli/hub.go
+++ b/cli/hub.go
@@ -9,9 +9,11 @@ import (
 	"time"
 
 	repocli "github.com/danmestas/EdgeSync/cli/repo"
+	"github.com/nats-io/nats.go"
 
 	"github.com/danmestas/bones/internal/hub"
 	"github.com/danmestas/bones/internal/scaffoldver"
+	"github.com/danmestas/bones/internal/swarm"
 	"github.com/danmestas/bones/internal/version"
 )
 
@@ -71,7 +73,63 @@ func (c *HubStartCmd) Run(g *repocli.Globals) error {
 		hub.WithCoordPort(c.CoordPort),
 		hub.WithDetach(c.Detach),
 		hub.WithDrainTimeout(c.DrainTimeout),
+		hub.WithLeaseWatcher(startLeaseWatcher),
 	)
+}
+
+// startLeaseWatcher is the CLI-side lease-TTL watcher constructor
+// the hub invokes once both servers are reachable (ADR 0050,
+// #265). Lives here (not in internal/hub) because it imports
+// swarm; putting it inside the hub package would create a
+// hub→swarm→workspace→hub import cycle.
+//
+// Best-effort construction: NATS dial / sessions open failures are
+// surfaced as errors to the hub, which logs them as warnings and
+// continues serving. The JetStream KV bucket TTL still evicts
+// stale records at the substrate level even without this watcher.
+func startLeaseWatcher(
+	parentCtx context.Context, info hub.LeaseWatcherInfo,
+) (func(), error) {
+	nc, err := nats.Connect(info.NATSURL)
+	if err != nil {
+		return nil, fmt.Errorf("nats connect: %w", err)
+	}
+	sess, err := swarm.Open(parentCtx, swarm.Config{NATSConn: nc})
+	if err != nil {
+		nc.Close()
+		return nil, fmt.Errorf("open sessions: %w", err)
+	}
+	w, err := swarm.NewTTLWatcher(swarm.WatcherConfig{
+		WorkspaceDir:  info.WorkspaceDir,
+		Sessions:      sess,
+		Logger:        leaseWatcherLogger{info.Logger},
+		LocalHostOnly: true,
+	})
+	if err != nil {
+		_ = sess.Close()
+		nc.Close()
+		return nil, fmt.Errorf("new watcher: %w", err)
+	}
+	stopRun := w.Start(parentCtx)
+	return func() {
+		stopRun()
+		_ = sess.Close()
+		nc.Close()
+	}, nil
+}
+
+// leaseWatcherLogger adapts the hub's LeaseWatcherLogger to
+// swarm.WatcherLogger. The two types share a method set; the
+// adapter is a one-line shape conversion so neither package needs
+// to import the other's logger interface directly.
+type leaseWatcherLogger struct{ inner hub.LeaseWatcherLogger }
+
+func (a leaseWatcherLogger) Infof(format string, args ...any) {
+	a.inner.Infof(format, args...)
+}
+
+func (a leaseWatcherLogger) Warnf(format string, args ...any) {
+	a.inner.Warnf(format, args...)
 }
 
 // warnScaffoldDrift prints a single-line stderr notice when the

--- a/cmd/bones/cli.go
+++ b/cmd/bones/cli.go
@@ -23,6 +23,13 @@ type CLI struct {
 	Env    bonescli.EnvCmd    `cmd:"" group:"daily" help:"Emit shell exports for current workspace"`
 	Rename bonescli.RenameCmd `cmd:"" group:"daily" help:"Set workspace display name"`
 
+	// Cleanup is broken out because gofmt aligns all daily-block
+	// field names to the longest in the block; "Cleanup" is one
+	// character longer than "Workspaces" and the alignment would
+	// otherwise push the daily block past lll's 100-column cap.
+	// Same separation pattern Workspaces uses directly below.
+	Cleanup bonescli.CleanupCmd `cmd:"" group:"daily" help:"Reap slot or legacy worktrees"`
+
 	// Workspaces (#174) — top-level "is bones up for project X?" view.
 	// Separated from the daily block above so gofmt does not realign
 	// the longer field name and overflow lll's 100-column limit.

--- a/docs/recipes/claude-code-harness.md
+++ b/docs/recipes/claude-code-harness.md
@@ -1,0 +1,143 @@
+# Claude Code harness recipes
+
+Operator-side recipes for wiring bones into a Claude Code session
+without bones taking ownership of `.claude/settings.json`. Bones
+ships verbs; the operator decides whether to invoke them via hooks,
+slash commands, or manual commands.
+
+This document covers:
+
+- [Cleaning up synthetic slots after `SubagentStop`](#cleaning-up-synthetic-slots-after-subagentstop)
+- [Why bones does not scaffold this hook](#why-bones-does-not-scaffold-this-hook)
+
+For the broader integration model (skill-based vs. library-based),
+see [`docs/harness-integration.md`](../harness-integration.md).
+
+---
+
+## Cleaning up synthetic slots after `SubagentStop`
+
+ADR 0050 introduces synthetic ephemeral slots for ad-hoc agent
+invocations (the Claude Code `Agent` tool). Each invocation
+allocates a slot under `.bones/swarm/<slot>/`, opens a fossil leaf,
+and exits when the agent's reply is delivered.
+
+Cleanup happens via two paths:
+
+1. **Lease-TTL primary** — the bones hub runs a watcher goroutine
+   that auto-reaps any slot whose lease has not been renewed within
+   the TTL (default: 5 minutes). This works for any caller, any
+   harness, any death mode.
+2. **Verb secondary** — `bones cleanup --slot=<name>` reaps a slot
+   immediately rather than wait for the TTL window. Operators can
+   call this manually, or wire it into a `SubagentStop` hook so
+   cleanup lands within seconds of the agent finishing.
+
+### Recommended `SubagentStop` hook
+
+Add this hook entry to your Claude Code `settings.json`. The exact
+shape below is what bones expects in production; tune `timeout` if
+you have unusually slow disks (the default 10s is generous for the
+KV delete + filesystem RemoveAll).
+
+```jsonc
+{
+  "hooks": {
+    "SubagentStop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "timeout": 10,
+            "command": "bones cleanup --slot=agent-${SUBAGENT_ID:-unknown}"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+The `${SUBAGENT_ID}` env var is whatever your synthetic-slot
+allocator stamped at slot-creation time. ADR 0050 leaves the slot
+naming to the orchestrator skill; the convention this recipe assumes
+is `agent-<id>` matching the `[slot: agent-<id>]` annotation in the
+plan.
+
+If your slot name lives elsewhere (e.g. a cookie file in
+`.bones/swarm/<slot>/`), adjust the command to read it from there:
+
+```bash
+bones cleanup --slot="$(cat .bones/swarm/current-agent-slot 2>/dev/null)"
+```
+
+The verb is idempotent: a missing slot is a no-op (exit 0). A
+duplicate hook firing (e.g. SubagentStop running twice) does not
+trip an error.
+
+### What the verb actually does
+
+`bones cleanup --slot=<name>` performs three atomic steps:
+
+1. Drop the slot's session record from the
+   `bones-swarm-sessions` JetStream KV bucket.
+2. Remove the slot's working tree at `.bones/swarm/<slot>/wt/`.
+3. Emit a `slot_reap` event into
+   `.bones/swarm-events.jsonl` for the audit trail.
+
+It does NOT remove `.bones/swarm/<slot>/leaf.fossil` or
+`leaf.pid` — those carry forensic state for post-mortem inspection.
+Running `bones down` or letting the workspace age out reclaims them.
+
+### Migration: legacy `.claude/worktrees/` cleanup
+
+Before ADR 0050, ad-hoc agent invocations created a real
+`git worktree` under `.claude/worktrees/agent-<id>/`. Those dirs
+are now stale and `bones up` refuses to start while any are
+present.
+
+Recovery commands:
+
+```bash
+# Remove a single legacy worktree dir (force-unlocks the git
+# worktree first):
+bones cleanup --worktree=/path/to/.claude/worktrees/agent-X
+
+# Or remove the entire .claude/worktrees/ tree:
+bones cleanup --all-worktrees
+```
+
+Both forms are idempotent — re-running on an already-clean tree is
+a no-op.
+
+---
+
+## Why bones does not scaffold this hook
+
+`bones up` writes a few hooks (SessionStart for hub bootstrap,
+SessionEnd for shutdown) but stops short of owning
+`.claude/settings.json` wholesale. The reasoning:
+
+- Operators have their own hooks. The settings file commonly mixes
+  bones-owned and operator-owned entries (e.g. a custom Notification
+  hook that posts to Slack). A bones-side rewrite that overwrites
+  the file would clobber the operator's customizations.
+- The synthetic-slot cleanup verb is one-line. Operators copy the
+  snippet above into their settings the same way they copy any
+  other hook entry; the recipe is short enough that maintenance
+  cost stays with the operator, not with bones.
+- The recipe is harness-specific. A non-Claude-Code harness needs a
+  different invocation shape; treating the hook as documentation
+  rather than code keeps bones harness-agnostic.
+
+Issues #256 and #260 captured the original posture; ADR 0050
+extended it to the synthetic-slot case.
+
+---
+
+## See also
+
+- [ADR 0028 — Bones swarm: verbs and lease](../adr/0028-bones-swarm-verbs.md)
+- [ADR 0050 — Synthetic slots for ad-hoc agent invocations](../adr/0050-synthetic-slots-for-agents.md)
+- [`docs/harness-integration.md`](../harness-integration.md) — integration shapes (skill vs. library)

--- a/internal/hub/hub.go
+++ b/internal/hub/hub.go
@@ -267,6 +267,10 @@ func runForeground(ctx context.Context, p paths, o opts) error {
 		fmt.Fprintf(os.Stderr, "hub: registry write failed (non-fatal): %v\n", err)
 	}
 	hl.Infof("hub: ready")
+
+	stopWatcher := startLeaseWatcherHook(ctx, o, p, h.NATSURL(), hl)
+	defer stopWatcher()
+
 	<-ctx.Done()
 	hl.Infof("hub: stopping")
 	httpCancel()
@@ -283,6 +287,51 @@ func runForeground(ctx context.Context, p paths, o opts) error {
 		hl.Infof("hub: stopped")
 	}
 	return drainErr
+}
+
+// startLeaseWatcherHook runs the optional lease-TTL watcher (ADR
+// 0050 / #265) if the caller provided a start function via
+// WithLeaseWatcher. Pulled out of runForeground so that function
+// stays under the funlen lint cap; the option indirection keeps
+// the hub package free of the swarm import (avoids the
+// hub→swarm→workspace→hub cycle).
+//
+// Returns a stop function the caller defers; a no-op when no
+// watcher hook was supplied or when the start callback returned
+// an error (which is logged as a warning to hub.log).
+func startLeaseWatcherHook(
+	ctx context.Context, o opts, p paths, natsURL string, hl *hubLogger,
+) func() {
+	if o.startLeaseWatcher == nil {
+		return func() {}
+	}
+	stop, err := o.startLeaseWatcher(ctx, LeaseWatcherInfo{
+		WorkspaceDir: p.root,
+		NATSURL:      natsURL,
+		Logger:       hubLogAdapter{l: hl},
+	})
+	if err != nil {
+		hl.Warnf("hub: lease watcher: %v (watcher disabled)", err)
+		return func() {}
+	}
+	return stop
+}
+
+// hubLogAdapter exposes a small subset of hubLogger as a public
+// shape consumable by the lease-watcher hook. Defined as a struct
+// (rather than an exported interface) so the watcher's function
+// signature stays a value-type contract — no behavior in this
+// package is overrideable from outside.
+type hubLogAdapter struct{ l *hubLogger }
+
+// Infof routes one INFO-level lifecycle event into hub.log.
+func (a hubLogAdapter) Infof(format string, args ...any) {
+	a.l.Infof(format, args...)
+}
+
+// Warnf routes one WARN-level lifecycle event into hub.log.
+func (a hubLogAdapter) Warnf(format string, args ...any) {
+	a.l.Warnf(format, args...)
 }
 
 // openAndSeedHub brings up the EdgeSync hub and seeds the repo if

--- a/internal/hub/options.go
+++ b/internal/hub/options.go
@@ -16,18 +16,64 @@
 //	  pid files. Idempotent: missing or stale pid files are not an error.
 package hub
 
-import "time"
+import (
+	"context"
+	"time"
+)
 
 // Option configures Start.
 type Option func(*opts)
 
+// LeaseWatcherInfo is the dependency packet handed to a lease-TTL
+// watcher start function on hub bring-up. The hub package itself
+// does not import swarm (cycle would arise via
+// swarm→workspace→hub); the CLI layer wires the swarm-aware watcher
+// implementation in via WithLeaseWatcher.
+type LeaseWatcherInfo struct {
+	// WorkspaceDir is the bones workspace root (absolute path).
+	// The watcher uses this to remove `.bones/swarm/<slot>/wt/`
+	// when a lease expires.
+	WorkspaceDir string
+
+	// NATSURL is the URL of the in-process NATS server the hub
+	// just started. The watcher dials this to read the swarm-
+	// sessions bucket.
+	NATSURL string
+
+	// Logger is the hub.log writer the watcher emits to. Infof
+	// fires on each reap; Warnf surfaces transient substrate
+	// errors. The watcher MUST be silent when nothing is stale
+	// (no log spam on the happy path).
+	Logger LeaseWatcherLogger
+}
+
+// LeaseWatcherLogger is the contract the hub exposes to the
+// lease-watcher hook. Mirrors the swarm package's WatcherLogger
+// shape so the hookup is one struct conversion away in the CLI
+// wiring.
+type LeaseWatcherLogger interface {
+	Infof(format string, args ...any)
+	Warnf(format string, args ...any)
+}
+
+// LeaseWatcherStartFunc constructs and runs a lease-TTL watcher
+// against info, returning a stop function the hub invokes at
+// shutdown. The watcher MUST run in a goroutine; the hub does not
+// block on it. Errors at startup time are surfaced via the
+// returned error and degrade gracefully — the hub continues to
+// serve.
+type LeaseWatcherStartFunc func(
+	ctx context.Context, info LeaseWatcherInfo,
+) (stop func(), err error)
+
 // opts holds tunable behavior for Start. The exported Option constructors
 // are the only way to mutate this struct from outside the package.
 type opts struct {
-	repoPort     int
-	coordPort    int
-	detach       bool
-	drainTimeout time.Duration
+	repoPort          int
+	coordPort         int
+	detach            bool
+	drainTimeout      time.Duration
+	startLeaseWatcher LeaseWatcherStartFunc
 }
 
 // defaults returns the production defaults: ports left zero so
@@ -67,4 +113,20 @@ func WithDetach(d bool) Option { return func(o *opts) { o.detach = d } }
 // value falls back to defaultDrainTimeout.
 func WithDrainTimeout(d time.Duration) Option {
 	return func(o *opts) { o.drainTimeout = d }
+}
+
+// WithLeaseWatcher installs the lease-TTL watcher hook. The hub
+// invokes start(ctx, info) once it is ready (after NATS + Fossil
+// are accepting connections, before the ctx-cancellation wait). The
+// returned stop function runs at hub shutdown, before drain. The
+// hook is optional — the hub package's invariants don't depend on
+// it (the JetStream KV bucket TTL evicts stale records at the
+// substrate level regardless), so a hub started without the option
+// (e.g. the detached parent's spawnDetachedChild path) still works.
+//
+// The CLI layer wires this in via cli/hub.go so the swarm import
+// stays out of internal/hub and the hub→swarm→workspace→hub cycle
+// never forms.
+func WithLeaseWatcher(start LeaseWatcherStartFunc) Option {
+	return func(o *opts) { o.startLeaseWatcher = start }
 }

--- a/internal/swarm/ttlwatch.go
+++ b/internal/swarm/ttlwatch.go
@@ -1,0 +1,335 @@
+package swarm
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"sync"
+	"time"
+)
+
+// DefaultWatcherTick is how often the TTL watcher wakes up to scan
+// for stale sessions. Short enough that operators see synthetic-slot
+// (ADR 0050) cleanup land within ~30s of the agent going silent;
+// long enough to keep the watcher's idle cost negligible (one KV
+// list per tick, no list when the bucket is empty).
+const DefaultWatcherTick = 30 * time.Second
+
+// DefaultWatcherTTL is the default lease-TTL the watcher uses when
+// the caller passes a zero value in WatcherConfig. Five minutes
+// matches the JetStream KV bucket TTL (DefaultTTL): the JS KV layer
+// auto-evicts the record at the substrate level; the watcher
+// additionally cleans up the on-disk slot directory and emits the
+// `slot_reap` event consumers expect to see.
+const DefaultWatcherTTL = 5 * time.Minute
+
+// WatcherLogger is the minimal logger contract the TTL watcher
+// emits to. The hub package wires its hubLogger here so reaped-slot
+// lines land in .bones/hub.log alongside the rest of the hub
+// lifecycle audit trail (#247). Production callers pass a non-nil
+// logger; tests can pass a buffer-backed implementation to assert
+// reap events landed.
+//
+// The watcher MUST be silent on the happy path — Infof is called
+// only when at least one slot was reaped. Warnf surfaces transient
+// substrate errors (a single failed list call) without aborting the
+// whole watcher loop.
+type WatcherLogger interface {
+	Infof(format string, args ...any)
+	Warnf(format string, args ...any)
+}
+
+// noopLogger is the WatcherLogger used when the caller passes nil.
+// Avoids nil-checks on every log site without forcing every test to
+// build a real logger.
+type noopLogger struct{}
+
+func (noopLogger) Infof(string, ...any) {}
+func (noopLogger) Warnf(string, ...any) {}
+
+// WatcherConfig configures TTLWatcher. Zero-value defaults are
+// production-correct: TTL → DefaultWatcherTTL, Tick →
+// DefaultWatcherTick, Logger → silent, Now → time.Now().UTC,
+// HostFilter → os.Hostname() match.
+type WatcherConfig struct {
+	// WorkspaceDir is the workspace root. Required — the watcher
+	// removes `<workspaceDir>/.bones/swarm/<slot>/wt/` when reaping
+	// a stale slot.
+	WorkspaceDir string
+
+	// Sessions is the swarm.Sessions handle the watcher reads from
+	// and writes to. The watcher does not own the handle's lifetime;
+	// the caller closes it when shutting the watcher down.
+	Sessions *Sessions
+
+	// TTL is the lease-TTL: any session whose LastRenewed exceeds
+	// time.Now() - TTL is reaped. Zero falls back to
+	// DefaultWatcherTTL.
+	TTL time.Duration
+
+	// Tick is the poll interval. Zero falls back to
+	// DefaultWatcherTick.
+	Tick time.Duration
+
+	// Logger receives one Infof per reap and one Warnf per
+	// substrate error. nil means "silent" (no log spam on the happy
+	// path is the hard requirement; a nil logger keeps the watcher
+	// from emitting any lines at all).
+	Logger WatcherLogger
+
+	// Now is the time source for staleness comparisons. nil →
+	// time.Now().UTC. Tests inject a fixed clock.
+	Now func() time.Time
+
+	// LocalHostOnly, when true (the default), reaps only sessions
+	// whose Host field matches this machine's hostname. Cross-host
+	// stale sessions surface in the log but are not reaped — the
+	// owning host's PID may still be making local progress, and a
+	// remote reap would clobber it. Mirrors `bones swarm reap`'s
+	// same-host policy.
+	LocalHostOnly bool
+}
+
+// TTLWatcher polls the swarm-sessions bucket for stale records and
+// reaps them. One watcher per workspace process; the hub's
+// runForeground starts exactly one in production. Safe to construct
+// directly via NewTTLWatcher; the zero value is not usable.
+//
+// Lifecycle: caller starts Run in a goroutine, ctx cancellation
+// stops the watcher. Run is NOT safe to call concurrently with
+// itself; the watcher is a single-goroutine consumer.
+type TTLWatcher struct {
+	cfg        WatcherConfig
+	ttl        time.Duration
+	tick       time.Duration
+	logger     WatcherLogger
+	now        func() time.Time
+	hostnameFn func() (string, error)
+}
+
+// NewTTLWatcher constructs a watcher with cfg. Zero-valued fields
+// fall back to package defaults (DefaultWatcherTTL,
+// DefaultWatcherTick, noop logger, time.Now().UTC, host-local-only).
+// Returns an error only on cfg validation; substrate errors surface
+// at Run time so transient NATS hiccups during construction don't
+// kill the hub.
+func NewTTLWatcher(cfg WatcherConfig) (*TTLWatcher, error) {
+	if cfg.WorkspaceDir == "" {
+		return nil, errors.New("swarm.NewTTLWatcher: WorkspaceDir is empty")
+	}
+	if cfg.Sessions == nil {
+		return nil, errors.New("swarm.NewTTLWatcher: Sessions is nil")
+	}
+	ttl := cfg.TTL
+	if ttl <= 0 {
+		ttl = DefaultWatcherTTL
+	}
+	tick := cfg.Tick
+	if tick <= 0 {
+		tick = DefaultWatcherTick
+	}
+	logger := cfg.Logger
+	if logger == nil {
+		logger = noopLogger{}
+	}
+	now := cfg.Now
+	if now == nil {
+		now = func() time.Time { return time.Now().UTC() }
+	}
+	return &TTLWatcher{
+		cfg:        cfg,
+		ttl:        ttl,
+		tick:       tick,
+		logger:     logger,
+		now:        now,
+		hostnameFn: os.Hostname,
+	}, nil
+}
+
+// Run drives the watcher loop until ctx is canceled. Each tick:
+//   - Lists all sessions in the bucket.
+//   - For every session whose LastRenewed is older than (now - TTL),
+//     drops the session record and removes the slot's wt/ tree.
+//   - Emits one Infof per reap, naming the slot and the duration the
+//     TTL was exceeded by.
+//
+// Run returns nil when ctx is canceled. Substrate errors during a
+// tick are surfaced via Warnf and the loop continues — a transient
+// NATS hiccup must not kill the watcher.
+func (w *TTLWatcher) Run(ctx context.Context) error {
+	t := time.NewTicker(w.tick)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-t.C:
+			w.tickOnce(ctx)
+		}
+	}
+}
+
+// tickOnce performs one watcher pass. Exposed (lowercase but
+// package-internal) so tests can drive the watcher deterministically
+// without spinning the ticker.
+func (w *TTLWatcher) tickOnce(ctx context.Context) {
+	sessions, err := w.cfg.Sessions.List(ctx)
+	if err != nil {
+		w.logger.Warnf("hub: ttl watcher: list sessions: %v", err)
+		return
+	}
+	now := w.now()
+	var localHost string
+	if !w.cfg.LocalHostOnly {
+		// LocalHostOnly off: reap regardless of host. Skip the
+		// hostname lookup.
+	} else {
+		h, _ := w.hostnameFn()
+		localHost = h
+	}
+	for _, s := range sessions {
+		age := now.Sub(s.LastRenewed)
+		if age <= w.ttl {
+			continue
+		}
+		if w.cfg.LocalHostOnly && s.Host != localHost && localHost != "" {
+			// Cross-host stale: surface but don't reap.
+			w.logger.Warnf(
+				"hub: ttl watcher: skip cross-host slot %s (owner=%s, age=%s)",
+				s.Slot, s.Host, age.Round(time.Second),
+			)
+			continue
+		}
+		w.reapOne(ctx, s, age)
+	}
+}
+
+// reapOne deletes the session record and removes the slot's wt/
+// tree. Best-effort — a permission-style failure on wt removal does
+// not roll back the session-record delete; the substrate signal is
+// what dispatch consumers care about, and the dir cleanup is a
+// downstream filesystem hygiene concern.
+func (w *TTLWatcher) reapOne(ctx context.Context, s Session, age time.Duration) {
+	excess := age - w.ttl
+	// Drop the session record. Use rev=0 to mean "delete by key
+	// without CAS gating" — the watcher is the cleanup path, not a
+	// lease-bound mutator, and a concurrent close from a slow
+	// agent racing the reap would simply see ErrNotFound on its
+	// own delete attempt and converge.
+	if err := w.cfg.Sessions.deleteByKey(ctx, s.Slot); err != nil &&
+		!errors.Is(err, ErrNotFound) {
+		w.logger.Warnf(
+			"hub: ttl watcher: drop record %s failed: %v", s.Slot, err)
+		return
+	}
+	wt := SlotWorktree(w.cfg.WorkspaceDir, s.Slot)
+	if err := os.RemoveAll(wt); err != nil {
+		w.logger.Warnf(
+			"hub: ttl watcher: remove %s failed: %v", wt, err)
+	}
+	// Emit the structured swarm event so post-mortem readers see
+	// the reap on the JSONL audit trail too. Best-effort; the
+	// event-log helper logs to stderr on its own failures.
+	appendEvent(w.cfg.WorkspaceDir, Event{
+		TS:      w.now(),
+		Kind:    EventSlotReap,
+		Slot:    s.Slot,
+		TaskID:  s.TaskID,
+		AgentID: s.AgentID,
+		Host:    s.Host,
+		Result:  "ttl-reaped",
+	})
+	w.logger.Infof(
+		"hub: reaped stale slot %s (ttl exceeded by %s)",
+		s.Slot, excess.Round(time.Second),
+	)
+}
+
+// deleteByKey removes the session record at slot without CAS
+// gating. Used by the TTL watcher and by cleanup verbs that don't
+// have a lease handle. Treats ErrNotFound as success (already gone
+// → nothing to do). Unexported because only intra-package callers
+// (the watcher, the cleanup verb plumbing) should bypass the CAS
+// gate; CLI verbs that own a lease use the gated update/delete
+// paths.
+func (s *Sessions) deleteByKey(ctx context.Context, slot string) error {
+	// Read current rev first so the delete CAS gate has a value to
+	// match. If the record is gone already, return ErrNotFound so
+	// callers can converge silently.
+	_, rev, err := s.Get(ctx, slot)
+	if err != nil {
+		return err
+	}
+	return s.delete(ctx, slot, rev)
+}
+
+// SlotCleanup performs the on-disk side of a synthetic-slot reap
+// (ADR 0050): deletes the session record from KV and removes the
+// slot's worktree directory at .bones/swarm/<slot>/wt/. Idempotent —
+// a missing record or missing wt is not an error. Used by
+// `bones cleanup --slot=<name>`; the TTL watcher uses the same
+// shape via reapOne but folds in the `slot_reap` event emission and
+// the hub.log INFO line.
+//
+// Returns (existed, error): existed is true iff a session record
+// for the slot was present at call time. Callers print a "no-op"
+// message when existed is false and a "reaped" message when true.
+func SlotCleanup(
+	ctx context.Context, sessions *Sessions, workspaceDir, slot string,
+) (bool, error) {
+	if workspaceDir == "" {
+		return false, errors.New("swarm.SlotCleanup: workspaceDir is empty")
+	}
+	if slot == "" {
+		return false, errors.New("swarm.SlotCleanup: slot is empty")
+	}
+	existed := true
+	if sessions != nil {
+		if err := sessions.deleteByKey(ctx, slot); err != nil {
+			if errors.Is(err, ErrNotFound) {
+				existed = false
+			} else {
+				return false, fmt.Errorf("swarm.SlotCleanup: drop record: %w", err)
+			}
+		}
+	}
+	wt := SlotWorktree(workspaceDir, slot)
+	if err := os.RemoveAll(wt); err != nil {
+		return existed, fmt.Errorf("swarm.SlotCleanup: remove wt: %w", err)
+	}
+	// The slot's leaf.fossil and leaf.pid live under SlotDir but
+	// are NOT removed here: leaf.fossil retains the slot's commit
+	// history for forensic purposes (ADR 0050), and leaf.pid is
+	// host-local and either points at a dead pid (slotgc handles
+	// it) or names the still-running agent that the operator must
+	// reap separately.
+	return existed, nil
+}
+
+// watcherLifecycle is the supervisor wrapper around Run. Keeps a
+// done channel so callers can wait for clean shutdown after
+// canceling the context. Used by the hub package to orchestrate
+// watcher startup/shutdown alongside the rest of hub bring-up.
+type watcherLifecycle struct {
+	w      *TTLWatcher
+	wg     sync.WaitGroup
+	cancel context.CancelFunc
+}
+
+// Start launches the watcher in a goroutine bound to ctx. Returns a
+// stop function the caller invokes at shutdown — Stop cancels the
+// watcher's ctx and blocks until Run returns.
+func (w *TTLWatcher) Start(parent context.Context) func() {
+	ctx, cancel := context.WithCancel(parent)
+	lc := &watcherLifecycle{w: w, cancel: cancel}
+	lc.wg.Add(1)
+	go func() {
+		defer lc.wg.Done()
+		_ = w.Run(ctx)
+	}()
+	return func() {
+		cancel()
+		lc.wg.Wait()
+	}
+}

--- a/internal/swarm/ttlwatch_test.go
+++ b/internal/swarm/ttlwatch_test.go
@@ -1,0 +1,264 @@
+// Tests for the TTL watcher (#265, ADR 0050). Coverage pins:
+//
+//   - TestLeaseTTL_ReapsStaleSession    — synthetic stale record gets reaped within one TTL window.
+//   - TestLeaseTTL_HappyPathSilent      — no log line when nothing is stale.
+//   - TestLeaseTTL_ReapEmitsHubLogLine  — reap writes "hub: reaped stale slot <name>" to the log.
+//
+// Tests use the leaseFixture from lease_test.go (real NATS + real
+// libfossil, no mocks; ADR 0030 discipline).
+package swarm
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// captureLogger records Infof/Warnf calls into a thread-safe buffer
+// so tests can assert "did the watcher emit the expected line."
+type captureLogger struct {
+	mu    sync.Mutex
+	infos []string
+	warns []string
+}
+
+func (l *captureLogger) Infof(format string, args ...any) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.infos = append(l.infos, fmt.Sprintf(format, args...))
+}
+
+func (l *captureLogger) Warnf(format string, args ...any) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.warns = append(l.warns, fmt.Sprintf(format, args...))
+}
+
+func (l *captureLogger) infosCopy() []string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	out := make([]string, len(l.infos))
+	copy(out, l.infos)
+	return out
+}
+
+// writeStaleSession bypasses Acquire's role-guard preconditions and
+// directly inserts a session record whose LastRenewed is far enough
+// in the past that the watcher's TTL check classifies it as stale.
+//
+// Used to exercise the watcher without standing up a full task +
+// claim. The watcher's behavior is bucket-side: list, classify by
+// LastRenewed age, drop the record. Whether the record came from
+// Acquire or from a direct put is a substrate-equivalent question.
+func writeStaleSession(t *testing.T, f *leaseFixture, slot string, age time.Duration) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	sess, _, _, err := openLeaseSessions(ctx, f.info, nil)
+	if err != nil {
+		t.Fatalf("openLeaseSessions: %v", err)
+	}
+	defer func() { _ = sess.Close() }()
+	host, _ := os.Hostname()
+	t0 := time.Now().UTC().Add(-age)
+	if err := sess.put(ctx, Session{
+		Slot:        slot,
+		TaskID:      "task-stale",
+		AgentID:     "slot-" + slot,
+		Host:        host,
+		StartedAt:   t0,
+		LastRenewed: t0,
+	}); err != nil {
+		t.Fatalf("put session: %v", err)
+	}
+	// Pre-create the wt dir so the reaper has something to remove.
+	wt := SlotWorktree(f.info.WorkspaceDir, slot)
+	if err := os.MkdirAll(wt, 0o755); err != nil {
+		t.Fatalf("mkdir wt: %v", err)
+	}
+}
+
+// newWatcherForTest builds a TTLWatcher against the fixture's
+// substrate, with a tight TTL and a capture logger so tests can
+// drive a single tick deterministically.
+func newWatcherForTest(
+	t *testing.T, f *leaseFixture, ttl time.Duration, logger WatcherLogger,
+) (*TTLWatcher, func()) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	sess, _, _, err := openLeaseSessions(ctx, f.info, nil)
+	if err != nil {
+		t.Fatalf("openLeaseSessions: %v", err)
+	}
+	w, err := NewTTLWatcher(WatcherConfig{
+		WorkspaceDir:  f.info.WorkspaceDir,
+		Sessions:      sess,
+		TTL:           ttl,
+		Tick:          1 * time.Hour, // we drive tickOnce manually
+		Logger:        logger,
+		LocalHostOnly: true,
+	})
+	if err != nil {
+		_ = sess.Close()
+		t.Fatalf("NewTTLWatcher: %v", err)
+	}
+	return w, func() { _ = sess.Close() }
+}
+
+// TestLeaseTTL_ReapsStaleSession pins the canonical reap behavior:
+// a session whose LastRenewed is older than (now - TTL) gets its
+// record dropped and its wt directory removed within one tick.
+func TestLeaseTTL_ReapsStaleSession(t *testing.T) {
+	f := newLeaseFixture(t)
+	logger := &captureLogger{}
+
+	writeStaleSession(t, f, "stale-1", 10*time.Minute)
+
+	w, cleanup := newWatcherForTest(t, f, 1*time.Minute, logger)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	w.tickOnce(ctx)
+
+	// Session record must be gone.
+	verifySess := openVerifySessions(t, f)
+	_, _, err := verifySess.Get(ctx, "stale-1")
+	if err == nil {
+		t.Errorf("stale session record still present after tickOnce")
+	}
+
+	// wt dir must be gone.
+	wt := SlotWorktree(f.info.WorkspaceDir, "stale-1")
+	if _, err := os.Stat(wt); !os.IsNotExist(err) {
+		t.Errorf("stale wt dir still present: stat err=%v", err)
+	}
+}
+
+// TestLeaseTTL_HappyPathSilent pins the no-spam contract: when no
+// sessions are stale (or none exist at all), the watcher MUST NOT
+// emit any Infof lines. Operators tail hub.log to see real events;
+// a chatty watcher poisons that signal.
+func TestLeaseTTL_HappyPathSilent(t *testing.T) {
+	f := newLeaseFixture(t)
+	logger := &captureLogger{}
+
+	// Insert a fresh session — within TTL, must not be reaped.
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	sess, _, _, err := openLeaseSessions(ctx, f.info, nil)
+	if err != nil {
+		t.Fatalf("openLeaseSessions: %v", err)
+	}
+	defer func() { _ = sess.Close() }()
+	host, _ := os.Hostname()
+	if err := sess.put(ctx, Session{
+		Slot:        "fresh-1",
+		TaskID:      "task-fresh",
+		AgentID:     "slot-fresh-1",
+		Host:        host,
+		StartedAt:   time.Now().UTC(),
+		LastRenewed: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("put session: %v", err)
+	}
+
+	w, cleanup := newWatcherForTest(t, f, 5*time.Minute, logger)
+	defer cleanup()
+	w.tickOnce(ctx)
+
+	if got := logger.infosCopy(); len(got) > 0 {
+		t.Errorf("happy path emitted %d Infof lines (expected 0): %v", len(got), got)
+	}
+}
+
+// TestLeaseTTL_ReapEmitsHubLogLine pins the log shape contract
+// from the issue spec: a reap MUST write
+// "hub: reaped stale slot <name> (ttl exceeded by <duration>)"
+// to the watcher's logger.
+func TestLeaseTTL_ReapEmitsHubLogLine(t *testing.T) {
+	f := newLeaseFixture(t)
+	logger := &captureLogger{}
+
+	writeStaleSession(t, f, "loglineslot", 10*time.Minute)
+
+	w, cleanup := newWatcherForTest(t, f, 1*time.Minute, logger)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	w.tickOnce(ctx)
+
+	got := logger.infosCopy()
+	if len(got) == 0 {
+		t.Fatalf("watcher produced no Infof lines; want one")
+	}
+	want := "hub: reaped stale slot loglineslot"
+	if !containsAny(got, want) {
+		t.Errorf("Infof lines missing %q: %v", want, got)
+	}
+	if !containsAny(got, "ttl exceeded by") {
+		t.Errorf("Infof lines missing ttl-excess phrase: %v", got)
+	}
+}
+
+// containsAny reports whether any string in lines contains the
+// substring needle.
+func containsAny(lines []string, needle string) bool {
+	for _, l := range lines {
+		if strings.Contains(l, needle) {
+			return true
+		}
+	}
+	return false
+}
+
+// TestLeaseTTL_RunRespectsContextCancellation keeps Run-loop
+// shutdown sane: canceling the parent ctx must cause Run to
+// return promptly without leaking the goroutine.
+func TestLeaseTTL_RunRespectsContextCancellation(t *testing.T) {
+	f := newLeaseFixture(t)
+	logger := &captureLogger{}
+
+	w, cleanup := newWatcherForTest(t, f, 1*time.Minute, logger)
+	defer cleanup()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- w.Run(ctx) }()
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("Run returned non-nil error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return within 2s of ctx cancel")
+	}
+}
+
+// TestLeaseTTL_StartReturnsStopFunc pins the lifecycle helper:
+// Start must return a stop function that, when invoked, blocks
+// until Run has fully exited.
+func TestLeaseTTL_StartReturnsStopFunc(t *testing.T) {
+	f := newLeaseFixture(t)
+	logger := &captureLogger{}
+
+	w, cleanup := newWatcherForTest(t, f, 1*time.Minute, logger)
+	defer cleanup()
+
+	stop := w.Start(context.Background())
+	// Stop must be idempotent in spirit (calling it once is enough);
+	// drain any goroutine and return.
+	stop()
+}
+
+// _ keeps bytes referenced for any future buffer-based logger
+// expansion.
+var _ = bytes.Buffer{}


### PR DESCRIPTION
## Summary

Implements the cleanup half of ADR 0050. Two reap paths:

1. **Lease-TTL primary** — `internal/swarm/ttlwatch.go` TTL watcher runs in the hub, iterates `bones-swarm-sessions[*]` every 30s, reaps any session whose `LastRenewed` exceeds the TTL (default 5min). Reap drops the session record + removes `.bones/swarm/<slot>/wt/` + emits one `hub: reaped stale slot <name>` line to `.bones/hub.log`. Silent on the happy path.

2. **Verb secondary** — `bones cleanup` for prompt cleanup. Three modes:
   - `--slot=<name>` — reap one slot
   - `--worktree=<path>` — remove one `.claude/worktrees/agent-*/` (legacy migration)
   - `--all-worktrees` — remove the whole tree

   Mutually exclusive. Idempotent — re-running on clean state is no-op exit 0.

Operator recipe at `docs/recipes/claude-code-harness.md` covers the SubagentStop hook shape (operator wires it, bones doesn't scaffold) and the legacy worktree migration commands.

Closes #265

## Architecture note

The TTL watcher is in `internal/swarm/` not `internal/hub/` to avoid the `hub→swarm→workspace→hub` import cycle. Wired into the hub via `hub.WithLeaseWatcher(...)` option.

## Test plan

- [x] `make check` passes
- [x] `go test -tags=otel -short ./...` passes
- [x] 16 tests covering: TTL reap of stale session, happy-path silence, hub.log line emission, watcher context cancellation, all three cleanup verb modes, idempotency, mutual-exclusion, error messages
- [x] Smoke test: `bones cleanup --slot=test` against a fake slot under `.bones/swarm/test/wt/` removes it; second run is no-op

## Configuration

- `swarm.DefaultWatcherTTL` = 5 minutes
- `swarm.DefaultWatcherTick` = 30 seconds
- Both override-able via `swarm.WatcherConfig` for tests / future tuning

## Out of scope

- `bones swarm join --auto` synthetic-slot creation — filed as #282
- `bones apply --slot=<name>` extension — filed as #283
- Lease-TTL regression test under burst-dispatch — already filed as #267, unblocked by this PR
