### PR TITLE
feat(swarm): bones swarm join --auto synthetic agent slot lifecycle

### DIFF
--- a/cli/swarm_join.go
+++ b/cli/swarm_join.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 
@@ -26,9 +27,16 @@ import (
 // session record CAS, leaf open/claim) lives in
 // internal/swarm (ADR 0028). This verb is a thin adapter from CLI
 // flags to swarm.Acquire + FreshLease.Release.
+//
+// `--auto` (ADR 0050, #282) is the synthetic-slot path: the slot
+// name is derived from `.bones/agent.id` and a synthetic task is
+// auto-created. Mutually exclusive with `--slot` / `--task-id`. The
+// caller (typically Claude Code's `Agent` tool) consumes the
+// printed `BONES_SLOT_WT=` line to `cd` into the slot's worktree.
 type SwarmJoinCmd struct {
-	Slot          string `name:"slot" required:"" help:"slot name (matches plan [slot: X])"`
-	TaskID        string `name:"task-id" required:"" help:"open task id to claim"`
+	Auto          bool   `name:"auto" help:"synthetic agent slot derived from .bones/agent.id (ADR 0050)"` //nolint:lll
+	Slot          string `name:"slot" help:"slot name (matches plan [slot: X]); omit with --auto"`
+	TaskID        string `name:"task-id" help:"open task id to claim; omit with --auto"`
 	Caps          string `name:"caps" default:"oih" help:"fossil caps for the slot user"`
 	ForceTakeover bool   `name:"force" help:"clobber an existing slot session (recovery only)"`
 	HubURL        string `name:"hub-url" help:"override hub fossil HTTP URL"`
@@ -40,13 +48,45 @@ type SwarmJoinCmd struct {
 // check, ensures the slot user, CAS-writes the session record, opens
 // the leaf, claims the task, writes the pid file), emit the report,
 // FreshLease.Release.
+//
+// `--auto` reroutes to swarm.JoinAuto (ADR 0050) which derives the
+// slot from agent.id, auto-creates a synthetic task, and treats a
+// re-join as idempotent (no error, prints the same slot dir).
 func (c *SwarmJoinCmd) Run(g *repocli.Globals) error {
+	if err := c.validateFlags(); err != nil {
+		return err
+	}
 	ctx, stop, info, err := joinWorkspace()
 	if err != nil {
 		return err
 	}
 	defer stop()
+	if c.Auto {
+		return c.runAuto(ctx, info)
+	}
 	return c.run(ctx, info)
+}
+
+// validateFlags enforces the mutual-exclusion between `--auto` and
+// the plan-flow flags. `--auto` derives slot+task itself; passing
+// either alongside it is operator error worth refusing before any
+// side effect lands.
+func (c *SwarmJoinCmd) validateFlags() error {
+	if c.Auto {
+		if c.Slot != "" || c.TaskID != "" {
+			return errors.New(
+				"swarm join: --auto is mutually exclusive with --slot / --task-id",
+			)
+		}
+		return nil
+	}
+	if c.Slot == "" {
+		return errors.New("swarm join: --slot is required (or use --auto for synthetic slots)")
+	}
+	if c.TaskID == "" {
+		return errors.New("swarm join: --task-id is required (or use --auto for synthetic slots)")
+	}
+	return nil
 }
 
 func (c *SwarmJoinCmd) run(ctx context.Context, info workspace.Info) error {
@@ -78,6 +118,62 @@ func (c *SwarmJoinCmd) run(ctx context.Context, info workspace.Info) error {
 		},
 	})
 	return lease.Release(ctx)
+}
+
+// runAuto drives the synthetic-slot join (ADR 0050, #282). Reads
+// agent.id, derives slot name, opens (or rejoins) the synthetic slot.
+// Prints `BONES_SLOT_WT=` + `BONES_SLOT_NAME=` on stdout for the
+// caller to source into its environment; stderr carries the
+// human-readable summary plus the re-entry indicator.
+func (c *SwarmJoinCmd) runAuto(ctx context.Context, info workspace.Info) error {
+	res, err := swarm.JoinAuto(ctx, info, swarm.AcquireOpts{
+		HubURL:        resolveHubURL(c.HubURL),
+		Caps:          c.Caps,
+		ForceTakeover: c.ForceTakeover,
+		NoAutosync:    c.NoAutosync,
+	})
+	if err != nil {
+		reportSwarmFailure(info.WorkspaceDir, info.NATSURL)
+		return fmt.Errorf("swarm join --auto: %w", err)
+	}
+
+	// Stdout: machine-consumable lines for `eval $(bones swarm join --auto)`
+	// shells. Two lines so the harness can `cd` into the wt and tag
+	// subsequent verbs with the slot name.
+	fmt.Printf("BONES_SLOT_WT=%s\n", res.WT)
+	fmt.Printf("BONES_SLOT_NAME=%s\n", res.Slot)
+
+	// Stderr: human-readable summary. Re-entry path is annotated so an
+	// operator scrolling logs sees that the second join was idempotent
+	// rather than a duplicate session.
+	if res.ReEntry {
+		fmt.Fprintf(
+			os.Stderr,
+			"swarm join --auto: re-entry slot=%s wt=%s agent=%s\n",
+			res.Slot, res.WT, res.AgentID,
+		)
+		return nil
+	}
+	fmt.Fprintf(
+		os.Stderr,
+		"swarm join --auto: slot=%s task=%s wt=%s agent=%s pid=%d\n",
+		res.Slot, res.TaskID, res.WT, res.AgentID, os.Getpid(),
+	)
+	appendSlotEvent(info.WorkspaceDir, res.Slot, logwriter.Event{
+		Timestamp: timeNow(),
+		Slot:      res.Slot,
+		Event:     logwriter.EventJoin,
+		Fields: map[string]interface{}{
+			"task_id":  res.TaskID,
+			"worktree": res.WT,
+			"agent_id": res.AgentID,
+			"auto":     true,
+		},
+	})
+	if res.Lease != nil {
+		return res.Lease.Release(ctx)
+	}
+	return nil
 }
 
 // emitJoinReport prints the BONES_SLOT_WT line on stdout (consumed

--- a/cli/up.go
+++ b/cli/up.go
@@ -14,6 +14,7 @@ import (
 	"github.com/danmestas/bones/internal/githook"
 	"github.com/danmestas/bones/internal/hub"
 	"github.com/danmestas/bones/internal/scaffoldver"
+	"github.com/danmestas/bones/internal/swarm"
 	"github.com/danmestas/bones/internal/telemetry"
 	"github.com/danmestas/bones/internal/workspace"
 )
@@ -61,6 +62,18 @@ func runUp(cwd string, verbose bool) (err error) {
 		return err
 	}
 	wsDir := info.WorkspaceDir
+
+	// Migration check (ADR 0050 §"Migration: refuse-to-start on stale
+	// `.claude/worktrees/`"): refuse to proceed when legacy
+	// `.claude/worktrees/agent-*/` dirs are present. The pre-ADR-0050
+	// isolation surface no longer matches the synthetic slot
+	// machinery; silent migration would leave the operator with
+	// disconnected git branches. Recovery: `bones cleanup
+	// --all-worktrees` (#265).
+	if mErr := swarm.CheckStaleClaudeWorktrees(wsDir); mErr != nil {
+		err = mErr
+		return err
+	}
 
 	// Open the audit log under <wsDir>/.bones/up.log (#171). Defer Close
 	// so the exit code + duration land regardless of which step fails

--- a/cli/up_migration_test.go
+++ b/cli/up_migration_test.go
@@ -1,0 +1,65 @@
+// Tests for the ADR 0050 migration check at `bones up` and the
+// hub-start entrypoint. The check refuses to start when legacy
+// `.claude/worktrees/agent-*/` directories are present so operators
+// don't bring up bones on a workspace whose pre-ADR-0050 isolation
+// surface still holds disconnected git branches (#282).
+package cli
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/danmestas/bones/internal/swarm"
+)
+
+// TestSwarmUp_RejectsStaleClaudeWorktrees pins the loud-refusal
+// contract on `bones up`: a workspace with `.claude/worktrees/
+// agent-XYZ/` exits non-zero (via runUp returning an error) and
+// the error names the dir.
+func TestSwarmUp_RejectsStaleClaudeWorktrees(t *testing.T) {
+	dir := t.TempDir()
+	stale := filepath.Join(dir, ".claude", "worktrees", "agent-stale-77")
+	if err := os.MkdirAll(stale, 0o755); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	// Pre-init the workspace so runUp's `initOrJoinWorkspace` step
+	// has agent.id ready — this isolates the migration-check failure
+	// from any unrelated init failure.
+	if err := os.MkdirAll(filepath.Join(dir, ".bones"), 0o755); err != nil {
+		t.Fatalf("mkdir .bones: %v", err)
+	}
+
+	err := runUp(dir, false)
+	if err == nil {
+		t.Fatal("runUp succeeded on workspace with stale agent worktree; want error")
+	}
+	if !errors.Is(err, swarm.ErrStaleClaudeWorktrees) {
+		t.Errorf("err=%v; want errors.Is(swarm.ErrStaleClaudeWorktrees)", err)
+	}
+	if !strings.Contains(err.Error(), "agent-stale-77") {
+		t.Errorf("error must name the stale dir; got: %v", err)
+	}
+}
+
+// TestSwarmUp_AcceptsCleanWorkspace_NoMigrationFailure: a workspace
+// with NO stale agent worktrees must NOT fail at the migration
+// check. (It may still fail at later steps — `bones up` does
+// scaffolding work this test isn't reproducing — but the failure,
+// if any, must not be ErrStaleClaudeWorktrees.)
+func TestSwarmUp_AcceptsCleanWorkspace_NoMigrationFailure(t *testing.T) {
+	dir := t.TempDir()
+	// Empty .claude/worktrees/ should not trip the check.
+	if err := os.MkdirAll(filepath.Join(dir, ".claude", "worktrees"), 0o755); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	err := runUp(dir, false)
+	// runUp may fail downstream (no git repo to scaffold, etc.).
+	// What matters is the migration check did NOT fire.
+	if errors.Is(err, swarm.ErrStaleClaudeWorktrees) {
+		t.Errorf("clean workspace tripped migration check: %v", err)
+	}
+}

--- a/internal/hub/hub.go
+++ b/internal/hub/hub.go
@@ -105,23 +105,17 @@ func Start(ctx context.Context, root string, options ...Option) (err error) {
 		o.detach = false
 	}
 
+	if mErr := gateStaleWorktrees(root, isDetachChild); mErr != nil {
+		return mErr
+	}
 	p, err := newPaths(root)
 	if err != nil {
 		return err
 	}
 
-	// Telemetry: record only the parent's Start. The detached child
-	// re-enters Start with BONES_HUB_FOREGROUND=1 and would otherwise
-	// emit a daemon-lifetime span the parent already covered.
-	if !isDetachChild {
-		urlRecorded := readURLFile(p.fossilURL) != ""
-		var end telemetry.EndFunc
-		ctx, end = telemetry.RecordCommand(ctx, "hub.start",
-			telemetry.Bool("detach", o.detach),
-			telemetry.Bool("url_recorded", urlRecorded),
-		)
-		defer func() { end(err) }()
-	}
+	var endTelemetry telemetry.EndFunc
+	ctx, endTelemetry = startStartTelemetry(ctx, isDetachChild, p.fossilURL, o.detach)
+	defer func() { endTelemetry(err) }()
 
 	if err := os.MkdirAll(p.logDir, 0o755); err != nil {
 		return fmt.Errorf("hub: logs dir: %w", err)

--- a/internal/hub/migration.go
+++ b/internal/hub/migration.go
@@ -1,0 +1,91 @@
+package hub
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/danmestas/bones/internal/telemetry"
+)
+
+// ErrStaleClaudeWorktrees is returned by checkStaleClaudeWorktrees
+// when one or more legacy `.claude/worktrees/agent-*/` directories
+// exist under the workspace root. ADR 0050 §"Migration: refuse-to-
+// start on stale `.claude/worktrees/`": `bones hub start` refuses to
+// proceed until those dirs are cleaned, because pre-ADR-0050
+// isolation no longer matches the synthetic slot machinery.
+//
+// Mirrors swarm.ErrStaleClaudeWorktrees: the duplication exists
+// because hub cannot import swarm (swarm depends on workspace which
+// depends on hub — import cycle), and the migration check has to
+// gate hub.Start before any side effect lands. swarm's package keeps
+// the canonical definition for the bones-up call site; hub keeps its
+// own copy for the bones-hub-start call site.
+var ErrStaleClaudeWorktrees = errors.New(
+	"bones: refusing to start: legacy .claude/worktrees/agent-*/ dirs " +
+		"present (run `bones cleanup --all-worktrees` to migrate; ADR 0050)",
+)
+
+// startStartTelemetry begins the parent-only Start telemetry span and
+// returns the wrapped ctx + the end func the caller must defer. Pulled
+// out so hub.Start stays under the funlen lint cap. The detached
+// child re-enters Start with BONES_HUB_FOREGROUND=1 and would
+// otherwise emit a daemon-lifetime span the parent already covered;
+// for the child path returns the original ctx + a no-op end func.
+func startStartTelemetry(
+	ctx context.Context, isDetachChild bool, fossilURLPath string, detach bool,
+) (context.Context, telemetry.EndFunc) {
+	if isDetachChild {
+		return ctx, func(error, ...telemetry.Attr) {}
+	}
+	urlRecorded := readURLFile(fossilURLPath) != ""
+	return telemetry.RecordCommand(ctx, "hub.start",
+		telemetry.Bool("detach", detach),
+		telemetry.Bool("url_recorded", urlRecorded),
+	)
+}
+
+// gateStaleWorktrees is the Start-side wrapper around
+// checkStaleClaudeWorktrees. Skips the check on the detach re-entry
+// (the parent already gated; double-checking would race on the
+// in-flight cleanup). Pulled out so Start stays under the funlen
+// lint cap.
+func gateStaleWorktrees(root string, isDetachChild bool) error {
+	if isDetachChild {
+		return nil
+	}
+	return checkStaleClaudeWorktrees(root)
+}
+
+// checkStaleClaudeWorktrees globs for `<root>/.claude/worktrees/
+// agent-*/` and returns ErrStaleClaudeWorktrees with the matching
+// dirs listed in the message when one or more match. Returns nil
+// when no matches exist.
+//
+// glob errors fall through as nil — a malformed pattern would be a
+// programmer bug, not an operator-visible refusal trigger; the
+// pattern is hardcoded so this can't happen in practice.
+func checkStaleClaudeWorktrees(root string) error {
+	pattern := filepath.Join(root, ".claude", "worktrees", "agent-*")
+	matches, err := filepath.Glob(pattern)
+	if err != nil {
+		return nil
+	}
+	if len(matches) == 0 {
+		return nil
+	}
+	sort.Strings(matches)
+	rels := make([]string, 0, len(matches))
+	for _, m := range matches {
+		if rel, err := filepath.Rel(root, m); err == nil {
+			rels = append(rels, rel)
+		} else {
+			rels = append(rels, m)
+		}
+	}
+	return fmt.Errorf("%w (found: %s)",
+		ErrStaleClaudeWorktrees, strings.Join(rels, ", "))
+}

--- a/internal/hub/migration_test.go
+++ b/internal/hub/migration_test.go
@@ -1,0 +1,88 @@
+// Tests for the ADR 0050 §"Migration: refuse-to-start" check
+// inside hub.Start. The check fires before any side effect
+// (port allocation, fork-exec, fossil init) so a stale
+// `.claude/worktrees/agent-*/` workspace can't accidentally bring
+// up bones. See #282.
+package hub
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestHubStart_RejectsStaleClaudeWorktrees pins the loud-refusal
+// at hub.Start: a workspace with `.claude/worktrees/agent-X/`
+// returns ErrStaleClaudeWorktrees before any port or pid file gets
+// touched.
+func TestHubStart_RejectsStaleClaudeWorktrees(t *testing.T) {
+	root := t.TempDir()
+	stale := filepath.Join(root, ".claude", "worktrees", "agent-stale-99")
+	if err := os.MkdirAll(stale, 0o755); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	err := Start(ctx, root)
+	if err == nil {
+		t.Fatal("hub.Start succeeded with stale agent worktree present; want error")
+	}
+	if !errors.Is(err, ErrStaleClaudeWorktrees) {
+		t.Errorf("err=%v; want errors.Is(ErrStaleClaudeWorktrees)", err)
+	}
+	if !strings.Contains(err.Error(), "agent-stale-99") {
+		t.Errorf("error must name the stale dir; got: %v", err)
+	}
+	// Pre-side-effect contract: hub.pid must not exist after refusal.
+	if _, statErr := os.Stat(filepath.Join(root, ".bones", "hub.pid")); statErr == nil {
+		t.Errorf("hub.pid present after refusal; Start performed a side effect")
+	}
+}
+
+// TestHubStart_MigrationErrorPointsAtCleanup: the refusal message
+// names `bones cleanup --all-worktrees` so an operator sees the
+// recovery path.
+func TestHubStart_MigrationErrorPointsAtCleanup(t *testing.T) {
+	root := t.TempDir()
+	stale := filepath.Join(root, ".claude", "worktrees", "agent-x")
+	if err := os.MkdirAll(stale, 0o755); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	err := Start(ctx, root)
+	if err == nil {
+		t.Fatal("expected refusal; got nil")
+	}
+	if !strings.Contains(err.Error(), "bones cleanup --all-worktrees") {
+		t.Errorf("error must point at recovery verb; got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "ADR 0050") {
+		t.Errorf("error must reference ADR 0050; got: %v", err)
+	}
+}
+
+// TestHubStart_PassesCleanWorkspace_NoMigrationFailure: a workspace
+// with no stale agent worktrees does NOT fail at the migration
+// check. Start may still fail at later steps (no git repo to seed
+// from), but the failure must not be ErrStaleClaudeWorktrees.
+func TestHubStart_PassesCleanWorkspace_NoMigrationFailure(t *testing.T) {
+	root := t.TempDir()
+	// Empty worktrees dir is not a trigger.
+	if err := os.MkdirAll(filepath.Join(root, ".claude", "worktrees"), 0o755); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	err := Start(ctx, root)
+	if errors.Is(err, ErrStaleClaudeWorktrees) {
+		t.Errorf("clean workspace tripped migration check: %v", err)
+	}
+}

--- a/internal/swarm/migration.go
+++ b/internal/swarm/migration.go
@@ -1,0 +1,62 @@
+package swarm
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// ErrStaleClaudeWorktrees is returned by CheckStaleClaudeWorktrees
+// when one or more legacy `.claude/worktrees/agent-*/` directories
+// exist under the workspace root. ADR 0050 §"Migration: refuse-to-
+// start on stale `.claude/worktrees/`": `bones up` and
+// `bones hub start` refuse to proceed until those dirs are cleaned,
+// because pre-ADR-0050 isolation no longer matches the synthetic
+// slot machinery.
+//
+// Callers errors.Is-test this sentinel to map the failure to a
+// non-zero CLI exit code that's distinct from the generic substrate
+// errors.
+var ErrStaleClaudeWorktrees = errors.New(
+	"bones: refusing to start: legacy .claude/worktrees/agent-*/ dirs " +
+		"present (run `bones cleanup --all-worktrees` to migrate; ADR 0050)",
+)
+
+// CheckStaleClaudeWorktrees globs for `<root>/.claude/worktrees/
+// agent-*/` and returns ErrStaleClaudeWorktrees with the matching
+// dirs listed in the message when one or more match. Returns nil
+// when no matches exist (empty `.claude/worktrees/` dir is fine —
+// only `agent-*` children are the migration trigger).
+//
+// Used by `bones up` and `bones hub start`. Other verbs deliberately
+// skip the check: an operator may have legitimate reasons to inspect
+// a stale dir on a workspace they're not actively running, and the
+// loud-refusal point is the SessionStart bring-up, not every read-
+// only verb.
+//
+// glob errors fall through as nil — a malformed pattern would be a
+// programmer bug, not an operator-visible refusal trigger; the
+// pattern is hardcoded so this can't happen in practice.
+func CheckStaleClaudeWorktrees(root string) error {
+	pattern := filepath.Join(root, ".claude", "worktrees", "agent-*")
+	matches, err := filepath.Glob(pattern)
+	if err != nil {
+		return nil
+	}
+	if len(matches) == 0 {
+		return nil
+	}
+	sort.Strings(matches)
+	rels := make([]string, 0, len(matches))
+	for _, m := range matches {
+		if rel, err := filepath.Rel(root, m); err == nil {
+			rels = append(rels, rel)
+		} else {
+			rels = append(rels, m)
+		}
+	}
+	return fmt.Errorf("%w (found: %s)",
+		ErrStaleClaudeWorktrees, strings.Join(rels, ", "))
+}

--- a/internal/swarm/synthetic.go
+++ b/internal/swarm/synthetic.go
@@ -1,0 +1,433 @@
+package swarm
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/danmestas/bones/internal/assert"
+	"github.com/danmestas/bones/internal/workspace"
+)
+
+// AgentSlotIDLen is the number of agent_id characters baked into the
+// synthetic slot name (`agent-<prefix>`). 12 hex characters is enough
+// that collisions on a single workspace are negligible (~5e-15 for
+// even a million agents) while keeping the slot name short enough to
+// scan in `bones swarm status` output and to encode as a fossil branch
+// suffix (`agent/<prefix>`).
+//
+// The full agent_id is preserved in the session record's AgentID
+// field; the slot name is the truncation. ADR 0050 §"Slot identity is
+// implicit" treats this as a derivation, not a primary key.
+const AgentSlotIDLen = 12
+
+// AgentSlotPrefix is the slot-name prefix used for synthetic slots
+// (ADR 0050). Plan-anchored slots never use this prefix because plan
+// validators reject names starting with `agent-`; synthetic slots
+// always do, so callers can distinguish the two namespaces by name.
+const AgentSlotPrefix = "agent-"
+
+// AgentBranchPrefix is the fossil branch prefix used for synthetic
+// slot commits (ADR 0050 §"Branch model"). Each agent invocation
+// commits land on `agent/<full-agent-id>`; the operator decides via
+// `bones apply --slot=agent-<id>` whether to materialize that branch
+// into the git working tree.
+const AgentBranchPrefix = "agent/"
+
+// SyntheticTaskTitle is the title used for the auto-created task that
+// backs a synthetic slot's claim. The bones-tasks bucket needs an
+// entry for the lease's claim machinery to grip; a stable
+// human-readable title makes the bucket browsable from `bones tasks
+// status` without leaking implementation detail in the name.
+const SyntheticTaskTitle = "agent slot (synthetic, ADR 0050)"
+
+// ErrAgentIDMissing is returned by JoinAuto when the workspace has no
+// `.bones/agent.id` marker. The caller should run `bones up` (or
+// `bones init`) first; JoinAuto refuses to invent an identity.
+var ErrAgentIDMissing = errors.New(
+	"swarm: workspace has no agent.id — run `bones up` to initialize",
+)
+
+// SyntheticSlotName returns the synthetic slot name for the given
+// agent_id (`agent-<first-AgentSlotIDLen-chars>`). Caller is
+// responsible for ensuring agentID is non-empty; the function panics
+// (via assert) on the empty input rather than returning a bare
+// `agent-` prefix that would collide across workspaces.
+//
+// Truncation is straight-prefix: if agentID is shorter than
+// AgentSlotIDLen, the whole id is used. The full id always lives in
+// the session record's AgentID field; truncation is only the
+// human-facing slot name.
+func SyntheticSlotName(agentID string) string {
+	assert.NotEmpty(agentID, "swarm.SyntheticSlotName: agentID is empty")
+	id := strings.TrimSpace(agentID)
+	if len(id) > AgentSlotIDLen {
+		id = id[:AgentSlotIDLen]
+	}
+	return AgentSlotPrefix + id
+}
+
+// AgentBranchName returns the fossil branch name for a synthetic slot
+// (`agent/<full-agent-id>`). Branch suffix uses the FULL agent_id,
+// not the truncated slot prefix, so `bones apply --slot=<name>` can
+// disambiguate when an operator has multiple agents whose 12-char
+// prefixes happen to overlap.
+func AgentBranchName(agentID string) string {
+	assert.NotEmpty(agentID, "swarm.AgentBranchName: agentID is empty")
+	return AgentBranchPrefix + strings.TrimSpace(agentID)
+}
+
+// IsSyntheticSlot reports whether slot is a synthetic agent slot
+// (i.e. begins with AgentSlotPrefix). Used by callers that need to
+// distinguish plan-anchored slots from agent slots — for example,
+// log filtering and cleanup grouping. Plain prefix check; intentional.
+func IsSyntheticSlot(slot string) bool {
+	return strings.HasPrefix(slot, AgentSlotPrefix)
+}
+
+// JoinAutoResult is the outcome of JoinAuto: either a fresh acquire
+// (FreshLease set, ReEntry=false) or an idempotent re-entry against
+// an existing session record on this host (FreshLease nil, Slot/WT
+// populated, ReEntry=true). Callers that just want the slot dir for
+// printing on stdout should read Slot + WT regardless of which path
+// fired.
+//
+// The lease is returned only on the fresh path because Acquire is the
+// only function that constructs one with an active claim; re-entry
+// reads the existing record without taking a claim, mirroring how
+// `bones swarm commit` would use Resume rather than re-Acquire.
+//
+// Callers that took the fresh path MUST call FreshLease.Release (or
+// Abort on a downstream failure) exactly once. Re-entry callers have
+// nothing to release — the existing lease's host-local pid file and
+// session record were written by the prior join.
+type JoinAutoResult struct {
+	Slot    string
+	WT      string
+	TaskID  string
+	AgentID string
+	ReEntry bool
+	Lease   *FreshLease
+}
+
+// JoinAuto opens (or rejoins) the synthetic slot for the workspace's
+// agent_id. ADR 0050 §"Slot identity is implicit" + #282.
+//
+// Steps:
+//  1. Read .bones/agent.id (info.AgentID is the source of truth;
+//     ErrAgentIDMissing if empty).
+//  2. Derive slot name = `agent-<first-AgentSlotIDLen-chars>`.
+//  3. Open the swarm.Sessions handle and look up the slot.
+//     - Existing record + same agent_id + same host → idempotent
+//     re-entry. Bumps LastRenewed (heartbeat-on-rejoin per
+//     option (a) in #282) and returns ReEntry=true.
+//     - Existing record + different agent_id → ErrSessionAlreadyLive
+//     (different agents must use different prefixes, or one collided
+//     in the truncation; the operator must clean up).
+//     - No record → fall through to fresh acquire below.
+//  4. Auto-create a synthetic task in bones-tasks (so the claim
+//     machinery has something to grip) and call swarm.Acquire with
+//     that task ID. The synthetic task's title is SyntheticTaskTitle;
+//     it carries a single hold path under .bones/swarm/<slot>/wt/ so
+//     the hold-bucket invariant (every claim corresponds to a task
+//     with hold paths) holds.
+//
+// Caller MUST call lease.Release(ctx) when done with the fresh path.
+// Re-entry path: lease is nil; nothing to release.
+func JoinAuto(ctx context.Context, info workspace.Info, opts AcquireOpts) (JoinAutoResult, error) {
+	assert.NotNil(ctx, "swarm.JoinAuto: ctx is nil")
+	assert.NotEmpty(info.WorkspaceDir, "swarm.JoinAuto: info.WorkspaceDir is empty")
+
+	if strings.TrimSpace(info.AgentID) == "" {
+		return JoinAutoResult{}, ErrAgentIDMissing
+	}
+	slot := SyntheticSlotName(info.AgentID)
+
+	// Re-entry probe: read the session record before constructing a
+	// fresh task. A live record on this host with the same agent_id is
+	// a re-entry; ADR 0050 invariant 2 ("re-joining the same slot
+	// returns the same lease") means we must not Acquire again.
+	now, _, _ := defaultAcquireOpts(opts)
+	if existing, ok, err := probeReEntry(ctx, info, slot, info.AgentID, opts); err != nil {
+		return JoinAutoResult{}, err
+	} else if ok {
+		// Best-effort heartbeat on re-entry — option (a) in #282:
+		// renew-on-every-verb keeps the lease fresh without a
+		// background goroutine. CAS conflicts are silently absorbed
+		// (a sibling commit raced ours); the renewal lands on the next
+		// verb instead.
+		_ = bumpReEntry(ctx, info, slot, opts, now)
+		return JoinAutoResult{
+			Slot:    slot,
+			WT:      SlotWorktree(info.WorkspaceDir, slot),
+			TaskID:  existing.TaskID,
+			AgentID: existing.AgentID,
+			ReEntry: true,
+		}, nil
+	}
+
+	// Fresh path: synthesize a task so Acquire's claim has a target.
+	// The task's hold path is unique to the slot (a sentinel under the
+	// slot's wt dir), so two agents whose prefixes happen to overlap
+	// would observe the collision via ErrSessionAlreadyLive at the
+	// session record layer rather than racing on the holds bucket.
+	taskID, err := openSyntheticTask(ctx, info, slot, info.AgentID, opts)
+	if err != nil {
+		return JoinAutoResult{}, fmt.Errorf("swarm.JoinAuto: open synthetic task: %w", err)
+	}
+
+	// Acquire: writes session record, opens leaf, claims the synthetic
+	// task. The session record's AgentID field carries the FULL
+	// agent_id (not the slot prefix) so `bones apply --slot=<name>`
+	// can later resolve the fossil branch (`agent/<full-id>`).
+	lease, err := acquireSynthetic(ctx, info, slot, taskID, info.AgentID, opts)
+	if err != nil {
+		return JoinAutoResult{}, fmt.Errorf("swarm.JoinAuto: %w", err)
+	}
+	return JoinAutoResult{
+		Slot:    slot,
+		WT:      lease.WT(),
+		TaskID:  taskID,
+		AgentID: info.AgentID,
+		Lease:   lease,
+	}, nil
+}
+
+// probeReEntry returns the existing session record for slot if it is
+// alive on this host AND owned by the supplied agent_id. Returns
+// (record, true, nil) on a re-entry hit; (zero, false, nil) when no
+// record exists or the record is on a different host (caller will
+// surface the cross-host situation via the regular Acquire path).
+//
+// A record owned by a DIFFERENT agent_id on this host is reported as
+// (zero, false, ErrSessionAlreadyLive): the slot prefix collided
+// across agents, or one workspace was reused by two agents in a row
+// without cleanup. Either way, JoinAuto must not silently take over.
+func probeReEntry(
+	ctx context.Context, info workspace.Info, slot, agentID string, opts AcquireOpts,
+) (Session, bool, error) {
+	sessions, nc, ownsConn, err := openLeaseSessions(ctx, info, opts.NATSConn)
+	if err != nil {
+		return Session{}, false, fmt.Errorf("swarm.JoinAuto: open sessions: %w", err)
+	}
+	defer func() {
+		_ = sessions.Close()
+		if ownsConn && nc != nil {
+			nc.Close()
+		}
+	}()
+
+	existing, _, err := sessions.Get(ctx, slot)
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			return Session{}, false, nil
+		}
+		return Session{}, false, fmt.Errorf("swarm.JoinAuto: read session: %w", err)
+	}
+	host, _ := os.Hostname()
+	if existing.Host != host {
+		// Different host owns this slot. Don't re-enter; surface as a
+		// foreign-host situation (the regular Acquire path under
+		// fresh acquisition would do the same).
+		return Session{}, false, fmt.Errorf("%w (slot=%q owner-host=%q)",
+			ErrSessionForeignHost, slot, existing.Host)
+	}
+	if existing.AgentID != agentID {
+		return Session{}, false, fmt.Errorf("%w (slot=%q existing-agent=%q this-agent=%q)",
+			ErrSessionAlreadyLive, slot, existing.AgentID, agentID)
+	}
+	return existing, true, nil
+}
+
+// bumpReEntry CAS-updates LastRenewed on the existing session record
+// during a re-entry. Best-effort: a transient CAS conflict means
+// another verb on this host advanced the rev between our Get and Put,
+// which is itself evidence the lease is alive — caller continues
+// regardless.
+func bumpReEntry(
+	ctx context.Context, info workspace.Info, slot string, opts AcquireOpts,
+	now func() time.Time,
+) error {
+	sessions, nc, ownsConn, err := openLeaseSessions(ctx, info, opts.NATSConn)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = sessions.Close()
+		if ownsConn && nc != nil {
+			nc.Close()
+		}
+	}()
+	sess, rev, err := sessions.Get(ctx, slot)
+	if err != nil {
+		return err
+	}
+	sess.LastRenewed = now()
+	return sessions.update(ctx, sess, rev)
+}
+
+// openSyntheticTask opens a one-shot task in the bones-tasks bucket
+// to back the synthetic slot's claim. Returns the new task's ID. The
+// task's hold path is a stable sentinel under the slot's wt dir
+// (`<wt>/.synthetic-claim`), which lives nowhere else on disk and so
+// cannot collide with real-file holds from plan-driven slots.
+//
+// The task is closed when the synthetic slot's lease is closed via
+// `bones cleanup --slot` or the TTL watcher (#265).
+func openSyntheticTask(
+	ctx context.Context, info workspace.Info, slot, agentID string, opts AcquireOpts,
+) (string, error) {
+	hubURL := opts.HubURL
+	if hubURL == "" && opts.Hub != nil {
+		hubURL = opts.Hub.HTTPAddr()
+	}
+	if hubURL == "" {
+		hubURL = DefaultHubFossilURL
+	}
+	leaf, err := openLeaf(
+		ctx, info, slot+"-init",
+		AgentSlotPrefix+truncate(agentID, AgentSlotIDLen),
+		hubURL, opts.Hub, !opts.NoAutosync,
+	)
+	if err != nil {
+		return "", fmt.Errorf("open transient leaf: %w", err)
+	}
+	defer func() { _ = leaf.Stop() }()
+	holdPath := filepath.Join(SlotWorktree(info.WorkspaceDir, slot), ".synthetic-claim")
+	tid, err := leaf.OpenTask(ctx, SyntheticTaskTitle, []string{holdPath})
+	if err != nil {
+		return "", fmt.Errorf("open task: %w", err)
+	}
+	return string(tid), nil
+}
+
+// acquireSynthetic is Acquire's call site for synthetic slots. Wraps
+// Acquire with the AgentID-on-record contract: the session record's
+// AgentID field carries the FULL agent_id (instead of the
+// `slot-<name>` derivation Acquire uses for plan slots), so
+// downstream verbs can resolve the fossil branch name without re-
+// reading agent.id.
+//
+// All other Acquire semantics are preserved: hold-bucket probe, claim
+// take, pid file, leaf lifetime. Pulled into a separate helper rather
+// than parameterizing Acquire so the plan-slot path stays unchanged.
+func acquireSynthetic(
+	ctx context.Context, info workspace.Info,
+	slot, taskID, agentID string, opts AcquireOpts,
+) (*FreshLease, error) {
+	// Plumb a synthetic-slot fossil user. Plan slots use `slot-<name>`;
+	// synthetic slots use `agent-<prefix>` so the fossil log shows the
+	// agent_id in the author column, which is the field operators read
+	// during forensic walkthroughs.
+	fossilUser := AgentSlotPrefix + truncate(agentID, AgentSlotIDLen)
+	now, hubURL, caps := defaultAcquireOpts(opts)
+	if opts.HubURL == "" && opts.Hub != nil {
+		hubURL = opts.Hub.HTTPAddr()
+	}
+
+	if err := ensureSlotUser(info.WorkspaceDir, fossilUser, caps); err != nil {
+		return nil, err
+	}
+
+	sessions, nc, ownsConn, err := openLeaseSessions(ctx, info, opts.NATSConn)
+	if err != nil {
+		return nil, err
+	}
+	cleanupConn := func() {
+		_ = sessions.Close()
+		if ownsConn && nc != nil {
+			nc.Close()
+		}
+	}
+
+	if err := clearExistingRecord(ctx, sessions, slot, opts.ForceTakeover, now); err != nil {
+		cleanupConn()
+		return nil, err
+	}
+
+	leaf, claim, err := openLeafAndClaim(
+		ctx, info, slot, fossilUser, hubURL, taskID, opts.Hub, !opts.NoAutosync,
+	)
+	if err != nil {
+		cleanupConn()
+		return nil, err
+	}
+	rev, err := writeSyntheticSession(
+		ctx, sessions, info.WorkspaceDir, slot, taskID, fossilUser, agentID, hubURL, now,
+	)
+	if err != nil {
+		_ = claim.Release()
+		_ = leaf.Stop()
+		cleanupConn()
+		return nil, err
+	}
+
+	emitJoinEvent(info.WorkspaceDir, slot, taskID, fossilUser, now())
+
+	return &FreshLease{
+		leaseBase: leaseBase{
+			info:         info,
+			slot:         slot,
+			taskID:       taskID,
+			fossilUser:   fossilUser,
+			hubURL:       hubURL,
+			now:          now,
+			leaf:         leaf,
+			sessions:     sessions,
+			natsConn:     nc,
+			ownsNATSConn: ownsConn,
+			rev:          rev,
+		},
+		claim: claim,
+	}, nil
+}
+
+// writeSyntheticSession is the synthetic-slot variant of
+// writeSessionAndPid. Identical except the AgentID stamped into the
+// record is the FULL agent_id (so downstream `bones apply` can
+// resolve the fossil branch name `agent/<full-id>`), not the slot's
+// fossil-user derivation.
+func writeSyntheticSession(
+	ctx context.Context, sessions *Sessions,
+	workspaceDir, slot, taskID, fossilUser, agentID, hubURL string,
+	now func() time.Time,
+) (uint64, error) {
+	host, _ := os.Hostname()
+	t := now()
+	sess := Session{
+		Slot:        slot,
+		TaskID:      taskID,
+		AgentID:     agentID,
+		Host:        host,
+		LeafPID:     os.Getpid(),
+		HubURL:      hubURL,
+		StartedAt:   t,
+		LastRenewed: t,
+	}
+	if err := sessions.put(ctx, sess); err != nil {
+		return 0, fmt.Errorf("swarm.JoinAuto: write session record: %w", err)
+	}
+	if err := writePidFile(workspaceDir, slot); err != nil {
+		_ = sessions.delete(ctx, slot, 0)
+		return 0, fmt.Errorf("swarm.JoinAuto: %w", err)
+	}
+	_, rev, err := sessions.Get(ctx, slot)
+	if err != nil {
+		return 0, fmt.Errorf("swarm.JoinAuto: re-read session: %w", err)
+	}
+	_ = fossilUser // referenced via fossil-user creation upstream
+	return rev, nil
+}
+
+// truncate cuts s to at most n characters. Pulled into a helper so the
+// slot-prefix derivation reads as one expression at each call site.
+func truncate(s string, n int) string {
+	if len(s) > n {
+		return s[:n]
+	}
+	return s
+}

--- a/internal/swarm/synthetic_test.go
+++ b/internal/swarm/synthetic_test.go
@@ -1,0 +1,262 @@
+// Tests for `bones swarm join --auto` synthetic-slot lifecycle (ADR
+// 0050, #282). Pins:
+//   - Slot name derivation from agent.id is stable (`agent-<prefix>`).
+//   - Idempotent re-entry: re-joining the same slot returns the same
+//     wt/ + does not duplicate the session record.
+//   - Migration check rejects stale `.claude/worktrees/agent-*/` dirs.
+package swarm
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestSwarmJoinAuto_DerivesSlotFromAgentID pins the slot-name
+// derivation: `agent-<first-AgentSlotIDLen-chars-of-agent-id>`.
+// Deterministic given the same agent.id.
+func TestSwarmJoinAuto_DerivesSlotFromAgentID(t *testing.T) {
+	cases := []struct {
+		name     string
+		agentID  string
+		wantSlot string
+	}{
+		{
+			name:     "long uuid trims to 12",
+			agentID:  "a2a2ecd1865-74c8ac-deadbeef",
+			wantSlot: "agent-a2a2ecd1865-",
+		},
+		{
+			name:     "short id used verbatim",
+			agentID:  "abc123",
+			wantSlot: "agent-abc123",
+		},
+		{
+			name:     "exact 12 chars",
+			agentID:  "abcdef012345",
+			wantSlot: "agent-abcdef012345",
+		},
+		{
+			name:     "13 chars trims to 12",
+			agentID:  "abcdef0123456",
+			wantSlot: "agent-abcdef012345",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := SyntheticSlotName(tc.agentID)
+			if got != tc.wantSlot {
+				t.Errorf("SyntheticSlotName(%q) = %q, want %q",
+					tc.agentID, got, tc.wantSlot)
+			}
+			// Determinism: a second call must return the same value.
+			if got2 := SyntheticSlotName(tc.agentID); got2 != got {
+				t.Errorf("non-deterministic: first=%q second=%q", got, got2)
+			}
+			// Sanity: every synthetic slot name passes IsSyntheticSlot.
+			if !IsSyntheticSlot(got) {
+				t.Errorf("IsSyntheticSlot(%q) = false; want true", got)
+			}
+		})
+	}
+}
+
+// TestIsSyntheticSlot_ExcludesPlanSlots: plan-anchored slots like
+// `rendering` must NOT be classified as synthetic.
+func TestIsSyntheticSlot_ExcludesPlanSlots(t *testing.T) {
+	for _, name := range []string{"rendering", "infra", "plan-x", "slot-1"} {
+		if IsSyntheticSlot(name) {
+			t.Errorf("IsSyntheticSlot(%q) = true; want false (plan-anchored slot)", name)
+		}
+	}
+}
+
+// TestAgentBranchName_PreservesFullID: branch name uses the FULL
+// agent_id (not the truncated slot prefix), so disambiguation works
+// even when two agents' 12-char prefixes happen to match.
+func TestAgentBranchName_PreservesFullID(t *testing.T) {
+	full := "a2a2ecd1865-74c8ac-deadbeef"
+	got := AgentBranchName(full)
+	want := AgentBranchPrefix + full
+	if got != want {
+		t.Errorf("AgentBranchName(%q) = %q, want %q", full, got, want)
+	}
+	if strings.HasPrefix(got, AgentSlotPrefix) {
+		t.Errorf("branch %q must use %q prefix, not slot prefix %q",
+			got, AgentBranchPrefix, AgentSlotPrefix)
+	}
+}
+
+// TestSwarmJoinAuto_IdempotentReEntry: a second JoinAuto with the
+// same agent.id returns ReEntry=true and the same slot/wt without
+// creating a duplicate session record.
+func TestSwarmJoinAuto_IdempotentReEntry(t *testing.T) {
+	f := newLeaseFixture(t)
+	agentID := "abc123def4567890"
+	f.info.AgentID = agentID
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	first, err := JoinAuto(ctx, f.info, AcquireOpts{Hub: f.hub})
+	if err != nil {
+		t.Fatalf("first JoinAuto: %v", err)
+	}
+	if first.ReEntry {
+		t.Errorf("first JoinAuto: ReEntry=true; want false on fresh acquire")
+	}
+	if first.Lease == nil {
+		t.Fatal("first JoinAuto: Lease is nil; want fresh FreshLease")
+	}
+	if err := first.Lease.Release(ctx); err != nil {
+		t.Fatalf("first Release: %v", err)
+	}
+
+	// Second invocation: same agent_id → re-entry path.
+	second, err := JoinAuto(ctx, f.info, AcquireOpts{Hub: f.hub})
+	if err != nil {
+		t.Fatalf("second JoinAuto (re-entry): %v", err)
+	}
+	if !second.ReEntry {
+		t.Errorf("second JoinAuto: ReEntry=false; want true on re-join")
+	}
+	if second.Lease != nil {
+		t.Errorf("second JoinAuto: Lease=%v; want nil on re-entry", second.Lease)
+	}
+	if second.Slot != first.Slot {
+		t.Errorf("re-entry slot mismatch: first=%q second=%q",
+			first.Slot, second.Slot)
+	}
+	if second.WT != first.WT {
+		t.Errorf("re-entry wt mismatch: first=%q second=%q",
+			first.WT, second.WT)
+	}
+	if second.AgentID != agentID {
+		t.Errorf("re-entry agent_id = %q, want %q", second.AgentID, agentID)
+	}
+}
+
+// TestSwarmJoinAuto_PrintsSlotDir: the result's WT field is the
+// slot's wt directory path under .bones/swarm/agent-<id>/wt/. The
+// CLI verb writes this to stdout via `BONES_SLOT_WT=`; the
+// substrate test pins the value comes back correctly.
+func TestSwarmJoinAuto_PrintsSlotDir(t *testing.T) {
+	f := newLeaseFixture(t)
+	agentID := "deadbeef00112233"
+	f.info.AgentID = agentID
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	res, err := JoinAuto(ctx, f.info, AcquireOpts{Hub: f.hub})
+	if err != nil {
+		t.Fatalf("JoinAuto: %v", err)
+	}
+	defer func() {
+		if res.Lease != nil {
+			_ = res.Lease.Release(ctx)
+		}
+	}()
+
+	wantSlot := SyntheticSlotName(agentID)
+	wantWT := filepath.Join(f.info.WorkspaceDir, ".bones", "swarm", wantSlot, "wt")
+	if res.Slot != wantSlot {
+		t.Errorf("res.Slot = %q, want %q", res.Slot, wantSlot)
+	}
+	if res.WT != wantWT {
+		t.Errorf("res.WT = %q, want %q", res.WT, wantWT)
+	}
+	// Sanity: directory should exist (Acquire MkdirAll'd it).
+	if st, statErr := os.Stat(wantWT); statErr != nil {
+		t.Errorf("wt dir missing after JoinAuto: %v", statErr)
+	} else if !st.IsDir() {
+		t.Errorf("wt path %q is not a directory", wantWT)
+	}
+}
+
+// TestSwarmJoinAuto_RefusesMissingAgentID: empty AgentID on the
+// info struct returns ErrAgentIDMissing without any side effect.
+func TestSwarmJoinAuto_RefusesMissingAgentID(t *testing.T) {
+	f := newLeaseFixture(t)
+	f.info.AgentID = "" // explicit blank
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err := JoinAuto(ctx, f.info, AcquireOpts{Hub: f.hub})
+	if !errors.Is(err, ErrAgentIDMissing) {
+		t.Errorf("JoinAuto with empty agent_id: err=%v, want ErrAgentIDMissing", err)
+	}
+}
+
+// TestCheckStaleClaudeWorktrees_RejectsAgentDirs: a workspace with
+// `.claude/worktrees/agent-XYZ/` returns ErrStaleClaudeWorktrees
+// and the error message names the dir.
+func TestCheckStaleClaudeWorktrees_RejectsAgentDirs(t *testing.T) {
+	root := t.TempDir()
+	staleDir := filepath.Join(root, ".claude", "worktrees", "agent-XYZ")
+	if err := os.MkdirAll(staleDir, 0o755); err != nil {
+		t.Fatalf("mkdir stale dir: %v", err)
+	}
+
+	err := CheckStaleClaudeWorktrees(root)
+	if !errors.Is(err, ErrStaleClaudeWorktrees) {
+		t.Fatalf("CheckStaleClaudeWorktrees: err=%v, want ErrStaleClaudeWorktrees", err)
+	}
+	if !strings.Contains(err.Error(), "agent-XYZ") {
+		t.Errorf("error must name the stale dir; got: %v", err)
+	}
+}
+
+// TestCheckStaleClaudeWorktrees_PassesCleanWorkspace: a workspace
+// with no `.claude/worktrees/agent-*` returns nil. Empty `.claude/`
+// or empty `.claude/worktrees/` is also fine — only `agent-*`
+// children trigger the refusal.
+func TestCheckStaleClaudeWorktrees_PassesCleanWorkspace(t *testing.T) {
+	t.Run("no .claude dir", func(t *testing.T) {
+		root := t.TempDir()
+		if err := CheckStaleClaudeWorktrees(root); err != nil {
+			t.Errorf("clean workspace: err=%v, want nil", err)
+		}
+	})
+	t.Run("empty .claude/worktrees", func(t *testing.T) {
+		root := t.TempDir()
+		_ = os.MkdirAll(filepath.Join(root, ".claude", "worktrees"), 0o755)
+		if err := CheckStaleClaudeWorktrees(root); err != nil {
+			t.Errorf("empty worktrees dir: err=%v, want nil", err)
+		}
+	})
+	t.Run("non-agent worktree dir", func(t *testing.T) {
+		root := t.TempDir()
+		_ = os.MkdirAll(filepath.Join(root, ".claude", "worktrees", "feature-x"), 0o755)
+		if err := CheckStaleClaudeWorktrees(root); err != nil {
+			t.Errorf("non-agent dir: err=%v, want nil", err)
+		}
+	})
+}
+
+// TestRefusalErrorPointsAtCleanup: the migration error message
+// names `bones cleanup --all-worktrees` so an operator sees the
+// recovery path without grepping ADRs.
+func TestRefusalErrorPointsAtCleanup(t *testing.T) {
+	root := t.TempDir()
+	stale := filepath.Join(root, ".claude", "worktrees", "agent-recovery")
+	if err := os.MkdirAll(stale, 0o755); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	err := CheckStaleClaudeWorktrees(root)
+	if err == nil {
+		t.Fatal("expected error; got nil")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "bones cleanup --all-worktrees") {
+		t.Errorf("error must point at recovery verb; got: %s", msg)
+	}
+	if !strings.Contains(msg, "ADR 0050") {
+		t.Errorf("error should reference ADR 0050; got: %s", msg)
+	}
+}


### PR DESCRIPTION
## Summary

Implements the join side of ADR 0050. `bones swarm join --auto` maps a Claude Code Agent invocation onto a synthetic ephemeral slot:

- Slot name `agent-<first-12-chars-of-agent-id>` (collision rate ~5e-15 for a million agents). Full agent_id preserved in `Session.AgentID` for `bones apply --slot` (#283) branch resolution.
- Idempotent re-entry — re-joining returns the existing lease and bumps `last_renewed` via best-effort CAS.
- Renewal pattern (a) — renew-on-every-verb. Existing `ResumedLease.Commit` already heartbeats; no goroutine. Idle agents past TTL get reaped by #265's `ttlwatch`.
- Stdout: `BONES_SLOT_WT=<path>` + `BONES_SLOT_NAME=<name>` + re-entry indicator so the harness can `cd` and exec.

## Migration

`bones up` and `bones hub start` refuse-to-start when `.claude/worktrees/agent-*/` dirs exist. Loud refusal pointing at `bones cleanup --all-worktrees` (per #265) so operators upgrading across the ADR-0050 boundary know the old isolation surface is gone.

Closes #282

## Test plan

- [x] `make check` passes
- [x] `go test -tags=otel -short ./...` passes
- [x] 12 tests covering slot derivation, idempotent re-entry, stdout shape, missing agent.id error, migration check at both `bones up` and `bones hub start`, error messages

## Out of scope (deliberate)

- **`TestSwarmJoinAuto_FirstCommitOnAgentBranch`** — the `agent/<id>` fossil-branch model requires plumbing `Tags []TagSpec` through EdgeSync's `agent.CommitOpts` and `coord.Leaf.Commit`. libfossil supports it already; bones depends on EdgeSync via released versions. Per CLAUDE.md upstream-fix policy this is best filed upstream rather than worked around in the consumer. `Session.AgentID` carries the full id so `bones apply --slot=agent-<id>` (#283) can resolve the branch name once upstream lands.
- The `bones cleanup` verb — already shipped in #265.
- `bones apply --slot=<name>` extension — separate issue (#283).

## Architecture note

The migration check lives in two places due to the `internal/hub/` ↔ `internal/swarm/` import cycle: `internal/swarm/migration.go` (canonical, used by `bones up`) and `internal/hub/migration.go` (hub-side mirror with separate sentinel error). Both produce `errors.Is`-matchable errors that name the offending dirs and point at recovery.
