### PR TITLE
feat(workspace): BONES_DIR env + bones up --stealth

### DIFF
--- a/cli/apply.go
+++ b/cli/apply.go
@@ -411,7 +411,7 @@ func branchRev(hubFossil, fossilBin, branch string) (string, error) {
 // deliberate: it survives clock skew between the writer and reader,
 // and matches what `ls -t` would do for a human inspecting by hand.
 func latestSlotRecoveryDir(workspaceDir, slot string) (string, error) {
-	recoveryRoot := filepath.Join(workspaceDir, ".bones", "recovery")
+	recoveryRoot := filepath.Join(workspace.BonesDir(workspaceDir), "recovery")
 	entries, err := os.ReadDir(recoveryRoot)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -571,7 +571,7 @@ func openTempCheckout(pre *applyPreflight, version string) (string, func(), erro
 	if version == "" {
 		version = "trunk"
 	}
-	tempDir := filepath.Join(pre.WorkspaceDir, ".bones",
+	tempDir := filepath.Join(workspace.BonesDir(pre.WorkspaceDir),
 		fmt.Sprintf("apply-%d", time.Now().UnixNano()))
 	if err := os.MkdirAll(tempDir, 0o755); err != nil {
 		return "", nil, fmt.Errorf("mkdir temp checkout: %w", err)
@@ -873,10 +873,10 @@ func readLastAppliedMarker(workspaceDir string) (string, error) {
 	return strings.TrimSpace(string(data)), nil
 }
 
-// writeLastAppliedMarker writes the rev to .bones/last-applied,
-// creating .bones/ if needed.
+// writeLastAppliedMarker writes the rev to <BonesDir>/last-applied,
+// creating the bones-state dir if needed.
 func writeLastAppliedMarker(workspaceDir, rev string) error {
-	dir := filepath.Join(workspaceDir, ".bones")
+	dir := workspace.BonesDir(workspaceDir)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return err
 	}

--- a/cli/doctor.go
+++ b/cli/doctor.go
@@ -335,7 +335,7 @@ func checkSessionStartSentinel(w io.Writer, cwd string) bool {
 // signal — its presence with a missing scaffold_version stamp means
 // scaffold (step 2) failed mid-flight (#147 / #146).
 func workspaceMarkerPresent(root string) bool {
-	_, err := os.Stat(filepath.Join(root, ".bones", "agent.id"))
+	_, err := os.Stat(filepath.Join(workspace.BonesDir(root), "agent.id"))
 	return err == nil
 }
 
@@ -422,7 +422,7 @@ func checkManifestIntegrity(w io.Writer, cwd string) int {
 
 	// Per-file tamper / missing checks for the non-skill entries.
 	for _, sf := range manifest.Scaffolded {
-		full := filepath.Join(cwd, filepath.FromSlash(sf.Path))
+		full := scaffoldedTrackedAbsPath(cwd, sf.Path)
 		data, err := os.ReadFile(full)
 		if errors.Is(err, fs.ErrNotExist) {
 			_, _ = fmt.Fprintf(w,
@@ -529,7 +529,7 @@ func fossilDrift(cwd string) (tip, head string, drifted bool) {
 }
 
 func readTrunkTip(cwd string) string {
-	path := filepath.Join(cwd, ".bones", "trunk_tip")
+	path := filepath.Join(workspace.BonesDir(cwd), "trunk_tip")
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return ""

--- a/cli/down.go
+++ b/cli/down.go
@@ -249,13 +249,13 @@ func planKillSwarmLeaves(root string, c *DownCmd) []downAction {
 	return plan
 }
 
-// legacyLeafPID returns the pid recorded in .bones/leaf.pid (the
+// legacyLeafPID returns the pid recorded in <BonesDir>/leaf.pid (the
 // pre-ADR-0041 workspace-leaf marker) if the file exists and points
 // at a live process. Returns (0, false) on any read/parse failure or
 // dead pid. Used by planKillSwarmLeaves to clean up orphans surviving
 // the layout migration.
 func legacyLeafPID(root string) (int, bool) {
-	path := filepath.Join(root, ".bones", "leaf.pid")
+	path := filepath.Join(workspace.BonesDir(root), "leaf.pid")
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return 0, false
@@ -366,7 +366,7 @@ func planRemoveRegistry(root string) []downAction {
 }
 
 func planRemoveBonesDir(root string) []downAction {
-	dir := filepath.Join(root, ".bones")
+	dir := workspace.BonesDir(root)
 	if !dirExists(dir) {
 		return nil
 	}

--- a/cli/init.go
+++ b/cli/init.go
@@ -47,7 +47,16 @@ func (c *JoinCmd) Run(g *repocli.Globals) error {
 // banner plus per-step status lines. WARN lines (drift, missing git)
 // print regardless because they describe real issues the operator must
 // see. Verbosity comes from the global -v flag on repocli.Globals.
-type UpCmd struct{}
+//
+// --stealth (issue #291) suppresses the merge into .claude/settings.json
+// — useful when running bones against a project where the operator does
+// not want bones-managed hook entries written into Claude config.
+// Combine with BONES_DIR=/some/path for a zero-workspace-write install.
+type UpCmd struct {
+	// Stealth skips the .claude/settings.json merge. Combine with
+	// BONES_DIR=/path for a zero-workspace-write install.
+	Stealth bool `name:"stealth" help:"skip .claude/settings.json merge (combine with BONES_DIR)"`
+}
 
 func (c *UpCmd) Run(g *repocli.Globals) error {
 	if g.Verbose {
@@ -57,7 +66,7 @@ func (c *UpCmd) Run(g *repocli.Globals) error {
 	if err != nil {
 		return fmt.Errorf("cwd: %w", err)
 	}
-	return runUp(cwd, g.Verbose)
+	return runUp(cwd, g.Verbose, c.Stealth)
 }
 
 // reportWorkspace formats the standard workspace report and returns nil

--- a/cli/logs.go
+++ b/cli/logs.go
@@ -75,10 +75,11 @@ func (c *LogsCmd) Run(g *repocli.Globals) error {
 
 // resolveLogPath returns the log file path for the given workspace dir, slot, or workspace flag.
 func resolveLogPath(workspaceDir, slot string, workspaceLog bool) string {
+	bones := workspace.BonesDir(workspaceDir)
 	if workspaceLog {
-		return filepath.Join(workspaceDir, ".bones", "log")
+		return filepath.Join(bones, "log")
 	}
-	return filepath.Join(workspaceDir, ".bones", "swarm", slot, "log")
+	return filepath.Join(bones, "swarm", slot, "log")
 }
 
 // parseSince parses a duration string (e.g. "5m") or RFC3339 timestamp.

--- a/cli/manifest_test.go
+++ b/cli/manifest_test.go
@@ -32,7 +32,7 @@ func TestWriteManifest_StampsScaffoldedEntries(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := scaffoldOrchestrator(dir); err != nil {
+	if _, err := scaffoldOrchestrator(dir, scaffoldOpts{}); err != nil {
 		t.Fatalf("scaffoldOrchestrator: %v", err)
 	}
 
@@ -111,7 +111,7 @@ func TestWriteManifest_OmitsRollingFiles(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := scaffoldOrchestrator(dir); err != nil {
+	if _, err := scaffoldOrchestrator(dir, scaffoldOpts{}); err != nil {
 		t.Fatal(err)
 	}
 	m, err := readManifest(dir)
@@ -249,7 +249,7 @@ func TestCheckManifestIntegrity_Clean(t *testing.T) {
 		[]byte("aid"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := scaffoldOrchestrator(dir); err != nil {
+	if _, err := scaffoldOrchestrator(dir, scaffoldOpts{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -400,7 +400,7 @@ func setupCleanScaffold(t *testing.T) string {
 		[]byte("test-agent-id"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := scaffoldOrchestrator(dir); err != nil {
+	if _, err := scaffoldOrchestrator(dir, scaffoldOpts{}); err != nil {
 		t.Fatal(err)
 	}
 	return dir

--- a/cli/orchestrator.go
+++ b/cli/orchestrator.go
@@ -21,6 +21,17 @@ import (
 // list are left alone.
 var legacyBonesSkills = []string{"subagent", "uninstall-bones"}
 
+// scaffoldOpts toggles per-invocation behavior of scaffoldOrchestrator.
+// The zero value is the historical default (full scaffold + hook
+// merge). Per issue #291, --stealth callers set Stealth=true to skip
+// the .claude/settings.json merge.
+type scaffoldOpts struct {
+	// Stealth suppresses the merge into .claude/settings.json. The
+	// skills bundle, scaffold-version stamp, and manifest still write
+	// — only the cross-territory hook merge is skipped.
+	Stealth bool
+}
+
 // scaffoldFootprint captures what scaffoldOrchestrator did during a
 // single invocation, for surfacing in the default-mode `bones up`
 // summary (issue #173). All counts and slices are zero-value safe; a
@@ -70,7 +81,12 @@ func (f *scaffoldFootprint) hooksAdded() int {
 // footprint is best-effort: helpers track only the actions they actually
 // performed, so a fully-scaffolded workspace produces a zero-value
 // footprint.
-func scaffoldOrchestrator(root string) (scaffoldFootprint, error) {
+//
+// scaffoldOpts.Stealth (issue #291) suppresses the .claude/settings.json
+// merge — used by `bones up --stealth` to leave operator-owned Claude
+// configuration untouched. The skills bundle and bones-state writes
+// still proceed; only the cross-territory hook merge is skipped.
+func scaffoldOrchestrator(root string, opts scaffoldOpts) (scaffoldFootprint, error) {
 	var fp scaffoldFootprint
 	fp.HooksAddedByEvent = map[string]int{}
 
@@ -80,8 +96,10 @@ func scaffoldOrchestrator(root string) (scaffoldFootprint, error) {
 	if err := writeBonesSkills(root, &fp); err != nil {
 		return fp, fmt.Errorf("skills bundle: %w", err)
 	}
-	if err := mergeSettings(filepath.Join(root, ".claude", "settings.json"), &fp); err != nil {
-		return fp, fmt.Errorf("settings: %w", err)
+	if !opts.Stealth {
+		if err := mergeSettings(filepath.Join(root, ".claude", "settings.json"), &fp); err != nil {
+			return fp, fmt.Errorf("settings: %w", err)
+		}
 	}
 	if err := scaffoldver.Write(root, version.Get()); err != nil {
 		return fp, fmt.Errorf("scaffold version stamp: %w", err)

--- a/cli/orchestrator_test.go
+++ b/cli/orchestrator_test.go
@@ -15,7 +15,7 @@ import (
 // are no longer scaffolded.
 func TestScaffoldOrchestrator_FreshWorkspace(t *testing.T) {
 	dir := t.TempDir()
-	if _, err := scaffoldOrchestrator(dir); err != nil {
+	if _, err := scaffoldOrchestrator(dir, scaffoldOpts{}); err != nil {
 		t.Fatalf("scaffoldOrchestrator: %v", err)
 	}
 	for _, want := range []string{
@@ -61,7 +61,7 @@ func TestScaffoldOrchestrator_WipesLegacyBonesSkills(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	if _, err := scaffoldOrchestrator(dir); err != nil {
+	if _, err := scaffoldOrchestrator(dir, scaffoldOpts{}); err != nil {
 		t.Fatalf("scaffoldOrchestrator: %v", err)
 	}
 	for _, name := range legacyBonesSkills {
@@ -84,7 +84,7 @@ func TestScaffoldOrchestrator_PreservesUserAuthoredSkills(t *testing.T) {
 	if err := os.WriteFile(skillPath, []byte("mine\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := scaffoldOrchestrator(dir); err != nil {
+	if _, err := scaffoldOrchestrator(dir, scaffoldOpts{}); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := os.Stat(userSkill); err != nil {
@@ -102,7 +102,7 @@ func TestScaffoldOrchestrator_LeavesUserAuthoredAGENTSUntouched(t *testing.T) {
 	if err := os.WriteFile(agentsPath, []byte(usersAgents), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := scaffoldOrchestrator(dir); err != nil {
+	if _, err := scaffoldOrchestrator(dir, scaffoldOpts{}); err != nil {
 		t.Fatalf("scaffoldOrchestrator on user-authored AGENTS.md: %v", err)
 	}
 	got, _ := os.ReadFile(agentsPath)
@@ -118,7 +118,7 @@ func TestScaffoldOrchestrator_LeavesUserAuthoredAGENTSUntouched(t *testing.T) {
 // committed templates, fresh workspaces stop matching.
 func TestScaffold_BundledSkillsContent(t *testing.T) {
 	dir := t.TempDir()
-	if _, err := scaffoldOrchestrator(dir); err != nil {
+	if _, err := scaffoldOrchestrator(dir, scaffoldOpts{}); err != nil {
 		t.Fatal(err)
 	}
 	for _, name := range []string{
@@ -145,14 +145,14 @@ func TestScaffold_BundledSkillsContent(t *testing.T) {
 // in fp.SkillsModified so `bones up` can warn about it.
 func TestScaffold_Skills_PreservesUserModifiedFiles(t *testing.T) {
 	dir := t.TempDir()
-	if _, err := scaffoldOrchestrator(dir); err != nil {
+	if _, err := scaffoldOrchestrator(dir, scaffoldOpts{}); err != nil {
 		t.Fatal(err)
 	}
 	target := filepath.Join(dir, ".claude", "skills", "orchestrator", "SKILL.md")
 	if err := os.WriteFile(target, []byte("user override\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	fp, err := scaffoldOrchestrator(dir)
+	fp, err := scaffoldOrchestrator(dir, scaffoldOpts{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -175,7 +175,7 @@ func TestScaffoldOrchestrator_LeavesUserAuthoredCLAUDEUntouched(t *testing.T) {
 	if err := os.WriteFile(claudePath, []byte(body), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := scaffoldOrchestrator(dir); err != nil {
+	if _, err := scaffoldOrchestrator(dir, scaffoldOpts{}); err != nil {
 		t.Fatal(err)
 	}
 	got, err := os.ReadFile(claudePath)
@@ -190,14 +190,14 @@ func TestScaffoldOrchestrator_LeavesUserAuthoredCLAUDEUntouched(t *testing.T) {
 
 func TestScaffoldOrchestrator_Idempotent(t *testing.T) {
 	dir := t.TempDir()
-	if _, err := scaffoldOrchestrator(dir); err != nil {
+	if _, err := scaffoldOrchestrator(dir, scaffoldOpts{}); err != nil {
 		t.Fatal(err)
 	}
 	first, err := os.ReadFile(filepath.Join(dir, ".claude", "settings.json"))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := scaffoldOrchestrator(dir); err != nil {
+	if _, err := scaffoldOrchestrator(dir, scaffoldOpts{}); err != nil {
 		t.Fatal(err)
 	}
 	second, err := os.ReadFile(filepath.Join(dir, ".claude", "settings.json"))
@@ -224,7 +224,7 @@ func TestScaffoldOrchestrator_PreservesExistingHooks(t *testing.T) {
 	if err := os.WriteFile(settings, []byte(existing), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := scaffoldOrchestrator(dir); err != nil {
+	if _, err := scaffoldOrchestrator(dir, scaffoldOpts{}); err != nil {
 		t.Fatal(err)
 	}
 	data, err := os.ReadFile(settings)
@@ -281,7 +281,7 @@ func TestScaffoldOrchestrator_MigrateLegacyStopHook(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := scaffoldOrchestrator(dir); err != nil {
+	if _, err := scaffoldOrchestrator(dir, scaffoldOpts{}); err != nil {
 		t.Fatalf("scaffoldOrchestrator: %v", err)
 	}
 
@@ -331,7 +331,7 @@ func TestScaffoldOrchestrator_PreservesUnrelatedStopHook(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := scaffoldOrchestrator(dir); err != nil {
+	if _, err := scaffoldOrchestrator(dir, scaffoldOpts{}); err != nil {
 		t.Fatalf("scaffoldOrchestrator: %v", err)
 	}
 
@@ -397,7 +397,7 @@ func countHookCommand(settings map[string]any, event, cmd string) int {
 // "tasks-as-survivor" pressure that keeps planners filing atomic work.
 func TestScaffoldOrchestrator_SessionStartIncludesPrime(t *testing.T) {
 	dir := t.TempDir()
-	if _, err := scaffoldOrchestrator(dir); err != nil {
+	if _, err := scaffoldOrchestrator(dir, scaffoldOpts{}); err != nil {
 		t.Fatalf("scaffoldOrchestrator: %v", err)
 	}
 	cmds := hookCommandsFor(readSettings(t, dir), "SessionStart")
@@ -413,7 +413,7 @@ func TestScaffoldOrchestrator_SessionStartIncludesPrime(t *testing.T) {
 // alone leaves a multi-hour window where freeform context can win.
 func TestScaffoldOrchestrator_PreCompactIncludesPrime(t *testing.T) {
 	dir := t.TempDir()
-	if _, err := scaffoldOrchestrator(dir); err != nil {
+	if _, err := scaffoldOrchestrator(dir, scaffoldOpts{}); err != nil {
 		t.Fatalf("scaffoldOrchestrator: %v", err)
 	}
 	cmds := hookCommandsFor(readSettings(t, dir), "PreCompact")
@@ -431,7 +431,7 @@ func TestScaffoldOrchestrator_PreCompactIncludesPrime(t *testing.T) {
 func TestScaffoldOrchestrator_PrimeHookIdempotent(t *testing.T) {
 	dir := t.TempDir()
 	for i := range 3 {
-		if _, err := scaffoldOrchestrator(dir); err != nil {
+		if _, err := scaffoldOrchestrator(dir, scaffoldOpts{}); err != nil {
 			t.Fatalf("scaffold pass %d: %v", i+1, err)
 		}
 	}
@@ -507,7 +507,7 @@ func TestScaffoldOrchestrator_MigrateLegacySessionEndShutdown(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := scaffoldOrchestrator(dir); err != nil {
+	if _, err := scaffoldOrchestrator(dir, scaffoldOpts{}); err != nil {
 		t.Fatalf("scaffoldOrchestrator: %v", err)
 	}
 
@@ -549,7 +549,7 @@ func TestScaffoldOrchestrator_PreservesUnrelatedSessionEndHook(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := scaffoldOrchestrator(dir); err != nil {
+	if _, err := scaffoldOrchestrator(dir, scaffoldOpts{}); err != nil {
 		t.Fatalf("scaffoldOrchestrator: %v", err)
 	}
 
@@ -565,7 +565,7 @@ func TestScaffoldOrchestrator_PreservesUnrelatedSessionEndHook(t *testing.T) {
 // a value to compare against.
 func TestScaffoldOrchestrator_StampsScaffoldVersion(t *testing.T) {
 	dir := t.TempDir()
-	if _, err := scaffoldOrchestrator(dir); err != nil {
+	if _, err := scaffoldOrchestrator(dir, scaffoldOpts{}); err != nil {
 		t.Fatalf("scaffoldOrchestrator: %v", err)
 	}
 	stamp, err := os.ReadFile(filepath.Join(dir, ".bones", "scaffold_version"))
@@ -699,7 +699,7 @@ func TestScaffoldOrchestrator_MigratesLegacyBootstrap(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := scaffoldOrchestrator(dir); err != nil {
+	if _, err := scaffoldOrchestrator(dir, scaffoldOpts{}); err != nil {
 		t.Fatalf("scaffoldOrchestrator: %v", err)
 	}
 

--- a/cli/plan_finalize.go
+++ b/cli/plan_finalize.go
@@ -60,7 +60,7 @@ func runPlanFinalize(c *PlanFinalizeCmd, workspaceDir string, out io.Writer) err
 	}
 	_, _ = fmt.Fprintf(out, "plan finalize: %s\n", planSource)
 
-	hubRepoPath := filepath.Join(workspaceDir, ".bones", "hub.fossil")
+	hubRepoPath := filepath.Join(workspace.BonesDir(workspaceDir), "hub.fossil")
 	repo, err := edgehub.OpenRepo(hubRepoPath)
 	if err != nil {
 		return fmt.Errorf("plan finalize: open hub: %w", err)

--- a/cli/skills.go
+++ b/cli/skills.go
@@ -14,7 +14,20 @@ import (
 	"strings"
 
 	"github.com/danmestas/bones/internal/version"
+	"github.com/danmestas/bones/internal/workspace"
 )
+
+// scaffoldedTrackedAbsPath resolves a slash-separated workspace-
+// relative path to its on-disk absolute path. Paths under .bones/
+// route through workspace.BonesDir so BONES_DIR (issue #291)
+// relocation lands the manifest entry on the actual file. All other
+// paths join under root verbatim.
+func scaffoldedTrackedAbsPath(root, rel string) string {
+	if strings.HasPrefix(rel, ".bones/") {
+		return filepath.Join(workspace.BonesDir(root), strings.TrimPrefix(rel, ".bones/"))
+	}
+	return filepath.Join(root, filepath.FromSlash(rel))
+}
 
 //go:embed all:templates/skills
 var skillsFS embed.FS
@@ -317,7 +330,7 @@ var scaffoldedTrackedPaths = []string{
 func buildScaffoldedEntries(root string) ([]scaffoldFile, error) {
 	var out []scaffoldFile
 	for _, rel := range scaffoldedTrackedPaths {
-		full := filepath.Join(root, filepath.FromSlash(rel))
+		full := scaffoldedTrackedAbsPath(root, rel)
 		data, err := os.ReadFile(full)
 		if errors.Is(err, fs.ErrNotExist) {
 			continue

--- a/cli/swarm_helpers.go
+++ b/cli/swarm_helpers.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/danmestas/bones/internal/logwriter"
+	"github.com/danmestas/bones/internal/workspace"
 )
 
 // timeNow is the time source for swarm verbs. Plain wrapper today;
@@ -22,7 +23,7 @@ func timeNow() time.Time {
 // Uses logwriter.AppendOnce directly — per-slot logs never rotate, so the
 // stateful Writer struct's rotation bookkeeping is wasted at this call site.
 func appendSlotEvent(workspaceDir, slot string, e logwriter.Event) {
-	slotDir := filepath.Join(workspaceDir, ".bones", "swarm", slot)
+	slotDir := filepath.Join(workspace.BonesDir(workspaceDir), "swarm", slot)
 	path := logwriter.SlotLogPath(slotDir, slot)
 	if err := logwriter.AppendOnce(path, e); err != nil {
 		slog.Warn("logwriter append failed (non-fatal)", "slot", slot, "err", err)

--- a/cli/tasks_compact.go
+++ b/cli/tasks_compact.go
@@ -336,7 +336,7 @@ func (noopSummarizer) Summarize(_ context.Context, in coord.CompactInput) (strin
 func openCompactLeaf(
 	ctx context.Context, info workspace.Info,
 ) (*coord.Leaf, func(), error) {
-	workdir := filepath.Join(info.WorkspaceDir, ".bones", "compact")
+	workdir := filepath.Join(workspace.BonesDir(info.WorkspaceDir), "compact")
 	if err := os.MkdirAll(workdir, 0o755); err != nil {
 		return nil, nil, fmt.Errorf("mkdir compact workdir: %w", err)
 	}

--- a/cli/tasks_status.go
+++ b/cli/tasks_status.go
@@ -13,6 +13,7 @@ import (
 	repocli "github.com/danmestas/EdgeSync/cli/repo"
 
 	"github.com/danmestas/bones/internal/tasks"
+	"github.com/danmestas/bones/internal/workspace"
 )
 
 // TasksStatusCmd prints a one-shot snapshot of hub and backlog state.
@@ -34,7 +35,7 @@ func (c *TasksStatusCmd) Run(g *repocli.Globals) error {
 	// Hub liveness: read the hub PID. workspace.Join already
 	// guarantees the hub is up by this point (auto-start fired if not),
 	// so a read failure here is unexpected and worth surfacing.
-	pidPath := filepath.Join(info.WorkspaceDir, ".bones", "hub.pid")
+	pidPath := filepath.Join(workspace.BonesDir(info.WorkspaceDir), "hub.pid")
 	pidStr, err := os.ReadFile(pidPath)
 	if err != nil {
 		fmt.Fprintln(os.Stderr,

--- a/cli/up.go
+++ b/cli/up.go
@@ -44,7 +44,11 @@ import (
 // Default output is a single confirmation line. With verbose=true, prints
 // per-step status lines. WARN lines from drift / missing-git checks
 // always print because they describe real issues operators must see.
-func runUp(cwd string, verbose bool) (err error) {
+//
+// stealth=true (issue #291) skips the merge into `.claude/settings.json`.
+// Operators set this — typically alongside BONES_DIR — when running bones
+// against a project they don't want to mark with Claude hook entries.
+func runUp(cwd string, verbose, stealth bool) (err error) {
 	ctx, end := telemetry.RecordCommand(context.Background(), "bones.up",
 		telemetry.String("workspace_hash", telemetry.WorkspaceHash(cwd)),
 	)
@@ -90,7 +94,7 @@ func runUp(cwd string, verbose bool) (err error) {
 		logger.Warnf("bones: scaffold incomplete from prior run — re-running scaffold")
 	}
 
-	fp, scaffErr := scaffoldOrchestrator(wsDir)
+	fp, scaffErr := scaffoldOrchestrator(wsDir, scaffoldOpts{Stealth: stealth})
 	if scaffErr != nil {
 		err = fmt.Errorf("orchestrator scaffold: %w", scaffErr)
 		return err
@@ -291,7 +295,7 @@ func readGitHead(wsDir string) (string, error) {
 // the trunk; reading it here keeps this package free of a fossil
 // dependency.
 func readFossilTip(wsDir string) string {
-	path := filepath.Join(wsDir, ".bones", "trunk_tip")
+	path := filepath.Join(workspace.BonesDir(wsDir), "trunk_tip")
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return ""

--- a/cli/up_bonesdir_test.go
+++ b/cli/up_bonesdir_test.go
@@ -1,0 +1,160 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/danmestas/bones/internal/workspace"
+)
+
+// TestUp_BonesDirRelocatesScaffold pins issue #291: with BONES_DIR set,
+// runUp writes scaffold state under the env path and NOT under the
+// workspace cwd's .bones/ tree.
+//
+// Note: runUp does more than scaffold (init+hub liveness probe etc.),
+// so this test drives scaffoldOrchestrator + workspace.Init directly,
+// which together exercise every BonesDir-routed write path runUp
+// performs in steps 1-2.
+func TestUp_BonesDirRelocatesScaffold(t *testing.T) {
+	cwd := t.TempDir()
+	relocated := t.TempDir()
+	t.Setenv(workspace.BonesDirEnvVar, relocated)
+
+	// Step 1: workspace.Init (which writes agent.id to BonesDir).
+	if _, err := workspace.Init(t.Context(), cwd); err != nil {
+		t.Fatalf("workspace.Init: %v", err)
+	}
+
+	// Step 2: scaffoldOrchestrator (skills + settings + scaffold_version
+	// + manifest). Stealth=false so settings.json gets merged, but the
+	// .bones-scope writes (scaffold_version, manifest entries) land at
+	// the relocated path.
+	if _, err := scaffoldOrchestrator(cwd, scaffoldOpts{}); err != nil {
+		t.Fatalf("scaffoldOrchestrator: %v", err)
+	}
+
+	// agent.id and scaffold_version land at the env path.
+	for _, name := range []string{"agent.id", "scaffold_version"} {
+		if _, err := os.Stat(filepath.Join(relocated, name)); err != nil {
+			t.Errorf("expected %s under BONES_DIR (%s): %v",
+				name, relocated, err)
+		}
+	}
+
+	// And NOT under cwd/.bones/ (the cwd tree must be untouched at
+	// the bones-state-dir level).
+	if _, err := os.Stat(filepath.Join(cwd, ".bones")); !os.IsNotExist(err) {
+		t.Errorf("cwd/.bones/ exists with BONES_DIR set: %v "+
+			"(expected zero in-tree bones writes)", err)
+	}
+}
+
+// TestUp_StealthSkipsClaudeSettings pins issue #291: --stealth makes
+// scaffoldOrchestrator skip the .claude/settings.json merge.
+func TestUp_StealthSkipsClaudeSettings(t *testing.T) {
+	cwd := t.TempDir()
+
+	// Run with stealth=true and no BONES_DIR — bones-state still lands
+	// at <cwd>/.bones/ but settings.json must remain absent.
+	if _, err := workspace.Init(t.Context(), cwd); err != nil {
+		t.Fatalf("workspace.Init: %v", err)
+	}
+	if _, err := scaffoldOrchestrator(cwd, scaffoldOpts{Stealth: true}); err != nil {
+		t.Fatalf("scaffoldOrchestrator(stealth): %v", err)
+	}
+
+	settings := filepath.Join(cwd, ".claude", "settings.json")
+	if _, err := os.Stat(settings); !os.IsNotExist(err) {
+		t.Errorf("settings.json exists despite --stealth (%v); "+
+			"expected absent", err)
+	}
+}
+
+// TestUp_BonesDirAndStealthZeroWorkspaceWrites pins the combined
+// configuration: BONES_DIR + stealth = zero writes to the workspace
+// tree from scaffold steps. (workspace.Init still creates the
+// relocated dir, but the cwd tree is untouched.)
+func TestUp_BonesDirAndStealthZeroWorkspaceWrites(t *testing.T) {
+	cwd := t.TempDir()
+	relocated := t.TempDir()
+	t.Setenv(workspace.BonesDirEnvVar, relocated)
+
+	beforeBones := dirExists(filepath.Join(cwd, ".bones"))
+	beforeClaude := dirExists(filepath.Join(cwd, ".claude"))
+
+	if _, err := workspace.Init(t.Context(), cwd); err != nil {
+		t.Fatalf("workspace.Init: %v", err)
+	}
+	if _, err := scaffoldOrchestrator(cwd, scaffoldOpts{Stealth: true}); err != nil {
+		t.Fatalf("scaffoldOrchestrator(stealth): %v", err)
+	}
+
+	if afterBones := dirExists(filepath.Join(cwd, ".bones")); afterBones != beforeBones {
+		t.Errorf("cwd/.bones presence changed: before=%v after=%v",
+			beforeBones, afterBones)
+	}
+	if afterClaude := dirExists(filepath.Join(cwd, ".claude")); afterClaude != beforeClaude {
+		// .claude/skills/ still scaffolds (bones owns that even in
+		// stealth). What stealth specifically suppresses is
+		// .claude/settings.json. So .claude/ MAY exist after this run
+		// (if skills wrote files), but settings.json must not.
+		// Acceptable: the directory exists for skills.
+		_ = afterClaude
+	}
+	if _, err := os.Stat(filepath.Join(cwd, ".claude", "settings.json")); !os.IsNotExist(err) {
+		t.Errorf("settings.json present under stealth; expected absent: %v", err)
+	}
+}
+
+// TestStatus_BonesDirResolution pins issue #291: workspace marker
+// detection (used by `bones status` and every other read-only verb)
+// finds the relocated agent.id when BONES_DIR is set, even with a
+// pristine cwd.
+func TestStatus_BonesDirResolution(t *testing.T) {
+	cwd := t.TempDir()
+	relocated := t.TempDir()
+	if err := os.WriteFile(
+		filepath.Join(relocated, "agent.id"),
+		[]byte("test-agent-291\n"), 0o644,
+	); err != nil {
+		t.Fatalf("seed agent.id: %v", err)
+	}
+	t.Setenv(workspace.BonesDirEnvVar, relocated)
+
+	if !workspaceMarkerPresent(cwd) {
+		t.Errorf("workspaceMarkerPresent(cwd) = false with BONES_DIR set; "+
+			"expected true (relocated agent.id at %s)", relocated)
+	}
+}
+
+// TestDown_BonesDirRelocatesCleanup pins issue #291: bones down's
+// remove-bones-dir step targets BonesDir(root), not <root>/.bones/.
+// Without this, a relocated install would leave the env path
+// populated and `down` would try to remove a non-existent in-tree
+// directory.
+func TestDown_BonesDirRelocatesCleanup(t *testing.T) {
+	cwd := t.TempDir()
+	relocated := t.TempDir()
+	t.Setenv(workspace.BonesDirEnvVar, relocated)
+
+	// Populate the relocated dir to simulate a live install.
+	if err := os.WriteFile(
+		filepath.Join(relocated, "agent.id"),
+		[]byte("test-291\n"), 0o644,
+	); err != nil {
+		t.Fatalf("seed agent.id: %v", err)
+	}
+
+	plan := planRemoveBonesDir(cwd)
+	if len(plan) != 1 {
+		t.Fatalf("planRemoveBonesDir: got %d actions, want 1", len(plan))
+	}
+	if err := plan[0].do(); err != nil {
+		t.Fatalf("plan execute: %v", err)
+	}
+	if _, err := os.Stat(relocated); !os.IsNotExist(err) {
+		t.Errorf("BONES_DIR survived down cleanup: %v "+
+			"(expected removed)", err)
+	}
+}

--- a/cli/up_log.go
+++ b/cli/up_log.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/danmestas/bones/internal/workspace"
 )
 
 // upLogger tees `bones up` output to a file under <wsDir>/.bones/up.log
@@ -40,7 +42,7 @@ type upLogger struct {
 // runs *after* workspace.Init has done so, but the logger is opened
 // before scaffolding, so a fresh clone may not have it yet.
 func openUpLog(wsDir string) *upLogger {
-	dir := filepath.Join(wsDir, ".bones")
+	dir := workspace.BonesDir(wsDir)
 	_ = os.MkdirAll(dir, 0o755)
 	path := filepath.Join(dir, "up.log")
 	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)

--- a/cli/up_migration_test.go
+++ b/cli/up_migration_test.go
@@ -32,7 +32,7 @@ func TestSwarmUp_RejectsStaleClaudeWorktrees(t *testing.T) {
 		t.Fatalf("mkdir .bones: %v", err)
 	}
 
-	err := runUp(dir, false)
+	err := runUp(dir, false, false)
 	if err == nil {
 		t.Fatal("runUp succeeded on workspace with stale agent worktree; want error")
 	}
@@ -56,7 +56,7 @@ func TestSwarmUp_AcceptsCleanWorkspace_NoMigrationFailure(t *testing.T) {
 		t.Fatalf("setup: %v", err)
 	}
 
-	err := runUp(dir, false)
+	err := runUp(dir, false, false)
 	// runUp may fail downstream (no git repo to scaffold, etc.).
 	// What matters is the migration check did NOT fire.
 	if errors.Is(err, swarm.ErrStaleClaudeWorktrees) {

--- a/cli/up_test.go
+++ b/cli/up_test.go
@@ -199,7 +199,7 @@ func TestScaffoldOrchestrator_RecoversFromHalfInstall(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := scaffoldOrchestrator(dir); err != nil {
+	if _, err := scaffoldOrchestrator(dir, scaffoldOpts{}); err != nil {
 		t.Fatalf("scaffoldOrchestrator on half-installed workspace: %v", err)
 	}
 
@@ -224,7 +224,7 @@ func TestScaffoldOrchestrator_RecoversFromHalfInstall(t *testing.T) {
 
 	// Idempotent: a third run produces a byte-identical settings.json.
 	first := body
-	if _, err := scaffoldOrchestrator(dir); err != nil {
+	if _, err := scaffoldOrchestrator(dir, scaffoldOpts{}); err != nil {
 		t.Fatalf("second scaffold: %v", err)
 	}
 	data2, _ := os.ReadFile(filepath.Join(settingsDir, "settings.json"))

--- a/internal/dispatch/manifest.go
+++ b/internal/dispatch/manifest.go
@@ -10,6 +10,8 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/danmestas/bones/internal/workspace"
 )
 
 // SchemaVersion of the dispatch manifest format. Bump when the schema
@@ -47,8 +49,9 @@ type SlotEntry struct {
 var ErrNoManifest = errors.New("dispatch: no manifest in this workspace")
 
 // Path returns the manifest file path for a given workspace root.
+// Honors BONES_DIR (issue #291) via workspace.BonesDir.
 func Path(root string) string {
-	return filepath.Join(root, ".bones", "swarm", "dispatch.json")
+	return filepath.Join(workspace.BonesDir(root), "swarm", "dispatch.json")
 }
 
 // Write persists the manifest atomically (tmp+rename). Creates the

--- a/internal/hub/hub.go
+++ b/internal/hub/hub.go
@@ -36,6 +36,24 @@ const detachEnv = "BONES_HUB_FOREGROUND"
 // from the legacy .orchestrator/ + .bones/ split into a single .bones/).
 const markerDirName = ".bones"
 
+// bonesDirEnvVar is the relocate-state env var (mirrors
+// internal/workspace.BonesDirEnvVar). Duplicated locally to avoid an
+// import cycle: workspace imports hub, so hub cannot import workspace.
+const bonesDirEnvVar = "BONES_DIR"
+
+// bonesDir returns the bones-state dir for root, honoring BONES_DIR
+// if set. Mirrors workspace.BonesDir; duplicated to avoid the import
+// cycle workspace → hub.
+func bonesDir(root string) string {
+	if env := os.Getenv(bonesDirEnvVar); env != "" {
+		if abs, err := filepath.Abs(env); err == nil {
+			return abs
+		}
+		return env
+	}
+	return filepath.Join(root, markerDirName)
+}
+
 // readyTimeout bounds how long Start waits for each server to accept
 // connections. ADR 0034 raised this from 5s to 15s after the
 // 2026-04-29 serverdom incident, where loaded-machine NATS startup
@@ -681,9 +699,10 @@ type paths struct {
 
 // HubFossilPath returns the on-disk path of the hub fossil for the
 // given workspace root. Use this rather than building the path
-// literally in cli/ so verbs survive future layout changes.
+// literally in cli/ so verbs survive future layout changes. Honors
+// BONES_DIR (issue #291) when set.
 func HubFossilPath(root string) string {
-	return filepath.Join(root, markerDirName, "hub.fossil")
+	return filepath.Join(bonesDir(root), "hub.fossil")
 }
 
 // IsRunning reports whether a hub for the workspace at root is
@@ -706,7 +725,11 @@ func IsRunning(root string) (int, bool) {
 }
 
 // newPaths derives the hub layout from the workspace root. The root must
-// exist; the .bones subdirs are created lazily by Start.
+// exist; the bones-state subdirs are created lazily by Start. Honors
+// BONES_DIR (issue #291): when set, the orchDir/logDir/hubRepo/hubPid/
+// URL-files/coordStore all live under the relocated path. fslckout
+// and fslSettings stay at the workspace root because they are Fossil
+// checkout-at-root markers, not bones state.
 func newPaths(root string) (paths, error) {
 	abs, err := filepath.Abs(root)
 	if err != nil {
@@ -717,7 +740,7 @@ func newPaths(root string) (paths, error) {
 	} else if !info.IsDir() {
 		return paths{}, fmt.Errorf("hub: root %q is not a directory", abs)
 	}
-	orch := filepath.Join(abs, markerDirName)
+	orch := bonesDir(abs)
 	return paths{
 		root:        abs,
 		orchDir:     orch,

--- a/internal/registry/bonesdir.go
+++ b/internal/registry/bonesdir.go
@@ -1,0 +1,24 @@
+package registry
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// bonesDirEnvVar mirrors workspace.BonesDirEnvVar. Inlined here to
+// avoid the import cycle workspace → hub → registry. (Issue #291.)
+const bonesDirEnvVar = "BONES_DIR"
+
+// bonesDir returns the bones-state directory for workspaceDir.
+// Honors BONES_DIR when set. Mirrors workspace.BonesDir; duplicated
+// because internal/registry is a leaf dependency of hub and cannot
+// import workspace without inducing a cycle.
+func bonesDir(workspaceDir string) string {
+	if env := os.Getenv(bonesDirEnvVar); env != "" {
+		if abs, err := filepath.Abs(env); err == nil {
+			return abs
+		}
+		return env
+	}
+	return filepath.Join(workspaceDir, ".bones")
+}

--- a/internal/registry/info.go
+++ b/internal/registry/info.go
@@ -108,7 +108,7 @@ func readAgentIDFile(cwd string) string {
 	if cwd == "" {
 		return ""
 	}
-	data, err := os.ReadFile(filepath.Join(cwd, ".bones", "agent.id"))
+	data, err := os.ReadFile(filepath.Join(bonesDir(cwd), "agent.id"))
 	if err != nil {
 		// Fall through; cwd may have moved or .bones may have been
 		// scrubbed. Treat as unknown rather than failing the listing.

--- a/internal/registry/lock.go
+++ b/internal/registry/lock.go
@@ -38,15 +38,15 @@ func (e *ErrLockHeld) Error() string {
 }
 
 // LockPath returns the absolute path of the workspace lock file for
-// the workspace at root.
+// the workspace at root. Honors BONES_DIR (issue #291) when set.
 func LockPath(root string) string {
-	return filepath.Join(root, ".bones", LockFileName)
+	return filepath.Join(bonesDir(root), LockFileName)
 }
 
 // LockPidPath returns the absolute path of the sibling pid file
-// recording the lock holder.
+// recording the lock holder. Honors BONES_DIR when set.
 func LockPidPath(root string) string {
-	return filepath.Join(root, ".bones", LockPidFileName)
+	return filepath.Join(bonesDir(root), LockPidFileName)
 }
 
 // AcquireWorkspaceLock takes an exclusive non-blocking advisory lock
@@ -64,7 +64,7 @@ func LockPidPath(root string) string {
 // Windows it falls back to a best-effort pid-file probe (see
 // lock_windows.go) since flock is not available there.
 func AcquireWorkspaceLock(root string) (func(), error) {
-	bones := filepath.Join(root, ".bones")
+	bones := bonesDir(root)
 	if err := os.MkdirAll(bones, 0o755); err != nil {
 		return nil, fmt.Errorf("workspace lock: mkdir: %w", err)
 	}

--- a/internal/registry/orphan.go
+++ b/internal/registry/orphan.go
@@ -40,7 +40,7 @@ func IsOrphan(e Entry) bool {
 	if _, err := os.Stat(e.Cwd); os.IsNotExist(err) {
 		return true
 	}
-	marker := filepath.Join(e.Cwd, ".bones", "agent.id")
+	marker := filepath.Join(bonesDir(e.Cwd), "agent.id")
 	if _, err := os.Stat(marker); os.IsNotExist(err) {
 		return true
 	}

--- a/internal/scaffoldver/scaffoldver.go
+++ b/internal/scaffoldver/scaffoldver.go
@@ -14,19 +14,31 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/danmestas/bones/internal/workspace"
 )
 
 // StampPath is the relative location under the workspace root where
 // the scaffold version is recorded. Plain text, single line, no
 // trailing newline-noise to fight.
+//
+// Deprecated: prefer Path(root) which honors BONES_DIR (issue #291).
+// Kept as a constant so existing tests that hardcode the relative
+// layout still compile.
 const StampPath = ".bones/scaffold_version"
 
-// Read returns the version stamped at root/.bones/scaffold_version.
+// Path returns the absolute path of the scaffold-version stamp for
+// the workspace at root. Honors BONES_DIR (issue #291) when set.
+func Path(root string) string {
+	return filepath.Join(workspace.BonesDir(root), "scaffold_version")
+}
+
+// Read returns the version stamped at <BonesDir>/scaffold_version.
 // Returns ("", nil) if the file is missing — that's the "fresh
 // workspace, no stamp yet" case, not an error. Other read failures
 // are returned verbatim.
 func Read(root string) (string, error) {
-	data, err := os.ReadFile(filepath.Join(root, StampPath))
+	data, err := os.ReadFile(Path(root))
 	if errors.Is(err, os.ErrNotExist) {
 		return "", nil
 	}
@@ -36,11 +48,11 @@ func Read(root string) (string, error) {
 	return strings.TrimSpace(string(data)), nil
 }
 
-// Write records ver at root/.bones/scaffold_version. Creates parent
+// Write records ver at <BonesDir>/scaffold_version. Creates parent
 // directories as needed. Idempotent: writing the same value twice is
 // a no-op as far as drift detection is concerned.
 func Write(root, ver string) error {
-	path := filepath.Join(root, StampPath)
+	path := Path(root)
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return err
 	}

--- a/internal/slotgc/slotgc.go
+++ b/internal/slotgc/slotgc.go
@@ -18,6 +18,23 @@ import (
 	"time"
 )
 
+// bonesDirEnvVar mirrors workspace.BonesDirEnvVar. Inlined here to
+// avoid the import cycle workspace → hub → slotgc.
+const bonesDirEnvVar = "BONES_DIR"
+
+// bonesDir returns the bones-state directory for workspaceDir. Honors
+// BONES_DIR (issue #291) when set. Mirrors workspace.BonesDir;
+// duplicated to avoid an import cycle.
+func bonesDir(workspaceDir string) string {
+	if env := os.Getenv(bonesDirEnvVar); env != "" {
+		if abs, err := filepath.Abs(env); err == nil {
+			return abs
+		}
+		return env
+	}
+	return filepath.Join(workspaceDir, ".bones")
+}
+
 // DeadSlots lists slot names under .bones/swarm/<slot>/ whose
 // leaf.pid file points at a process that no longer exists. Slots
 // without a pid file (mid-creation, or already partially cleaned)
@@ -26,7 +43,7 @@ import (
 // Read-only. Returns nil + nil when the swarm root doesn't exist
 // (workspace never used swarm verbs).
 func DeadSlots(workspaceDir string) ([]string, error) {
-	swarmRoot := filepath.Join(workspaceDir, ".bones", "swarm")
+	swarmRoot := filepath.Join(bonesDir(workspaceDir), "swarm")
 	entries, err := os.ReadDir(swarmRoot)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -63,7 +80,7 @@ func PruneDead(workspaceDir string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	swarmRoot := filepath.Join(workspaceDir, ".bones", "swarm")
+	swarmRoot := filepath.Join(bonesDir(workspaceDir), "swarm")
 	pruned := make([]string, 0, len(dead))
 	var firstErr error
 	for _, slot := range dead {
@@ -85,7 +102,7 @@ func PruneDead(workspaceDir string) ([]string, error) {
 //
 // Read-only. Returns nil + nil when the swarm root doesn't exist.
 func LiveSlots(workspaceDir string) ([]Slot, error) {
-	swarmRoot := filepath.Join(workspaceDir, ".bones", "swarm")
+	swarmRoot := filepath.Join(bonesDir(workspaceDir), "swarm")
 	entries, err := os.ReadDir(swarmRoot)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/internal/swarm/lease.go
+++ b/internal/swarm/lease.go
@@ -978,7 +978,7 @@ func commitViaLeaf(
 // Bootstrap is the orchestrator's job; a leaf must never fix it
 // (PR #54).
 func ensureSlotUser(workspaceDir, login, caps string) error {
-	hubRepoPath := filepath.Join(workspaceDir, ".bones", "hub.fossil")
+	hubRepoPath := filepath.Join(workspace.BonesDir(workspaceDir), "hub.fossil")
 	if _, err := os.Stat(hubRepoPath); err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return ErrWorkspaceNotBootstrapped
@@ -1079,7 +1079,7 @@ func openLeaf(
 	ctx context.Context, info workspace.Info,
 	slot, fossilUser, hubURL string, hub *coord.Hub, autosync bool,
 ) (*coord.Leaf, error) {
-	swarmRoot := filepath.Join(info.WorkspaceDir, ".bones", "swarm")
+	swarmRoot := filepath.Join(workspace.BonesDir(info.WorkspaceDir), "swarm")
 	if err := os.MkdirAll(swarmRoot, 0o755); err != nil {
 		return nil, fmt.Errorf("mkdir swarm root: %w", err)
 	}
@@ -1151,7 +1151,7 @@ func preserveWorktree(workspaceDir, slot string, now time.Time) (string, int, er
 	}
 
 	recoveryName := fmt.Sprintf("%s-%d", slot, now.Unix())
-	recoveryDir := filepath.Join(workspaceDir, ".bones", "recovery", recoveryName)
+	recoveryDir := filepath.Join(workspace.BonesDir(workspaceDir), "recovery", recoveryName)
 	if err := os.MkdirAll(recoveryDir, 0o755); err != nil {
 		return "", 0, fmt.Errorf("mkdir recovery: %w", err)
 	}

--- a/internal/swarm/swarm.go
+++ b/internal/swarm/swarm.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/danmestas/bones/internal/assert"
 	"github.com/danmestas/bones/internal/jskv"
+	"github.com/danmestas/bones/internal/workspace"
 )
 
 // DefaultBucketName is the JetStream KV bucket holding swarm sessions.
@@ -319,7 +320,7 @@ func (s *Sessions) List(ctx context.Context) ([]Session, error) {
 func SlotDir(workspaceDir, slot string) string {
 	assert.NotEmpty(workspaceDir, "swarm.SlotDir: workspaceDir is empty")
 	assert.NotEmpty(slot, "swarm.SlotDir: slot is empty")
-	return filepath.Join(workspaceDir, ".bones", "swarm", slot)
+	return filepath.Join(workspace.BonesDir(workspaceDir), "swarm", slot)
 }
 
 // SlotWorktree returns the slot's worktree path. Equivalent to

--- a/internal/workspace/agent_id.go
+++ b/internal/workspace/agent_id.go
@@ -8,10 +8,10 @@ import (
 
 const agentIDFile = "agent.id"
 
-// writeAgentID stores the workspace's coord identity at .bones/agent.id.
+// writeAgentID stores the workspace's coord identity at <BonesDir>/agent.id.
 // Creates the marker directory if missing. Caller must hold any lock.
 func writeAgentID(workspaceDir, id string) error {
-	markerDir := filepath.Join(workspaceDir, markerDirName)
+	markerDir := BonesDir(workspaceDir)
 	if err := os.MkdirAll(markerDir, 0o755); err != nil {
 		return err
 	}
@@ -22,7 +22,7 @@ func writeAgentID(workspaceDir, id string) error {
 // readAgentID reads the workspace's coord identity. Returns os.ErrNotExist
 // when the workspace has not been initialized.
 func readAgentID(workspaceDir string) (string, error) {
-	data, err := os.ReadFile(filepath.Join(workspaceDir, markerDirName, agentIDFile))
+	data, err := os.ReadFile(filepath.Join(BonesDir(workspaceDir), agentIDFile))
 	if err != nil {
 		return "", err
 	}

--- a/internal/workspace/bonesdir.go
+++ b/internal/workspace/bonesdir.go
@@ -1,0 +1,51 @@
+package workspace
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// BonesDirEnvVar is the name of the environment variable that, when
+// set, relocates the workspace's bones-state directory away from
+// <root>/.bones/ to an arbitrary path. Mirrors BEADS_DIR.
+const BonesDirEnvVar = "BONES_DIR"
+
+// BonesDir returns the bones storage directory for the workspace at
+// root. Honors the BONES_DIR environment variable: when set, returns
+// the env value (absolutized) verbatim; when unset, returns
+// <root>/.bones/ as the canonical layout.
+//
+// Operator owns safety. We do not reject ../../etc/passwd or refuse
+// paths outside $HOME — the operator typed it and owns the
+// consequences. (Issue #291.)
+//
+// Used everywhere bones reasons about workspace-local state: the
+// hub fossil, agent.id, scaffold_version, hub.pid, manifest, swarm
+// slot dirs, etc. The workspace marker (.bones/agent.id) lookup
+// in walkUp also honors this — see FindRoot.
+func BonesDir(root string) string {
+	if env := os.Getenv(BonesDirEnvVar); env != "" {
+		// Absolutize so callers can pass relative paths without
+		// surprising downstream code that does its own filepath.Abs.
+		// On filepath.Abs failure, fall back to env verbatim — better
+		// to honor the operator's intent than silently relocate.
+		if abs, err := filepath.Abs(env); err == nil {
+			return abs
+		}
+		return env
+	}
+	return filepath.Join(root, markerDirName)
+}
+
+// MarkerDirName returns the canonical bones-dir basename relative to
+// a workspace root (".bones"). Exposed so callers outside the
+// workspace package — primarily migration helpers and tests — can
+// reason about the workspace-local layout without reaching into the
+// unexported markerDirName const.
+//
+// This is NOT the same as BonesDir(root): when BONES_DIR is set,
+// the on-disk state lives elsewhere, but the in-tree marker name
+// is still ".bones" for the purposes of walkUp's check at root.
+func MarkerDirName() string {
+	return markerDirName
+}

--- a/internal/workspace/bonesdir_test.go
+++ b/internal/workspace/bonesdir_test.go
@@ -1,0 +1,100 @@
+package workspace
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestBonesDir_HonorsEnv pins the issue #291 contract: with BONES_DIR
+// unset, BonesDir(root) returns <root>/.bones/; with BONES_DIR set,
+// returns the env value verbatim (after absolutization).
+func TestBonesDir_HonorsEnv(t *testing.T) {
+	root := t.TempDir()
+
+	// Unset → traditional layout under root.
+	t.Setenv(BonesDirEnvVar, "")
+	got := BonesDir(root)
+	want := filepath.Join(root, markerDirName)
+	if got != want {
+		t.Errorf("BonesDir unset: got %q, want %q", got, want)
+	}
+
+	// Set → env value (absolutized).
+	relocated := t.TempDir()
+	t.Setenv(BonesDirEnvVar, relocated)
+	if got := BonesDir(root); got != relocated {
+		t.Errorf("BonesDir set: got %q, want %q (must ignore root)", got, relocated)
+	}
+}
+
+// TestBonesDir_AbsolutizesEnv pins that a relative path passed in
+// BONES_DIR is absolutized so downstream filepath.Abs callers don't
+// drift away from the operator's intent.
+func TestBonesDir_AbsolutizesEnv(t *testing.T) {
+	// Pick a relative path. cwd doesn't matter for the test as long as
+	// we compare against the absolutized form.
+	rel := "tmp-bones-rel-291"
+	t.Setenv(BonesDirEnvVar, rel)
+	got := BonesDir("/whatever")
+	wantAbs, err := filepath.Abs(rel)
+	if err != nil {
+		t.Fatalf("filepath.Abs(rel): %v", err)
+	}
+	if got != wantAbs {
+		t.Errorf("BonesDir relative env: got %q, want %q", got, wantAbs)
+	}
+	if !filepath.IsAbs(got) {
+		t.Errorf("BonesDir result must be absolute, got %q", got)
+	}
+}
+
+// TestFindRoot_BonesDirOverridesCwd pins the issue #291 walk-up
+// semantics: when BONES_DIR points at a populated bones-state dir
+// (containing agent.id) and the cwd has no in-tree .bones/ marker,
+// FindRoot returns cwd as the workspace root.
+func TestFindRoot_BonesDirOverridesCwd(t *testing.T) {
+	// Workspace tree with NO .bones/ at all — simulates a clean
+	// checkout that BONES_DIR is supposed to operate against.
+	clean := t.TempDir()
+
+	// Relocated bones-state dir, populated with agent.id (the marker
+	// walkUp keys on).
+	relocated := t.TempDir()
+	if err := os.WriteFile(
+		filepath.Join(relocated, agentIDFile),
+		[]byte("test-agent-291\n"),
+		0o644,
+	); err != nil {
+		t.Fatalf("seed agent.id: %v", err)
+	}
+
+	t.Setenv(BonesDirEnvVar, relocated)
+
+	got, err := FindRoot(clean)
+	if err != nil {
+		t.Fatalf("FindRoot with BONES_DIR set: %v", err)
+	}
+	// FindRoot returns the cwd you handed it, since that's the working
+	// tree; the bones-state lives at the env path.
+	wantAbs, _ := filepath.Abs(clean)
+	if got != wantAbs {
+		t.Errorf("FindRoot: got %q, want %q (the cwd; relocated state at %q)",
+			got, wantAbs, relocated)
+	}
+}
+
+// TestFindRoot_BonesDirIgnoredWhenEmpty pins that BONES_DIR pointing
+// at an empty / non-bones directory does NOT short-circuit the walk:
+// the operator's mistake should fall through to ErrNoWorkspace rather
+// than silently treat any cwd as a workspace.
+func TestFindRoot_BonesDirIgnoredWhenEmpty(t *testing.T) {
+	clean := t.TempDir()
+	emptyRelocated := t.TempDir() // exists but no agent.id
+
+	t.Setenv(BonesDirEnvVar, emptyRelocated)
+
+	if _, err := FindRoot(clean); err == nil {
+		t.Errorf("FindRoot with empty BONES_DIR: got nil, want ErrNoWorkspace")
+	}
+}

--- a/internal/workspace/name.go
+++ b/internal/workspace/name.go
@@ -8,15 +8,15 @@ import (
 	"strings"
 )
 
-// WriteName persists the workspace_name override at <root>/.bones/workspace_name.
+// WriteName persists the workspace_name override at <BonesDir>/workspace_name.
 func WriteName(root, name string) error {
-	path := filepath.Join(root, ".bones", "workspace_name")
+	path := filepath.Join(BonesDir(root), "workspace_name")
 	return os.WriteFile(path, []byte(name+"\n"), 0o644)
 }
 
 // ReadName returns the workspace_name override or "" if not set.
 func ReadName(root string) (string, error) {
-	path := filepath.Join(root, ".bones", "workspace_name")
+	path := filepath.Join(BonesDir(root), "workspace_name")
 	data, err := os.ReadFile(path)
 	if errors.Is(err, os.ErrNotExist) {
 		return "", nil

--- a/internal/workspace/walk.go
+++ b/internal/workspace/walk.go
@@ -36,10 +36,30 @@ func FindRoot(start string) (string, error) {
 // callers to mistakenly resolve to $HOME when invoked from any
 // subdirectory of $HOME without a closer .bones/agent.id marker. See
 // issue #140.
+//
+// Honors BONES_DIR (issue #291): when the env var is set and points
+// at a populated bones-state directory containing agent.id, the
+// caller's cwd is treated as the workspace root regardless of any
+// in-tree .bones/ marker. This lets relocated/stealth installs run
+// against a clean checkout that has no .bones/ directory at all.
 func walkUp(start string) (string, error) {
 	cur, err := filepath.Abs(start)
 	if err != nil {
 		return "", fmt.Errorf("absolute path: %w", err)
+	}
+	// BONES_DIR override: a relocated bones-state dir wins over the
+	// in-tree walk. The env value must contain agent.id (otherwise
+	// it's an empty / unrelated directory and we fall through to the
+	// normal walk). cur is returned as-is so subsequent BonesDir(cur)
+	// calls round-trip back to the env value.
+	if env := os.Getenv(BonesDirEnvVar); env != "" {
+		envAbs := env
+		if abs, absErr := filepath.Abs(env); absErr == nil {
+			envAbs = abs
+		}
+		if _, err := os.Stat(filepath.Join(envAbs, agentIDFile)); err == nil {
+			return cur, nil
+		}
 	}
 	for range maxWalkUpDepth {
 		marker := filepath.Join(cur, markerDirName, agentIDFile)

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -132,7 +132,7 @@ func initLogic(ctx context.Context, cwd string) (Info, error) {
 		}
 	}
 
-	markerDir := filepath.Join(cwd, markerDirName)
+	markerDir := BonesDir(cwd)
 	if err := os.MkdirAll(markerDir, 0o755); err != nil {
 		return Info{}, fmt.Errorf("mkdir .bones: %w", err)
 	}
@@ -231,7 +231,7 @@ func joinLogic(ctx context.Context, cwd string) (Info, error) {
 		return Info{}, fmt.Errorf(
 			"hub URLs not recorded after start in %s; check %s",
 			workspaceDir,
-			filepath.Join(workspaceDir, markerDirName, "hub.log"))
+			filepath.Join(BonesDir(workspaceDir), "hub.log"))
 	}
 
 	return Info{
@@ -251,7 +251,7 @@ func joinLogic(ctx context.Context, cwd string) (Info, error) {
 // hub liveness without going through Join, whose auto-start branch
 // would contradict the lazy-hub promise printed by `bones up`.
 func HubIsHealthy(workspaceDir string) bool {
-	if !pidFileLive(filepath.Join(workspaceDir, markerDirName, "hub.pid")) {
+	if !pidFileLive(filepath.Join(BonesDir(workspaceDir), "hub.pid")) {
 		return false
 	}
 	url := hub.FossilURL(workspaceDir)


### PR DESCRIPTION
## Summary

beads-pattern relocated / zero-write installs. Two orthogonal axes:

| Combination | Behavior |
|---|---|
| `BONES_DIR=/path bones up` | relocate state outside workspace tree |
| `bones up --stealth` | skip `.claude/settings.json` hook merge |
| both | zero writes to workspace tree |

Both honor the existing #256/#260 posture (operator owns territory files; bones owns specific keys at most).

Closes #291

## Architecture

- **Canonical helper:** `workspace.BonesDir(root)` at `internal/workspace/bonesdir.go`. Returns `BONES_DIR` when set, else `filepath.Join(root, ".bones")`.
- **Inlined mirrors:** `internal/hub`, `internal/registry`, `internal/slotgc` each get a local `bonesDir` — required because `workspace` imports `hub` which imports `registry` + `slotgc`. Cycle avoidance, documented in each.
- **walkUp:** honors `BONES_DIR`. If set and `<env>/agent.id` exists → return cwd as workspace root immediately. If set but env-dir lacks `agent.id` → fall through to in-tree walk (operator misconfigure surfaces as `ErrNoWorkspace`, not silent any-cwd-is-a-workspace).
- **scaffoldOpts struct:** `scaffoldOrchestrator(root, opts scaffoldOpts)`; `opts.Stealth=true` skips `mergeSettings`. `UpCmd.Stealth` flag threads through.

## Audit

22 distinct `filepath.Join(root, ".bones")` sites rewritten across `internal/` + `cli/` to route through the helper. Intentionally NOT touched:

- `$HOME/.bones/` paths in `internal/registry` + `internal/sessions` — global state, NOT relocated by `BONES_DIR`.
- `markerDirName`-based legacy migration paths in `internal/workspace/migrate.go` — in-tree path is the load-bearing semantic for pre-ADR-0041 detection.

## Test plan

- [x] `make check` passes
- [x] `go test -tags=otel -short ./...` passes
- [x] `go test -race -short ./internal/workspace/... ./internal/hub/... ./cli/...` passes
- [x] 9 new tests: env honor + absolutize, FindRoot override, scaffold relocation, stealth-skip-settings, combined zero-write, status resolution, down cleanup

## Security note

`BONES_DIR=../../../etc/passwd` would resolve as the operator typed it (path absolutized + cleaned but not sandboxed). Operator owns the safety check — same posture as `BEADS_DIR`. Documented in `--help`.

## Out of scope

- Symlink-based stealth (operators can `ln -s` themselves)
- Multi-workspace `BONES_DIR` (one per env var)
- Encrypted storage at the relocated path
