### PR TITLE
feat(up): warn on tracked-but-deleted files

### DIFF
--- a/cli/tracked_deleted.go
+++ b/cli/tracked_deleted.go
@@ -1,0 +1,61 @@
+package cli
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// maxTrackedDeletedListed bounds how many missing paths we print
+// inline. Above this, the warning collapses to "... and N more" so
+// the bones up output stays scannable on workspaces with large
+// dirty trees.
+const maxTrackedDeletedListed = 5
+
+// trackedDeletedFiles returns paths in the git index that are
+// missing from the working tree (deleted without `git rm`). Wraps
+// `git ls-files --deleted`. Returns nil with no error when the
+// directory is not a git repo or git is not on PATH — bones up
+// already tolerates non-git workspaces.
+func trackedDeletedFiles(root string) ([]string, error) {
+	cmd := exec.Command("git", "ls-files", "--deleted")
+	cmd.Dir = root
+	out, err := cmd.Output()
+	if err != nil {
+		// Not a git repo, no git, or some other failure. Don't surface
+		// — bones up is not the right place to nag about non-git state.
+		return nil, nil
+	}
+	trimmed := strings.TrimRight(string(out), "\n")
+	if trimmed == "" {
+		return nil, nil
+	}
+	return strings.Split(trimmed, "\n"), nil
+}
+
+// formatTrackedDeletedWarning renders the one-line WARN body for a
+// non-empty set of missing-tracked paths. Truncates to the first
+// maxTrackedDeletedListed entries to keep output scannable.
+//
+// #303 driver: surface dirty index state so the operator can either
+// `git rm` the entries or restore them. Since #302 the hub itself
+// tolerates this state, so this is informational rather than a
+// blocker.
+func formatTrackedDeletedWarning(missing []string) string {
+	n := len(missing)
+	listed := missing
+	suffix := ""
+	if n > maxTrackedDeletedListed {
+		listed = missing[:maxTrackedDeletedListed]
+		suffix = fmt.Sprintf(" ... and %d more",
+			n-maxTrackedDeletedListed)
+	}
+	noun := "files are"
+	if n == 1 {
+		noun = "file is"
+	}
+	return fmt.Sprintf(
+		"%d tracked %s missing from working tree (deleted without "+
+			"'git rm'): %s%s",
+		n, noun, strings.Join(listed, ", "), suffix)
+}

--- a/cli/tracked_deleted_test.go
+++ b/cli/tracked_deleted_test.go
@@ -1,0 +1,134 @@
+package cli
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestTrackedDeletedFiles_DetectsDeletedFile pins the #303 detection:
+// `git ls-files --deleted` is the source of truth. After #302 the
+// hub no longer crashes on this state, but bones up should still
+// surface it so the operator can clean up.
+func TestTrackedDeletedFiles_DetectsDeletedFile(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	root := newGitRepoForTrackedTest(t)
+	if err := os.Remove(filepath.Join(root, "tracked.txt")); err != nil {
+		t.Fatalf("remove tracked.txt: %v", err)
+	}
+
+	got, err := trackedDeletedFiles(root)
+	if err != nil {
+		t.Fatalf("trackedDeletedFiles: %v", err)
+	}
+	if len(got) != 1 || got[0] != "tracked.txt" {
+		t.Fatalf("want [tracked.txt], got %v", got)
+	}
+}
+
+// TestTrackedDeletedFiles_CleanRepo returns nil for a clean repo so
+// bones up does not warn when there's nothing to surface.
+func TestTrackedDeletedFiles_CleanRepo(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	root := newGitRepoForTrackedTest(t)
+	got, err := trackedDeletedFiles(root)
+	if err != nil {
+		t.Fatalf("trackedDeletedFiles: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("clean repo; want nil, got %v", got)
+	}
+}
+
+// TestTrackedDeletedFiles_NotAGitRepo gracefully returns nil
+// without surfacing an error. bones up already tolerates non-git
+// workspaces; this should not nag about that orthogonal condition.
+func TestTrackedDeletedFiles_NotAGitRepo(t *testing.T) {
+	root := t.TempDir()
+	got, err := trackedDeletedFiles(root)
+	if err != nil {
+		t.Fatalf("non-git: want nil error, got %v", err)
+	}
+	if got != nil {
+		t.Fatalf("non-git: want nil paths, got %v", got)
+	}
+}
+
+// TestFormatTrackedDeletedWarning_Singular pins grammar.
+func TestFormatTrackedDeletedWarning_Singular(t *testing.T) {
+	got := formatTrackedDeletedWarning([]string{"a.txt"})
+	if !strings.Contains(got, "1 tracked file is missing") {
+		t.Fatalf("singular grammar wrong: %s", got)
+	}
+}
+
+// TestFormatTrackedDeletedWarning_Plural pins grammar + listing.
+func TestFormatTrackedDeletedWarning_Plural(t *testing.T) {
+	got := formatTrackedDeletedWarning([]string{"a.txt", "b.txt"})
+	if !strings.Contains(got, "2 tracked files are missing") {
+		t.Fatalf("plural grammar wrong: %s", got)
+	}
+	if !strings.Contains(got, "a.txt, b.txt") {
+		t.Fatalf("missing listing: %s", got)
+	}
+}
+
+// TestFormatTrackedDeletedWarning_Truncates limits inline path
+// listing to maxTrackedDeletedListed and renders an "... and N
+// more" suffix above that.
+func TestFormatTrackedDeletedWarning_Truncates(t *testing.T) {
+	missing := []string{
+		"path1.go", "path2.go", "path3.go", "path4.go",
+		"path5.go", "path6.go", "path7.go",
+	}
+	got := formatTrackedDeletedWarning(missing)
+	if !strings.Contains(got, "and 2 more") {
+		t.Fatalf("expected truncation suffix; got: %s", got)
+	}
+	// Inline listing must include the first 5 and exclude the rest.
+	for _, want := range []string{"path1.go", "path5.go"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected %s inline; got: %s", want, got)
+		}
+	}
+	for _, dont := range []string{"path6.go", "path7.go"} {
+		if strings.Contains(got, dont) {
+			t.Fatalf("expected %s truncated; got: %s", dont, got)
+		}
+	}
+}
+
+// newGitRepoForTrackedTest creates a temp git repo with one
+// committed file. Named to avoid colliding with hub-test helpers
+// (different package).
+func newGitRepoForTrackedTest(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	mustGit(t, root, "init", "-q")
+	if err := os.WriteFile(filepath.Join(root, "tracked.txt"),
+		[]byte("hi"), 0o644); err != nil {
+		t.Fatalf("write tracked: %v", err)
+	}
+	mustGit(t, root, "add", "tracked.txt")
+	mustGit(t, root,
+		"-c", "user.email=t@t",
+		"-c", "user.name=t",
+		"-c", "commit.gpgsign=false",
+		"commit", "-qm", "init")
+	return root
+}
+
+func mustGit(t *testing.T, root string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = root
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+}

--- a/cli/up.go
+++ b/cli/up.go
@@ -108,17 +108,7 @@ func runUp(cwd string, verbose, stealth bool) (err error) {
 		return err
 	}
 
-	gitignoreAdded, gitignoreErr := ensureBonesGitignore(wsDir, stealth)
-	if gitignoreErr != nil {
-		// Non-fatal: a read-only filesystem or gitignore the operator
-		// pinned with chmod 444 must not block scaffold. Surface as a
-		// warning so the host-local agent.id risk is at least visible.
-		logger.Warnf("up: WARN  gitignore: %v", gitignoreErr)
-	}
-
-	if dErr := checkFossilDrift(wsDir); dErr != nil {
-		logger.Warnf("up: WARN  %v", dErr)
-	}
+	gitignoreAdded := runPostScaffoldChecks(wsDir, stealth, logger)
 
 	if verbose {
 		logger.Infof("up: workspace ready. Run any verb (e.g., `bones tasks status`) " +
@@ -133,6 +123,39 @@ func runUp(cwd string, verbose, stealth bool) (err error) {
 	}
 	printHubStatus(logger.Tee(os.Stdout), wsDir)
 	return nil
+}
+
+// runPostScaffoldChecks runs the workspace-wide checks that follow
+// orchestrator scaffold + git-hook install. None of them should
+// block bones up — the scaffold already landed; these are
+// informational. Returns the gitignore entries added so the caller
+// can surface them in the footprint summary.
+//
+// Three checks today:
+//   - ensureBonesGitignore (#306): adds .bones/ + skill manifest entries.
+//   - trackedDeletedFiles (#303): warns about tracked-but-missing files.
+//   - checkFossilDrift: warns when fossil tip diverges from git HEAD.
+func runPostScaffoldChecks(
+	wsDir string, stealth bool, logger *upLogger,
+) []string {
+	gitignoreAdded, gitignoreErr := ensureBonesGitignore(wsDir, stealth)
+	if gitignoreErr != nil {
+		// Non-fatal: a read-only filesystem or gitignore the operator
+		// pinned with chmod 444 must not block scaffold. Surface as a
+		// warning so the host-local agent.id risk is at least visible.
+		logger.Warnf("up: WARN  gitignore: %v", gitignoreErr)
+	}
+
+	if missing, _ := trackedDeletedFiles(wsDir); len(missing) > 0 {
+		logger.Warnf("up: WARN  %s",
+			formatTrackedDeletedWarning(missing))
+	}
+
+	if dErr := checkFossilDrift(wsDir); dErr != nil {
+		logger.Warnf("up: WARN  %v", dErr)
+	}
+
+	return gitignoreAdded
 }
 
 // emitFootprintSummary surfaces per-action file/hook changes from the


### PR DESCRIPTION
## Summary

- Re-scoped after #302 landed: the hub no longer crashes on tracked-but-deleted files, but the dirty index state is still worth surfacing so operators can `git rm` or restore.
- New `trackedDeletedFiles` wraps `git ls-files --deleted`. `formatTrackedDeletedWarning` renders the one-line WARN body, truncating inline listing at 5 paths.
- Wired into `runPostScaffoldChecks` (extracted from `runUp` to stay under the funlen cap once gitignore + tracked-deleted + drift sat side-by-side).
- Non-fatal everywhere: non-git workspace → silent no-op; git unavailable → silent no-op.

## Test plan

- [x] `go test -run 'TestTrackedDeletedFiles|TestFormatTrackedDeletedWarning' ./cli/ -v` — six cases pass: detects-deleted, clean-repo, not-a-git-repo, singular-grammar, plural-grammar, truncates-at-5
- [x] `make check` — fmt-check, vet, lint, race, todo-check OK (funlen specifically called out the regression; refactor closes it)
- [x] `go test -tags=otel -short ./...` (CI gate) — all packages pass

Closes #303