### PR TITLE
feat(hooks): Claude Code hook protocol contract + doctor self-heal

### DIFF
--- a/cli/doctor.go
+++ b/cli/doctor.go
@@ -16,6 +16,7 @@ import (
 	edgecli "github.com/danmestas/EdgeSync/cli"
 	repocli "github.com/danmestas/EdgeSync/cli/repo"
 
+	"github.com/danmestas/bones/internal/clauderhooks"
 	"github.com/danmestas/bones/internal/githook"
 	"github.com/danmestas/bones/internal/hub"
 	"github.com/danmestas/bones/internal/registry"
@@ -44,6 +45,11 @@ type DoctorCmd struct {
 	Quiet  bool `name:"quiet" short:"q" help:"only show workspaces with issues (with --all)"`
 	ShowOK bool `name:"show-ok" help:"include OK workspaces in --all output (verbose mode)"`
 	JSON   bool `name:"json" help:"emit machine-readable JSON"`
+	// NoFix flips bones doctor into report-only mode for the ADR
+	// 0051 hook-protocol auto-rewrite. Default behavior auto-heals
+	// stale .claude/settings.json hook entries; --no-fix surfaces
+	// drift as WARN lines without rewriting the file.
+	NoFix bool `name:"no-fix" help:"report-only: do not auto-rewrite stale hook entries"`
 }
 
 // Run invokes the EdgeSync doctor first; on completion (regardless
@@ -139,13 +145,16 @@ func (c *DoctorCmd) runTelemetryReport() {
 // runBypassReport calls runBypassReportTo with stdout. Kept for the
 // existing call site in DoctorCmd.Run; the warn count is unused in
 // single-workspace mode (the per-line WARN prefix is the signal).
+//
+// Threads c.NoFix into the bypass report so ADR 0051's hook-protocol
+// auto-rewrite is opt-out via `bones doctor --no-fix`.
 func (c *DoctorCmd) runBypassReport() {
 	cwd, err := os.Getwd()
 	if err != nil {
 		fmt.Printf("  WARN  cwd: %v\n", err)
 		return
 	}
-	_, _ = runBypassReportTo(os.Stdout, cwd)
+	_, _ = runBypassReportToWith(os.Stdout, cwd, c.NoFix)
 }
 
 // runBypassReportTo is the writer-injection variant of runBypassReport.
@@ -156,7 +165,17 @@ func (c *DoctorCmd) runBypassReport() {
 //
 // The warn count is the source of truth — callers must not scrape it from
 // the output buffer (display format is not a stable interface).
+//
+// Default is auto-rewrite mode (noFix=false). Tests and report-only
+// callers should use runBypassReportToWith directly.
 func runBypassReportTo(w io.Writer, cwd string) (warns int, err error) {
+	return runBypassReportToWith(w, cwd, false)
+}
+
+// runBypassReportToWith is the noFix-aware variant. ADR 0051's
+// auto-rewrite respects the noFix flag; everything else stays
+// unchanged.
+func runBypassReportToWith(w io.Writer, cwd string, noFix bool) (warns int, err error) {
 	_, _ = fmt.Fprintln(w)
 	_, _ = fmt.Fprintln(w, "=== bones substrate gates (ADR 0034) ===")
 
@@ -205,7 +224,7 @@ func runBypassReportTo(w io.Writer, cwd string) (warns int, err error) {
 		_, _ = fmt.Fprintf(w, "  OK    scaffold version v%s matches binary\n", stamp)
 	}
 
-	warns += checkScaffoldGates(w, cwd)
+	warns += checkScaffoldGates(w, cwd, noFix)
 	warns += checkManifestIntegrity(w, cwd)
 	warns += checkOrphanHubs(w)
 	warns += checkStaleSlotDirs(w, cwd)
@@ -230,13 +249,43 @@ func runBypassReportTo(w io.Writer, cwd string) (warns int, err error) {
 	return warns, nil
 }
 
-// checkBonesScaffoldedHooks verifies the Claude-format hooks bones up
-// installs (`bones hub start`, `bones tasks prime --json` x2). When
-// .claude/ exists at all, all three entries must be present in
-// settings.json. When .claude/ is absent, the check is silent — bones
-// supports harnesses with no .claude/ directory via AGENTS.md.
-// Returns true if a WARN was emitted.
+// checkBonesScaffoldedHooks verifies the Claude-format hooks bones
+// up installs (`bones hub start`, `bones tasks prime --hook=session-
+// start`). When .claude/ exists at all, all bones-owned entries must
+// be present in settings.json. When .claude/ is absent, the check is
+// silent — bones supports harnesses with no .claude/ directory.
+//
+// Per ADR 0051 this check is also the auto-rewrite surface for the
+// hook protocol migration. Three concrete patches are applied (when
+// noFix is false; report-only when true):
+//
+//   - stale `bones tasks prime --json` under SessionStart →
+//     rewrite to `bones tasks prime --hook=session-start` with
+//     matcher "startup|compact" so the SessionStart compact
+//     matcher fires on post-compact sessions.
+//   - any `bones tasks prime` entry under PreCompact → remove
+//     entirely. PreCompact has no `additionalContext` mechanism in
+//     the Claude Code hook protocol; the v0.12 placement was a
+//     silent no-op.
+//   - missing SessionStart `bones tasks prime --hook=session-start`
+//     → install it. Covers the case where doctor runs against a
+//     post-binary-upgrade workspace without re-running `bones up`.
+//
+// Each patch prints one FIX line per applied change so the operator
+// sees what doctor migrated. With --no-fix, the same conditions
+// surface as WARN lines without rewriting the file.
+//
+// Returns true if a WARN was emitted (NOT true on FIX-class output:
+// a successful auto-rewrite is healing, not a finding).
 func checkBonesScaffoldedHooks(w io.Writer, cwd string) bool {
+	return checkBonesScaffoldedHooksWith(w, cwd, false)
+}
+
+// checkBonesScaffoldedHooksWith is the noFix-aware sibling. Doctor's
+// Run path threads --no-fix through; the legacy entry point above
+// preserves the false default for callers that don't care about the
+// new flag.
+func checkBonesScaffoldedHooksWith(w io.Writer, cwd string, noFix bool) bool {
 	claudeDir := filepath.Join(cwd, ".claude")
 	if info, err := os.Stat(claudeDir); err != nil || !info.IsDir() {
 		return false
@@ -254,28 +303,178 @@ func checkBonesScaffoldedHooks(w io.Writer, cwd string) bool {
 		return true
 	}
 	hooks, _ := root["hooks"].(map[string]any)
-	want := []struct {
-		event string
-		cmd   string
-	}{
-		{"SessionStart", "bones hub start"},
-		{"SessionStart", "bones tasks prime --json"},
-		{"PreCompact", "bones tasks prime --json"},
+	if hooks == nil {
+		hooks = map[string]any{}
 	}
-	var missing []string
-	for _, h := range want {
-		if !hookCommandPresent(hooks, h.event, h.cmd) {
-			missing = append(missing, h.event+":"+h.cmd)
+
+	rewrites, warns := migrateHookProtocolEntries(w, hooks, noFix)
+	if len(rewrites) > 0 && !noFix {
+		root["hooks"] = hooks
+		out, err := json.MarshalIndent(root, "", "  ")
+		if err != nil {
+			_, _ = fmt.Fprintf(w, "  WARN  serialize settings.json: %v\n", err)
+			return true
+		}
+		if err := os.WriteFile(settingsPath, append(out, '\n'), 0o644); err != nil {
+			_, _ = fmt.Fprintf(w, "  WARN  rewrite settings.json: %v\n", err)
+			return true
 		}
 	}
+
+	// Per-entry status — list every bones-owned hook surface so
+	// operators see the picture, not just an aggregate.
+	reportHookEntries(w, hooks)
+
+	missing := missingBonesOwnedHooks(hooks)
 	if len(missing) > 0 {
 		_, _ = fmt.Fprintf(w,
 			"  WARN  .claude/settings.json missing bones hooks: %s — run `bones up` to refresh\n",
 			strings.Join(missing, ", "))
 		return true
 	}
-	_, _ = fmt.Fprintln(w, "  OK    .claude/settings.json has bones-owned hook entries")
+	if warns > 0 {
+		return true
+	}
 	return false
+}
+
+// migrateHookProtocolEntries applies the ADR 0051 migration in
+// place on hooks. Returns the list of human-readable rewrite
+// summaries (for the FIX/WARN log lines) and the WARN count when
+// noFix mode just reports.
+//
+// Operations performed:
+//
+//   - SessionStart: `bones tasks prime --json` → replace command
+//     in-place with `bones tasks prime --hook=session-start`. Move
+//     the entry into a group whose matcher is "startup|compact" so
+//     post-compact sessions also fire the prime.
+//   - PreCompact: any `bones tasks prime *` entry is removed. The
+//     event group is cleaned up if it ends up empty.
+//   - SessionStart: install the canonical prime entry if absent.
+//
+// The function never rewrites a file directly — it mutates the
+// in-memory hooks map; the caller is responsible for marshaling and
+// writing settings.json.
+func migrateHookProtocolEntries(w io.Writer, hooks map[string]any,
+	noFix bool) (rewrites []string, warns int) {
+	primeCmd := clauderhooks.PrimeCommandFor(clauderhooks.EventSessionStart)
+
+	// Rewrite stale SessionStart `bones tasks prime --json` to the
+	// envelope-emitting form, parking the entry under the
+	// "startup|compact" matcher group.
+	if hookCommandPresent(hooks, "SessionStart", "bones tasks prime --json") {
+		summary := "rewrote SessionStart bones tasks prime --json " +
+			"→ --hook=session-start (matcher \"startup|compact\")"
+		if noFix {
+			_, _ = fmt.Fprintf(w,
+				"  WARN  .claude/settings.json: %s — run without --no-fix to apply\n",
+				summary)
+			warns++
+		} else {
+			pruneCommandFromEvent(hooks, "SessionStart", "bones tasks prime --json")
+			addHookWithMatcher(hooks, "SessionStart",
+				clauderhooks.SessionStartMatcher, primeCmd)
+			_, _ = fmt.Fprintf(w,
+				"  FIX   .claude/settings.json: %s\n", summary)
+			rewrites = append(rewrites, summary)
+		}
+	}
+
+	// Remove any `bones tasks prime` entry from PreCompact. Per ADR
+	// 0051 PreCompact has no `additionalContext` mechanism in the
+	// Claude Code hook protocol, so the v0.12 placement was a silent
+	// no-op. Substring match covers --json, --hook=*, and bare forms.
+	if hasPrimeUnderPreCompact(hooks) {
+		summary := "removed PreCompact `bones tasks prime` entry " +
+			"(slot has no additionalContext support; ADR 0051)"
+		if noFix {
+			_, _ = fmt.Fprintf(w,
+				"  WARN  .claude/settings.json: %s — run without --no-fix to apply\n",
+				summary)
+			warns++
+		} else {
+			pruneCommandFromEvent(hooks, "PreCompact", "bones tasks prime")
+			_, _ = fmt.Fprintf(w,
+				"  FIX   .claude/settings.json: %s\n", summary)
+			rewrites = append(rewrites, summary)
+		}
+	}
+
+	// Install the canonical prime entry if it's still missing after
+	// rewrite/migration. Covers a workspace whose v0.12 entries were
+	// hand-pruned but the new form was never installed.
+	if !hookCommandPresent(hooks, "SessionStart", primeCmd) {
+		summary := fmt.Sprintf(
+			"installed SessionStart %s (matcher %q)",
+			primeCmd, clauderhooks.SessionStartMatcher)
+		if noFix {
+			_, _ = fmt.Fprintf(w,
+				"  WARN  .claude/settings.json: %s — run without --no-fix to apply\n",
+				summary)
+			warns++
+		} else {
+			addHookWithMatcher(hooks, "SessionStart",
+				clauderhooks.SessionStartMatcher, primeCmd)
+			_, _ = fmt.Fprintf(w,
+				"  FIX   .claude/settings.json: %s\n", summary)
+			rewrites = append(rewrites, summary)
+		}
+	}
+	return rewrites, warns
+}
+
+// hasPrimeUnderPreCompact reports whether any hook entry under the
+// PreCompact event has a command containing `bones tasks prime`.
+// Used to drive the ADR 0051 PreCompact-prune migration.
+func hasPrimeUnderPreCompact(hooks map[string]any) bool {
+	groups, _ := hooks["PreCompact"].([]any)
+	for _, g := range groups {
+		gm, ok := g.(map[string]any)
+		if !ok {
+			continue
+		}
+		entries, _ := gm["hooks"].([]any)
+		for _, e := range entries {
+			em, ok := e.(map[string]any)
+			if !ok {
+				continue
+			}
+			cmd, _ := em["command"].(string)
+			if strings.Contains(cmd, "bones tasks prime") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// missingBonesOwnedHooks returns the (event, cmd) pairs from
+// bonesOwnedHookCommands that are not present in hooks. Used by
+// checkBonesScaffoldedHooksWith to decide if a WARN should fire.
+func missingBonesOwnedHooks(hooks map[string]any) []string {
+	var missing []string
+	for _, h := range bonesOwnedHookCommands {
+		if !hookCommandPresent(hooks, h.Event, h.Command) {
+			missing = append(missing, h.Event+":"+h.Command)
+		}
+	}
+	return missing
+}
+
+// reportHookEntries prints one line per bones-relevant hook entry so
+// the operator sees per-entry status, not just an aggregate. Mirrors
+// the per-finding line style used elsewhere in doctor.
+func reportHookEntries(w io.Writer, hooks map[string]any) {
+	_, _ = fmt.Fprintln(w, "  hooks:")
+	for _, h := range bonesOwnedHookCommands {
+		status := "OK"
+		if !hookCommandPresent(hooks, h.Event, h.Command) {
+			status = "MISS"
+		}
+		_, _ = fmt.Fprintf(w, "    %-32s %-44s %s\n",
+			h.Event+":", h.Command, status)
+	}
 }
 
 // checkScaffoldGates runs the hooks-presence and SessionStart-sentinel
@@ -285,9 +484,13 @@ func checkBonesScaffoldedHooks(w io.Writer, cwd string) bool {
 //
 // Per issue #252, AGENTS.md is no longer scaffolded by `bones up` and
 // is therefore not checked here.
-func checkScaffoldGates(w io.Writer, cwd string) int {
+//
+// Per ADR 0051 the hook-presence check is also where doctor's
+// auto-rewrite of the Claude Code hook protocol entries lives;
+// noFix=true switches it to report-only.
+func checkScaffoldGates(w io.Writer, cwd string, noFix bool) int {
 	var warns int
-	if checkBonesScaffoldedHooks(w, cwd) {
+	if checkBonesScaffoldedHooksWith(w, cwd, noFix) {
 		warns++
 	}
 	if checkSessionStartSentinel(w, cwd) {

--- a/cli/doctor_all.go
+++ b/cli/doctor_all.go
@@ -106,8 +106,16 @@ func runDoctorPerWorkspace(entries []registry.Entry) []workspaceResult {
 
 // runDoctorOne runs the bypass report for one workspace, capturing output
 // and counting WARN findings. Hub liveness is checked via HTTP probe.
-// Issue count comes from runBypassReportTo's return value, not from
+// Issue count comes from runBypassReportToWith's return value, not from
 // scraping the rendered output.
+//
+// ADR 0051's auto-rewrite is FORCED off here regardless of the
+// caller's --no-fix flag. `bones doctor --all` walks every
+// registered workspace on the host; auto-rewriting all of them on a
+// single invocation is too high a blast radius — the operator may
+// not even be in any of those workspaces' shells. Stale entries
+// surface as WARN lines; the operator runs `bones doctor` (no
+// --all) inside the offending workspace to apply the migration.
 func runDoctorOne(e registry.Entry) workspaceResult {
 	r := workspaceResult{Entry: e}
 
@@ -119,7 +127,8 @@ func runDoctorOne(e registry.Entry) workspaceResult {
 		printFix(&buf, FixForHubDown())
 		r.Issues++
 	}
-	bypassWarns, _ := runBypassReportTo(&buf, e.Cwd)
+	// noFix=true: --all is report-only. See function doc above.
+	bypassWarns, _ := runBypassReportToWith(&buf, e.Cwd, true)
 	r.Issues += bypassWarns
 	r.Detail = buf.String()
 	return r

--- a/cli/doctor_all_test.go
+++ b/cli/doctor_all_test.go
@@ -147,6 +147,107 @@ func TestDoctorAllJSON(t *testing.T) {
 	}
 }
 
+// TestDoctorAll_DoesNotRewriteSettings pins the ADR 0051 contract
+// for --all mode: per-workspace auto-rewrite is off in the
+// multi-workspace path. A `bones doctor --all` invocation walks
+// every registered workspace on the host; rewriting all of them on
+// a single invocation is too high a blast radius. Stale entries
+// surface as WARN lines; the operator runs `bones doctor` (no
+// --all) inside the offending workspace to apply the migration.
+//
+// Fixture: two workspaces, each with a stale v0.12 `bones tasks
+// prime --json` entry under SessionStart. Run renderDoctorAll.
+// Assert: both settings.json files are byte-identical to before
+// (no auto-rewrite); WARN lines surface in the per-workspace
+// detail (so the operator sees the drift).
+func TestDoctorAll_DoesNotRewriteSettings(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+	}))
+	defer srv.Close()
+
+	v012 := `{
+  "hooks": {
+    "SessionStart": [
+      {"matcher": "", "hooks": [
+        {"command": "bones tasks prime --json", "type": "command", "timeout": 10},
+        {"command": "bones hub start", "type": "command", "timeout": 10}
+      ]}
+    ],
+    "PreCompact": [
+      {"matcher": "", "hooks": [
+        {"command": "bones tasks prime --json", "type": "command", "timeout": 10}
+      ]}
+    ]
+  }
+}`
+	type wkFixture struct {
+		dir          string
+		settingsPath string
+		before       []byte
+	}
+	wks := make([]wkFixture, 0, 2)
+	for _, name := range []string{"alpha", "beta"} {
+		dir := makeFakeWorkspace(t, name)
+		settingsDir := filepath.Join(dir, ".claude")
+		if err := os.MkdirAll(settingsDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		settingsPath := filepath.Join(settingsDir, "settings.json")
+		if err := os.WriteFile(settingsPath, []byte(v012), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		before, err := os.ReadFile(settingsPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		wks = append(wks, wkFixture{
+			dir:          dir,
+			settingsPath: settingsPath,
+			before:       before,
+		})
+
+		if err := registry.Write(registry.Entry{
+			Cwd: dir, Name: name, HubURL: srv.URL, NATSURL: "nats://x",
+			HubPID: os.Getpid(), StartedAt: time.Now().UTC(),
+		}); err != nil {
+			t.Fatalf("seed %s: %v", name, err)
+		}
+	}
+
+	var buf bytes.Buffer
+	// ShowOK so the per-workspace detail (including WARN lines) is
+	// rendered even on workspaces flagged as OK by hub-alive checks.
+	renderDoctorAll(&buf, doctorAllOpts{ShowOK: true})
+	out := buf.String()
+
+	for _, wk := range wks {
+		after, err := os.ReadFile(wk.settingsPath)
+		if err != nil {
+			t.Fatalf("read %s: %v", wk.settingsPath, err)
+		}
+		if !bytes.Equal(wk.before, after) {
+			t.Errorf("%s: --all rewrote settings.json; "+
+				"ADR 0051 says --all is report-only.\n"+
+				"--- before ---\n%s\n--- after ---\n%s",
+				wk.dir, wk.before, after)
+		}
+	}
+
+	// The ADR 0051 stale entries must surface as WARN lines in the
+	// rendered output so the operator knows there is drift to fix.
+	if !strings.Contains(out, "WARN") {
+		t.Errorf("--all output did not surface WARN lines for stale " +
+			"hook entries; operator would not know about the drift")
+	}
+	// FIX lines must NOT appear — those would imply auto-rewrite ran.
+	if strings.Contains(out, "FIX") {
+		t.Errorf("--all output contained FIX line; --all must not "+
+			"auto-rewrite (ADR 0051):\n%s", out)
+	}
+}
+
 func TestDoctorAllJSONEmpty(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	var buf bytes.Buffer

--- a/cli/doctor_test.go
+++ b/cli/doctor_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -225,6 +226,297 @@ func TestRunSwarmReport_DoesNotAutoStartHub(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(root, ".bones", "hub.pid")); err == nil {
 		t.Errorf("runSwarmReport created .bones/hub.pid; #228 says it must not write hub state")
+	}
+}
+
+// TestCheckBonesScaffoldedHooks_RewritesV012Prime pins ADR 0051's
+// auto-rewrite for the SessionStart slot: a stale `bones tasks
+// prime --json` entry must be rewritten to the envelope-emitting
+// `bones tasks prime --hook=session-start` form, parked under a
+// "startup|compact" matcher group, when doctor runs in default
+// (auto-fix) mode. The rewrite must surface a single FIX line.
+func TestCheckBonesScaffoldedHooks_RewritesV012Prime(t *testing.T) {
+	dir := t.TempDir()
+	claude := filepath.Join(dir, ".claude")
+	if err := os.MkdirAll(claude, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	v012 := `{
+  "hooks": {
+    "SessionStart": [
+      {"matcher": "", "hooks": [
+        {"command": "bones tasks prime --json", "type": "command", "timeout": 10},
+        {"command": "bones hub start", "type": "command", "timeout": 10}
+      ]}
+    ]
+  }
+}`
+	settingsPath := filepath.Join(claude, "settings.json")
+	if err := os.WriteFile(settingsPath, []byte(v012), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	checkBonesScaffoldedHooks(&buf, dir)
+	out := buf.String()
+
+	if !strings.Contains(out, "FIX") {
+		t.Errorf("expected FIX line for ADR 0051 rewrite, got:\n%s", out)
+	}
+	if !strings.Contains(out, "--hook=session-start") {
+		t.Errorf("expected FIX message naming new envelope flag, got:\n%s", out)
+	}
+
+	got, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := string(got)
+	if strings.Contains(body, "bones tasks prime --json") {
+		t.Errorf("v0.12 `--json` form not pruned by auto-rewrite:\n%s", body)
+	}
+	if !strings.Contains(body, "bones tasks prime --hook=session-start") {
+		t.Errorf("envelope-emitting form not installed by auto-rewrite:\n%s", body)
+	}
+	if !strings.Contains(body, `"matcher": "startup|compact"`) {
+		t.Errorf("startup|compact matcher not installed:\n%s", body)
+	}
+}
+
+// TestCheckBonesScaffoldedHooks_RemovesPreCompactPrime pins ADR 0051's
+// PreCompact-prune: any `bones tasks prime` entry under PreCompact
+// must be removed entirely (PreCompact has no `additionalContext`
+// mechanism in the Claude Code hook protocol; the v0.12 placement
+// was a silent no-op). Removal must surface a single FIX line.
+func TestCheckBonesScaffoldedHooks_RemovesPreCompactPrime(t *testing.T) {
+	dir := t.TempDir()
+	claude := filepath.Join(dir, ".claude")
+	if err := os.MkdirAll(claude, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	v012 := `{
+  "hooks": {
+    "SessionStart": [
+      {"matcher": "startup|compact", "hooks": [
+        {"command": "bones tasks prime --hook=session-start", "type": "command", "timeout": 10}
+      ]},
+      {"matcher": "", "hooks": [
+        {"command": "bones hub start", "type": "command", "timeout": 10}
+      ]}
+    ],
+    "PreCompact": [
+      {"matcher": "", "hooks": [
+        {"command": "bones tasks prime --json", "type": "command", "timeout": 10}
+      ]}
+    ]
+  }
+}`
+	settingsPath := filepath.Join(claude, "settings.json")
+	if err := os.WriteFile(settingsPath, []byte(v012), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	checkBonesScaffoldedHooks(&buf, dir)
+	out := buf.String()
+
+	if !strings.Contains(out, "removed PreCompact") {
+		t.Errorf("expected FIX line about PreCompact removal, got:\n%s", out)
+	}
+
+	got, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := string(got)
+	var parsed map[string]any
+	if err := json.Unmarshal(got, &parsed); err != nil {
+		t.Fatalf("parse rewritten settings: %v", err)
+	}
+	hooks, _ := parsed["hooks"].(map[string]any)
+	pcGroups, _ := hooks["PreCompact"].([]any)
+	for _, g := range pcGroups {
+		gm := g.(map[string]any)
+		entries, _ := gm["hooks"].([]any)
+		for _, e := range entries {
+			em := e.(map[string]any)
+			if cmd, _ := em["command"].(string); strings.Contains(cmd, "bones tasks prime") {
+				t.Errorf("PreCompact still has `%s` after auto-rewrite:\n%s",
+					cmd, body)
+			}
+		}
+	}
+}
+
+// TestCheckBonesScaffoldedHooks_PreservesNonBonesEntries pins that
+// the auto-rewrite does NOT touch user-owned hook entries — only the
+// bones-owned migrations land. A user's PreCompact hook for an
+// unrelated tool must survive intact.
+func TestCheckBonesScaffoldedHooks_PreservesNonBonesEntries(t *testing.T) {
+	dir := t.TempDir()
+	claude := filepath.Join(dir, ".claude")
+	if err := os.MkdirAll(claude, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mixed := `{
+  "hooks": {
+    "SessionStart": [
+      {"matcher": "", "hooks": [
+        {"command": "bones tasks prime --json", "type": "command", "timeout": 10},
+        {"command": "bones hub start", "type": "command", "timeout": 10},
+        {"command": "user-thing", "type": "command", "timeout": 10}
+      ]}
+    ],
+    "PreCompact": [
+      {"matcher": "", "hooks": [
+        {"command": "bones tasks prime --json", "type": "command", "timeout": 10},
+        {"command": "user-precompact-tool", "type": "command", "timeout": 10}
+      ]}
+    ]
+  }
+}`
+	settingsPath := filepath.Join(claude, "settings.json")
+	if err := os.WriteFile(settingsPath, []byte(mixed), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	checkBonesScaffoldedHooks(&buf, dir)
+
+	got, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := string(got)
+	if !strings.Contains(body, "user-thing") {
+		t.Errorf("user-owned SessionStart hook stripped by auto-rewrite:\n%s", body)
+	}
+	if !strings.Contains(body, "user-precompact-tool") {
+		t.Errorf("user-owned PreCompact hook stripped by auto-rewrite "+
+			"(only `bones tasks prime` entries should be removed):\n%s", body)
+	}
+}
+
+// TestCheckBonesScaffoldedHooks_IdempotentOnFreshScaffold pins that
+// running doctor against an already-correct settings.json produces
+// no rewrites. This is the hot path — every doctor run on a healthy
+// workspace must be a no-op on settings.json.
+func TestCheckBonesScaffoldedHooks_IdempotentOnFreshScaffold(t *testing.T) {
+	dir := t.TempDir()
+	claude := filepath.Join(dir, ".claude")
+	if err := os.MkdirAll(claude, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	canonical := `{
+  "hooks": {
+    "SessionStart": [
+      {"matcher": "startup|compact", "hooks": [
+        {"command": "bones tasks prime --hook=session-start", "type": "command", "timeout": 10}
+      ]},
+      {"matcher": "", "hooks": [
+        {"command": "bones hub start", "type": "command", "timeout": 10}
+      ]}
+    ]
+  }
+}`
+	settingsPath := filepath.Join(claude, "settings.json")
+	if err := os.WriteFile(settingsPath, []byte(canonical), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	before, err := os.Stat(settingsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	if checkBonesScaffoldedHooks(&buf, dir) {
+		t.Errorf("idempotent run reported a WARN; output:\n%s", buf.String())
+	}
+	out := buf.String()
+	if strings.Contains(out, "FIX") {
+		t.Errorf("idempotent run emitted FIX line; output:\n%s", out)
+	}
+
+	after, err := os.Stat(settingsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !after.ModTime().Equal(before.ModTime()) {
+		t.Errorf("idempotent doctor run rewrote settings.json " +
+			"(mtime changed); auto-rewrite must no-op on canonical state")
+	}
+}
+
+// TestCheckBonesScaffoldedHooks_NoFixReportsOnly pins that
+// `bones doctor --no-fix` surfaces stale entries as WARN lines but
+// does NOT modify settings.json.
+func TestCheckBonesScaffoldedHooks_NoFixReportsOnly(t *testing.T) {
+	dir := t.TempDir()
+	claude := filepath.Join(dir, ".claude")
+	if err := os.MkdirAll(claude, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	v012 := `{
+  "hooks": {
+    "SessionStart": [
+      {"matcher": "", "hooks": [
+        {"command": "bones tasks prime --json", "type": "command", "timeout": 10},
+        {"command": "bones hub start", "type": "command", "timeout": 10}
+      ]}
+    ],
+    "PreCompact": [
+      {"matcher": "", "hooks": [
+        {"command": "bones tasks prime --json", "type": "command", "timeout": 10}
+      ]}
+    ]
+  }
+}`
+	settingsPath := filepath.Join(claude, "settings.json")
+	if err := os.WriteFile(settingsPath, []byte(v012), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	before, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	if !checkBonesScaffoldedHooksWith(&buf, dir, true /* noFix */) {
+		t.Errorf("--no-fix run on stale settings should emit WARN; output:\n%s",
+			buf.String())
+	}
+	out := buf.String()
+	if strings.Contains(out, "FIX") {
+		t.Errorf("--no-fix run emitted FIX line; output:\n%s", out)
+	}
+	if !strings.Contains(out, "WARN") {
+		t.Errorf("--no-fix run on stale settings did not WARN; output:\n%s", out)
+	}
+
+	after, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(before, after) {
+		t.Errorf("--no-fix run modified settings.json; auto-rewrite " +
+			"must respect --no-fix")
+	}
+}
+
+// TestDoctorCmd_AcceptsNoFixFlag verifies Kong wires up the new
+// flag. Existence of the flag is the contract — the actual
+// auto-rewrite behavior is tested via the unit tests above.
+func TestDoctorCmd_AcceptsNoFixFlag(t *testing.T) {
+	var c DoctorCmd
+	parser, err := kong.New(&c)
+	if err != nil {
+		t.Fatalf("kong.New: %v", err)
+	}
+	if _, err := parser.Parse([]string{"--no-fix"}); err != nil {
+		t.Fatalf("parse --no-fix: %v", err)
+	}
+	if !c.NoFix {
+		t.Fatalf("NoFix flag not set")
 	}
 }
 

--- a/cli/manifest_test.go
+++ b/cli/manifest_test.go
@@ -132,22 +132,25 @@ func TestWriteManifest_OmitsRollingFiles(t *testing.T) {
 // non-bones hook to settings.json does NOT change the recorded
 // SettingsHooksSHA256. The hash is computed over the bones-owned
 // subset only.
+//
+// Per ADR 0051 PreCompact is no longer a bones-owned slot — entries
+// there (whatever shape) must NOT influence the hash.
 func TestHashBonesOwnedHooks_IgnoresUserHooks(t *testing.T) {
 	bonesOnly := map[string]any{
 		"SessionStart": []any{
 			map[string]any{
-				"matcher": "",
+				"matcher": "startup|compact",
 				"hooks": []any{
-					map[string]any{"command": "bones tasks prime --json", "type": "command"},
-					map[string]any{"command": "bones hub start", "type": "command"},
+					map[string]any{
+						"command": "bones tasks prime --hook=session-start",
+						"type":    "command",
+					},
 				},
 			},
-		},
-		"PreCompact": []any{
 			map[string]any{
 				"matcher": "",
 				"hooks": []any{
-					map[string]any{"command": "bones tasks prime --json", "type": "command"},
+					map[string]any{"command": "bones hub start", "type": "command"},
 				},
 			},
 		},
@@ -155,19 +158,30 @@ func TestHashBonesOwnedHooks_IgnoresUserHooks(t *testing.T) {
 	bonesPlusUser := map[string]any{
 		"SessionStart": []any{
 			map[string]any{
+				"matcher": "startup|compact",
+				"hooks": []any{
+					map[string]any{
+						"command": "bones tasks prime --hook=session-start",
+						"type":    "command",
+					},
+				},
+			},
+			map[string]any{
 				"matcher": "",
 				"hooks": []any{
-					map[string]any{"command": "bones tasks prime --json", "type": "command"},
 					map[string]any{"command": "bones hub start", "type": "command"},
 					map[string]any{"command": "user-thing", "type": "command"},
 				},
 			},
 		},
+		// User-owned PreCompact entry — must be ignored by the
+		// bones-owned hash (PreCompact is not in
+		// bonesOwnedHookCommands per ADR 0051).
 		"PreCompact": []any{
 			map[string]any{
 				"matcher": "",
 				"hooks": []any{
-					map[string]any{"command": "bones tasks prime --json", "type": "command"},
+					map[string]any{"command": "user-precompact", "type": "command"},
 				},
 			},
 		},
@@ -198,18 +212,18 @@ func TestHashBonesOwnedHooks_DetectsMissingBonesHook(t *testing.T) {
 	full := map[string]any{
 		"SessionStart": []any{
 			map[string]any{
-				"matcher": "",
+				"matcher": "startup|compact",
 				"hooks": []any{
-					map[string]any{"command": "bones tasks prime --json", "type": "command"},
-					map[string]any{"command": "bones hub start", "type": "command"},
+					map[string]any{
+						"command": "bones tasks prime --hook=session-start",
+						"type":    "command",
+					},
 				},
 			},
-		},
-		"PreCompact": []any{
 			map[string]any{
 				"matcher": "",
 				"hooks": []any{
-					map[string]any{"command": "bones tasks prime --json", "type": "command"},
+					map[string]any{"command": "bones hub start", "type": "command"},
 				},
 			},
 		},
@@ -217,17 +231,12 @@ func TestHashBonesOwnedHooks_DetectsMissingBonesHook(t *testing.T) {
 	missingHubStart := map[string]any{
 		"SessionStart": []any{
 			map[string]any{
-				"matcher": "",
+				"matcher": "startup|compact",
 				"hooks": []any{
-					map[string]any{"command": "bones tasks prime --json", "type": "command"},
-				},
-			},
-		},
-		"PreCompact": []any{
-			map[string]any{
-				"matcher": "",
-				"hooks": []any{
-					map[string]any{"command": "bones tasks prime --json", "type": "command"},
+					map[string]any{
+						"command": "bones tasks prime --hook=session-start",
+						"type":    "command",
+					},
 				},
 			},
 		},

--- a/cli/orchestrator.go
+++ b/cli/orchestrator.go
@@ -210,16 +210,21 @@ func mergeSettings(path string, fp *scaffoldFootprint) error {
 
 	// ADR 0051 migration: the v0.12 SessionStart `bones tasks prime
 	// --json` entry was a Claude-Code-protocol no-op; replace it
-	// with the envelope-emitting form. We prune by exact command
-	// string so user-added variants are left alone.
+	// with the envelope-emitting form. pruneCommandFromEvent
+	// substring-matches, but the needle here is specific enough
+	// (`bones tasks prime --json`) that it only catches the v0.12
+	// command — user-added prime variants in other shapes survive.
 	pruneCommandFromEvent(hooks, "SessionStart", "bones tasks prime --json")
 
 	// ADR 0051 migration: PreCompact has no `additionalContext`
 	// mechanism documented in the Claude Code hook protocol. Any
 	// `bones tasks prime` entry there never injected context — drop
-	// every such entry. We use a substring match so the prune
-	// covers --json, --hook=*, and bare `bones tasks prime` forms
-	// equally.
+	// every such entry. PreCompact is no longer a bones-owned slot
+	// per ADR 0051; the broader `bones tasks prime` substring needle
+	// is intentional here so --json, --hook=*, and bare forms are
+	// removed equally. User scripts that happen to invoke
+	// `bones tasks prime` from PreCompact are exceptional and would
+	// have been a v0.12-era workaround; they are not preserved.
 	pruneCommandFromEvent(hooks, "PreCompact", "bones tasks prime")
 
 	// Install the canonical envelope-emitting prime entry under

--- a/cli/orchestrator.go
+++ b/cli/orchestrator.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/danmestas/bones/internal/clauderhooks"
 	"github.com/danmestas/bones/internal/scaffoldver"
 	"github.com/danmestas/bones/internal/version"
 )
@@ -145,15 +146,32 @@ func removeLegacyBonesSkills(root string) error {
 	return nil
 }
 
-// mergeSettings idempotently installs the SessionStart + PreCompact
-// hooks bones relies on into the consumer's .claude/settings.json.
-// Creates the file if absent. Preserves all existing top-level keys,
-// hook events, and entries.
+// mergeSettings idempotently installs the SessionStart hooks bones
+// relies on into the consumer's .claude/settings.json. Creates the
+// file if absent. Preserves all existing top-level keys, hook events,
+// and entries.
 //
 // Per ADR 0041 the SessionStart hub-startup entry is `bones hub start`
 // (not the legacy bash hub-bootstrap.sh shim). Pre-ADR-0041 entries are
 // pruned during scaffold so re-running over an existing workspace does
 // not leave the legacy command coexisting with the new one.
+//
+// Per ADR 0051 (Claude Code hook protocol contract) bones tasks prime
+// now emits the documented `hookSpecificOutput`/`additionalContext`
+// envelope via `--hook=session-start`. The pre-ADR-0051 invocation
+// `bones tasks prime --json` printed the bones-shape JSON Claude Code
+// did not understand and silently dropped — see the ADR for the
+// migration story. mergeSettings:
+//
+//   - prunes the v0.12 `bones tasks prime --json` entry from any
+//     SessionStart group it appears in (legacy);
+//   - prunes any `bones tasks prime` entry from PreCompact entirely
+//     (PreCompact has no `additionalContext` mechanism in the Claude
+//     Code hook protocol — it was the wrong slot from day one);
+//   - installs `bones tasks prime --hook=session-start` under
+//     SessionStart with matcher `startup|compact`, which fires on
+//     fresh sessions AND after manual / auto compaction, replacing
+//     the broken v0.12 PreCompact slot.
 //
 // Hub teardown is no longer wired into any session lifecycle hook. Per
 // ADR 0038 the hub is workspace-scoped and `bones down` is the explicit
@@ -190,19 +208,38 @@ func mergeSettings(path string, fp *scaffoldFootprint) error {
 	migrateStopToSessionEnd(hooks)
 	migrateSessionEndShutdown(hooks)
 
-	// Prime first so task context lands in the agent's window before any
-	// other hook output. coord.Prime is the only thing that survives
-	// session boundaries — specs written outside `bones tasks` evaporate
-	// at the next compaction, which keeps planners filing atomic work
-	// rather than bypassing the tracker with freeform docs.
-	if addHook(hooks, "SessionStart", "bones tasks prime --json") {
+	// ADR 0051 migration: the v0.12 SessionStart `bones tasks prime
+	// --json` entry was a Claude-Code-protocol no-op; replace it
+	// with the envelope-emitting form. We prune by exact command
+	// string so user-added variants are left alone.
+	pruneCommandFromEvent(hooks, "SessionStart", "bones tasks prime --json")
+
+	// ADR 0051 migration: PreCompact has no `additionalContext`
+	// mechanism documented in the Claude Code hook protocol. Any
+	// `bones tasks prime` entry there never injected context — drop
+	// every such entry. We use a substring match so the prune
+	// covers --json, --hook=*, and bare `bones tasks prime` forms
+	// equally.
+	pruneCommandFromEvent(hooks, "PreCompact", "bones tasks prime")
+
+	// Install the canonical envelope-emitting prime entry under
+	// SessionStart with matcher "startup|compact" so the same hook
+	// fires on fresh sessions AND after compaction. The matcher is
+	// the documented Claude Code "exact strings, pipe-separated"
+	// form (see ADR 0051 §"PreCompact is not the right slot" for
+	// why this replaces the v0.12 PreCompact placement).
+	primeCmd := clauderhooks.PrimeCommandFor(clauderhooks.EventSessionStart)
+	if addHookWithMatcher(hooks, "SessionStart",
+		clauderhooks.SessionStartMatcher, primeCmd) {
 		recordHook(fp, "SessionStart")
 	}
+
+	// `bones hub start` keeps its existing default-matcher placement
+	// (every session starts the hub if not already running). It is
+	// not subject to ADR 0051's envelope contract — it's a
+	// side-effecting daemon launcher, not a context-injection hook.
 	if addHook(hooks, "SessionStart", "bones hub start") {
 		recordHook(fp, "SessionStart")
-	}
-	if addHook(hooks, "PreCompact", "bones tasks prime --json") {
-		recordHook(fp, "PreCompact")
 	}
 
 	root["hooks"] = hooks
@@ -295,7 +332,22 @@ func pruneCommandFromEvent(hooks map[string]any, event, needle string) {
 // addHook returns true when a fresh entry was appended, false when the
 // hook was already present (idempotent no-op). The boolean lets the
 // caller report a precise "merged N hooks" count in the up summary.
+//
+// Default matcher is "" (fires on every occurrence of the event). For
+// matcher-scoped placement use addHookWithMatcher.
 func addHook(hooks map[string]any, event, cmd string) bool {
+	return addHookWithMatcher(hooks, event, "", cmd)
+}
+
+// addHookWithMatcher is the matcher-aware sibling of addHook. It
+// places cmd under the hook group whose `matcher` field equals the
+// requested matcher, creating that group if absent. Idempotent:
+// re-adding the same (event, matcher, cmd) tuple is a no-op.
+//
+// Per ADR 0051 bones uses matcher "startup|compact" on SessionStart
+// for the prime entry so a single command covers fresh sessions
+// AND post-compact sessions.
+func addHookWithMatcher(hooks map[string]any, event, matcher, cmd string) bool {
 	groups, _ := hooks[event].([]any)
 
 	grpIdx := -1
@@ -304,15 +356,15 @@ func addHook(hooks map[string]any, event, cmd string) bool {
 		if !ok {
 			continue
 		}
-		matcher, _ := gm["matcher"].(string)
-		if matcher == "" {
+		mv, _ := gm["matcher"].(string)
+		if mv == matcher {
 			grpIdx = i
 			break
 		}
 	}
 	if grpIdx == -1 {
 		groups = append(groups, map[string]any{
-			"matcher": "",
+			"matcher": matcher,
 			"hooks":   []any{},
 		})
 		grpIdx = len(groups) - 1

--- a/cli/orchestrator_test.go
+++ b/cli/orchestrator_test.go
@@ -389,45 +389,114 @@ func countHookCommand(settings map[string]any, event, cmd string) int {
 	return n
 }
 
+// matcherForCommand returns the matcher string of the hook group
+// containing cmd under settings.hooks[event]. Empty string if the
+// command is not found or its group has no matcher set. Used to pin
+// ADR 0051's matcher-aware placement.
+func matcherForCommand(settings map[string]any, event, cmd string) string {
+	hooks, _ := settings["hooks"].(map[string]any)
+	groups, _ := hooks[event].([]any)
+	for _, g := range groups {
+		gm, ok := g.(map[string]any)
+		if !ok {
+			continue
+		}
+		entries, _ := gm["hooks"].([]any)
+		for _, e := range entries {
+			em, ok := e.(map[string]any)
+			if !ok {
+				continue
+			}
+			if c, _ := em["command"].(string); c == cmd {
+				m, _ := gm["matcher"].(string)
+				return m
+			}
+		}
+	}
+	return ""
+}
+
 // TestScaffoldOrchestrator_SessionStartIncludesPrime asserts that the
-// scaffold injects `bones tasks prime --json` into SessionStart so a
-// fresh agent's context boots from the tasks substrate. Without this,
-// freeform specs written outside `bones tasks` survive session
-// boundaries on equal footing with filed tasks, which removes the
-// "tasks-as-survivor" pressure that keeps planners filing atomic work.
+// scaffold injects the envelope-emitting `bones tasks prime --hook=
+// session-start` into SessionStart so a fresh agent's context boots
+// from the tasks substrate. Without this, freeform specs written
+// outside `bones tasks` survive session boundaries on equal footing
+// with filed tasks, which removes the "tasks-as-survivor" pressure
+// that keeps planners filing atomic work.
+//
+// Per ADR 0051 the v0.12 `--json` form was a Claude-Code-protocol
+// no-op (it printed the bones-shape JSON Claude Code did not parse);
+// the canonical install now writes the envelope-emitting form.
 func TestScaffoldOrchestrator_SessionStartIncludesPrime(t *testing.T) {
 	dir := t.TempDir()
 	if _, err := scaffoldOrchestrator(dir, scaffoldOpts{}); err != nil {
 		t.Fatalf("scaffoldOrchestrator: %v", err)
 	}
 	cmds := hookCommandsFor(readSettings(t, dir), "SessionStart")
-	want := "bones tasks prime --json"
+	want := "bones tasks prime --hook=session-start"
 	if !slices.Contains(cmds, want) {
 		t.Fatalf("SessionStart hooks missing %q; got %v", want, cmds)
 	}
+	// The pre-ADR-0051 `--json` form must NOT be installed: it was
+	// the silently-broken v0.12 entry.
+	for _, c := range cmds {
+		if c == "bones tasks prime --json" {
+			t.Errorf("legacy v0.12 `bones tasks prime --json` "+
+				"still installed (ADR 0051 says drop it); got: %v", cmds)
+		}
+	}
 }
 
-// TestScaffoldOrchestrator_PreCompactIncludesPrime asserts the
-// PreCompact event runs `bones tasks prime --json`. Compaction is the
-// longer-horizon failure mode for narrative drift — wiring SessionStart
-// alone leaves a multi-hour window where freeform context can win.
-func TestScaffoldOrchestrator_PreCompactIncludesPrime(t *testing.T) {
+// TestScaffoldOrchestrator_PreCompactHasNoPrime asserts that ADR 0051's
+// "PreCompact is the wrong slot" decision is enforced at scaffold time:
+// no `bones tasks prime` entry of any form may be installed under
+// PreCompact, and the event group itself should be empty (or absent)
+// after a fresh scaffold. The Claude Code hook protocol does not
+// document an `additionalContext` mechanism for PreCompact, so any
+// such entry was a silent no-op in v0.12.
+//
+// Replaces the old TestScaffoldOrchestrator_PreCompactIncludesPrime
+// which pinned the broken-by-design v0.12 placement.
+func TestScaffoldOrchestrator_PreCompactHasNoPrime(t *testing.T) {
 	dir := t.TempDir()
 	if _, err := scaffoldOrchestrator(dir, scaffoldOpts{}); err != nil {
 		t.Fatalf("scaffoldOrchestrator: %v", err)
 	}
 	cmds := hookCommandsFor(readSettings(t, dir), "PreCompact")
-	want := "bones tasks prime --json"
-	if !slices.Contains(cmds, want) {
-		t.Fatalf("PreCompact hooks missing %q; got %v", want, cmds)
+	for _, c := range cmds {
+		if strings.Contains(c, "bones tasks prime") {
+			t.Errorf("PreCompact must not carry any `bones tasks prime` "+
+				"entry per ADR 0051; got %q", c)
+		}
+	}
+}
+
+// TestScaffoldOrchestrator_SessionStartPrimeMatcher pins the
+// "startup|compact" matcher placement: ADR 0051 substitutes the
+// SessionStart `compact` matcher for the v0.12 PreCompact slot. A
+// single hook entry must cover both fresh sessions and post-compact
+// sessions, so the prime entry's group must carry the documented
+// pipe-alternation matcher rather than the default `""` matcher.
+func TestScaffoldOrchestrator_SessionStartPrimeMatcher(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := scaffoldOrchestrator(dir, scaffoldOpts{}); err != nil {
+		t.Fatalf("scaffoldOrchestrator: %v", err)
+	}
+	settings := readSettings(t, dir)
+	matcher := matcherForCommand(settings, "SessionStart",
+		"bones tasks prime --hook=session-start")
+	if matcher != "startup|compact" {
+		t.Errorf("SessionStart prime matcher = %q, want %q "+
+			"(ADR 0051 §PreCompact-is-not-the-right-slot)",
+			matcher, "startup|compact")
 	}
 }
 
 // TestScaffoldOrchestrator_PrimeHookIdempotent asserts that re-running
-// `bones up` does not duplicate the prime entries. Locks in the
-// addHook dedup contract — without it, a downstream user who runs
+// `bones up` does not duplicate the prime entry. Locks in the addHook
+// dedup contract — without it, a downstream user who runs
 // `bones up --reinstall-hooks` repeatedly would accumulate multiple
-// prime calls per event.
+// prime calls.
 func TestScaffoldOrchestrator_PrimeHookIdempotent(t *testing.T) {
 	dir := t.TempDir()
 	for i := range 3 {
@@ -436,10 +505,66 @@ func TestScaffoldOrchestrator_PrimeHookIdempotent(t *testing.T) {
 		}
 	}
 	settings := readSettings(t, dir)
-	const cmd = "bones tasks prime --json"
-	for _, event := range []string{"SessionStart", "PreCompact"} {
-		if got := countHookCommand(settings, event, cmd); got != 1 {
-			t.Errorf("%s prime entry count = %d, want 1", event, got)
+	const cmd = "bones tasks prime --hook=session-start"
+	if got := countHookCommand(settings, "SessionStart", cmd); got != 1 {
+		t.Errorf("SessionStart prime entry count = %d, want 1", got)
+	}
+}
+
+// TestScaffoldOrchestrator_MigratesV012PrimeJSON pins ADR 0051's
+// auto-migration contract for `bones up` re-run: a workspace whose
+// settings.json has the v0.12 `bones tasks prime --json` entries
+// (one under SessionStart, one under PreCompact) must, after
+// scaffoldOrchestrator runs, contain only the new `--hook=session-
+// start` entry. The legacy entries are pruned, the new entry is
+// installed, and PreCompact is left without any prime entry.
+func TestScaffoldOrchestrator_MigratesV012PrimeJSON(t *testing.T) {
+	dir := t.TempDir()
+	settingsPath := filepath.Join(dir, ".claude", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	v012 := `{
+  "hooks": {
+    "SessionStart": [
+      {"matcher": "", "hooks": [
+        {"command": "bones tasks prime --json", "type": "command", "timeout": 10},
+        {"command": "bones hub start", "type": "command", "timeout": 10}
+      ]}
+    ],
+    "PreCompact": [
+      {"matcher": "", "hooks": [
+        {"command": "bones tasks prime --json", "type": "command", "timeout": 10}
+      ]}
+    ]
+  }
+}`
+	if err := os.WriteFile(settingsPath, []byte(v012), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := scaffoldOrchestrator(dir, scaffoldOpts{}); err != nil {
+		t.Fatalf("scaffoldOrchestrator: %v", err)
+	}
+	settings := readSettings(t, dir)
+
+	// New form is installed.
+	ssCmds := hookCommandsFor(settings, "SessionStart")
+	if !slices.Contains(ssCmds, "bones tasks prime --hook=session-start") {
+		t.Errorf("envelope-emitting prime not installed; SessionStart=%v", ssCmds)
+	}
+	// Legacy form is pruned.
+	if slices.Contains(ssCmds, "bones tasks prime --json") {
+		t.Errorf("legacy SessionStart `bones tasks prime --json` not pruned; "+
+			"SessionStart=%v", ssCmds)
+	}
+	// PreCompact entries are gone (per ADR 0051: wrong slot, no
+	// `additionalContext` support).
+	pcCmds := hookCommandsFor(settings, "PreCompact")
+	for _, c := range pcCmds {
+		if strings.Contains(c, "bones tasks prime") {
+			t.Errorf("PreCompact `bones tasks prime` not pruned by ADR 0051 "+
+				"migration; got %q", c)
 		}
 	}
 }

--- a/cli/skills.go
+++ b/cli/skills.go
@@ -122,10 +122,18 @@ type skillManifest struct {
 // entries — not the whole settings.json, because the user is free to
 // add their own hooks alongside bones's, and the manifest must not
 // false-positive on those.
+//
+// Per ADR 0051 the canonical prime command is the envelope-emitting
+// `--hook=session-start` form, placed under SessionStart only with
+// matcher "startup|compact" (a single entry covers fresh sessions
+// AND post-compact sessions). PreCompact is no longer a bones-owned
+// slot: that event has no `additionalContext` mechanism in the
+// Claude Code hook protocol so the v0.12 PreCompact `bones tasks
+// prime --json` entry was a silent no-op. doctor's auto-rewrite
+// migrates legacy installs forward.
 var bonesOwnedHookCommands = []struct{ Event, Command string }{
-	{"SessionStart", "bones tasks prime --json"},
+	{"SessionStart", "bones tasks prime --hook=session-start"},
 	{"SessionStart", "bones hub start"},
-	{"PreCompact", "bones tasks prime --json"},
 }
 
 // writeBonesSkills materializes the embedded skill bundle into

--- a/cli/tasks_prime.go
+++ b/cli/tasks_prime.go
@@ -9,24 +9,53 @@ import (
 
 	repocli "github.com/danmestas/EdgeSync/cli/repo"
 
+	"github.com/danmestas/bones/internal/clauderhooks"
 	"github.com/danmestas/bones/internal/coord"
 	"github.com/danmestas/bones/internal/version"
 )
 
 // SessionStartSentinelFile is the workspace-relative path of the
-// SessionStart hook sentinel. `bones tasks prime` (wired as both
-// SessionStart and PreCompact hooks by `bones up`) refreshes the file
-// on entry, and `bones doctor` reads it to detect "hooks configured
-// but never fire" failure modes (#172).
+// SessionStart hook sentinel. `bones tasks prime` (wired as a
+// SessionStart hook by `bones up`) refreshes the file on entry,
+// and `bones doctor` reads it to detect "hooks configured but never
+// fire" failure modes (#172).
 const SessionStartSentinelFile = ".bones/last-session-prime"
 
 // TasksPrimeCmd prints an agent context summary (open/ready/claimed tasks,
 // recent threads, peers online).
+//
+// Three output modes:
+//
+//   - default (no flags): human-readable markdown via formatPrime().
+//   - --json: raw bones JSON shape ({open_tasks, ready_tasks, ...}).
+//     Stable contract for operator scripts (separately governed by
+//     issue #321's schema-contract work).
+//   - --hook=session-start: Claude Code hook protocol envelope wrapping
+//     the formatPrime() markdown in `hookSpecificOutput.additionalContext`.
+//     This is the form `bones up` writes into .claude/settings.json
+//     so Claude Code's SessionStart hook reader actually injects bones
+//     context into the agent window. See ADR 0051.
+//
+// `--json` and `--hook=X` describe two distinct consumers and are
+// mutually exclusive: the operator-script surface (--json) and the
+// Claude Code protocol surface (--hook). Combining them is a CLI
+// error.
 type TasksPrimeCmd struct {
-	JSON bool `name:"json" help:"emit JSON"`
+	JSON bool `name:"json" help:"emit raw bones JSON shape (operator scripts)"`
+	// Hook selects an event whose Claude Code hook envelope should
+	// be emitted. Empty (default) means no envelope. See ADR 0051
+	// for the supported values and the protocol contract.
+	Hook string `name:"hook" enum:"session-start," default:"" help:"emit Claude Code hook envelope"`
 }
 
 func (c *TasksPrimeCmd) Run(g *repocli.Globals) error {
+	if c.JSON && c.Hook != "" {
+		return fmt.Errorf("--json and --hook=%s are mutually exclusive: "+
+			"--json is the bones-shape operator surface; "+
+			"--hook is the Claude Code protocol surface (ADR 0051)",
+			c.Hook)
+	}
+
 	ctx, stop, info, err := joinWorkspace()
 	if err != nil {
 		return err
@@ -51,7 +80,18 @@ func (c *TasksPrimeCmd) Run(g *repocli.Globals) error {
 		if err != nil {
 			return err
 		}
-		if c.JSON {
+		switch {
+		case c.Hook != "":
+			// ADR 0051: emit the Claude Code hook envelope so the
+			// SessionStart hook reader injects formatPrime()'s
+			// markdown into the agent's context window.
+			event, ok := clauderhooks.FlagToEvent(clauderhooks.FlagValue(c.Hook))
+			if !ok {
+				return fmt.Errorf("unknown --hook value %q (ADR 0051)", c.Hook)
+			}
+			env := clauderhooks.NewEnvelope(event, formatPrime(result))
+			return clauderhooks.Emit(os.Stdout, env)
+		case c.JSON:
 			// Always emit the envelope, even when the workspace
 			// has zero tasks/threads/peers. The SessionStart hook
 			// attaches stdout into agent context: an empty payload
@@ -59,9 +99,10 @@ func (c *TasksPrimeCmd) Run(g *repocli.Globals) error {
 			// while an empty-but-present envelope is the "bones is
 			// here, nothing claimed yet" signal (#170).
 			return emitJSON(os.Stdout, primeToJSON(result))
+		default:
+			fmt.Print(formatPrime(result))
+			return nil
 		}
-		fmt.Print(formatPrime(result))
-		return nil
 	}))
 }
 

--- a/cli/tasks_prime_test.go
+++ b/cli/tasks_prime_test.go
@@ -3,15 +3,21 @@ package cli
 import (
 	"bytes"
 	"encoding/json"
+	"strings"
 	"testing"
 
+	"github.com/alecthomas/kong"
+	"github.com/danmestas/bones/internal/clauderhooks"
 	"github.com/danmestas/bones/internal/coord"
 )
 
 // TestPrimeJSON_ZeroTasksEnvelope pins #170: when the workspace has
 // zero tasks, zero threads, and zero peers, `bones tasks prime --json`
-// must still emit a non-empty envelope so the SessionStart hook
-// injects a "bones is active here" signal into agent context.
+// must still emit a non-empty envelope so a downstream operator
+// script reading the bones-shape JSON sees the workspace is active.
+//
+// `--json` is the operator-script surface (separately governed by
+// issue #321) — it stays unchanged by ADR 0051's hook-protocol work.
 //
 // The envelope must round-trip with the documented top-level keys
 // — open_tasks, ready_tasks, claimed_tasks, threads, peers — and
@@ -63,5 +69,97 @@ func TestPrimeJSON_PopulatedEnvelope(t *testing.T) {
 	}
 	if _, ok := got["open_tasks"]; !ok {
 		t.Errorf("populated envelope missing open_tasks; got=%q", buf.String())
+	}
+}
+
+// TestTasksPrimeCmd_JSONHookMutex pins ADR 0051's CLI contract:
+// `--json` (operator-script surface) and `--hook=X` (Claude Code
+// protocol surface) describe two distinct consumers and must not
+// be combinable. Kong's parser accepts both flags individually; the
+// combination must error at Run() time.
+func TestTasksPrimeCmd_JSONHookMutex(t *testing.T) {
+	var c TasksPrimeCmd
+	parser, err := kong.New(&c)
+	if err != nil {
+		t.Fatalf("kong.New: %v", err)
+	}
+	if _, err := parser.Parse([]string{"--json", "--hook=session-start"}); err != nil {
+		t.Fatalf("kong parse should accept both flags individually; got %v", err)
+	}
+	err = c.Run(nil)
+	if err == nil {
+		t.Fatal("Run() with --json + --hook=session-start must error")
+	}
+	if !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Errorf("error should mention mutual exclusion; got: %v", err)
+	}
+}
+
+// TestTasksPrimeCmd_HookFlagAcceptsSessionStart verifies Kong parses
+// the supported --hook value. The blank "" alternative in the enum
+// list lets the absent flag round-trip cleanly.
+func TestTasksPrimeCmd_HookFlagAcceptsSessionStart(t *testing.T) {
+	var c TasksPrimeCmd
+	parser, err := kong.New(&c)
+	if err != nil {
+		t.Fatalf("kong.New: %v", err)
+	}
+	if _, err := parser.Parse([]string{"--hook=session-start"}); err != nil {
+		t.Fatalf("parse --hook=session-start: %v", err)
+	}
+	if c.Hook != "session-start" {
+		t.Errorf("Hook = %q, want session-start", c.Hook)
+	}
+}
+
+// TestTasksPrimeCmd_HookFlagRejectsUnknown pins that Kong's enum
+// constraint refuses unsupported values. `--hook=pre-compact` was
+// considered and rejected (ADR 0051 §"PreCompact is not the right
+// slot") — Kong must surface an error.
+func TestTasksPrimeCmd_HookFlagRejectsUnknown(t *testing.T) {
+	var c TasksPrimeCmd
+	parser, err := kong.New(&c)
+	if err != nil {
+		t.Fatalf("kong.New: %v", err)
+	}
+	if _, err := parser.Parse([]string{"--hook=pre-compact"}); err == nil {
+		t.Errorf("--hook=pre-compact must be rejected (ADR 0051): " +
+			"PreCompact has no additionalContext mechanism in the " +
+			"Claude Code hook protocol")
+	}
+}
+
+// TestEmitHookEnvelope_RoundtripSessionStart pins ADR 0051's
+// roundtrip contract at the cli/ layer: emit a SessionStart envelope
+// using the same helper bones tasks prime uses, parse it, and assert
+// `additionalContext` carries the formatPrime() markdown. This is
+// the cli/-level mirror of clauderhooks/envelope_test.go's package
+// roundtrip — it guards against a future cli/ refactor accidentally
+// stripping the envelope.
+func TestEmitHookEnvelope_RoundtripSessionStart(t *testing.T) {
+	want := formatPrime(coord.PrimeResult{})
+	env := clauderhooks.NewEnvelope(clauderhooks.EventSessionStart, want)
+
+	var buf bytes.Buffer
+	if err := clauderhooks.Emit(&buf, env); err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+
+	got, err := clauderhooks.Parse(buf.Bytes())
+	if err != nil {
+		t.Fatalf("Parse: %v\npayload=%q", err, buf.String())
+	}
+	if got.HookSpecificOutput.HookEventName != clauderhooks.EventSessionStart {
+		t.Errorf("hookEventName = %q, want SessionStart",
+			got.HookSpecificOutput.HookEventName)
+	}
+	if got.HookSpecificOutput.AdditionalContext != want {
+		t.Errorf("additionalContext mismatch:\ngot:  %q\nwant: %q",
+			got.HookSpecificOutput.AdditionalContext, want)
+	}
+	if !strings.Contains(got.HookSpecificOutput.AdditionalContext,
+		"# Agent Tasks Context") {
+		t.Errorf("envelope additionalContext lost the formatPrime() " +
+			"markdown header; check formatPrime drift")
 	}
 }

--- a/cli/up_test.go
+++ b/cli/up_test.go
@@ -185,8 +185,10 @@ func TestScaffoldOrchestrator_RecoversFromHalfInstall(t *testing.T) {
 		[]byte("test-agent"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	// Simulate a half-merged settings.json: bones SessionStart hook is
-	// in but PreCompact is not.
+	// Simulate a half-merged settings.json: bones SessionStart entry
+	// for the (legacy) prime hook is in, but `bones hub start` and
+	// the migration to ADR 0051's --hook=session-start form have not
+	// run.
 	settingsDir := filepath.Join(dir, ".claude")
 	if err := os.MkdirAll(settingsDir, 0o755); err != nil {
 		t.Fatal(err)
@@ -207,19 +209,26 @@ func TestScaffoldOrchestrator_RecoversFromHalfInstall(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(bones, "scaffold_version")); err != nil {
 		t.Errorf("scaffold_version stamp not written after recovery: %v", err)
 	}
-	// settings.json now has the full hook set.
+	// settings.json now has the full ADR 0051 hook set: the new
+	// envelope-emitting prime form + bones hub start. Per ADR 0051,
+	// the legacy `--json` form is migrated away during recovery.
 	data, err := os.ReadFile(filepath.Join(settingsDir, "settings.json"))
 	if err != nil {
 		t.Fatal(err)
 	}
 	body := string(data)
 	for _, want := range []string{
-		"bones tasks prime --json", // present in partial
-		"bones hub start",          // added by recovery
+		"bones tasks prime --hook=session-start", // ADR 0051 canonical form
+		"bones hub start",                        // added by recovery
 	} {
 		if !strings.Contains(body, want) {
 			t.Errorf("settings.json missing %q after recovery:\n%s", want, body)
 		}
+	}
+	// Legacy form must have been migrated out.
+	if strings.Contains(body, "bones tasks prime --json") {
+		t.Errorf("legacy `bones tasks prime --json` survived "+
+			"ADR 0051 migration:\n%s", body)
 	}
 
 	// Idempotent: a third run produces a byte-identical settings.json.

--- a/cmd/bones/integration/up_recovery_test.go
+++ b/cmd/bones/integration/up_recovery_test.go
@@ -63,7 +63,11 @@ func TestCLI_UpRecoversFromHalfInstall(t *testing.T) {
 		t.Fatalf("read settings.json: %v", err)
 	}
 	body := string(settingsData)
-	for _, want := range []string{"bones tasks prime --json", "bones hub start"} {
+	// Per ADR 0051 the canonical prime command is the envelope-emitting
+	// `--hook=session-start` form, not the legacy `--json` form.
+	for _, want := range []string{
+		"bones tasks prime --hook=session-start", "bones hub start",
+	} {
 		if !strings.Contains(body, want) {
 			t.Errorf("settings.json missing %q after recovery:\n%s", want, body)
 		}

--- a/docs/adr/0036-prime-on-session-boundaries.md
+++ b/docs/adr/0036-prime-on-session-boundaries.md
@@ -1,5 +1,7 @@
 # ADR 0036: Prime on session boundaries
 
+**Status:** Partially superseded by ADR 0051 (2026-05-08) — the SessionStart placement intent survives; the PreCompact placement does not. ADR 0051 replaces PreCompact with the SessionStart `compact` matcher and switches the command from `bones tasks prime --json` to `bones tasks prime --hook=session-start` (Claude Code hook protocol envelope).
+
 ## Context
 
 bones already has the primitives for tasks-as-survivor: `coord.Prime` returns a snapshot of the workspace's open/ready/claimed tasks plus chat threads and live peers (`internal/coord/prime.go`), and `bones tasks prime --json` serializes that snapshot stably (`cli/tasks_prime.go`, schema in `cli/tasks_format.go`). What was missing was the wiring: nothing in the `bones up` scaffold called Prime at session boundaries, so an agent's working context booted from whatever the harness happened to surface — including freeform spec files in the workspace.

--- a/docs/adr/0051-claude-code-hook-protocol.md
+++ b/docs/adr/0051-claude-code-hook-protocol.md
@@ -1,0 +1,115 @@
+# ADR 0051 — Claude Code hook protocol contract
+
+**Status:** Accepted (2026-05-08)
+
+## Context
+
+Claude Code's SessionStart hook reader expects a documented JSON envelope on stdout:
+
+```json
+{
+  "hookSpecificOutput": {
+    "hookEventName": "SessionStart",
+    "additionalContext": "<text injected into agent context>"
+  }
+}
+```
+
+Bones' v0.12 install wrote `bones tasks prime --json` into both the SessionStart and PreCompact slots of `.claude/settings.json`. That command emits the bones-shape JSON (`{open_tasks, ready_tasks, ...}`) — a payload Claude Code does not parse. The hook reader saw no `hookSpecificOutput`, found no `additionalContext`, and silently dropped the output. Every operator running `bones up` against a Claude Code workspace got the SessionStart hook plumbed and bones-blind from second one (#170).
+
+Two distinct surfaces collapse into the same command in v0.12:
+
+- **Operator-script consumers** read the bones-shape JSON to inspect workspace state. This surface is governed separately by #321's schema-contract work and is unchanged by this ADR.
+- **The Claude Code hook protocol** requires the `hookSpecificOutput` envelope. This surface is what this ADR governs.
+
+The Claude Code hook reference (https://docs.claude.com/en/docs/claude-code/hooks) documents `additionalContext` as the context-injection mechanism for **three** hook events: `SessionStart`, `UserPromptSubmit`, and `UserPromptExpansion`. **PreCompact has no `additionalContext` mechanism** — its only documented output is `decision: "block"` to block compaction. The v0.12 PreCompact placement was the wrong slot from day one, not just a wrong command form.
+
+The Claude Code hook reference further documents that SessionStart's matcher field accepts pipe-alternation of exact strings: `startup`, `resume`, `clear`, `compact`. Matcher `startup|compact` fires on fresh sessions AND after manual / auto compaction — exactly the lifecycle window the v0.12 PreCompact slot tried (and failed) to cover.
+
+## Decision
+
+Bones owns a typed `HookEnvelope` per supported event in the new `internal/clauderhooks` package; `cli/tasks_prime.go` emits it via `--hook=session-start`; `cli/orchestrator.go`'s `mergeSettings` and `cli/doctor.go`'s auto-rewrite read the same canonical command form from that package. One source of truth for the protocol shape.
+
+Concrete public surface:
+
+- `internal/clauderhooks/envelope.go` defines `HookEnvelope`, `HookSpecificOutput`, `EventName`, `EventSessionStart`, `FlagValue`, `FlagSessionStart`, `FlagToEvent`, `NewEnvelope`, `Emit`, `Parse`, `PrimeCommandFor`, `SessionStartMatcher`.
+- `internal/clauderhooks/envelope_test.go` carries the roundtrip test pattern: emit → parse-as-Claude-Code-would → assert `additionalContext` populated. New events MUST add a row to the supported-events table below + a peer roundtrip test. No ADR amendment is required for a new event addition; the test pattern IS the contract.
+- `bones tasks prime` gains `--hook=session-start`. `--json --hook=X` is rejected at Run() time (two distinct consumers; combining hides the contract).
+- `bones up` writes one SessionStart group with `matcher: "startup|compact"` containing `bones tasks prime --hook=session-start`, plus the existing default-matcher group containing `bones hub start`. PreCompact is no longer a bones-owned slot.
+- `bones doctor` auto-rewrites stale `.claude/settings.json` entries by default; `bones doctor --no-fix` reports without rewriting. Three rewrite operations land:
+  1. `SessionStart: bones tasks prime --json` → rewritten to `bones tasks prime --hook=session-start` under matcher `startup|compact`.
+  2. Any `bones tasks prime` entry under PreCompact → removed entirely.
+  3. Missing canonical SessionStart prime entry → installed.
+- The `bones-manifest.json` `settings_hooks_sha256` field re-hashes automatically because `bonesOwnedHookCommands` (cli/skills.go) changed shape. No version-field bump is needed beyond the binary's own version stamp.
+
+### Supported events table
+
+| Event           | Matcher                      | Bones command (canonical)                    | Envelope `hookEventName` | Emits `additionalContext`? |
+| --------------- | ---------------------------- | -------------------------------------------- | ------------------------ | -------------------------- |
+| `SessionStart`  | `startup\|compact`           | `bones tasks prime --hook=session-start`     | `SessionStart`           | yes                        |
+
+Events bones does NOT emit context for, with the reason recorded so a future contributor doesn't relitigate:
+
+| Event              | Reason                                                                                                                                        |
+| ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `PreCompact`       | No `additionalContext` mechanism documented in the Claude Code hook protocol. Only supports `decision: "block"`. The v0.12 placement was a silent no-op. |
+| `UserPromptSubmit` | Out of scope: bones does not own per-prompt context injection. Skills layer is the place if a need arises.                                     |
+| `UserPromptExpansion` | Out of scope: same reason as UserPromptSubmit.                                                                                              |
+
+Adding a new event to the supported set: add the row above, add a peer roundtrip test in `internal/clauderhooks/envelope_test.go`, add the FlagValue → EventName mapping in `FlagToEvent`, and extend `mergeSettings` + `doctor`'s auto-rewrite as needed. No ADR amendment.
+
+### PreCompact is not the right slot
+
+The v0.12 `bones up` scaffold installed `bones tasks prime --json` under BOTH SessionStart and PreCompact. The reasoning was: SessionStart primes a fresh session; PreCompact primes the post-compact session before context is rebuilt. Claude Code's protocol does not support that division of labor — PreCompact has no context-injection mechanism. The replacement is the SessionStart `compact` matcher, which fires on the synthetic SessionStart event Claude Code emits after auto / manual compaction. One hook entry under SessionStart matcher `startup|compact` covers both lifecycle moments.
+
+This ADR removes the PreCompact bones-owned slot. Doctor's auto-rewrite migrates v0.12 installs forward by removing any `bones tasks prime` entry from PreCompact entirely.
+
+## Consequences
+
+**Pulled-down complexity** (what the caller no longer has to know):
+
+- Operators upgrading from v0.12 do nothing: re-run `bones up` OR run `bones doctor` and the rewrite lands. Both paths converge on the canonical state.
+- Skill / hook authors adding a new context-injection event read the supported-events table, copy the roundtrip test, and ship — no ADR work.
+- The `bones tasks prime --json` operator surface (#321) stays unchanged. Operator scripts reading the bones-shape JSON keep working.
+
+**Pushed-up complexity** (what the caller must now know):
+
+- `bones tasks prime` has two non-default output modes (`--json` and `--hook=X`) which are mutually exclusive. CLI help text and Run()-time error explain the distinction. Cost: one extra paragraph in `bones tasks prime --help` output.
+- Doctor now writes `.claude/settings.json` by default. The blast radius is the bones-owned hook subset only — user-owned entries are left intact, and `--no-fix` exists for operators who want to inspect drift before applying it.
+
+**Invariants and the tests that enforce each:**
+
+| Invariant                                                                                            | Enforcing test                                                                  |
+| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| Emit produces a JSON object Claude Code would parse with `additionalContext` populated.              | `internal/clauderhooks/envelope_test.go::TestRoundtrip_SessionStart`            |
+| The on-the-wire shape uses exactly `hookSpecificOutput` / `hookEventName` / `additionalContext`.     | `internal/clauderhooks/envelope_test.go::TestRoundtrip_RawJSONShape`            |
+| `--json --hook=X` is rejected.                                                                       | `cli/tasks_prime_test.go::TestTasksPrimeCmd_JSONHookMutex`                       |
+| `--hook=pre-compact` is rejected at the flag layer (PreCompact is not a supported event).            | `cli/tasks_prime_test.go::TestTasksPrimeCmd_HookFlagRejectsUnknown`             |
+| `bones up` installs the canonical SessionStart entry with matcher `startup\|compact`.                | `cli/orchestrator_test.go::TestScaffoldOrchestrator_SessionStartPrimeMatcher`   |
+| `bones up` does not install any `bones tasks prime` entry under PreCompact.                          | `cli/orchestrator_test.go::TestScaffoldOrchestrator_PreCompactHasNoPrime`       |
+| Doctor's auto-rewrite migrates a v0.12 SessionStart `--json` entry forward.                          | `cli/doctor_test.go::TestCheckBonesScaffoldedHooks_RewritesV012Prime`           |
+| Doctor's auto-rewrite removes any v0.12 PreCompact `bones tasks prime` entry.                        | `cli/doctor_test.go::TestCheckBonesScaffoldedHooks_RemovesPreCompactPrime`      |
+| Doctor's auto-rewrite preserves user-owned hook entries (only bones-owned commands are touched).     | `cli/doctor_test.go::TestCheckBonesScaffoldedHooks_PreservesNonBonesEntries`    |
+| Doctor's auto-rewrite is idempotent (no mtime change on canonical state).                            | `cli/doctor_test.go::TestCheckBonesScaffoldedHooks_IdempotentOnFreshScaffold`   |
+| `bones doctor --no-fix` reports without rewriting.                                                   | `cli/doctor_test.go::TestCheckBonesScaffoldedHooks_NoFixReportsOnly`            |
+
+### Coordination with #322 (hub RPC log)
+
+Issue #322 (separately briefed) will land a hub RPC log that records hook firings. When the SessionStart entry fires under matcher `compact` it represents post-compaction priming, which is operationally distinct from `startup` priming. The log entry should carry a `matcher` field so the two cases can be differentiated at query time. This ADR does not implement the log wiring — it only flags the extension point so #322's implementation does not need to relitigate the SessionStart-matcher decision.
+
+## Out of scope
+
+- **`--json` schema-contract work** is governed by #321. This ADR does not alter the bones-shape JSON one byte.
+- **Skill-level hook handling** (a SKILL.md that uses Claude Code's `hooks:` frontmatter) is unrelated to bones-owned settings.json templating. Skills can install their own hooks alongside bones's; both surfaces are independent.
+- **Reduce-but-don't-close on #129 and #170**: those issues' failure mode (bones-blind sessions) disappears once this ADR lands. They stay open pending operator-side verification on real workspaces post-merge; closure is a follow-up.
+
+## References
+
+- Issue #320: triage brief that scoped this ADR.
+- Issue #170: zero-tasks envelope contract (operator surface — preserved by this ADR).
+- Issue #321: `--json` schema contract (operator surface — out of scope).
+- Issue #322: hub RPC log for hook firings (coordination point).
+- ADR 0036: prime on session boundaries (the original v0.12 placement decision; superseded in part by this ADR — the SessionStart placement intent survives, the PreCompact placement does not).
+- ADR 0048: skills bundle (records #165's failure mode and the skill-substrate prerequisite for hook output to be actionable).
+- Claude Code Hooks Reference: https://docs.claude.com/en/docs/claude-code/hooks
+- Durable transcript with envelope evidence: `~/.claude/projects/-Users-dmestas-projects-serverdom/5b69e0c4-280d-4f6c-8771-3b3eb21338f1.jsonl` — search for `hookSpecificOutput` to see the shape Claude Code accepts in the wild.

--- a/internal/clauderhooks/envelope.go
+++ b/internal/clauderhooks/envelope.go
@@ -1,0 +1,156 @@
+// Package clauderhooks defines the Claude Code hook protocol envelope
+// bones uses when emitting context for hook events.
+//
+// See ADR 0051 (docs/adr/0051-claude-code-hook-protocol.md) for the
+// full contract: which Claude Code hook events accept context
+// injection, how the envelope is shaped, and the roundtrip-test
+// pattern that gates schema drift.
+//
+// The package is the single source of truth for the protocol shape.
+// Emitters (`bones tasks prime --hook=session-start`), validators
+// (`bones doctor`), and the templating that writes hook commands into
+// `.claude/settings.json` (`bones up`) all import the constants and
+// helpers from here so a future protocol change lands in one place.
+package clauderhooks
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+// EventName names a Claude Code hook event that supports
+// `additionalContext` injection. The string values match the
+// `hookEventName` Claude Code expects in the envelope.
+type EventName string
+
+const (
+	// EventSessionStart is the SessionStart hook event. Per the
+	// Claude Code hooks reference, SessionStart fires on `startup`,
+	// `resume`, `clear`, and `compact` matchers; all four route
+	// through the same envelope shape.
+	//
+	// Bones wires SessionStart with matcher "startup|compact" so a
+	// single entry primes both fresh sessions and post-compact
+	// sessions. See ADR 0051 for why PreCompact is NOT used: that
+	// event has no documented `additionalContext` mechanism.
+	EventSessionStart EventName = "SessionStart"
+)
+
+// FlagValue is the CLI surface used by `bones tasks prime --hook=X`.
+// The mapping FlagValue → EventName lives here so that flag parsing,
+// emit, and doctor's auto-rewrite all agree.
+type FlagValue string
+
+const (
+	// FlagSessionStart selects the SessionStart envelope. The hyphenated
+	// form is the operator-facing flag; the camel-cased EventName is
+	// what Claude Code expects on the wire.
+	FlagSessionStart FlagValue = "session-start"
+)
+
+// FlagToEvent maps the operator-facing --hook flag value to the
+// Claude Code event name. Returns the empty string + false when the
+// flag value is not a known event.
+func FlagToEvent(v FlagValue) (EventName, bool) {
+	switch v {
+	case FlagSessionStart:
+		return EventSessionStart, true
+	}
+	return "", false
+}
+
+// HookSpecificOutput is the inner object Claude Code parses out of
+// the hook's stdout JSON. `HookEventName` must match the firing
+// event; `AdditionalContext` carries the markdown / text bones wants
+// to inject into the agent's context window.
+//
+// Per the Claude Code hook protocol, this object is wrapped under
+// the top-level `hookSpecificOutput` field of the stdout JSON.
+type HookSpecificOutput struct {
+	HookEventName     EventName `json:"hookEventName"`
+	AdditionalContext string    `json:"additionalContext"`
+}
+
+// HookEnvelope is the top-level JSON object Claude Code parses from
+// a hook's stdout. Bones emits exactly this shape — no extra fields,
+// no wrapping — so Claude Code's hook reader picks up the
+// `additionalContext` payload and injects it into the agent's
+// context window.
+type HookEnvelope struct {
+	HookSpecificOutput HookSpecificOutput `json:"hookSpecificOutput"`
+}
+
+// NewEnvelope builds a HookEnvelope for event with the given context
+// text. It does not validate the event name: the caller is expected
+// to pass a constant from this package or a value already vetted by
+// FlagToEvent.
+func NewEnvelope(event EventName, additionalContext string) HookEnvelope {
+	return HookEnvelope{
+		HookSpecificOutput: HookSpecificOutput{
+			HookEventName:     event,
+			AdditionalContext: additionalContext,
+		},
+	}
+}
+
+// Emit writes a HookEnvelope as JSON to w with a trailing newline.
+// Errors from json.Marshal or w.Write are returned verbatim so the
+// caller can decide how to surface a hook-emit failure.
+func Emit(w io.Writer, env HookEnvelope) error {
+	data, err := json.Marshal(env)
+	if err != nil {
+		return fmt.Errorf("marshal hook envelope: %w", err)
+	}
+	data = append(data, '\n')
+	if _, err := w.Write(data); err != nil {
+		return fmt.Errorf("write hook envelope: %w", err)
+	}
+	return nil
+}
+
+// Parse unmarshals raw envelope bytes into a HookEnvelope. Used by
+// the roundtrip test to verify what Claude Code would parse from
+// bones's stdout. Errors out on invalid JSON or a missing
+// `hookSpecificOutput` field.
+func Parse(data []byte) (HookEnvelope, error) {
+	var env HookEnvelope
+	if err := json.Unmarshal(data, &env); err != nil {
+		return HookEnvelope{}, fmt.Errorf("parse hook envelope: %w", err)
+	}
+	if env.HookSpecificOutput.HookEventName == "" {
+		return HookEnvelope{}, fmt.Errorf(
+			"parse hook envelope: missing hookSpecificOutput.hookEventName")
+	}
+	return env, nil
+}
+
+// PrimeCommandFor returns the canonical `bones tasks prime` command
+// string bones writes into .claude/settings.json for the given
+// event. This is the single source of truth used by:
+//
+//   - `bones up`'s settings.json templating (cli/orchestrator.go's
+//     mergeSettings) when scaffolding a fresh hook entry.
+//   - `bones doctor`'s auto-rewrite when migrating a stale entry
+//     forward (cli/doctor.go).
+//
+// Returns the empty string for events that don't have a canonical
+// prime command (currently only SessionStart does).
+func PrimeCommandFor(event EventName) string {
+	switch event {
+	case EventSessionStart:
+		return "bones tasks prime --hook=session-start"
+	}
+	return ""
+}
+
+// SessionStartMatcher is the matcher pattern bones uses on the
+// SessionStart hook group it owns. The pipe-alternation form is the
+// documented Claude Code matcher syntax for "fires on multiple
+// exact-string matchers": `startup` covers fresh sessions; `compact`
+// covers the after-auto-or-manual-compaction session. The two
+// together are what bones-tasks-prime context injection must cover.
+//
+// See ADR 0051 §"PreCompact is not the right slot" for why this
+// matcher is the substitute for the v0.12 PreCompact slot.
+const SessionStartMatcher = "startup|compact"

--- a/internal/clauderhooks/envelope_test.go
+++ b/internal/clauderhooks/envelope_test.go
@@ -1,0 +1,131 @@
+package clauderhooks
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestRoundtrip_SessionStart pins the load-bearing contract for
+// ADR 0051: emit a SessionStart envelope, parse it as Claude Code
+// would (treating bones's stdout as the JSON Claude Code reads), and
+// assert `additionalContext` survived the trip. New hook events
+// added in future iterations must add a peer test here — that's the
+// extension point ADR 0051 documents.
+func TestRoundtrip_SessionStart(t *testing.T) {
+	const ctx = "# Agent Tasks Context\n\n## Open Tasks (0)\n_No open tasks._\n"
+	env := NewEnvelope(EventSessionStart, ctx)
+
+	var buf bytes.Buffer
+	if err := Emit(&buf, env); err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+
+	got, err := Parse(buf.Bytes())
+	if err != nil {
+		t.Fatalf("Parse: %v\npayload=%q", err, buf.String())
+	}
+
+	if got.HookSpecificOutput.HookEventName != EventSessionStart {
+		t.Errorf("hookEventName = %q, want %q",
+			got.HookSpecificOutput.HookEventName, EventSessionStart)
+	}
+	if got.HookSpecificOutput.AdditionalContext != ctx {
+		t.Errorf("additionalContext mismatch:\ngot:  %q\nwant: %q",
+			got.HookSpecificOutput.AdditionalContext, ctx)
+	}
+}
+
+// TestRoundtrip_RawJSONShape pins the *exact* on-the-wire shape
+// Claude Code expects: a top-level `hookSpecificOutput` object with
+// `hookEventName` and `additionalContext` string fields.
+//
+// We re-parse the emitted bytes through a generic map[string]any so
+// the test catches any future struct-tag or field-name drift that
+// would silently change the wire format.
+func TestRoundtrip_RawJSONShape(t *testing.T) {
+	env := NewEnvelope(EventSessionStart, "hello")
+	var buf bytes.Buffer
+	if err := Emit(&buf, env); err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+
+	var generic map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &generic); err != nil {
+		t.Fatalf("unmarshal: %v\npayload=%q", err, buf.String())
+	}
+
+	hso, ok := generic["hookSpecificOutput"].(map[string]any)
+	if !ok {
+		t.Fatalf("missing hookSpecificOutput key; got=%v", generic)
+	}
+	if hso["hookEventName"] != "SessionStart" {
+		t.Errorf("hookEventName = %v, want SessionStart", hso["hookEventName"])
+	}
+	if hso["additionalContext"] != "hello" {
+		t.Errorf("additionalContext = %v, want hello", hso["additionalContext"])
+	}
+}
+
+// TestEmit_TrailingNewline pins that emitted JSON ends in '\n' so
+// log readers and stdout-line-buffered tools don't see a partial
+// line. Claude Code is line-buffer-tolerant either way; the newline
+// is hygiene.
+func TestEmit_TrailingNewline(t *testing.T) {
+	var buf bytes.Buffer
+	if err := Emit(&buf, NewEnvelope(EventSessionStart, "x")); err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	if !strings.HasSuffix(buf.String(), "\n") {
+		t.Errorf("emitted bytes do not end in newline: %q", buf.String())
+	}
+}
+
+// TestParse_InvalidJSON ensures a non-JSON payload surfaces as an
+// error rather than a half-populated envelope. This is the failure
+// mode bones doctor's roundtrip check must distinguish from a
+// successfully-emitted-but-empty envelope.
+func TestParse_InvalidJSON(t *testing.T) {
+	if _, err := Parse([]byte("not json")); err == nil {
+		t.Errorf("Parse(\"not json\") returned nil error")
+	}
+}
+
+// TestParse_MissingHookEventName guards the case where stdout
+// contains a JSON object but no `hookEventName` — Claude Code would
+// silently discard such output and bones doctor must treat it as
+// malformed.
+func TestParse_MissingHookEventName(t *testing.T) {
+	if _, err := Parse([]byte(`{"hookSpecificOutput":{}}`)); err == nil {
+		t.Errorf("Parse(empty hookSpecificOutput) returned nil error")
+	}
+}
+
+// TestFlagToEvent_KnownAndUnknown pins the mapping a CLI flag value
+// uses to resolve a Claude Code event name. Adding a new event
+// requires extending FlagToEvent and adding a peer roundtrip test;
+// the symmetry is what keeps the contract one-sided.
+func TestFlagToEvent_KnownAndUnknown(t *testing.T) {
+	if got, ok := FlagToEvent(FlagSessionStart); !ok || got != EventSessionStart {
+		t.Errorf("FlagToEvent(session-start) = (%q, %v), want (SessionStart, true)",
+			got, ok)
+	}
+	if got, ok := FlagToEvent(FlagValue("nope")); ok || got != "" {
+		t.Errorf("FlagToEvent(nope) = (%q, %v), want (\"\", false)", got, ok)
+	}
+}
+
+// TestPrimeCommandFor pins the canonical command form bones writes
+// into .claude/settings.json. Two consumers depend on this exact
+// string: cli/orchestrator.go's mergeSettings (during `bones up`)
+// and cli/doctor.go's auto-rewrite. Drift here desyncs them.
+func TestPrimeCommandFor(t *testing.T) {
+	if got := PrimeCommandFor(EventSessionStart); got != "bones tasks prime --hook=session-start" {
+		t.Errorf("PrimeCommandFor(SessionStart) = %q, want %q",
+			got, "bones tasks prime --hook=session-start")
+	}
+	if got := PrimeCommandFor(EventName("bogus")); got != "" {
+		t.Errorf("PrimeCommandFor(bogus) = %q, want empty", got)
+	}
+}


### PR DESCRIPTION
## Summary

- New `internal/clauderhooks/` package owns the typed `HookEnvelope` and the canonical `bones tasks prime --hook=session-start` command form. One source of truth used by `tasks_prime` (emit), `orchestrator.mergeSettings` (templating), and `doctor` (self-heal).
- New `--hook=session-start` flag on `bones tasks prime` emits the documented Claude Code envelope (`hookSpecificOutput.additionalContext`). `--json --hook=X` is rejected — two distinct consumer surfaces.
- `bones doctor` auto-rewrites stale `.claude/settings.json` hook entries by default. Three migrations: rewrite SessionStart `--json` → `--hook=session-start` (matcher `startup|compact`); remove any `bones tasks prime` entry from PreCompact; install canonical SessionStart entry if absent. `bones doctor --no-fix` reports without rewriting.
- ADR 0051 (`docs/adr/0051-claude-code-hook-protocol.md`) documents the contract, the supported-events table, and the roundtrip-test pattern. New hook events extend the table + add a peer roundtrip test — no ADR amendment.

## Architectural call (Option 2 per pre-merge consult)

The Claude Code hook protocol does NOT support `additionalContext` on PreCompact (verified against https://docs.claude.com/en/docs/claude-code/hooks). The v0.12 PreCompact slot was the wrong slot from day one, not just a wrong command form. This PR replaces it with the SessionStart `compact` matcher (`startup|compact` covers both fresh and post-compact sessions in one entry). One `--hook=` flag value, not two; doctor removes the dead PreCompact entry on migration.

This is a wider scaffold change than the original brief outlined but is the only way to make priming actually fire after compaction. Documented in detail in ADR 0051 §"PreCompact is not the right slot" and the consequences table.

## Migration path for v0.12 broken installs

Both `bones up` and `bones doctor` converge on the canonical state — operators upgrading from v0.12 do nothing special. End-to-end check ran against a synthetic v0.12 fixture: `doctor` printed two FIX lines, the resulting `settings.json` carries the canonical entries, and a re-run is a no-op (idempotent).

## Coordination

- #321 (`--json` schema contract) is the operator-script surface, untouched here.
- #322 (hub RPC log) will log hook firings; the SessionStart `compact` matcher case should be distinguishable in that log via a `matcher` field. Mentioned in ADR 0051 as an extension point; not implemented here.
- #129 / #170 failure mode disappears once this lands; closure deferred pending operator-side verification on real workspaces post-merge.

## Test plan

- [x] `go build -tags=otel ./...` (otel-tagged CI lane build): passes.
- [x] `go test -tags=otel -short ./...`: 972 passed, 1 pre-existing flake (`TestStatusAllEmptyRegistry` — fails on `main` too, unrelated).
- [x] `make check` (fmt-check, vet, lint, race, todo-check): static checks all clean; race surfaces only the same pre-existing flake.
- [x] End-to-end manual check: synthetic v0.12 settings.json → `bones doctor` prints FIX lines → settings.json migrated → `bones doctor` re-run is a no-op (mtime unchanged).
- [x] Roundtrip test (`internal/clauderhooks/envelope_test.go::TestRoundtrip_SessionStart`) pins the on-the-wire envelope shape against what Claude Code's hook reader parses.
- [ ] Post-merge: open Claude Code in a fresh workspace + verify `additionalContext` is non-empty in the SessionStart hook firing transcript (`~/.claude/projects/.../<sessionId>.jsonl`).

Closes #320