### PR TITLE
feat(tasks): bones tasks ready — list unblocked tasks

### DIFF
--- a/cli/tasks_common.go
+++ b/cli/tasks_common.go
@@ -36,6 +36,7 @@ type TasksCmd struct {
 	Dispatch  TasksDispatchCmd  `cmd:"" hidden:"" help:"Dispatch parent/worker (hub-only)"`
 	Aggregate TasksAggregateCmd `cmd:"" help:"Aggregate per-slot task summary"`
 	Compact   TasksCompactCmd   `cmd:"" help:"Compact eligible closed tasks (ADR 0016)"`
+	Ready     TasksReadyCmd     `cmd:"" help:"List unblocked, unclaimed open tasks"`
 }
 
 // TasksDispatchCmd groups dispatch parent/worker subcommands.

--- a/cli/tasks_ready.go
+++ b/cli/tasks_ready.go
@@ -1,0 +1,150 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	repocli "github.com/danmestas/EdgeSync/cli/repo"
+
+	"github.com/danmestas/bones/internal/tasks"
+	"github.com/danmestas/bones/internal/workspace"
+)
+
+// TasksReadyCmd lists open, unblocked, unclaimed tasks — the actionable
+// work an agent could pick up right now. Mirrors `bd ready` from beads.
+//
+// The verb is read-only; pairs with `bones tasks autoclaim` for the
+// claim step. Filtering and sort logic live in tasks.FilterReady /
+// tasks.SortReady so a future caller (e.g. a richer prime view) can
+// reuse the same predicate without going through the CLI.
+//
+// Default sort: priority highest-first (Context["priority"]="P<N>",
+// lower N wins), then CreatedAt oldest-first as the FIFO tiebreak.
+type TasksReadyCmd struct {
+	JSON  bool   `name:"json" help:"emit JSON array"`
+	Limit int    `name:"limit" default:"0" help:"max rows; 0 = unlimited"`
+	Slot  string `name:"slot" help:"filter to one slot's task scope"`
+	Mine  bool   `name:"mine" help:"only tasks the calling agent could claim"`
+}
+
+func (c *TasksReadyCmd) Run(g *repocli.Globals) error {
+	ctx, stop, info, err := joinWorkspace()
+	if err != nil {
+		return err
+	}
+	defer stop()
+
+	return taskCLIError(runOp(ctx, "ready", func(ctx context.Context) error {
+		return c.run(ctx, info, os.Stdout)
+	}))
+}
+
+// run is the testable seam: opens the manager, filters/sorts, renders
+// to out. Splitting Run from run keeps Kong's Globals out of the test
+// surface.
+func (c *TasksReadyCmd) run(
+	ctx context.Context, info workspace.Info, out io.Writer,
+) error {
+	mgr, closeNC, err := openManager(ctx, info)
+	if err != nil {
+		return fmt.Errorf("open manager: %w", err)
+	}
+	defer closeNC()
+	defer func() { _ = mgr.Close() }()
+
+	all, err := mgr.List(ctx)
+	if err != nil {
+		return err
+	}
+
+	ready := selectReady(all, c.Slot, c.Mine, info.AgentID, c.Limit, time.Now().UTC())
+	return emitReady(out, ready, c.JSON)
+}
+
+// selectReady runs the full filter pipeline used by `bones tasks
+// ready`: readiness gate → optional slot filter → optional mine
+// filter → sort → optional limit. Pure function so tests can drive
+// it without standing up NATS.
+//
+// `mine` and `agentID` are paired: when mine==true the filter keeps
+// only tasks whose ClaimedBy is empty or equals agentID. Since the
+// readiness gate already drops claimed-by-anyone tasks, the mine
+// filter is currently a near-no-op — kept here so a future readiness
+// rule that surfaces self-claimed tasks doesn't change the verb's
+// contract.
+func selectReady(
+	all []tasks.Task, slot string, mine bool, agentID string, limit int, now time.Time,
+) []tasks.Task {
+	out := tasks.FilterReady(all, now)
+	if slot != "" {
+		out = filterReadyBySlot(out, slot)
+	}
+	if mine {
+		out = filterReadyByAgent(out, agentID)
+	}
+	tasks.SortReady(out)
+	if limit > 0 && len(out) > limit {
+		out = out[:limit]
+	}
+	return out
+}
+
+// filterReadyBySlot keeps only tasks whose Context["slot"] equals
+// slot. Tasks without a slot context value are dropped — operators
+// asking for a specific slot do not want unscoped work mixed in.
+func filterReadyBySlot(in []tasks.Task, slot string) []tasks.Task {
+	out := make([]tasks.Task, 0, len(in))
+	for _, t := range in {
+		if t.Context["slot"] != slot {
+			continue
+		}
+		out = append(out, t)
+	}
+	return out
+}
+
+// filterReadyByAgent keeps tasks the named agent could claim — i.e.
+// unclaimed records or records already held by the same agent. The
+// readiness gate has already dropped any task with a non-empty
+// ClaimedBy, so under today's rules this is effectively a no-op; it
+// exists so the `--mine` contract is preserved if the gate's
+// definition ever loosens.
+func filterReadyByAgent(in []tasks.Task, agentID string) []tasks.Task {
+	out := make([]tasks.Task, 0, len(in))
+	for _, t := range in {
+		if t.ClaimedBy != "" && t.ClaimedBy != agentID {
+			continue
+		}
+		out = append(out, t)
+	}
+	return out
+}
+
+// emitReady writes the ready set in either JSON-array shape or the
+// per-line legacy shape that mirrors `bones tasks list`. Empty result
+// in plain mode prints the (no ready tasks) sentinel; empty result in
+// JSON mode emits the literal "[]" array so consumers can rely on a
+// JSON-parseable stream regardless of population.
+func emitReady(out io.Writer, ready []tasks.Task, asJSON bool) error {
+	if asJSON {
+		// Emit empty slice as "[]" rather than "null" so consumers
+		// can json.Unmarshal into []T without a nil-check fork.
+		if ready == nil {
+			ready = []tasks.Task{}
+		}
+		return emitJSON(out, ready)
+	}
+	if len(ready) == 0 {
+		_, err := fmt.Fprintln(out, "(no ready tasks)")
+		return err
+	}
+	for _, t := range ready {
+		if _, err := fmt.Fprintln(out, formatListLine(t)); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/cli/tasks_ready_test.go
+++ b/cli/tasks_ready_test.go
@@ -1,0 +1,281 @@
+// Tests for `bones tasks ready` — the read-only verb that lists
+// actionable (open, unblocked, unclaimed) tasks. Drives the pure
+// selectReady/emitReady seams so the suite stays fast and does not
+// need a NATS server. Real-substrate behavior is covered by the
+// existing autoclaim tests, which exercise coord.Ready against an
+// in-process JetStream.
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/danmestas/bones/internal/tasks"
+)
+
+// readyFixture builds a tasks.Task with the fields ready-tests care
+// about: id, title, status, optional priority and optional createdAt.
+// Defaults: status=open, no claim, no edges.
+func readyFixture(id, title string, opts ...func(*tasks.Task)) tasks.Task {
+	t := tasks.Task{
+		ID:        id,
+		Title:     title,
+		Status:    tasks.StatusOpen,
+		CreatedAt: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+	}
+	for _, opt := range opts {
+		opt(&t)
+	}
+	return t
+}
+
+func withPriority(p string) func(*tasks.Task) {
+	return func(t *tasks.Task) {
+		if t.Context == nil {
+			t.Context = map[string]string{}
+		}
+		t.Context["priority"] = p
+	}
+}
+
+func withSlot(s string) func(*tasks.Task) {
+	return func(t *tasks.Task) {
+		if t.Context == nil {
+			t.Context = map[string]string{}
+		}
+		t.Context["slot"] = s
+	}
+}
+
+func withCreatedAt(ts time.Time) func(*tasks.Task) {
+	return func(t *tasks.Task) { t.CreatedAt = ts }
+}
+
+func withStatus(s tasks.Status) func(*tasks.Task) {
+	return func(t *tasks.Task) { t.Status = s }
+}
+
+func withClaim(by string) func(*tasks.Task) {
+	return func(t *tasks.Task) { t.ClaimedBy = by }
+}
+
+func withEdge(kind tasks.EdgeType, target string) func(*tasks.Task) {
+	return func(t *tasks.Task) {
+		t.Edges = append(t.Edges, tasks.Edge{Type: kind, Target: target})
+	}
+}
+
+// TestTasksReady_FiltersBlocked asserts the readiness gate hides the
+// target of an open `blocks` edge: with B blocking A, only B surfaces
+// while B is open. Once B closes, A re-surfaces.
+func TestTasksReady_FiltersBlocked(t *testing.T) {
+	now := time.Now().UTC()
+	a := readyFixture("a", "alpha")
+	b := readyFixture("b", "blocker", withEdge(tasks.EdgeBlocks, "a"))
+
+	got := selectReady([]tasks.Task{a, b}, "", false, "", 0, now)
+	if len(got) != 1 || got[0].ID != "b" {
+		t.Fatalf("blocked: got %+v want only [b]", got)
+	}
+
+	// Close the blocker — A should now surface.
+	closedAt := now
+	b.Status = tasks.StatusClosed
+	b.ClosedAt = &closedAt
+	got = selectReady([]tasks.Task{a, b}, "", false, "", 0, now)
+	if len(got) != 1 || got[0].ID != "a" {
+		t.Fatalf("after close: got %+v want only [a]", got)
+	}
+}
+
+// TestTasksReady_SkipsClosed asserts closed tasks never surface.
+func TestTasksReady_SkipsClosed(t *testing.T) {
+	now := time.Now().UTC()
+	closedAt := now
+	a := readyFixture("a", "alpha", withStatus(tasks.StatusClosed))
+	a.ClosedAt = &closedAt
+	b := readyFixture("b", "bravo")
+
+	got := selectReady([]tasks.Task{a, b}, "", false, "", 0, now)
+	if len(got) != 1 || got[0].ID != "b" {
+		t.Fatalf("got %+v want only [b]", got)
+	}
+}
+
+// TestTasksReady_SkipsClaimed asserts claimed tasks never surface,
+// even when they're status=claimed (the post-claim state in this
+// model — beads' "in_progress" maps onto bones' "claimed").
+func TestTasksReady_SkipsClaimed(t *testing.T) {
+	now := time.Now().UTC()
+	claimed := readyFixture("a", "claimed",
+		withStatus(tasks.StatusClaimed), withClaim("agent-other"))
+	free := readyFixture("b", "free")
+
+	got := selectReady([]tasks.Task{claimed, free}, "", false, "", 0, now)
+	if len(got) != 1 || got[0].ID != "b" {
+		t.Fatalf("got %+v want only [b]", got)
+	}
+}
+
+// TestTasksReady_PrioritySort asserts P0 sorts above P1 sorts above
+// P2 in the default output, regardless of CreatedAt.
+func TestTasksReady_PrioritySort(t *testing.T) {
+	now := time.Now().UTC()
+	// Reverse the natural priority order in the input slice so the
+	// sort is doing real work.
+	p2 := readyFixture("p2", "two",
+		withPriority("P2"), withCreatedAt(now.Add(-3*time.Hour)))
+	p0 := readyFixture("p0", "zero",
+		withPriority("P0"), withCreatedAt(now.Add(-1*time.Hour)))
+	p1 := readyFixture("p1", "one",
+		withPriority("P1"), withCreatedAt(now.Add(-2*time.Hour)))
+
+	got := selectReady([]tasks.Task{p2, p0, p1}, "", false, "", 0, now)
+	if len(got) != 3 {
+		t.Fatalf("got %d tasks want 3", len(got))
+	}
+	gotIDs := []string{got[0].ID, got[1].ID, got[2].ID}
+	want := []string{"p0", "p1", "p2"}
+	for i := range want {
+		if gotIDs[i] != want[i] {
+			t.Fatalf("priority order: got %v want %v", gotIDs, want)
+		}
+	}
+}
+
+// TestTasksReady_FIFOWithinPriority asserts same-priority tasks sort
+// oldest-first by CreatedAt.
+func TestTasksReady_FIFOWithinPriority(t *testing.T) {
+	now := time.Now().UTC()
+	old := readyFixture("old", "old one",
+		withPriority("P1"), withCreatedAt(now.Add(-2*time.Hour)))
+	mid := readyFixture("mid", "mid one",
+		withPriority("P1"), withCreatedAt(now.Add(-1*time.Hour)))
+	newer := readyFixture("new", "new one",
+		withPriority("P1"), withCreatedAt(now))
+
+	got := selectReady([]tasks.Task{newer, old, mid}, "", false, "", 0, now)
+	if len(got) != 3 {
+		t.Fatalf("got %d tasks want 3", len(got))
+	}
+	gotIDs := []string{got[0].ID, got[1].ID, got[2].ID}
+	want := []string{"old", "mid", "new"}
+	for i := range want {
+		if gotIDs[i] != want[i] {
+			t.Fatalf("FIFO order: got %v want %v", gotIDs, want)
+		}
+	}
+}
+
+// TestTasksReady_JSON asserts --json produces a valid JSON array.
+func TestTasksReady_JSON(t *testing.T) {
+	now := time.Now().UTC()
+	a := readyFixture("a", "alpha", withPriority("P0"))
+	b := readyFixture("b", "bravo", withPriority("P1"))
+
+	ready := selectReady([]tasks.Task{a, b}, "", false, "", 0, now)
+	var buf bytes.Buffer
+	if err := emitReady(&buf, ready, true); err != nil {
+		t.Fatalf("emitReady: %v", err)
+	}
+
+	var decoded []tasks.Task
+	if err := json.Unmarshal(buf.Bytes(), &decoded); err != nil {
+		t.Fatalf("unmarshal: %v\noutput=%s", err, buf.String())
+	}
+	if len(decoded) != 2 {
+		t.Fatalf("got %d items want 2; output=%s", len(decoded), buf.String())
+	}
+	if decoded[0].ID != "a" || decoded[1].ID != "b" {
+		t.Fatalf("order: %v", decoded)
+	}
+}
+
+// TestTasksReady_EmptyEmits asserts the no-ready-tasks sentinel line
+// is emitted to stdout with no error (so the verb exits 0).
+func TestTasksReady_EmptyEmits(t *testing.T) {
+	now := time.Now().UTC()
+	got := selectReady([]tasks.Task{}, "", false, "", 0, now)
+	if len(got) != 0 {
+		t.Fatalf("empty input must yield empty output; got %+v", got)
+	}
+
+	var buf bytes.Buffer
+	if err := emitReady(&buf, got, false); err != nil {
+		t.Fatalf("emitReady: %v", err)
+	}
+	if !strings.Contains(buf.String(), "(no ready tasks)") {
+		t.Fatalf("expected sentinel line; got %q", buf.String())
+	}
+
+	// JSON mode on empty input emits "[]" so consumers see a parseable
+	// array rather than "null".
+	buf.Reset()
+	if err := emitReady(&buf, got, true); err != nil {
+		t.Fatalf("emitReady JSON: %v", err)
+	}
+	if !strings.HasPrefix(strings.TrimSpace(buf.String()), "[") {
+		t.Fatalf("JSON empty must start with [; got %q", buf.String())
+	}
+	var decoded []tasks.Task
+	if err := json.Unmarshal(buf.Bytes(), &decoded); err != nil {
+		t.Fatalf("JSON empty unmarshal: %v\nout=%s", err, buf.String())
+	}
+	if len(decoded) != 0 {
+		t.Fatalf("JSON empty: got %d items want 0", len(decoded))
+	}
+}
+
+// TestTasksReady_SlotFilter asserts --slot keeps only tasks with a
+// matching Context["slot"], dropping unscoped tasks too.
+func TestTasksReady_SlotFilter(t *testing.T) {
+	now := time.Now().UTC()
+	a := readyFixture("a", "alpha", withSlot("alpha"))
+	b := readyFixture("b", "bravo", withSlot("beta"))
+	u := readyFixture("u", "unslotted")
+
+	got := selectReady([]tasks.Task{a, b, u}, "alpha", false, "", 0, now)
+	if len(got) != 1 || got[0].ID != "a" {
+		t.Fatalf("slot filter: got %+v want only [a]", got)
+	}
+}
+
+// TestTasksReady_LimitTruncates asserts --limit caps the result at
+// the requested count, applied AFTER sort so the highest-priority
+// rows survive truncation.
+func TestTasksReady_LimitTruncates(t *testing.T) {
+	now := time.Now().UTC()
+	p0 := readyFixture("p0", "zero", withPriority("P0"))
+	p1 := readyFixture("p1", "one", withPriority("P1"))
+	p2 := readyFixture("p2", "two", withPriority("P2"))
+
+	got := selectReady([]tasks.Task{p2, p1, p0}, "", false, "", 2, now)
+	if len(got) != 2 {
+		t.Fatalf("got %d want 2", len(got))
+	}
+	if got[0].ID != "p0" || got[1].ID != "p1" {
+		t.Fatalf("limit kept wrong rows: %+v", got)
+	}
+}
+
+// TestTasksReady_UnprioritizedSortsLast asserts that tasks without a
+// parsable priority sink below tasks with one — explicitly ranked
+// work always surfaces above unranked work, matching the beads UX.
+func TestTasksReady_UnprioritizedSortsLast(t *testing.T) {
+	now := time.Now().UTC()
+	plain := readyFixture("plain", "no priority",
+		withCreatedAt(now.Add(-10*time.Hour)))
+	p2 := readyFixture("p2", "two", withPriority("P2"),
+		withCreatedAt(now.Add(-1*time.Hour)))
+
+	got := selectReady([]tasks.Task{plain, p2}, "", false, "", 0, now)
+	if len(got) != 2 {
+		t.Fatalf("got %d want 2", len(got))
+	}
+	if got[0].ID != "p2" || got[1].ID != "plain" {
+		t.Fatalf("got %+v want [p2, plain]", got)
+	}
+}

--- a/internal/tasks/ready.go
+++ b/internal/tasks/ready.go
@@ -1,0 +1,139 @@
+package tasks
+
+import (
+	"sort"
+	"time"
+)
+
+// FilterReady returns the subset of records that are eligible for an
+// agent to claim right now: open, unclaimed, no incoming open
+// blocks/supersedes/duplicates edges, no open child task naming the
+// record as Parent, and not deferred into the future relative to now.
+//
+// The DAG check mirrors coord.Ready (see internal/coord/ready.go) but
+// operates directly on []Task records so consumers that already have a
+// task list (the CLI's `tasks ready` verb) do not need to open a coord
+// session. The two implementations stay in sync by sharing the same
+// rule list — any new readiness gate must be added in both places.
+//
+// discovered-from edges are intentionally ignored — they are audit
+// metadata, not a ready-blocker.
+func FilterReady(records []Task, now time.Time) []Task {
+	b := buildReadyBlockers(records)
+	out := make([]Task, 0, len(records))
+	for _, r := range records {
+		if r.Status != StatusOpen {
+			continue
+		}
+		if r.ClaimedBy != "" {
+			continue
+		}
+		if _, ok := b.blocked[r.ID]; ok {
+			continue
+		}
+		if _, ok := b.superseded[r.ID]; ok {
+			continue
+		}
+		if _, ok := b.duplicated[r.ID]; ok {
+			continue
+		}
+		if _, ok := b.hasOpenChild[r.ID]; ok {
+			continue
+		}
+		if r.DeferUntil != nil && r.DeferUntil.After(now) {
+			continue
+		}
+		out = append(out, r)
+	}
+	return out
+}
+
+// readyBlockers holds the reverse-index sets computed in the first
+// pass of FilterReady. Membership in any of these sets hides a task
+// from the output (ADR 0014).
+type readyBlockers struct {
+	blocked      map[string]struct{}
+	superseded   map[string]struct{}
+	duplicated   map[string]struct{}
+	hasOpenChild map[string]struct{}
+}
+
+// buildReadyBlockers walks every non-closed task record once and
+// records what each such record's outgoing edges and Parent reference
+// imply about which OTHER task IDs are blocked.
+func buildReadyBlockers(records []Task) readyBlockers {
+	b := readyBlockers{
+		blocked:      make(map[string]struct{}),
+		superseded:   make(map[string]struct{}),
+		duplicated:   make(map[string]struct{}),
+		hasOpenChild: make(map[string]struct{}),
+	}
+	for _, r := range records {
+		if r.Status == StatusClosed {
+			continue
+		}
+		if r.Parent != "" {
+			b.hasOpenChild[r.Parent] = struct{}{}
+		}
+		for _, e := range r.Edges {
+			switch e.Type {
+			case EdgeBlocks:
+				b.blocked[e.Target] = struct{}{}
+			case EdgeSupersedes:
+				b.superseded[e.Target] = struct{}{}
+			case EdgeDuplicates:
+				b.duplicated[e.Target] = struct{}{}
+			}
+		}
+	}
+	return b
+}
+
+// SortReady sorts records in place by priority (highest first) then
+// CreatedAt ascending (oldest first within the same priority bucket).
+// Priority is read from Context["priority"] and parsed as a P<N>
+// rank where lower N == higher priority (P0 > P1 > P2). Tasks with
+// no parsable priority sort to the END of the list — explicitly
+// prioritized work always surfaces above unprioritized work.
+//
+// The sort is stable so callers that pre-sort on a secondary key see
+// that ordering preserved within ties.
+func SortReady(records []Task) {
+	sort.SliceStable(records, func(i, j int) bool {
+		pi, oki := PriorityRank(records[i])
+		pj, okj := PriorityRank(records[j])
+		switch {
+		case oki && !okj:
+			return true
+		case !oki && okj:
+			return false
+		case oki && okj && pi != pj:
+			return pi < pj
+		}
+		return records[i].CreatedAt.Before(records[j].CreatedAt)
+	})
+}
+
+// PriorityRank returns the numeric rank of t's priority and whether
+// the priority parsed cleanly. The convention matches beads:
+// Context["priority"] holds a "P<N>" string (e.g. "P0", "P1", "P2")
+// where lower N == higher priority. Unprioritized records report
+// (0, false) — callers use the second return to decide ordering.
+func PriorityRank(t Task) (int, bool) {
+	v, ok := t.Context["priority"]
+	if !ok || v == "" {
+		return 0, false
+	}
+	if len(v) < 2 || (v[0] != 'P' && v[0] != 'p') {
+		return 0, false
+	}
+	rank := 0
+	for i := 1; i < len(v); i++ {
+		c := v[i]
+		if c < '0' || c > '9' {
+			return 0, false
+		}
+		rank = rank*10 + int(c-'0')
+	}
+	return rank, true
+}

--- a/internal/tasks/ready_test.go
+++ b/internal/tasks/ready_test.go
@@ -1,0 +1,163 @@
+package tasks
+
+import (
+	"testing"
+	"time"
+)
+
+// TestFilterReady_DropsClosedClaimedAndDeferred asserts the pure
+// readiness gate matches coord.Ready's filter list: status==open,
+// no claim, no incoming open blocks/supersedes/duplicates edges, no
+// open child task naming the record as Parent, and not deferred into
+// the future.
+func TestFilterReady_DropsClosedClaimedAndDeferred(t *testing.T) {
+	now := time.Now().UTC()
+	closedAt := now
+	future := now.Add(time.Hour)
+
+	open := Task{ID: "open", Status: StatusOpen}
+	claimed := Task{ID: "claimed", Status: StatusOpen, ClaimedBy: "agent-x"}
+	closed := Task{ID: "closed", Status: StatusClosed, ClosedAt: &closedAt}
+	deferred := Task{ID: "deferred", Status: StatusOpen, DeferUntil: &future}
+
+	got := FilterReady([]Task{open, claimed, closed, deferred}, now)
+	if len(got) != 1 || got[0].ID != "open" {
+		t.Fatalf("got %+v want only [open]", got)
+	}
+}
+
+// TestFilterReady_RespectsBlocksEdges asserts an open `blocks` edge
+// hides its target. Closing the source unblocks the target.
+func TestFilterReady_RespectsBlocksEdges(t *testing.T) {
+	now := time.Now().UTC()
+	target := Task{ID: "target", Status: StatusOpen}
+	blocker := Task{
+		ID:     "blocker",
+		Status: StatusOpen,
+		Edges:  []Edge{{Type: EdgeBlocks, Target: "target"}},
+	}
+
+	got := FilterReady([]Task{target, blocker}, now)
+	if len(got) != 1 || got[0].ID != "blocker" {
+		t.Fatalf("with open blocker: got %+v want only [blocker]", got)
+	}
+
+	// Close the blocker; target should re-surface.
+	closedAt := now
+	blocker.Status = StatusClosed
+	blocker.ClosedAt = &closedAt
+	got = FilterReady([]Task{target, blocker}, now)
+	if len(got) != 1 || got[0].ID != "target" {
+		t.Fatalf("with closed blocker: got %+v want only [target]", got)
+	}
+}
+
+// TestFilterReady_RespectsParentChild asserts a parent task with an
+// open child is hidden until all children close.
+func TestFilterReady_RespectsParentChild(t *testing.T) {
+	now := time.Now().UTC()
+	parent := Task{ID: "parent", Status: StatusOpen}
+	child := Task{ID: "child", Status: StatusOpen, Parent: "parent"}
+
+	got := FilterReady([]Task{parent, child}, now)
+	if len(got) != 1 || got[0].ID != "child" {
+		t.Fatalf("with open child: got %+v want only [child]", got)
+	}
+
+	closedAt := now
+	child.Status = StatusClosed
+	child.ClosedAt = &closedAt
+	got = FilterReady([]Task{parent, child}, now)
+	if len(got) != 1 || got[0].ID != "parent" {
+		t.Fatalf("with closed child: got %+v want only [parent]", got)
+	}
+}
+
+// TestSortReady_PriorityThenCreatedAt asserts the sort orders by
+// priority (P0 > P1 > P2) then CreatedAt ascending within priority.
+func TestSortReady_PriorityThenCreatedAt(t *testing.T) {
+	now := time.Now().UTC()
+	mk := func(id, prio string, ageHours int) Task {
+		return Task{
+			ID:        id,
+			Context:   map[string]string{"priority": prio},
+			CreatedAt: now.Add(-time.Duration(ageHours) * time.Hour),
+		}
+	}
+	in := []Task{
+		mk("p1-new", "P1", 1),
+		mk("p0-new", "P0", 1),
+		mk("p1-old", "P1", 5),
+		mk("p0-old", "P0", 5),
+	}
+	SortReady(in)
+	want := []string{"p0-old", "p0-new", "p1-old", "p1-new"}
+	for i, w := range want {
+		if in[i].ID != w {
+			t.Fatalf("pos %d: got %q want %q (full: %v)",
+				i, in[i].ID, w, idsOf(in))
+		}
+	}
+}
+
+// TestSortReady_UnprioritizedAfterPrioritized asserts that records
+// with no parsable priority sort after every prioritized record,
+// regardless of CreatedAt.
+func TestSortReady_UnprioritizedAfterPrioritized(t *testing.T) {
+	now := time.Now().UTC()
+	old := Task{ID: "old-no-prio", CreatedAt: now.Add(-100 * time.Hour)}
+	prio := Task{
+		ID:        "new-p2",
+		Context:   map[string]string{"priority": "P2"},
+		CreatedAt: now,
+	}
+	in := []Task{old, prio}
+	SortReady(in)
+	if in[0].ID != "new-p2" || in[1].ID != "old-no-prio" {
+		t.Fatalf("got %v want [new-p2, old-no-prio]", idsOf(in))
+	}
+}
+
+// TestPriorityRank_ParsesValidShapes covers the parse contract:
+// "P<N>" forms with a single or multi-digit N parse, anything else
+// reports the second return as false.
+func TestPriorityRank_ParsesValidShapes(t *testing.T) {
+	cases := []struct {
+		val      string
+		wantRank int
+		wantOK   bool
+	}{
+		{"P0", 0, true},
+		{"P1", 1, true},
+		{"P10", 10, true},
+		{"p3", 3, true},
+		{"", 0, false},
+		{"high", 0, false},
+		{"P", 0, false},
+		{"PX", 0, false},
+		{"P1a", 0, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.val, func(t *testing.T) {
+			rec := Task{Context: map[string]string{"priority": tc.val}}
+			gotRank, gotOK := PriorityRank(rec)
+			if gotRank != tc.wantRank || gotOK != tc.wantOK {
+				t.Fatalf("val=%q: got (%d,%v) want (%d,%v)",
+					tc.val, gotRank, gotOK, tc.wantRank, tc.wantOK)
+			}
+		})
+	}
+
+	// No priority key at all.
+	if r, ok := PriorityRank(Task{}); r != 0 || ok {
+		t.Fatalf("empty Context: got (%d,%v) want (0,false)", r, ok)
+	}
+}
+
+func idsOf(ts []Task) []string {
+	out := make([]string, len(ts))
+	for i, t := range ts {
+		out[i] = t.ID
+	}
+	return out
+}


### PR DESCRIPTION
## Summary

`bones tasks ready` — beads-style "what's actionable right now?" verb. A task is ready iff:
1. Open
2. Unclaimed
3. No incoming open `blocks`/`supersedes`/`duplicates` edges
4. No open child task
5. Not future-deferred

Default sort: priority highest-first (P0 > P1 > P2), then created-at oldest-first (FIFO tie-break).

Closes #289

## Flags

| Flag | Behavior |
|---|---|
| `--json` | JSON array output |
| `--limit=N` | cap rows (0 = unlimited) |
| `--slot=X` | filter to one slot's task scope |
| `--mine` | only tasks the calling agent could claim |

## Reuse decision (the smell, owned)

Did NOT reuse `coord.Ready` directly. `coord.Ready` is network-bound with a `MaxReadyReturn` cap of 32 and no priority concept — wrong shape for a read-only listing verb needing unlimited output + priority sort. Factored the predicate into `internal/tasks/ready.go` (`FilterReady` + `SortReady` + `PriorityRank`) per the brief's "factor into a shared helper" guidance.

`coord.Ready` keeps its own copy of the same rules as a documentation contract — any new readiness gate must be added in both. **This is a duplication smell.** Worth a future consolidation issue if either path grows another rule.

## Test plan

- [x] `make check` passes
- [x] `go test -tags=otel -short ./cli/... ./internal/tasks/...` passes
- [x] `go test -race -short ./cli/...` passes
- [x] 14 tests: 5 in `internal/tasks` (pure helper), 9 in `cli/` (verb integration including all 7 brief-required + `--slot` + `--limit`)
