### PR TITLE
fix(hub): skip tracked-but-deleted files during seed

### DIFF
--- a/internal/hub/hub.go
+++ b/internal/hub/hub.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 	"net"
 	"os"
 	"os/exec"
@@ -862,36 +863,9 @@ func seedHubRepo(ctx context.Context, h *edgehub.Hub, p paths) error {
 		return err
 	}
 
-	// Build FileToCommit list from every tracked path. Reading every
-	// file into memory mirrors the bash flow (xargs fossil add); for
-	// the workspace sizes we target (single repo, hundreds of MB at
-	// most) this is fine.
-	commitFiles := make([]edgehub.FileToCommit, 0, len(files))
-	for _, rel := range files {
-		abs := filepath.Join(p.root, rel)
-		info, err := os.Lstat(abs)
-		if err != nil {
-			return fmt.Errorf("stat %s: %w", rel, err)
-		}
-		// Skip symlinks and non-regular files; the bash script's
-		// `fossil add` handled these as a no-op via fossil's own
-		// filters.
-		if !info.Mode().IsRegular() {
-			continue
-		}
-		data, err := os.ReadFile(abs)
-		if err != nil {
-			return fmt.Errorf("read %s: %w", rel, err)
-		}
-		perm := ""
-		if info.Mode()&0o111 != 0 {
-			perm = "x"
-		}
-		commitFiles = append(commitFiles, edgehub.FileToCommit{
-			Name:    rel,
-			Content: data,
-			Perm:    perm,
-		})
+	commitFiles, err := collectSeedFiles(p.root, files)
+	if err != nil {
+		return err
 	}
 
 	_, err = h.Commit(ctx, edgehub.CommitOpts{
@@ -904,6 +878,54 @@ func seedHubRepo(ctx context.Context, h *edgehub.Hub, p paths) error {
 		return fmt.Errorf("commit: %w", err)
 	}
 	return nil
+}
+
+// collectSeedFiles reads each git-tracked path from disk and returns
+// edgehub.FileToCommit entries. Mirrors the bash flow (xargs fossil
+// add); reading file contents into memory is fine at workspace sizes.
+//
+// Three classes of entries are skipped (not failed):
+//
+//   - tracked-but-deleted (ENOENT): `git ls-files` returns paths from
+//     the index, which can name files that have been removed from the
+//     working tree without `git rm`. fossil add would have skipped
+//     these silently; aborting the seed against a normal git state
+//     bricked every hub start in workspaces with any deleted-tracked
+//     file (#302).
+//   - non-regular files: symlinks, sockets, fifos. The legacy bash
+//     flow let fossil's own filters handle these as no-ops.
+//
+// Real I/O failures (permission, broken device) propagate.
+func collectSeedFiles(root string, files []string) ([]edgehub.FileToCommit, error) {
+	out := make([]edgehub.FileToCommit, 0, len(files))
+	for _, rel := range files {
+		abs := filepath.Join(root, rel)
+		info, err := os.Lstat(abs)
+		if err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				// Tracked-but-deleted; see comment above.
+				continue
+			}
+			return nil, fmt.Errorf("stat %s: %w", rel, err)
+		}
+		if !info.Mode().IsRegular() {
+			continue
+		}
+		data, err := os.ReadFile(abs)
+		if err != nil {
+			return nil, fmt.Errorf("read %s: %w", rel, err)
+		}
+		perm := ""
+		if info.Mode()&0o111 != 0 {
+			perm = "x"
+		}
+		out = append(out, edgehub.FileToCommit{
+			Name:    rel,
+			Content: data,
+			Perm:    perm,
+		})
+	}
+	return out, nil
 }
 
 // ErrSeedPrecondition is returned by Start when the workspace has no

--- a/internal/hub/seed_test.go
+++ b/internal/hub/seed_test.go
@@ -1,0 +1,83 @@
+package hub
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestCollectSeedFiles_SkipsMissingFiles pins the #302 fix: when
+// `git ls-files` returns a path missing from the working tree (a
+// normal git state when `rm` runs without `git rm`), the seed step
+// must skip it rather than abort hub bring-up. The previous behavior
+// crashed every hub start in workspaces with any tracked-but-deleted
+// file.
+func TestCollectSeedFiles_SkipsMissingFiles(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "present.txt"),
+		[]byte("a"), 0o644); err != nil {
+		t.Fatalf("write present: %v", err)
+	}
+	// missing.txt intentionally not created.
+
+	got, err := collectSeedFiles(root,
+		[]string{"present.txt", "missing.txt"})
+	if err != nil {
+		t.Fatalf("collectSeedFiles: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("want 1 file (present.txt only), got %d: %+v",
+			len(got), got)
+	}
+	if got[0].Name != "present.txt" {
+		t.Fatalf("want present.txt, got %s", got[0].Name)
+	}
+	if string(got[0].Content) != "a" {
+		t.Fatalf("want content 'a', got %q", got[0].Content)
+	}
+}
+
+// TestCollectSeedFiles_SkipsNonRegular pins the existing non-regular
+// skip alongside the new ENOENT skip so they don't drift apart.
+func TestCollectSeedFiles_SkipsNonRegular(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "real.txt"),
+		[]byte("hi"), 0o644); err != nil {
+		t.Fatalf("write real: %v", err)
+	}
+	if err := os.Symlink("real.txt",
+		filepath.Join(root, "link.txt")); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+
+	got, err := collectSeedFiles(root,
+		[]string{"real.txt", "link.txt"})
+	if err != nil {
+		t.Fatalf("collectSeedFiles: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("want 1 file (real.txt only; symlink skipped), "+
+			"got %d: %+v", len(got), got)
+	}
+	if got[0].Name != "real.txt" {
+		t.Fatalf("want real.txt, got %s", got[0].Name)
+	}
+}
+
+// TestCollectSeedFiles_PreservesExecBit mirrors the production
+// behavior at hub.go's previous loop site: files with any execute bit
+// get Perm "x". Pinned to catch regressions in the extraction.
+func TestCollectSeedFiles_PreservesExecBit(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "run.sh"),
+		[]byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write run.sh: %v", err)
+	}
+	got, err := collectSeedFiles(root, []string{"run.sh"})
+	if err != nil {
+		t.Fatalf("collectSeedFiles: %v", err)
+	}
+	if len(got) != 1 || got[0].Perm != "x" {
+		t.Fatalf("want Perm=\"x\" for 0o755 file, got %+v", got)
+	}
+}


### PR DESCRIPTION
## Summary

- `seedHubRepo` aborted hub bring-up the moment `os.Lstat` hit a tracked-but-deleted file (#302). Every hub start in such workspaces failed identically.
- Skip `ErrNotExist` in the same loop that already skips non-regular files. Surface real I/O failures unchanged.
- Extract `collectSeedFiles` so the file-filtering step is unit-testable without spawning a real edgehub.

## Test plan

- [x] `go test -run 'TestCollectSeedFiles' ./internal/hub/ -v` — three cases (skip-missing, skip-non-regular, exec-bit-preserved) pass
- [x] Confirmed RED before the fix: removed the `errors.Is(err, fs.ErrNotExist)` branch, reran the missing-files test, watched it fail with the exact `lstat ...: no such file or directory` error from #302's spy logs
- [x] `make check` — fmt-check, vet, lint, race, todo-check all OK
- [x] `go test -tags=otel -short ./...` (CI gate per `.github/workflows/ci.yml`) — all packages pass

Closes #302