### PR TITLE
fix(hub): emit hub URLs to stderr, not stdout

### DIFF
--- a/cmd/bones/integration/integration_test.go
+++ b/cmd/bones/integration/integration_test.go
@@ -2,6 +2,7 @@ package integration_test
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -779,20 +780,35 @@ func TestCLI_Prime(t *testing.T) {
 		// #170: even with zero tasks, the envelope must be present
 		// so the SessionStart hook injects a "bones is active"
 		// signal into agent context.
+		//
+		// #304: stdout MUST be parseable JSON. Earlier loose checks
+		// (`strings.Contains`) passed even when an auto-start hub
+		// preamble polluted stdout — this is the cold-start path,
+		// so it exercises spawnDetachedChild's printf. Strict
+		// json.Unmarshal is the contract the SessionStart hook
+		// consumer relies on.
 		stdout, stderr, code := runCmd(t, bonesBin, dir, "tasks", "prime", "--json")
 		if code != 0 {
 			t.Fatalf("prime --json exit=%d stderr=%s", code, stderr)
 		}
-		if len(strings.TrimSpace(stdout)) == 0 {
-			t.Fatalf("zero-tasks prime emitted empty stdout; want envelope")
+		var envelope struct {
+			OpenTasks    []any `json:"open_tasks"`
+			ReadyTasks   []any `json:"ready_tasks"`
+			ClaimedTasks []any `json:"claimed_tasks"`
+			Threads      []any `json:"threads"`
+			Peers        []any `json:"peers"`
 		}
-		for _, key := range []string{
-			`"open_tasks"`, `"ready_tasks"`, `"claimed_tasks"`,
-			`"threads"`, `"peers"`,
-		} {
-			if !strings.Contains(stdout, key) {
-				t.Errorf("envelope missing %s; got=%q", key, stdout)
-			}
+		if err := json.Unmarshal([]byte(stdout), &envelope); err != nil {
+			t.Fatalf("prime --json stdout is not valid JSON: %v\n"+
+				"got=%q\nstderr=%q", err, stdout, stderr)
+		}
+		// Slices must exist (zero-length is fine) so the agent
+		// context always sees the envelope shape.
+		if envelope.OpenTasks == nil {
+			t.Errorf("envelope.open_tasks is nil; want []")
+		}
+		if envelope.Peers == nil {
+			t.Errorf("envelope.peers is nil; want []")
 		}
 	})
 

--- a/internal/hub/hub.go
+++ b/internal/hub/hub.go
@@ -267,7 +267,12 @@ func runForeground(ctx context.Context, p paths, o opts) error {
 		defer close(httpDone)
 		_ = h.ServeHTTP(httpCtx)
 	}()
-	fmt.Printf("hub: fossil at %s, nats at %s\n", h.HTTPAddr(), h.NATSURL())
+	// Stderr (not stdout) so verbs that auto-start the hub via
+	// workspace.Join can emit clean stdout — `bones tasks prime
+	// --json` is wired into SessionStart and PreCompact hooks and
+	// must produce valid JSON on stdout for the hook contract (#304).
+	fmt.Fprintf(os.Stderr, "hub: fossil at %s, nats at %s\n",
+		h.HTTPAddr(), h.NATSURL())
 	if err := registry.Write(registry.Entry{
 		Cwd:       p.root,
 		Name:      filepath.Base(p.root),
@@ -528,7 +533,9 @@ func spawnDetachedChild(p paths, o opts) error {
 		return fmt.Errorf("hub: release child: %w", err)
 	}
 
-	fmt.Printf("hub: fossil at http://127.0.0.1:%d, nats at nats://127.0.0.1:%d (pid=%d)\n",
+	// Stderr per #304 — same JSON-stdout contract as line above.
+	fmt.Fprintf(os.Stderr,
+		"hub: fossil at http://127.0.0.1:%d, nats at nats://127.0.0.1:%d (pid=%d)\n",
 		o.repoPort, o.coordPort, pid)
 	return nil
 }


### PR DESCRIPTION
## Summary

- `bones tasks prime --json` (registered in both `SessionStart` and `PreCompact` hooks by `bones up`) emitted a non-JSON `hub: fossil at http://... nats at nats://... (pid=N)` line on stdout before the JSON. `jq .` and any structured consumer broke.
- Two `fmt.Printf` call sites in `internal/hub/hub.go` (`runForeground` line 270, `spawnDetachedChild` line 531) → `fmt.Fprintf(os.Stderr, ...)`. The hub package already used stderr for related diagnostics (registry write failures, port collisions); these two were the anomalies.
- Tightened `cmd/bones/integration/integration_test.go:778 (TestCLI_Prime/json_zero_tasks_envelope)` from a loose `strings.Contains(stdout, "open_tasks")` to a strict `json.Unmarshal(stdout, &envelope)`. The old assertion passed whether or not stdout was polluted; the new one fails on any non-JSON prefix.

## Test plan

- [x] **Confirmed RED before the fix**: stashed source change, ran `go test -run 'TestCLI_Prime/json_zero_tasks_envelope' ./cmd/bones/integration/` — failed with the exact production output: `prime --json stdout is not valid JSON: invalid character 'h' looking for beginning of value` followed by the polluted stdout (`hub: fossil at http://... (pid=66830)\n{"open_tasks":[],...}`).
- [x] **Restored fix**: same test now PASSes.
- [x] `make check` — fmt-check, vet, lint, race (which runs the integration tests, not skipped under -short), todo-check all OK.
- [x] `go test -tags=otel -short ./...` (CI gate) — all packages pass.

## Out of scope

The original #304 body referenced a "silent failure" half (verbs returning exit 0 when hub bring-up fails). Re-scoped before this PR — that symptom came from the same spy session that drove #302; with #302 merged, the seed cascade is gone, and a fresh repro is needed before fixing.

Closes #304