### PR TITLE
feat(up): gitignore .bones/ and skill manifest

### DIFF
--- a/cli/gitignore.go
+++ b/cli/gitignore.go
@@ -1,0 +1,83 @@
+package cli
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// gitignoreHeader marks the section bones-managed entries land under
+// in .gitignore. Operators can move the entries elsewhere or delete
+// them and bones up will not re-add anything they removed by name.
+const gitignoreHeader = "# bones (managed by `bones up`)"
+
+// ensureBonesGitignore appends bones-managed paths to <root>/.gitignore
+// when they are not already present. Creates .gitignore if absent.
+//
+// Always-ignored: .bones/ — the workspace state dir holds .bones/agent.id
+// (a host-local UUID) and per-session logs. Committing it pollutes the
+// repo for other contributors.
+//
+// When !stealth, also adds .claude/skills/.bones-manifest.json: pure
+// bones state recording which skill files bones owns. Skill content
+// itself is left ungitignored — operators may legitimately want to
+// commit it.
+//
+// Idempotent: re-running bones up does not duplicate entries. Match
+// is exact-line after TrimSpace, so an entry the operator moved into
+// a different section (e.g., re-grouped under their own header) is
+// still detected and not re-added.
+//
+// Returns the slice of newly-added entries (empty when no change was
+// needed) so the caller can surface the action in the up footprint.
+func ensureBonesGitignore(root string, stealth bool) ([]string, error) {
+	want := []string{".bones/"}
+	if !stealth {
+		want = append(want, ".claude/skills/.bones-manifest.json")
+	}
+
+	path := filepath.Join(root, ".gitignore")
+	existing, err := os.ReadFile(path)
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return nil, fmt.Errorf("read .gitignore: %w", err)
+	}
+
+	have := map[string]bool{}
+	for _, line := range strings.Split(string(existing), "\n") {
+		have[strings.TrimSpace(line)] = true
+	}
+
+	add := make([]string, 0, len(want))
+	for _, w := range want {
+		if !have[w] {
+			add = append(add, w)
+		}
+	}
+	if len(add) == 0 {
+		return nil, nil
+	}
+
+	var buf bytes.Buffer
+	buf.Write(existing)
+	if len(existing) > 0 && !bytes.HasSuffix(existing, []byte("\n")) {
+		buf.WriteByte('\n')
+	}
+	if len(existing) > 0 {
+		buf.WriteByte('\n')
+	}
+	buf.WriteString(gitignoreHeader)
+	buf.WriteByte('\n')
+	for _, a := range add {
+		buf.WriteString(a)
+		buf.WriteByte('\n')
+	}
+
+	if err := os.WriteFile(path, buf.Bytes(), 0o644); err != nil {
+		return nil, fmt.Errorf("write .gitignore: %w", err)
+	}
+	return add, nil
+}

--- a/cli/gitignore_test.go
+++ b/cli/gitignore_test.go
@@ -1,0 +1,154 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestEnsureBonesGitignore_FreshRepo creates the file from scratch
+// when no .gitignore exists. Pins the #306 fix: every fresh `bones up`
+// must leave the workspace with .bones/ ignored so a reflexive
+// `git add .` does not commit the host-local agent UUID.
+func TestEnsureBonesGitignore_FreshRepo(t *testing.T) {
+	root := t.TempDir()
+	added, err := ensureBonesGitignore(root, false)
+	if err != nil {
+		t.Fatalf("ensureBonesGitignore: %v", err)
+	}
+	if len(added) != 2 {
+		t.Fatalf("want 2 entries added (.bones/ + manifest), got %v", added)
+	}
+	body := readIgnoreFile(t, filepath.Join(root, ".gitignore"))
+	if !strings.Contains(body, ".bones/") {
+		t.Fatalf("missing .bones/ entry; got:\n%s", body)
+	}
+	if !strings.Contains(body, ".claude/skills/.bones-manifest.json") {
+		t.Fatalf("missing manifest entry; got:\n%s", body)
+	}
+	if !strings.Contains(body, gitignoreHeader) {
+		t.Fatalf("missing header; got:\n%s", body)
+	}
+}
+
+// TestEnsureBonesGitignore_Stealth pins the #291 boundary: stealth
+// mode must not register the .claude/-side entry, since stealth
+// itself skips touching .claude/settings.json.
+func TestEnsureBonesGitignore_Stealth(t *testing.T) {
+	root := t.TempDir()
+	added, err := ensureBonesGitignore(root, true)
+	if err != nil {
+		t.Fatalf("ensureBonesGitignore: %v", err)
+	}
+	if len(added) != 1 || added[0] != ".bones/" {
+		t.Fatalf("want only .bones/ added under stealth, got %v", added)
+	}
+	body := readIgnoreFile(t, filepath.Join(root, ".gitignore"))
+	if strings.Contains(body, ".claude/") {
+		t.Fatalf("stealth mode must not write .claude/ entries; got:\n%s",
+			body)
+	}
+}
+
+// TestEnsureBonesGitignore_Idempotent guards against duplicate
+// appends on bones up re-runs. Re-running should be a no-op even
+// when the entries live elsewhere in the file (e.g., the operator
+// re-grouped them under their own header).
+func TestEnsureBonesGitignore_Idempotent(t *testing.T) {
+	root := t.TempDir()
+
+	// First run.
+	if _, err := ensureBonesGitignore(root, false); err != nil {
+		t.Fatalf("first ensureBonesGitignore: %v", err)
+	}
+	first := readIgnoreFile(t, filepath.Join(root, ".gitignore"))
+
+	// Second run — must not duplicate anything.
+	added, err := ensureBonesGitignore(root, false)
+	if err != nil {
+		t.Fatalf("second ensureBonesGitignore: %v", err)
+	}
+	if len(added) != 0 {
+		t.Fatalf("re-run added %v; want no changes", added)
+	}
+	second := readIgnoreFile(t, filepath.Join(root, ".gitignore"))
+	if first != second {
+		t.Fatalf("re-run mutated file:\n--- first ---\n%s--- second ---\n%s",
+			first, second)
+	}
+}
+
+// TestEnsureBonesGitignore_AppendsToExisting preserves operator
+// content. The bones header lands at the bottom under a blank-line
+// separator; existing rules above are untouched.
+func TestEnsureBonesGitignore_AppendsToExisting(t *testing.T) {
+	root := t.TempDir()
+	pre := "node_modules/\ndist/\n"
+	writeIgnoreFile(t, filepath.Join(root, ".gitignore"), pre)
+
+	added, err := ensureBonesGitignore(root, false)
+	if err != nil {
+		t.Fatalf("ensureBonesGitignore: %v", err)
+	}
+	if len(added) != 2 {
+		t.Fatalf("want 2 entries added, got %v", added)
+	}
+	body := readIgnoreFile(t, filepath.Join(root, ".gitignore"))
+	if !strings.HasPrefix(body, pre) {
+		t.Fatalf("operator content not preserved at top:\n%s", body)
+	}
+	if !strings.Contains(body, ".bones/") {
+		t.Fatalf("missing .bones/ entry; got:\n%s", body)
+	}
+}
+
+// TestEnsureBonesGitignore_DetectsExistingEntry skips appending
+// when an entry is already present, even without the bones header
+// (operator may have added it manually).
+func TestEnsureBonesGitignore_DetectsExistingEntry(t *testing.T) {
+	root := t.TempDir()
+	writeIgnoreFile(t, filepath.Join(root, ".gitignore"),
+		"node_modules/\n.bones/\n")
+
+	added, err := ensureBonesGitignore(root, true) // stealth — only .bones/
+	if err != nil {
+		t.Fatalf("ensureBonesGitignore: %v", err)
+	}
+	if len(added) != 0 {
+		t.Fatalf("entry already present; want no-op, got added=%v", added)
+	}
+}
+
+// TestEnsureBonesGitignore_HandlesMissingTrailingNewline guards
+// against a malformed append when an existing .gitignore lacks a
+// trailing newline.
+func TestEnsureBonesGitignore_HandlesMissingTrailingNewline(t *testing.T) {
+	root := t.TempDir()
+	writeIgnoreFile(t, filepath.Join(root, ".gitignore"), "dist/")
+
+	if _, err := ensureBonesGitignore(root, false); err != nil {
+		t.Fatalf("ensureBonesGitignore: %v", err)
+	}
+	body := readIgnoreFile(t, filepath.Join(root, ".gitignore"))
+	if !strings.HasPrefix(body, "dist/\n") {
+		t.Fatalf("trailing newline not added before bones section; got:\n%s",
+			body)
+	}
+}
+
+func readIgnoreFile(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(b)
+}
+
+func writeIgnoreFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}

--- a/cli/up.go
+++ b/cli/up.go
@@ -108,6 +108,14 @@ func runUp(cwd string, verbose, stealth bool) (err error) {
 		return err
 	}
 
+	gitignoreAdded, gitignoreErr := ensureBonesGitignore(wsDir, stealth)
+	if gitignoreErr != nil {
+		// Non-fatal: a read-only filesystem or gitignore the operator
+		// pinned with chmod 444 must not block scaffold. Surface as a
+		// warning so the host-local agent.id risk is at least visible.
+		logger.Warnf("up: WARN  gitignore: %v", gitignoreErr)
+	}
+
 	if dErr := checkFossilDrift(wsDir); dErr != nil {
 		logger.Warnf("up: WARN  %v", dErr)
 	}
@@ -118,6 +126,10 @@ func runUp(cwd string, verbose, stealth bool) (err error) {
 	} else {
 		logger.Infof("up: ready at %s", wsDir)
 		emitFootprintSummary(logger, fp)
+		if len(gitignoreAdded) > 0 {
+			logger.Infof("up:   added to .gitignore: %s",
+				strings.Join(gitignoreAdded, ", "))
+		}
 	}
 	printHubStatus(logger.Tee(os.Stdout), wsDir)
 	return nil


### PR DESCRIPTION
## Summary

- Fresh `bones up` left `.bones/` and `.claude/` as `??` in `git status`. A reflexive `git add .` would commit `.bones/agent.id` — a host-local UUID.
- `ensureBonesGitignore` writes (or appends to) `.gitignore` with `.bones/` always, and `.claude/skills/.bones-manifest.json` when not in `--stealth` mode.
- Idempotent (exact-line match — operator can relocate the entries), non-fatal on write failure (warns, does not block scaffold).
- Skill content under `.claude/skills/<skill>/` left ungitignored: the manifest is the bones-owned record; the SKILL.md files are arguably content the operator may want committed.

## Test plan

- [x] `go test -run 'TestEnsureBonesGitignore' ./cli/ -v` — six cases pass: fresh repo, stealth, idempotent, append-to-existing, detect-existing-entry, missing-trailing-newline
- [x] `make check` — fmt-check, vet, lint, race, todo-check OK
- [x] `go test -tags=otel -short ./...` (CI gate) — all packages pass
- [x] Manual: `cd /tmp/fresh && git init -q && echo a > a && git add a && git commit -qm a && bones up && cat .gitignore` shows the bones header and entries; `git status` shows `.gitignore` modified, no `??` for `.bones/`

Closes #306