### PR TITLE
feat(apply): bones apply --slot=<name> materializes from agent branch

### DIFF
--- a/cli/apply.go
+++ b/cli/apply.go
@@ -12,35 +12,53 @@ import (
 	"time"
 
 	repocli "github.com/danmestas/EdgeSync/cli/repo"
+	"github.com/nats-io/nats.go"
 
 	"github.com/danmestas/bones/internal/hub"
+	"github.com/danmestas/bones/internal/swarm"
 	"github.com/danmestas/bones/internal/telemetry"
 	"github.com/danmestas/bones/internal/workspace"
 )
 
 // ApplyCmd materializes fossil-resident work into a target directory.
-// Two modes share the same verb (issue #234, ADR 0037):
+// Three modes share the same verb (issue #234, ADR 0037, ADR 0050):
 //
 //  1. Default (trunk fan-in): with no flags, reads the hub fossil's
 //     trunk tip and stages the changes into the project-root git
 //     working tree for the user to review and commit. See
 //     docs/superpowers/specs/2026-04-30-bones-apply-design.md.
-//  2. Slot mode (--slot=<name> --to=<dir>): copies the slot's most
-//     recent committed-artifacts tree from `.bones/recovery/<slot>-*`
-//     into <dir>. The timestamped path scheme is hidden — the
-//     operator passes only the slot name. (#234)
+//  2. Synthetic slot mode (--slot=agent-<id>): per ADR 0050, reads
+//     the agent's fossil branch (`agent/<full-id>`) tip and
+//     materializes its tree into the project-root git working tree.
+//     Same dirty-tree refusal, same telemetry path. Default writes
+//     files unstaged; --staged adds `git add` for each materialized
+//     path so the operator can `git diff --staged` the same way
+//     trunk mode produces.
+//  3. Recovery slot mode (--slot=<name> --to=<dir>): copies the
+//     slot's most recent committed-artifacts tree from
+//     `.bones/recovery/<slot>-*` into <dir>. Predates ADR 0050 and
+//     remains for plan-driven slots that write recovery artifacts.
 //
 // bones apply never runs `git commit`. In trunk mode it stages with
 // `git add -A` within fossil's tracked-paths set; the user owns the
-// commit message and the commit author identity. In slot mode it
-// writes files and stops — the operator decides what to do next.
+// commit message and the commit author identity. In synthetic slot
+// mode the default leaves files unstaged so `git status` shows the
+// branch's worth of work for the operator to review before staging.
 type ApplyCmd struct {
 	DryRun bool   `name:"dry-run" help:"show planned changes without writing or staging"`
-	Slot   string `name:"slot" help:"materialize this slot's committed artifacts; requires --to"`
-	To     string `name:"to" help:"target directory for --slot mode; created if missing"`
+	Slot   string `name:"slot" help:"materialize this slot's branch (synthetic) or recovery dir (with --to)"` //nolint:lll
+	To     string `name:"to" help:"target directory for recovery-mode --slot; created if missing"`
+	Staged bool   `name:"staged" help:"in synthetic slot mode, run git add on materialized files"`
 }
 
 func (c *ApplyCmd) Run(g *repocli.Globals) (err error) {
+	// Synthetic agent slots (ADR 0050) materialize from the fossil
+	// branch `agent/<full-id>` straight into the project's git tree;
+	// no --to is required (or accepted — the brief is explicit that
+	// the synthetic flow targets the operator's working tree).
+	if c.Slot != "" && swarm.IsSyntheticSlot(c.Slot) {
+		return c.runSyntheticSlotMode()
+	}
 	if c.Slot != "" || c.To != "" {
 		return c.runSlotMode()
 	}
@@ -58,7 +76,7 @@ func (c *ApplyCmd) Run(g *repocli.Globals) (err error) {
 	if err != nil {
 		return err
 	}
-	tempDir, cleanup, err := openTempCheckout(pre)
+	tempDir, cleanup, err := openTempCheckout(pre, "trunk")
 	if err != nil {
 		return err
 	}
@@ -113,6 +131,275 @@ func (c *ApplyCmd) runSlotMode() (err error) {
 	fmt.Fprintf(os.Stderr,
 		"bones apply: materialized slot %q → %s\n", c.Slot, c.To)
 	return nil
+}
+
+// runSyntheticSlotMode implements ADR 0050's `bones apply
+// --slot=agent-<id>` flow. It looks up the slot's session record to
+// recover the FULL agent_id, computes the fossil branch name
+// (`agent/<full-id>`), opens a temp checkout at that branch's tip, and
+// reuses the trunk-mode materialize pipeline (dirty-tree refusal,
+// classifyDiff against the previously-applied marker, write +
+// optionally stage). The git working tree is the target — `--to` is
+// reserved for the legacy recovery flow.
+func (c *ApplyCmd) runSyntheticSlotMode() (err error) {
+	outcome := &applyOutcome{DryRun: c.DryRun}
+	_, end := telemetry.RecordCommand(context.Background(), "apply",
+		telemetry.String("mode", "synthetic-slot"),
+		telemetry.String("slot", c.Slot),
+		telemetry.Bool("dry_run", c.DryRun),
+		telemetry.Bool("staged", c.Staged),
+	)
+	defer func() { end(err, outcome.attrs()...) }()
+
+	if c.To != "" {
+		return errors.New(
+			"bones apply: --to is for recovery-dir slots; synthetic agent " +
+				"slots materialize into the git working tree (drop --to)")
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("cwd: %w", err)
+	}
+	pre, err := runApplyPreflight(cwd)
+	if err != nil {
+		return err
+	}
+	branch, err := resolveSyntheticSlotBranch(context.Background(), pre.WorkspaceDir, c.Slot)
+	if err != nil {
+		return err
+	}
+	rev, err := branchRev(pre.HubFossil, pre.FossilBin, branch)
+	if err != nil {
+		return fmt.Errorf(
+			"bones apply: branch %q has no tip (slot=%q): %w",
+			branch, c.Slot, err)
+	}
+	tempDir, cleanup, err := openTempCheckout(pre, rev)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+	// Walk the checked-out tree to derive the manifest. fossil's
+	// `ls -R <repo> -r <rev>` is unreliable for branch tips written
+	// via libfossil's xfer pipeline (returns empty even when `fossil
+	// open <repo> <rev>` materializes the files); a directory walk
+	// over the temp checkout is the source of truth that matches what
+	// classifyDiff will diff against.
+	manifest, err := scanCheckoutManifest(tempDir)
+	if err != nil {
+		return fmt.Errorf(
+			"bones apply: scan branch %q checkout: %w", branch, err)
+	}
+	return c.applyBranchToWorkingTree(pre, tempDir, branch, manifest, rev, outcome)
+}
+
+// scanCheckoutManifest walks tempDir and returns the relative paths
+// of every regular file that is NOT under fossil's `.fslckout` /
+// `_FOSSIL_` private state. Used by the synthetic-slot apply path
+// because `fossil ls -R repo -r <rev>` returns empty for tips
+// written through libfossil's xfer protocol on Fossil 2.28; the
+// on-disk checkout is authoritative once `fossil open` has hydrated
+// it.
+func scanCheckoutManifest(tempDir string) ([]string, error) {
+	var paths []string
+	err := filepath.WalkDir(tempDir, func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		rel, err := filepath.Rel(tempDir, path)
+		if err != nil {
+			return err
+		}
+		if rel == "." {
+			return nil
+		}
+		// Skip fossil's private state files at the repo root.
+		base := filepath.Base(rel)
+		if base == ".fslckout" || base == "_FOSSIL_" || base == ".fos" {
+			if d.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if d.IsDir() {
+			return nil
+		}
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		if !info.Mode().IsRegular() {
+			return nil
+		}
+		paths = append(paths, filepath.ToSlash(rel))
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return paths, nil
+}
+
+// applyBranchToWorkingTree is the synthetic-slot variant of
+// applyFromCheckout. Same dirty-tree refusal and classifyDiff
+// pipeline, but skips the last-applied marker (each apply of an
+// agent branch is independent — the operator decides each time
+// whether to materialize) and only stages when --staged is set.
+//
+// Pulled into its own helper rather than parameterizing
+// applyFromCheckout because the trunk path has additional concerns
+// (last-applied marker, always-stage) that synthetic slots
+// deliberately don't carry.
+func (c *ApplyCmd) applyBranchToWorkingTree(
+	pre *applyPreflight, tempDir, branch string,
+	manifest []string, rev string, outcome *applyOutcome,
+) error {
+	if err := refuseIfDirty(pre.WorkspaceDir, manifest); err != nil {
+		outcome.DirtyRefused = true
+		return err
+	}
+	plan, err := classifyDiff(tempDir, pre.WorkspaceDir, manifest, nil)
+	if err != nil {
+		return err
+	}
+	outcome.Added = len(plan.Added)
+	outcome.Modified = len(plan.Modified)
+	total := len(plan.Added) + len(plan.Modified)
+	if total == 0 {
+		outcome.AlreadyUpToDate = true
+		fmt.Printf("bones apply: slot=%s already in working tree at %s\n",
+			c.Slot, shortRev(rev))
+		return nil
+	}
+	if c.DryRun {
+		printApplyDryRun(plan, rev)
+		return nil
+	}
+	if err := writeBranchPlanToTree(tempDir, pre.WorkspaceDir, plan, c.Staged); err != nil {
+		return err
+	}
+	stagedNote := "review with `git diff` and stage when ready"
+	if c.Staged {
+		stagedNote = "staged via --staged; review with `git diff --staged`"
+	}
+	fmt.Printf(
+		"applied %d changes from slot=%s @ %s. %s.\n",
+		total, c.Slot, shortRev(rev), stagedNote,
+	)
+	return nil
+}
+
+// writeBranchPlanToTree mirrors applyPlanToTree but defers the
+// `git add` step to a flag. Synthetic slots default to leaving files
+// unstaged (per the brief: "default mode leaves git status showing
+// the materialized files unstaged"); --staged opts into the
+// trunk-mode-style pre-staged flow.
+//
+// Deletes are not part of the synthetic-slot apply: an agent branch
+// is a tree, not a diff against trunk. The operator removes files
+// with their own tools.
+func writeBranchPlanToTree(tempCheckout, projectRoot string, plan *applyPlan, stage bool) error {
+	written := make([]string, 0, len(plan.Added)+len(plan.Modified))
+	written = append(written, plan.Added...)
+	written = append(written, plan.Modified...)
+	for _, p := range written {
+		src := filepath.Join(tempCheckout, p)
+		dst := filepath.Join(projectRoot, p)
+		data, err := os.ReadFile(src)
+		if err != nil {
+			return fmt.Errorf("read %s: %w", p, err)
+		}
+		info, err := os.Stat(src)
+		if err != nil {
+			return fmt.Errorf("stat %s: %w", p, err)
+		}
+		if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+			return fmt.Errorf("mkdir for %s: %w", p, err)
+		}
+		if err := os.WriteFile(dst, data, info.Mode().Perm()); err != nil {
+			return fmt.Errorf("write %s: %w", p, err)
+		}
+	}
+	if !stage || len(written) == 0 {
+		return nil
+	}
+	args := append([]string{"add", "--"}, written...)
+	cmd := exec.Command("git", args...)
+	cmd.Dir = projectRoot
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("git add: %w\n%s", err, out)
+	}
+	return nil
+}
+
+// resolveSyntheticSlotBranch looks up the slot's session record to
+// recover the full agent_id (the slot name itself is truncated to
+// AgentSlotIDLen chars), then returns `agent/<full-id>`. Returns a
+// user-facing error pointing at `bones swarm status` when the slot
+// is unknown — the most likely cause is a typo or a slot whose
+// session has already been reaped.
+//
+// Reads NATS URL from the workspace's recorded hub URL file rather
+// than going through workspace.Join, which would auto-start the hub
+// (incorrect for a verb that's only reading existing state).
+func resolveSyntheticSlotBranch(ctx context.Context, workspaceDir, slot string) (string, error) {
+	natsURL := hub.NATSURL(workspaceDir)
+	if natsURL == "" {
+		return "", fmt.Errorf(
+			"bones apply: no hub running — `bones up` first " +
+				"to bring the slot's session record online")
+	}
+	nc, err := nats.Connect(natsURL)
+	if err != nil {
+		return "", fmt.Errorf("bones apply: nats connect: %w", err)
+	}
+	defer nc.Close()
+	sess, err := swarm.Open(ctx, swarm.Config{NATSConn: nc})
+	if err != nil {
+		return "", fmt.Errorf("bones apply: open sessions: %w", err)
+	}
+	defer func() { _ = sess.Close() }()
+	rec, _, err := sess.Get(ctx, slot)
+	if err != nil {
+		if errors.Is(err, swarm.ErrNotFound) {
+			return "", fmt.Errorf(
+				"bones apply: unknown slot %q — see `bones swarm status` for live slot names",
+				slot)
+		}
+		return "", fmt.Errorf("bones apply: read session %q: %w", slot, err)
+	}
+	if strings.TrimSpace(rec.AgentID) == "" {
+		return "", fmt.Errorf(
+			"bones apply: slot %q has no recorded agent_id (session record incomplete)",
+			slot)
+	}
+	return swarm.AgentBranchName(rec.AgentID), nil
+}
+
+// branchRev returns the hex UUID at the head of a fossil branch.
+// Parses the first whitespace-separated token from the `hash:` (or
+// legacy `uuid:`) line of `fossil info` so trailing timestamp text
+// — which fossil includes on the same line — doesn't leak into the
+// rev string.
+func branchRev(hubFossil, fossilBin, branch string) (string, error) {
+	out, err := exec.Command(fossilBin, "info", "-R", hubFossil, branch).Output()
+	if err != nil {
+		return "", fmt.Errorf("fossil info %s: %w", branch, err)
+	}
+	for _, line := range strings.Split(string(out), "\n") {
+		line = strings.TrimSpace(line)
+		for _, prefix := range []string{"uuid:", "hash:"} {
+			if !strings.HasPrefix(line, prefix) {
+				continue
+			}
+			rest := strings.TrimSpace(strings.TrimPrefix(line, prefix))
+			if i := strings.IndexAny(rest, " \t"); i >= 0 {
+				rest = rest[:i]
+			}
+			return rest, nil
+		}
+	}
+	return "", fmt.Errorf("could not parse rev for branch %q from `fossil info`", branch)
 }
 
 // latestSlotRecoveryDir scans `.bones/recovery/` for entries matching
@@ -275,22 +562,27 @@ func (c *ApplyCmd) applyFromCheckout(
 	return nil
 }
 
-// openTempCheckout opens a fresh fossil checkout of the hub repo at trunk
-// tip in <workspace>/.bones/apply-<unix-nano>/. Returns the temp dir and
-// a cleanup function the caller must defer.
-func openTempCheckout(pre *applyPreflight) (string, func(), error) {
+// openTempCheckout opens a fresh fossil checkout of the hub repo at the
+// given version (a branch name like "trunk" or "agent/<id>", a tag, or
+// a hex UUID) in <workspace>/.bones/apply-<unix-nano>/. Returns the temp
+// dir and a cleanup function the caller must defer. Empty version
+// defaults to "trunk" so legacy callers don't have to think about it.
+func openTempCheckout(pre *applyPreflight, version string) (string, func(), error) {
+	if version == "" {
+		version = "trunk"
+	}
 	tempDir := filepath.Join(pre.WorkspaceDir, ".bones",
 		fmt.Sprintf("apply-%d", time.Now().UnixNano()))
 	if err := os.MkdirAll(tempDir, 0o755); err != nil {
 		return "", nil, fmt.Errorf("mkdir temp checkout: %w", err)
 	}
 	checkoutCmd := exec.Command(pre.FossilBin, "open", "--force",
-		pre.HubFossil, "--workdir", tempDir)
+		pre.HubFossil, version, "--workdir", tempDir)
 	checkoutCmd.Stdout = os.Stderr
 	checkoutCmd.Stderr = os.Stderr
 	if err := checkoutCmd.Run(); err != nil {
 		_ = os.RemoveAll(tempDir)
-		return "", nil, fmt.Errorf("fossil open temp checkout: %w", err)
+		return "", nil, fmt.Errorf("fossil open temp checkout @ %s: %w", version, err)
 	}
 	cleanup := func() {
 		closeCmd := exec.Command(pre.FossilBin, "close", "--force")
@@ -596,9 +888,17 @@ func writeLastAppliedMarker(workspaceDir, rev string) error {
 // repo without a live checkout — without `-r`, fossil ls expects to be
 // run inside a fossil working directory.
 func manifestAtRev(hubFossil, fossilBin, rev string) ([]string, error) {
-	out, err := exec.Command(fossilBin, "ls", "-R", hubFossil, "-r", rev).Output()
+	cmd := exec.Command(fossilBin, "ls", "-R", hubFossil, "-r", rev)
+	out, err := cmd.Output()
 	if err != nil {
-		return nil, fmt.Errorf("fossil ls @ %s: %w", rev, err)
+		// Surface stderr in the error so branch-name typos / missing
+		// branches give an actionable message rather than the bare
+		// "exit status 1".
+		var stderrSnippet string
+		if ee, ok := err.(*exec.ExitError); ok && len(ee.Stderr) > 0 {
+			stderrSnippet = ": " + strings.TrimSpace(string(ee.Stderr))
+		}
+		return nil, fmt.Errorf("fossil ls @ %s: %w%s", rev, err, stderrSnippet)
 	}
 	var paths []string
 	for _, line := range strings.Split(string(out), "\n") {

--- a/cli/apply_synthetic_slot_test.go
+++ b/cli/apply_synthetic_slot_test.go
@@ -1,0 +1,298 @@
+// Tests for `bones apply --slot=agent-<id>` (ADR 0050, issue #283).
+//
+// Synthetic-slot apply walks a real fossil branch (`agent/<full-id>`)
+// in the hub repo and materializes its tree into the project-root git
+// working tree. These tests wire the full pipeline: a real coord.Hub
+// (NATS + libfossil), a JoinAuto'd synthetic slot, a real commit on
+// the agent branch, then ApplyCmd.Run reading the session record and
+// extracting the branch.
+//
+// Skipped under -short because they require fossil + git on PATH and
+// stand up an in-process hub.
+package cli
+
+import (
+	"context"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	libfossilcli "github.com/danmestas/libfossil/cli"
+
+	"github.com/danmestas/bones/internal/coord"
+	"github.com/danmestas/bones/internal/swarm"
+	"github.com/danmestas/bones/internal/workspace"
+	"github.com/danmestas/bones/internal/wspath"
+)
+
+// syntheticApplyFixture sets up a workspace with a hub running, a
+// synthetic-slot session record on the bus, and a real commit on
+// `agent/<full-id>`. The git tree is initialized but empty (no
+// fossil-tracked files yet) so the apply path observes pure adds.
+type syntheticApplyFixture struct {
+	dir      string
+	hub      *coord.Hub
+	info     workspace.Info
+	agentID  string
+	slot     string
+	branch   string
+	commitID string
+}
+
+func syntheticFreePort(t *testing.T) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	addr := ln.Addr().String()
+	_ = ln.Close()
+	return addr
+}
+
+// writeHubURLFiles records the live hub's NATS + Fossil URLs at
+// `<root>/.bones/hub-{nats,fossil}-url` so cli helpers (which call
+// hub.NATSURL / hub.FossilURL) discover them. Mirrors what the real
+// hub.Start does on bring-up.
+func writeHubURLFiles(t *testing.T, dir string, hub *coord.Hub) {
+	t.Helper()
+	must(t, os.WriteFile(filepath.Join(dir, ".bones", "hub-nats-url"),
+		[]byte(hub.NATSURL()+"\n"), 0o644))
+	must(t, os.WriteFile(filepath.Join(dir, ".bones", "hub-fossil-url"),
+		[]byte(hub.HTTPAddr()+"\n"), 0o644))
+}
+
+// newSyntheticApplyFixture brings up the workspace + hub and stages
+// the inputs for an apply: a synthetic slot has joined, written a
+// file, and committed on its agent branch. Returns a populated
+// fixture pointing at the workspace dir (caller must Chdir).
+func newSyntheticApplyFixture(
+	t *testing.T, agentID, fileName, fileContent string,
+) *syntheticApplyFixture {
+	t.Helper()
+	if _, err := exec.LookPath("fossil"); err != nil {
+		t.Skip("fossil not on PATH")
+	}
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+	clearLeakedGitEnv(t)
+	dir := t.TempDir()
+	orch := filepath.Join(dir, ".bones")
+	must(t, os.MkdirAll(orch, 0o755))
+	must(t, os.WriteFile(filepath.Join(orch, "agent.id"),
+		[]byte(agentID+"\n"), 0o644))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	t.Cleanup(cancel)
+	hub, err := coord.OpenHub(ctx, orch, syntheticFreePort(t))
+	if err != nil {
+		t.Fatalf("OpenHub: %v", err)
+	}
+	t.Cleanup(func() { _ = hub.Stop() })
+	writeHubURLFiles(t, dir, hub)
+
+	info := workspace.Info{
+		WorkspaceDir: dir,
+		NATSURL:      hub.NATSURL(),
+		AgentID:      agentID,
+	}
+
+	// Stand up an empty git repo at the workspace root so apply's
+	// preflight passes. No commits required — the synthetic apply
+	// path is "tree → working tree", not a diff against trunk.
+	mustRunIn(t, dir, "git", "init", "-q")
+
+	// JoinAuto creates the synthetic slot's session record and a
+	// FreshLease. Release the fresh lease so we can Resume + Commit
+	// (Commit isn't on FreshLease).
+	join, err := swarm.JoinAuto(ctx, info, swarm.AcquireOpts{Hub: hub})
+	if err != nil {
+		t.Fatalf("JoinAuto: %v", err)
+	}
+	if err := join.Lease.Release(ctx); err != nil {
+		t.Fatalf("FreshLease.Release: %v", err)
+	}
+	resumed, err := swarm.Resume(ctx, info, join.Slot, swarm.AcquireOpts{Hub: hub})
+	if err != nil {
+		t.Fatalf("Resume: %v", err)
+	}
+	t.Cleanup(func() { _ = resumed.Release(ctx) })
+
+	holdPath := filepath.Join(resumed.WT(), fileName)
+	files := []coord.File{{
+		Path:    wspath.Must(holdPath),
+		Name:    fileName,
+		Content: []byte(fileContent),
+	}}
+	res, err := resumed.Commit(ctx, "synthetic apply test artifact", files)
+	if err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	if res.UUID == "" {
+		t.Fatalf("CommitResult.UUID empty")
+	}
+
+	return &syntheticApplyFixture{
+		dir:      dir,
+		hub:      hub,
+		info:     info,
+		agentID:  agentID,
+		slot:     join.Slot,
+		branch:   swarm.AgentBranchName(agentID),
+		commitID: res.UUID,
+	}
+}
+
+// TestApply_SlotFlag_MaterializesAgentBranch is the happy path: a
+// synthetic slot has committed one file on `agent/<full-id>`;
+// `bones apply --slot=agent-<prefix>` writes that file into the git
+// working tree.
+func TestApply_SlotFlag_MaterializesAgentBranch(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping NATS/fossil test in -short mode")
+	}
+	const agentID = "1111111111111111-mat-branch"
+	const fileName = "agent-output.md"
+	const fileContent = "synthetic-slot artifact (#283)\n"
+	f := newSyntheticApplyFixture(t, agentID, fileName, fileContent)
+	t.Chdir(f.dir)
+
+	cmd := &ApplyCmd{Slot: f.slot}
+	if err := cmd.Run(&libfossilcli.Globals{}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(f.dir, fileName))
+	if err != nil {
+		t.Fatalf("read materialized file: %v", err)
+	}
+	if string(got) != fileContent {
+		t.Errorf("%s = %q, want %q", fileName, got, fileContent)
+	}
+}
+
+// TestApply_SlotFlag_LeavesGitUncommitted verifies the default mode
+// (no --staged) leaves materialized files unstaged so `git status`
+// shows them as untracked. ADR 0050 §"Branch model" — operator
+// reviews before staging.
+func TestApply_SlotFlag_LeavesGitUncommitted(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping NATS/fossil test in -short mode")
+	}
+	const agentID = "2222222222222222-default-unstaged"
+	const fileName = "unstaged.txt"
+	f := newSyntheticApplyFixture(t, agentID, fileName, "default-unstaged\n")
+	t.Chdir(f.dir)
+
+	cmd := &ApplyCmd{Slot: f.slot}
+	if err := cmd.Run(&libfossilcli.Globals{}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	// The file should appear as untracked in `git status --porcelain`
+	// (status code "??") — NOT staged ("A " or "M ").
+	out := mustRunInCapture(t, f.dir, "git", "status", "--porcelain", fileName)
+	line := strings.TrimRight(string(out), "\n")
+	if !strings.HasPrefix(line, "??") {
+		t.Errorf("git status for %s = %q; want untracked (??), default mode must not stage",
+			fileName, line)
+	}
+}
+
+// TestApply_SlotFlag_DirtyTreeRefusal verifies the synthetic-slot path
+// uses the same dirty-tree refusal as trunk mode. If a fossil-tracked
+// path has uncommitted git changes, apply refuses with the same
+// "uncommitted changes" wording.
+func TestApply_SlotFlag_DirtyTreeRefusal(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping NATS/fossil test in -short mode")
+	}
+	const agentID = "3333333333333333-dirty-tree"
+	const fileName = "conflicted.txt"
+	f := newSyntheticApplyFixture(t, agentID, fileName, "from-agent-branch\n")
+
+	// Pre-populate the same path in the git working tree, commit it,
+	// then modify locally so it's dirty. The fossil manifest at the
+	// agent branch contains `conflicted.txt`; refuseIfDirty must
+	// notice the local modification and abort.
+	must(t, os.WriteFile(filepath.Join(f.dir, fileName), []byte("v1\n"), 0o644))
+	mustRunIn(t, f.dir, "git", "add", fileName)
+	mustRunIn(t, f.dir, "git", "-c", "user.name=t", "-c", "user.email=t@t",
+		"commit", "-q", "-m", "init")
+	must(t, os.WriteFile(filepath.Join(f.dir, fileName), []byte("locally edited\n"), 0o644))
+
+	t.Chdir(f.dir)
+	cmd := &ApplyCmd{Slot: f.slot}
+	err := cmd.Run(&libfossilcli.Globals{})
+	if err == nil ||
+		!strings.Contains(err.Error(), "bones apply: uncommitted changes") {
+		t.Fatalf("expected uncommitted-changes refusal, got %v", err)
+	}
+}
+
+// TestApply_SlotFlag_Staged verifies --staged adds materialized files
+// to the git index so `git diff --staged` shows them.
+func TestApply_SlotFlag_Staged(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping NATS/fossil test in -short mode")
+	}
+	const agentID = "4444444444444444-staged-flag"
+	const fileName = "staged.txt"
+	const fileContent = "staged via --staged\n"
+	f := newSyntheticApplyFixture(t, agentID, fileName, fileContent)
+	t.Chdir(f.dir)
+
+	cmd := &ApplyCmd{Slot: f.slot, Staged: true}
+	if err := cmd.Run(&libfossilcli.Globals{}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	out := mustRunInCapture(t, f.dir, "git", "status", "--porcelain", fileName)
+	line := strings.TrimRight(string(out), "\n")
+	// "A " in the index column means added-and-staged.
+	if !strings.HasPrefix(line, "A ") {
+		t.Errorf("git status for %s = %q; want staged (A ), --staged must `git add`",
+			fileName, line)
+	}
+}
+
+// TestApply_SlotFlag_UnknownSlot verifies an unknown synthetic slot
+// gets a clean error pointing at where to find live slot names.
+func TestApply_SlotFlag_UnknownSlot(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping NATS/fossil test in -short mode")
+	}
+	const agentID = "5555555555555555-unknown-slot"
+	// Build the fixture so a hub is running, then ask for a
+	// different (non-existent) synthetic slot. The session record for
+	// the fixture's slot is in KV; the bogus one is not.
+	f := newSyntheticApplyFixture(t, agentID, "ignored.txt", "ignored\n")
+	t.Chdir(f.dir)
+
+	cmd := &ApplyCmd{Slot: "agent-deadbeefdead"}
+	err := cmd.Run(&libfossilcli.Globals{})
+	if err == nil {
+		t.Fatalf("expected error for unknown slot, got nil")
+	}
+	if !strings.Contains(err.Error(), "unknown slot") ||
+		!strings.Contains(err.Error(), "bones swarm status") {
+		t.Errorf("expected guidance toward `bones swarm status`, got %v", err)
+	}
+}
+
+// mustRunInCapture runs a command and captures stdout, fatal on
+// non-zero exit. Used so tests can assert on git's status output
+// without leaking the inherited GIT_DIR (sandboxedEnv pins the cwd).
+func mustRunInCapture(t *testing.T, dir, name string, args ...string) []byte {
+	t.Helper()
+	cmd := exec.Command(name, args...)
+	cmd.Dir = dir
+	cmd.Env = sandboxedEnv(name, dir)
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("%s %v in %s: %v", name, args, dir, err)
+	}
+	return out
+}


### PR DESCRIPTION
## Summary

Extends ADR 0037's `bones apply` with `--slot=<name>` to materialize from a named slot's branch instead of trunk. Closes the operator-gated apply loop for ADR 0050: synthetic agent slots commit to `agent/<agent_id>` (per #288), operator chooses what lands in git via this flag.

Closes #283

## Resolution path

```
--slot=agent-<prefix>
  → IsSyntheticSlot(slot) gate
  → resolveSyntheticSlotBranch reads bones-swarm-sessions[slot]
  → swarm.AgentBranchName(rec.AgentID) → "agent/<full-id>"
  → branchRev → openTempCheckout(rev) → walk + materialize
```

Same dirty-tree refusal, same `--staged` flag, same other knobs as the trunk path. Plan-anchored slots without `--slot` fall through to trunk default (unchanged ADR 0037 behavior).

## Test plan

- [x] `make check` passes
- [x] `go test -tags=otel -short ./cli/... ./internal/swarm/... ./internal/coord/...` passes
- [x] `go test -race -short ./cli/... ./internal/swarm/...` passes
- [x] 5 tests: `MaterializesAgentBranch`, `LeavesGitUncommitted`, `DirtyTreeRefusal`, `Staged`, `UnknownSlot`

## Notable workaround

Fossil 2.28: `fossil ls -R <repo> -r <rev>` returns empty for branch tips written via libfossil's xfer pipeline, even though `fossil open <repo> <rev>` materializes the files correctly. Walked the temp checkout directory after open instead. Documented inline. May be a libfossil/fossil interop bug worth filing upstream if it bites again.

## Deferred

`bones apply --slot=?` / `bones apply --list-slots` — enumerates eligible slots with branch + sha + timestamp. Kept this PR focused on the core flag flow; ergonomics issue worth filing separately if/when operators ask for it.

## Architecture closure

This PR is the last piece of ADR 0050's implementation slate:
- #265 — lease-TTL + `bones cleanup` verb ✓
- #282 — `bones swarm join --auto` ✓
- #267 — burst-dispatch regression test ✓
- #288 — synthetic-slot commit on `agent/<id>` ✓
- #283 — `bones apply --slot=<name>` ✓ (this PR)

ADR 0050 is now fully implemented end-to-end.
