### PR TITLE
feat(swarm): synthetic slots commit on agent/<id> via leaf TagSpec

### DIFF
--- a/internal/coord/leaf.go
+++ b/internal/coord/leaf.go
@@ -499,11 +499,14 @@ func (l *Leaf) Commit(
 	}
 	// Agent.Commit auto-resolves the trunk tip when ParentID is unset,
 	// so the commit chains onto the latest tip from the post-pull state
-	// without bones needing to call Tip() and round-trip the rid.
+	// without bones needing to call Tip() and round-trip the rid. When
+	// co.tags carries the synthetic-slot branch pair (#288), the
+	// checkin lands on `agent/<id>` rather than advancing trunk.
 	rev, err := l.agent.Commit(ctx, agent.CommitOpts{
 		Files:   toCommit,
 		Message: commitComment,
 		Author:  commitUser,
+		Tags:    co.tags,
 	})
 	if err != nil {
 		return "", fmt.Errorf("coord.Leaf.Commit: %w", err)
@@ -592,13 +595,15 @@ func (l *Leaf) Push(
 	return res, nil
 }
 
-// CommitOption tunes Leaf.Commit. Construct with WithMessage / WithUser.
+// CommitOption tunes Leaf.Commit. Construct with WithMessage / WithUser
+// / WithTags.
 type CommitOption func(*commitConfig)
 
 // commitConfig holds the resolved options for a Leaf.Commit call.
 type commitConfig struct {
 	message string
 	user    string
+	tags    []agent.TagSpec
 }
 
 // WithMessage replaces the default "leaf commit for task <id>" comment
@@ -611,6 +616,16 @@ func WithMessage(msg string) CommitOption {
 // treated as "use slot identity."
 func WithUser(user string) CommitOption {
 	return func(c *commitConfig) { c.user = user }
+}
+
+// WithTags attaches libfossil tags to the new checkin (#288). The
+// canonical use is the synthetic-slot branch pair
+// (`branch=agent/<id>` + `sym-agent/<id>=*`) so the commit lands on
+// the agent's branch rather than advancing trunk; see
+// swarm.AgentBranchTags. Nil or empty slice is treated as "no tags";
+// the commit lands on trunk per default behavior.
+func WithTags(tags []agent.TagSpec) CommitOption {
+	return func(c *commitConfig) { c.tags = tags }
 }
 
 // normalizeLeadingSlash strips a single leading slash so absolute paths
@@ -628,9 +643,20 @@ func normalizeLeadingSlash(p string) string {
 func (l *Leaf) Tip(ctx context.Context) (string, error) {
 	assert.NotNil(l, "coord.Leaf.Tip: receiver is nil")
 	assert.NotNil(ctx, "coord.Leaf.Tip: ctx is nil")
-	rev, err := l.agent.Tip(ctx, "trunk")
+	return l.TipOnBranch(ctx, "trunk")
+}
+
+// TipOnBranch returns the manifest UUID at the head of the named
+// fossil branch, or "" on a branch with no checkins. branch="trunk"
+// is equivalent to Tip. Used by #288 verification tests to confirm
+// that synthetic-slot commits land on `agent/<id>` and not trunk.
+func (l *Leaf) TipOnBranch(ctx context.Context, branch string) (string, error) {
+	assert.NotNil(l, "coord.Leaf.TipOnBranch: receiver is nil")
+	assert.NotNil(ctx, "coord.Leaf.TipOnBranch: ctx is nil")
+	assert.NotEmpty(branch, "coord.Leaf.TipOnBranch: branch is empty")
+	rev, err := l.agent.Tip(ctx, branch)
 	if err != nil {
-		return "", fmt.Errorf("coord.Leaf.Tip: %w", err)
+		return "", fmt.Errorf("coord.Leaf.TipOnBranch(%q): %w", branch, err)
 	}
 	return string(rev), nil
 }

--- a/internal/swarm/lease.go
+++ b/internal/swarm/lease.go
@@ -555,7 +555,18 @@ func (l *ResumedLease) Commit(
 	if l.leaf == nil {
 		return CommitResult{}, fmt.Errorf("swarm.ResumedLease.Commit: leaf already stopped")
 	}
-	uuid, err := commitViaLeaf(ctx, l.leaf, l.taskID, message, files)
+	// #288: synthetic agent slots (slot name `agent-<prefix>`) commit on
+	// the per-agent fossil branch `agent/<full-id>` instead of advancing
+	// trunk. Plan-anchored slots leave Tags nil and continue the
+	// trunk-based-development model. The full agent_id lives on the
+	// session record's AgentID field, which Resume copied into
+	// l.fossilUser; for plan slots that field is `slot-<name>` and
+	// IsSyntheticSlot keeps the tag derivation off it.
+	var tags []TagSpec
+	if IsSyntheticSlot(l.slot) {
+		tags = AgentBranchTags(l.fossilUser)
+	}
+	uuid, err := commitViaLeaf(ctx, l.leaf, l.taskID, message, files, tags)
 	if err != nil {
 		return CommitResult{}, err
 	}
@@ -926,8 +937,14 @@ func writeSessionAndPid(
 
 // commitViaLeaf re-claims the lease's task on the freshly-Resumed
 // leaf, announces holds for the file paths, commits, and releases.
+//
+// tags is the optional libfossil tag set passed through to
+// coord.Leaf.Commit. Synthetic agent slots pass the
+// `branch=agent/<id>` + `sym-agent/<id>=*` pair (#288); plan slots
+// pass nil and the commit advances trunk.
 func commitViaLeaf(
-	ctx context.Context, leaf *coord.Leaf, taskID, message string, files []coord.File,
+	ctx context.Context, leaf *coord.Leaf, taskID, message string,
+	files []coord.File, tags []TagSpec,
 ) (string, error) {
 	claim, err := leaf.Claim(ctx, coord.TaskID(taskID))
 	if err != nil {
@@ -943,7 +960,11 @@ func commitViaLeaf(
 		return "", fmt.Errorf("swarm.ResumedLease.Commit: announce holds: %w", err)
 	}
 	defer releaseHolds()
-	uuid, err := leaf.Commit(ctx, claim, files, coord.WithMessage(message))
+	commitOpts := []coord.CommitOption{coord.WithMessage(message)}
+	if len(tags) > 0 {
+		commitOpts = append(commitOpts, coord.WithTags(tags))
+	}
+	uuid, err := leaf.Commit(ctx, claim, files, commitOpts...)
 	if err != nil {
 		return "", fmt.Errorf("swarm.ResumedLease.Commit: leaf commit: %w", err)
 	}

--- a/internal/swarm/synthetic.go
+++ b/internal/swarm/synthetic.go
@@ -9,9 +9,17 @@ import (
 	"strings"
 	"time"
 
+	"github.com/danmestas/EdgeSync/leaf/agent"
+
 	"github.com/danmestas/bones/internal/assert"
 	"github.com/danmestas/bones/internal/workspace"
 )
+
+// TagSpec is a re-export of agent.TagSpec so swarm callers don't need
+// to depend on the leaf module directly to construct branch-tag pairs.
+// Identical wire shape; carries the libfossil tag primitive
+// (`branch=<name>` and `sym-<name>=*`) attached at commit time.
+type TagSpec = agent.TagSpec
 
 // AgentSlotIDLen is the number of agent_id characters baked into the
 // synthetic slot name (`agent-<prefix>`). 12 hex characters is enough
@@ -79,6 +87,29 @@ func SyntheticSlotName(agentID string) string {
 func AgentBranchName(agentID string) string {
 	assert.NotEmpty(agentID, "swarm.AgentBranchName: agentID is empty")
 	return AgentBranchPrefix + strings.TrimSpace(agentID)
+}
+
+// AgentBranchTags returns the libfossil branch-tag pair that lands a
+// synthetic-slot commit on `agent/<full-agent-id>` instead of trunk.
+// ADR 0050 §"Branch model" + #288. The pair is:
+//
+//   - `branch=<name>`     — the libfossil branch propagation tag.
+//   - `sym-<name>=*`      — the symbolic-name tag that lets the branch
+//     resolve via fossil's name-lookup (`fossil whatis`, `bones apply
+//     --slot=<name>`).
+//
+// Both tags are required; the upstream EdgeSync/libfossil
+// implementation rejects the pair as malformed if either is missing
+// (see leaf v0.0.11 `TestAgent_Commit_BranchTags_LandsOnNamedBranch`).
+//
+// Caller is responsible for non-empty agentID; AgentBranchName panics
+// on empty input.
+func AgentBranchTags(agentID string) []TagSpec {
+	name := AgentBranchName(agentID)
+	return []TagSpec{
+		{Name: "branch", Value: name},
+		{Name: "sym-" + name, Value: "*"},
+	}
 }
 
 // IsSyntheticSlot reports whether slot is a synthetic agent slot

--- a/internal/swarm/synthetic_branch_commit_test.go
+++ b/internal/swarm/synthetic_branch_commit_test.go
@@ -1,0 +1,218 @@
+// Tests for the synthetic-slot agent-branch commit path (#288).
+// Wires the helper AgentBranchTags + leaf v0.0.11 CommitOpts.Tags
+// pass-through end-to-end:
+//
+//   - Synthetic slots commit on `agent/<full-id>` and DO NOT advance
+//     trunk (TestSyntheticSlot_CommitLandsOnAgentBranch).
+//   - Plan-anchored slots still commit on trunk, untagged
+//     (TestPlanSlot_CommitLandsOnTrunk). Regression: the synthetic-only
+//     tag derivation must not leak into the plan-slot path.
+//
+// Both tests use newLeaseFixture (real NATS + real Fossil per ADR
+// 0030) and post-commit verify by opening a fresh verifier leaf
+// against the hub and reading TipOnBranch.
+package swarm
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/danmestas/bones/internal/coord"
+	"github.com/danmestas/bones/internal/wspath"
+)
+
+// TestSyntheticSlot_CommitLandsOnAgentBranch is the #288 happy path:
+// JoinAuto a synthetic slot, Resume it, write a file, Commit, then
+// confirm the commit is reachable on `agent/<full-id>` and trunk's
+// tip is unchanged.
+//
+// N=1 commit deliberately — the burst-test #267 bumped against a 5s
+// mesh-start ceiling at N>=10 and this test only needs to pin the
+// branch landing, not exercise propagation.
+func TestSyntheticSlot_CommitLandsOnAgentBranch(t *testing.T) {
+	f := newLeaseFixture(t)
+	const agentID = "abcdef0123456789-deadbeef"
+	f.info.AgentID = agentID
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	// Capture trunk tip BEFORE any synthetic-slot commits so the
+	// "trunk did not advance" assertion has a baseline.
+	trunkBefore := readBranchTip(t, ctx, f, "trunk")
+
+	// JoinAuto returns a FreshLease; FreshLease has no Commit method
+	// so we Release and Resume to land in the ResumedLease.Commit path.
+	join, err := JoinAuto(ctx, f.info, AcquireOpts{Hub: f.hub})
+	if err != nil {
+		t.Fatalf("JoinAuto: %v", err)
+	}
+	if join.Lease == nil {
+		t.Fatal("JoinAuto: Lease is nil; want fresh acquire")
+	}
+	if !IsSyntheticSlot(join.Slot) {
+		t.Fatalf("JoinAuto returned non-synthetic slot %q", join.Slot)
+	}
+	if err := join.Lease.Release(ctx); err != nil {
+		t.Fatalf("FreshLease.Release: %v", err)
+	}
+
+	resumed, err := Resume(ctx, f.info, join.Slot, AcquireOpts{Hub: f.hub})
+	if err != nil {
+		t.Fatalf("Resume: %v", err)
+	}
+	t.Cleanup(func() { _ = resumed.Release(ctx) })
+
+	holdPath := filepath.Join(resumed.WT(), "agent.txt")
+	files := []coord.File{{
+		Path:    wspath.Must(holdPath),
+		Name:    "agent.txt",
+		Content: []byte("commit on agent branch (#288)\n"),
+	}}
+	res, err := resumed.Commit(ctx, "synthetic-slot commit", files)
+	if err != nil {
+		t.Fatalf("ResumedLease.Commit: %v", err)
+	}
+	if res.UUID == "" {
+		t.Fatalf("CommitResult.UUID is empty")
+	}
+	if res.PushErr != nil {
+		t.Fatalf("CommitResult.PushErr: %v", res.PushErr)
+	}
+
+	// Verify on the hub: the commit is the tip of `agent/<full-id>`
+	// and trunk has NOT advanced.
+	wantBranch := AgentBranchName(agentID)
+	branchTip := readBranchTip(t, ctx, f, wantBranch)
+	if branchTip == "" {
+		t.Fatalf("branch %q has no tip after commit; want UUID %q", wantBranch, res.UUID)
+	}
+	if branchTip != res.UUID {
+		t.Errorf("branch %q tip = %q, want commit UUID %q",
+			wantBranch, branchTip, res.UUID)
+	}
+
+	trunkAfter := readBranchTip(t, ctx, f, "trunk")
+	if trunkAfter != trunkBefore {
+		t.Errorf("trunk advanced on synthetic-slot commit: before=%q after=%q",
+			trunkBefore, trunkAfter)
+	}
+	if trunkAfter == res.UUID {
+		t.Errorf("synthetic-slot commit advanced trunk to its own UUID %q; want trunk untouched",
+			res.UUID)
+	}
+}
+
+// TestPlanSlot_CommitLandsOnTrunk is the regression guard: a plan-
+// anchored slot's commit MUST land on trunk (untagged), even after
+// #288 wired synthetic-slot tagging. Catches accidental
+// over-application of AgentBranchTags to non-synthetic slot names.
+func TestPlanSlot_CommitLandsOnTrunk(t *testing.T) {
+	f := newLeaseFixture(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	const slot = "rendering" // plan-style name; IsSyntheticSlot returns false
+	if IsSyntheticSlot(slot) {
+		t.Fatalf("test setup invalid: %q passes IsSyntheticSlot", slot)
+	}
+	holdPath := filepath.Join(f.dir, slot, "frame.txt")
+	taskID := string(f.createTask(t, "plan-slot-commit-task", holdPath))
+
+	lease, err := Acquire(ctx, f.info, slot, taskID, AcquireOpts{Hub: f.hub})
+	if err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	if err := lease.Release(ctx); err != nil {
+		t.Fatalf("Release fresh: %v", err)
+	}
+
+	resumed, err := Resume(ctx, f.info, slot, AcquireOpts{Hub: f.hub})
+	if err != nil {
+		t.Fatalf("Resume: %v", err)
+	}
+	t.Cleanup(func() { _ = resumed.Release(ctx) })
+
+	files := []coord.File{{
+		Path:    wspath.Must(holdPath),
+		Name:    "frame.txt",
+		Content: []byte("plan-slot artifact\n"),
+	}}
+	res, err := resumed.Commit(ctx, "plan-slot commit", files)
+	if err != nil {
+		t.Fatalf("ResumedLease.Commit: %v", err)
+	}
+	if res.UUID == "" {
+		t.Fatalf("CommitResult.UUID is empty")
+	}
+	if res.PushErr != nil {
+		t.Fatalf("CommitResult.PushErr: %v", res.PushErr)
+	}
+
+	// Trunk MUST advance to this commit; the agent-branch namespace
+	// MUST stay untouched (no `agent/...` branch should exist).
+	trunkTip := readBranchTip(t, ctx, f, "trunk")
+	if trunkTip != res.UUID {
+		t.Errorf("trunk tip = %q, want commit UUID %q (plan slot must commit on trunk)",
+			trunkTip, res.UUID)
+	}
+
+	// Sanity: a synthetic-style branch must not have been created. We
+	// can't enumerate branches portably, but probing the slot-derived
+	// branch name should return "". Use the slot string verbatim — if
+	// the implementation ever did wrongly tag, we'd see *some* branch
+	// tip; the test would fail in the trunk check above, but this
+	// makes the failure mode explicit.
+	stray := readBranchTip(t, ctx, f, "agent/"+slot)
+	if stray != "" {
+		t.Errorf("plan slot wrongly created agent-branch %q with tip %q",
+			"agent/"+slot, stray)
+	}
+}
+
+// readBranchTip opens a short-lived verifier leaf cloned from the
+// fixture's hub, lets autosync pull, and returns the tip UUID for the
+// named branch. Returns "" when the branch has no checkins. Used
+// instead of direct libfossil access because bones holds no
+// libfossil.Repo handles outside the agent.
+func readBranchTip(t *testing.T, ctx context.Context, f *leaseFixture, branch string) string {
+	t.Helper()
+	verifier, err := coord.OpenLeaf(ctx, coord.LeafConfig{
+		Hub:     f.hub,
+		Workdir: filepath.Join(f.dir, ".bones", "verify-"+branch),
+		SlotID:  "verify-" + sanitizeBranchForSlotID(branch),
+	})
+	if err != nil {
+		t.Fatalf("verifier OpenLeaf for branch %q: %v", branch, err)
+	}
+	defer func() { _ = verifier.Stop() }()
+
+	tip, err := verifier.TipOnBranch(ctx, branch)
+	if err != nil {
+		// Fossil treats "branch with no checkins" as a regular zero
+		// result, not an error; treat any error here as a real
+		// substrate fault.
+		t.Fatalf("TipOnBranch(%q): %v", branch, err)
+	}
+	return tip
+}
+
+// sanitizeBranchForSlotID maps `agent/<id>` (and any other branch
+// name with a slash) to a flat slot-id suitable for the verifier
+// leaf's workdir. Slot IDs are flat directory names; a slash would
+// land the verifier's leaf.fossil under the wrong path.
+func sanitizeBranchForSlotID(branch string) string {
+	out := make([]byte, 0, len(branch))
+	for i := 0; i < len(branch); i++ {
+		c := branch[i]
+		if c == '/' || c == '\\' {
+			out = append(out, '-')
+			continue
+		}
+		out = append(out, c)
+	}
+	return string(out)
+}

--- a/internal/swarm/synthetic_test.go
+++ b/internal/swarm/synthetic_test.go
@@ -91,6 +91,31 @@ func TestAgentBranchName_PreservesFullID(t *testing.T) {
 	}
 }
 
+// TestAgentBranchTags_Pair pins the libfossil branch-tag pair
+// AgentBranchTags emits (#288). Both `branch=<name>` and
+// `sym-<name>=*` are required by libfossil for the checkin to land
+// on the named branch — drop either and the upstream rejects the
+// pair as malformed (see leaf v0.0.11
+// `TestAgent_Commit_BranchTags_LandsOnNamedBranch`).
+func TestAgentBranchTags_Pair(t *testing.T) {
+	full := "a2a2ecd1865-74c8ac-deadbeef"
+	tags := AgentBranchTags(full)
+	if len(tags) != 2 {
+		t.Fatalf("AgentBranchTags(%q) returned %d tags; want exactly 2 (branch + sym pair)",
+			full, len(tags))
+	}
+	wantBranch := AgentBranchPrefix + full
+	if tags[0].Name != "branch" || tags[0].Value != wantBranch {
+		t.Errorf("tags[0] = {Name:%q Value:%q}, want {Name:%q Value:%q}",
+			tags[0].Name, tags[0].Value, "branch", wantBranch)
+	}
+	wantSymName := "sym-" + wantBranch
+	if tags[1].Name != wantSymName || tags[1].Value != "*" {
+		t.Errorf("tags[1] = {Name:%q Value:%q}, want {Name:%q Value:%q}",
+			tags[1].Name, tags[1].Value, wantSymName, "*")
+	}
+}
+
 // TestSwarmJoinAuto_IdempotentReEntry: a second JoinAuto with the
 // same agent.id returns ReEntry=true and the same slot/wt without
 // creating a duplicate session record.


### PR DESCRIPTION
## Summary

Wire EdgeSync/leaf v0.0.11's `agent.CommitOpts.Tags` into bones' swarm-commit path so synthetic agent slots land their work on fossil branch `agent/<agent_id>` instead of trunk. Precondition for ADR 0050's operator-gated apply model and #283.

Closes #288 (and unblocks #283).

## Helper

`swarm.AgentBranchTags(agentID) []TagSpec` emits the canonical fossil branch-tag pair:
- `{Name: "branch", Value: "agent/<id>"}` (propagating, libfossil-managed flags)
- `{Name: "sym-agent/<id>", Value: "*"}` (symbolic resolver)

Both required for fossil branch behavior end-to-end (BranchTip lookups, branch listing, subsequent commits on the same branch).

## Threading

- `coord.Leaf.Commit` gains `WithTags(tags []agent.TagSpec)` option; passes through to `agent.CommitOpts.Tags`.
- `coord.Leaf.TipOnBranch(ctx, branch)` for branch-scoped tip reads (refactored `Tip` to delegate for trunk).
- `swarm.commitViaLeaf` takes `tags []TagSpec`.
- `ResumedLease.Commit` derives them from `AgentBranchTags(l.fossilUser)` when `IsSyntheticSlot(l.slot)`, else nil → trunk default for plan slots.

Decision point: `IsSyntheticSlot(slot.Name)`. Plan-anchored slots commit on trunk; synthetic agent slots commit on `agent/<id>`.

## Test plan

- [x] `make check` passes
- [x] `go test -tags=otel -short ./internal/swarm/... ./internal/coord/...` passes
- [x] `go test -race -short ./internal/swarm/...` passes
- [x] 3 tests: `TestAgentBranchTags_Pair` (unit), `TestSyntheticSlot_CommitLandsOnAgentBranch` (integration), `TestPlanSlot_CommitLandsOnTrunk` (regression guard)

## TagSpec import path

`github.com/danmestas/EdgeSync/leaf/agent.TagSpec` (verified in leaf v0.0.11 `agent/code_artifact.go:58`).

## Out of scope

`bones apply --slot=<name>` (#283) — this PR makes agent commits land on the right branch; #283 is the reader path that materializes them into the git working tree.
