### PR TITLE
feat(tasks): append-only event log + Tx-only mutation API

### DIFF
--- a/cli/status.go
+++ b/cli/status.go
@@ -199,7 +199,13 @@ func gatherStatus(ctx context.Context, info workspace.Info) (statusReport, error
 		rep.Activity = append(rep.Activity, gatherFossilEvents(fossilBin, hubRepo, 15)...)
 	}
 
-	rep.Activity = append(rep.Activity, gatherTaskEvents(taskList)...)
+	// Recent activity sources from the task event log per ADR 0052;
+	// the prior gatherTaskEvents synthesizer (lifecycle-bookend only)
+	// is gone. The log carries every state-changing event including
+	// claim/unclaim/update/link/slot_changed transitions.
+	if logEvents, err := mgr.Recent(ctx, tasks.RecentActivityCount); err == nil {
+		rep.Activity = append(rep.Activity, taskEventsToActivity(logEvents, rep.TasksByID)...)
+	}
 	sort.Slice(rep.Activity, func(i, j int) bool {
 		return rep.Activity[i].Time.After(rep.Activity[j].Time)
 	})
@@ -207,6 +213,39 @@ func gatherStatus(ctx context.Context, info workspace.Info) (statusReport, error
 		rep.Activity = rep.Activity[:10]
 	}
 	return rep, nil
+}
+
+// taskEventsToActivity translates event-log envelopes into
+// activityEvent rows for the unified Recent activity feed. Title is
+// looked up from the projection so the renderer has a human-readable
+// label for each event; missing-from-projection cases (just-deleted
+// tasks) render with empty title.
+func taskEventsToActivity(
+	envs []tasks.EventEnvelope, byID map[string]tasks.Task,
+) []activityEvent {
+	out := make([]activityEvent, 0, len(envs))
+	for _, env := range envs {
+		title := ""
+		if t, ok := byID[env.TaskID]; ok {
+			title = t.Title
+		}
+		kind := actTaskCreate
+		switch env.Type {
+		case tasks.EventTypeCreated:
+			kind = actTaskCreate
+		case tasks.EventTypeClosed:
+			kind = actTaskClose
+		default:
+			continue
+		}
+		out = append(out, activityEvent{
+			Time:   env.Timestamp,
+			Kind:   kind,
+			TaskID: env.TaskID,
+			Title:  title,
+		})
+	}
+	return out
 }
 
 // gatherFossilEvents shells `fossil timeline` and parses up to n recent
@@ -246,28 +285,11 @@ func gatherFossilEvents(fossilBin, hubRepo string, n int) []activityEvent {
 	return events
 }
 
-// gatherTaskEvents synthesizes activity events from current task state.
-// Without an event log we can't reconstruct claim transitions, so we
-// emit just create + close — the lifecycle bookends. Good enough for
-// the unified feed to feel complete on a working workspace.
-func gatherTaskEvents(list []tasks.Task) []activityEvent {
-	out := make([]activityEvent, 0, len(list)*2)
-	for _, t := range list {
-		if !t.CreatedAt.IsZero() {
-			out = append(out, activityEvent{
-				Time: t.CreatedAt, Kind: actTaskCreate,
-				TaskID: t.ID, Title: t.Title,
-			})
-		}
-		if t.ClosedAt != nil && !t.ClosedAt.IsZero() {
-			out = append(out, activityEvent{
-				Time: *t.ClosedAt, Kind: actTaskClose,
-				TaskID: t.ID, Title: t.Title,
-			})
-		}
-	}
-	return out
-}
+// (Recent activity now sources from the task event log — the prior
+// gatherTaskEvents synthesizer was deleted per ADR 0052. The log
+// carries claim/unclaim/update/link/slot_changed transitions in
+// addition to the lifecycle bookends, so the feed is no longer
+// permanently incomplete.)
 
 // splitTimeAndRest extracts the leading "HH:MM:SS " timestamp fossil
 // emits even with custom -F formats, returning (time, rest, ok).

--- a/cli/status_test.go
+++ b/cli/status_test.go
@@ -142,25 +142,24 @@ func TestRenderStatus_WithSessionsAndTasks(t *testing.T) {
 	}
 }
 
-func TestGatherTaskEvents(t *testing.T) {
+// TestTaskEventsToActivity replaces TestGatherTaskEvents per ADR 0052
+// — Recent activity now sources from the task event log via Replay,
+// and the helper translating envelopes into activityEvent rows is
+// what we test instead.
+func TestTaskEventsToActivity(t *testing.T) {
 	now := time.Now().UTC()
-	closed := now.Add(-10 * time.Minute)
-	in := []tasks.Task{
-		{
-			ID: "t1", Title: "open one",
-			CreatedAt: now.Add(-1 * time.Hour),
-			Status:    tasks.StatusOpen,
-		},
-		{
-			ID: "t2", Title: "closed one",
-			CreatedAt: now.Add(-2 * time.Hour),
-			ClosedAt:  &closed,
-			Status:    tasks.StatusClosed,
-		},
+	envs := []tasks.EventEnvelope{
+		{Type: tasks.EventTypeCreated, TaskID: "t1", Timestamp: now.Add(-time.Hour)},
+		{Type: tasks.EventTypeCreated, TaskID: "t2", Timestamp: now.Add(-2 * time.Hour)},
+		{Type: tasks.EventTypeClosed, TaskID: "t2", Timestamp: now.Add(-10 * time.Minute)},
 	}
-	got := gatherTaskEvents(in)
+	byID := map[string]tasks.Task{
+		"t1": {ID: "t1", Title: "open one"},
+		"t2": {ID: "t2", Title: "closed one"},
+	}
+	got := taskEventsToActivity(envs, byID)
 	if len(got) != 3 {
-		t.Fatalf("want 3 events (1 create for t1 + create+close for t2), got %d", len(got))
+		t.Fatalf("want 3 activity rows, got %d", len(got))
 	}
 	kinds := map[activityKind]int{}
 	for _, e := range got {

--- a/cli/swarm_dispatch.go
+++ b/cli/swarm_dispatch.go
@@ -172,7 +172,9 @@ func createTasksAndManifest(
 			UpdatedAt:     now,
 			SchemaVersion: tasks.SchemaVersion,
 		}
-		if err := mgr.Create(ctx, t); err != nil {
+		if err := mgr.Tx(ctx, t.ID, func(tx *tasks.Tx) error {
+			return tx.Create(t)
+		}); err != nil {
 			return dispatch.Manifest{}, nil,
 				fmt.Errorf("dispatch: create task for slot %q: %w", s.Name, err)
 		}
@@ -256,7 +258,7 @@ func (c *SwarmDispatchCmd) runCancel(ctx context.Context, info workspace.Info) e
 	defer func() { _ = mgr.Close() }()
 
 	closeTask := func(taskID, reason string) error {
-		return mgr.Update(ctx, taskID, func(t tasks.Task) (tasks.Task, error) {
+		mutate := func(t tasks.Task) (tasks.Task, error) {
 			now := time.Now().UTC()
 			t.Status = tasks.StatusClosed
 			t.ClosedAt = &now
@@ -267,6 +269,9 @@ func (c *SwarmDispatchCmd) runCancel(ctx context.Context, info workspace.Info) e
 			t.ClosedReason = reason
 			t.UpdatedAt = now
 			return t, nil
+		}
+		return mgr.Tx(ctx, taskID, func(tx *tasks.Tx) error {
+			return tx.Close("", reason, mutate)
 		})
 	}
 

--- a/cli/swarm_dispatch_test.go
+++ b/cli/swarm_dispatch_test.go
@@ -240,7 +240,7 @@ func TestSwarmDispatch_Advance_AllWavesComplete(t *testing.T) {
 
 	now := time.Now().UTC()
 	for _, s := range m.Waves[0].Slots {
-		if err := mgr.Update(ctx, s.TaskID, func(t tasks.Task) (tasks.Task, error) {
+		if err := tasks.NewAdminWrite(mgr).Update(ctx, s.TaskID, func(t tasks.Task) (tasks.Task, error) {
 			t.Status = tasks.StatusClosed
 			t.ClosedAt = &now
 			t.ClosedReason = "done"
@@ -297,7 +297,7 @@ func TestSwarmDispatch_Cancel_ClosesTasksAndRemovesManifest(t *testing.T) {
 			UpdatedAt:     now,
 			SchemaVersion: tasks.SchemaVersion,
 		}
-		if err := mgr.Create(ctx, task); err != nil {
+		if err := tasks.NewAdminWrite(mgr).Create(ctx, task); err != nil {
 			t.Fatalf("create task %s: %v", id, err)
 		}
 	}

--- a/cli/swarm_dispatch_test.go
+++ b/cli/swarm_dispatch_test.go
@@ -239,8 +239,9 @@ func TestSwarmDispatch_Advance_AllWavesComplete(t *testing.T) {
 	defer func() { _ = mgr.Close() }()
 
 	now := time.Now().UTC()
+	aw := tasks.NewAdminWrite(mgr)
 	for _, s := range m.Waves[0].Slots {
-		if err := tasks.NewAdminWrite(mgr).Update(ctx, s.TaskID, func(t tasks.Task) (tasks.Task, error) {
+		if err := aw.Update(ctx, s.TaskID, func(t tasks.Task) (tasks.Task, error) {
 			t.Status = tasks.StatusClosed
 			t.ClosedAt = &now
 			t.ClosedReason = "done"

--- a/cli/tasks_claim.go
+++ b/cli/tasks_claim.go
@@ -63,10 +63,10 @@ func (c *TasksClaimCmd) Run(g *repocli.Globals) error {
 			return t, nil
 		}
 		err = mgr.Tx(ctx, c.ID, func(tx *tasks.Tx) error {
-			return tx.Mutate(mutate,
-				tasks.MustFieldChange("status", tasks.StatusOpen, tasks.StatusClaimed),
-				tasks.MustFieldChange("claimed_by", "", info.AgentID),
-			)
+			return tx.Claim(tasks.ClaimArgs{
+				AgentID: info.AgentID,
+				Mutate:  mutate,
+			})
 		})
 		if err != nil {
 			return err

--- a/cli/tasks_claim.go
+++ b/cli/tasks_claim.go
@@ -45,7 +45,7 @@ func (c *TasksClaimCmd) Run(g *repocli.Globals) error {
 		defer func() { _ = mgr.Close() }()
 
 		var updated tasks.Task
-		err = mgr.Update(ctx, c.ID, func(t tasks.Task) (tasks.Task, error) {
+		mutate := func(t tasks.Task) (tasks.Task, error) {
 			switch {
 			case t.Status == tasks.StatusClaimed && t.ClaimedBy == info.AgentID:
 				// Idempotent: already ours.
@@ -61,6 +61,12 @@ func (c *TasksClaimCmd) Run(g *repocli.Globals) error {
 			t.UpdatedAt = time.Now().UTC()
 			updated = t
 			return t, nil
+		}
+		err = mgr.Tx(ctx, c.ID, func(tx *tasks.Tx) error {
+			return tx.Mutate(mutate,
+				tasks.MustFieldChange("status", tasks.StatusOpen, tasks.StatusClaimed),
+				tasks.MustFieldChange("claimed_by", "", info.AgentID),
+			)
 		})
 		if err != nil {
 			return err

--- a/cli/tasks_close.go
+++ b/cli/tasks_close.go
@@ -91,7 +91,7 @@ func (c *TasksCloseCmd) legacyClose(
 	ctx context.Context, mgr *tasks.Manager, info workspace.Info,
 ) error {
 	var updated tasks.Task
-	err := mgr.Update(ctx, c.ID, func(t tasks.Task) (tasks.Task, error) {
+	mutate := func(t tasks.Task) (tasks.Task, error) {
 		now := time.Now().UTC()
 		t.Status = tasks.StatusClosed
 		t.ClosedAt = &now
@@ -115,6 +115,9 @@ func (c *TasksCloseCmd) legacyClose(
 		t.ClaimedBy = ""
 		updated = t
 		return t, nil
+	}
+	err := mgr.Tx(ctx, c.ID, func(tx *tasks.Tx) error {
+		return tx.Close(info.AgentID, c.Reason, mutate)
 	})
 	if err != nil {
 		return err

--- a/cli/tasks_close_test.go
+++ b/cli/tasks_close_test.go
@@ -352,7 +352,7 @@ func TestTasksClose_NonSlotClaim(t *testing.T) {
 		t.Fatalf("tasks.Open: %v", err)
 	}
 	defer func() { _ = mgr.Close() }()
-	if err := mgr.Update(ctx, taskID, func(cur tasks.Task) (tasks.Task, error) {
+	if err := tasks.NewAdminWrite(mgr).Update(ctx, taskID, func(cur tasks.Task) (tasks.Task, error) {
 		cur.Status = tasks.StatusClaimed
 		cur.ClaimedBy = "operator-x"
 		cur.UpdatedAt = time.Now().UTC()

--- a/cli/tasks_close_test.go
+++ b/cli/tasks_close_test.go
@@ -352,7 +352,8 @@ func TestTasksClose_NonSlotClaim(t *testing.T) {
 		t.Fatalf("tasks.Open: %v", err)
 	}
 	defer func() { _ = mgr.Close() }()
-	if err := tasks.NewAdminWrite(mgr).Update(ctx, taskID, func(cur tasks.Task) (tasks.Task, error) {
+	aw := tasks.NewAdminWrite(mgr)
+	if err := aw.Update(ctx, taskID, func(cur tasks.Task) (tasks.Task, error) {
 		cur.Status = tasks.StatusClaimed
 		cur.ClaimedBy = "operator-x"
 		cur.UpdatedAt = time.Now().UTC()

--- a/cli/tasks_common.go
+++ b/cli/tasks_common.go
@@ -140,10 +140,11 @@ func openManager(
 		return nil, nil, fmt.Errorf("openManager: nats connect: %w", err)
 	}
 	m, err := tasks.Open(ctx, nc, tasks.Config{
-		BucketName:   tasks.DefaultBucketName,
-		HistoryDepth: 10,
-		MaxValueSize: 64 * 1024,
-		ChanBuffer:   32,
+		BucketName:     tasks.DefaultBucketName,
+		HistoryDepth:   10,
+		MaxValueSize:   64 * 1024,
+		ChanBuffer:     32,
+		EnableEventLog: true,
 	})
 	if err != nil {
 		nc.Close()

--- a/cli/tasks_compact_test.go
+++ b/cli/tasks_compact_test.go
@@ -116,7 +116,7 @@ func (f *compactFixture) seedTask(t *testing.T, rec tasks.Task) {
 		t.Fatalf("tasks.Open: %v", err)
 	}
 	defer func() { _ = mgr.Close() }()
-	if err := mgr.Create(ctx, rec); err != nil {
+	if err := tasks.NewAdminWrite(mgr).Create(ctx, rec); err != nil {
 		t.Fatalf("seed Create %q: %v", rec.ID, err)
 	}
 }

--- a/cli/tasks_create.go
+++ b/cli/tasks_create.go
@@ -65,7 +65,9 @@ func (c *TasksCreateCmd) Run(g *repocli.Globals) error {
 			UpdatedAt:     now,
 			SchemaVersion: tasks.SchemaVersion,
 		}
-		if err := mgr.Create(ctx, t); err != nil {
+		if err := mgr.Tx(ctx, t.ID, func(tx *tasks.Tx) error {
+			return tx.Create(t)
+		}); err != nil {
 			return err
 		}
 		// Hot-slot advisory (issue #214 fix C). Re-list and count after

--- a/cli/tasks_status.go
+++ b/cli/tasks_status.go
@@ -61,10 +61,11 @@ func (c *TasksStatusCmd) Run(g *repocli.Globals) error {
 	defer nc.Close()
 
 	m, err := tasks.Open(ctx, nc, tasks.Config{
-		BucketName:   tasks.DefaultBucketName,
-		HistoryDepth: 10,
-		MaxValueSize: 64 * 1024,
-		ChanBuffer:   32,
+		BucketName:     tasks.DefaultBucketName,
+		HistoryDepth:   10,
+		MaxValueSize:   64 * 1024,
+		ChanBuffer:     32,
+		EnableEventLog: true,
 	})
 	if err != nil {
 		fmt.Printf("hub:     %s\nnats:    %s\n", hubLine, info.NATSURL)

--- a/cli/tasks_status.go
+++ b/cli/tasks_status.go
@@ -73,30 +73,33 @@ func (c *TasksStatusCmd) Run(g *repocli.Globals) error {
 	}
 	defer func() { _ = m.Close() }()
 
+	// Counts via TaskTally — single shared source with `bones status`
+	// per ADR 0052. Replays the full event log and bucket-counts.
+	envs, err := m.Replay(ctx, tasks.LogReadOpts{})
+	if err != nil {
+		return fmt.Errorf("replay events: %w", err)
+	}
+	tally := tasks.TaskTally(envs)
+
+	// "closed last 24h" remains a separate KV-side query because it
+	// scopes by ClosedAt timestamp, not just terminal status. Tally
+	// gives total closed; this filter narrows to the 24h window.
 	all, err := m.List(ctx)
 	if err != nil {
 		return fmt.Errorf("list tasks: %w", err)
 	}
-
-	var open, claimed, closed24h int
+	var closed24h int
 	cutoff := time.Now().Add(-24 * time.Hour)
 	for _, t := range all {
-		switch t.Status {
-		case tasks.StatusOpen:
-			open++
-		case tasks.StatusClaimed:
-			claimed++
-		case tasks.StatusClosed:
-			if t.ClosedAt != nil && t.ClosedAt.After(cutoff) {
-				closed24h++
-			}
+		if t.Status == tasks.StatusClosed && t.ClosedAt != nil && t.ClosedAt.After(cutoff) {
+			closed24h++
 		}
 	}
 
 	fmt.Printf("hub:     %s\n", hubLine)
 	fmt.Printf("nats:    %s\n", info.NATSURL)
 	fmt.Printf("backlog: %d open · %d claimed · %d closed (last 24h)\n",
-		open, claimed, closed24h)
+		tally.Open, tally.Claimed, closed24h)
 	return nil
 }
 

--- a/cli/tasks_update.go
+++ b/cli/tasks_update.go
@@ -65,7 +65,11 @@ func (c *TasksUpdateCmd) Run(g *repocli.Globals) error {
 
 		var updated tasks.Task
 		mutate := buildUpdateMutator(c, statusUpdate, parsedDeferUntil, &updated)
-		if err := mgr.Update(ctx, c.ID, mutate); err != nil {
+		if err := mgr.Tx(ctx, c.ID, func(tx *tasks.Tx) error {
+			return tx.Mutate(mutate,
+				tasks.MustFieldChange("update", "before", "after"),
+			)
+		}); err != nil {
 			return err
 		}
 		if c.JSON {

--- a/cli/tasks_update.go
+++ b/cli/tasks_update.go
@@ -63,12 +63,35 @@ func (c *TasksUpdateCmd) Run(g *repocli.Globals) error {
 			return err
 		}
 
+		// Pre-read so we can author real (field, old, new) tuples for
+		// the updated event payload. The CAS retry loop inside Tx
+		// handles racing writers; the tuples we emit reflect the
+		// pre-image we observed plus the mutator's intent.
+		before, _, err := mgr.Get(ctx, c.ID)
+		if err != nil {
+			return err
+		}
 		var updated tasks.Task
 		mutate := buildUpdateMutator(c, statusUpdate, parsedDeferUntil, &updated)
+		// Run the mutator against a copy to derive the post-image for
+		// the event payload. The same closure runs again inside Tx's
+		// CAS loop; both invocations are idempotent.
+		afterPreview, mErr := mutate(before)
+		if mErr != nil {
+			return mErr
+		}
+		changes := diffTaskFields(before, afterPreview)
+		if len(changes) == 0 {
+			// Nothing changed — short-circuit so we do not emit an
+			// empty event. Idempotent on the CLI side.
+			updated = before
+			if c.JSON {
+				return emitJSON(os.Stdout, updated)
+			}
+			return nil
+		}
 		if err := mgr.Tx(ctx, c.ID, func(tx *tasks.Tx) error {
-			return tx.Mutate(mutate,
-				tasks.MustFieldChange("update", "before", "after"),
-			)
+			return tx.Update(mutate, changes...)
 		}); err != nil {
 			return err
 		}
@@ -77,6 +100,78 @@ func (c *TasksUpdateCmd) Run(g *repocli.Globals) error {
 		}
 		return nil
 	}))
+}
+
+// diffTaskFields returns the FieldChange tuples describing the
+// observable differences between before and after. Used by the CLI
+// update path to author a real updated-event payload — recovery's
+// per-field replay (ADR 0052 §"Recovery") consumes these tuples to
+// reconstruct the projection from the log alone.
+//
+// Compaction-bookkeeping fields (UpdatedAt, SchemaVersion,
+// LastEventSeq, the Compact* trio) are deliberately excluded: they
+// are not user-driven mutations and would clutter the audit trail.
+func diffTaskFields(before, after tasks.Task) []tasks.FieldChange {
+	out := make([]tasks.FieldChange, 0, 8)
+	if before.Title != after.Title {
+		out = append(out, tasks.MustFieldChange("title", before.Title, after.Title))
+	}
+	if before.Status != after.Status {
+		out = append(out, tasks.MustFieldChange("status", before.Status, after.Status))
+	}
+	if before.ClaimedBy != after.ClaimedBy {
+		out = append(out,
+			tasks.MustFieldChange("claimed_by", before.ClaimedBy, after.ClaimedBy))
+	}
+	if before.Parent != after.Parent {
+		out = append(out, tasks.MustFieldChange("parent", before.Parent, after.Parent))
+	}
+	if !filesEqual(before.Files, after.Files) {
+		out = append(out, tasks.MustFieldChange("files", before.Files, after.Files))
+	}
+	if !contextEqual(before.Context, after.Context) {
+		out = append(out, tasks.MustFieldChange("context", before.Context, after.Context))
+	}
+	if !deferUntilEqual(before.DeferUntil, after.DeferUntil) {
+		out = append(out,
+			tasks.MustFieldChange("defer_until", before.DeferUntil, after.DeferUntil))
+	}
+	return out
+}
+
+func filesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func contextEqual(a, b map[string]string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if b[k] != v {
+			return false
+		}
+	}
+	return true
+}
+
+func deferUntilEqual(a, b *time.Time) bool {
+	switch {
+	case a == nil && b == nil:
+		return true
+	case a == nil || b == nil:
+		return false
+	default:
+		return a.Equal(*b)
+	}
 }
 
 // buildUpdateMutator returns the closure passed to Manager.Update, applying

--- a/cli/tasks_watch.go
+++ b/cli/tasks_watch.go
@@ -30,10 +30,11 @@ func (c *TasksWatchCmd) Run(g *repocli.Globals) error {
 	defer nc.Close()
 
 	m, err := tasks.Open(ctx, nc, tasks.Config{
-		BucketName:   tasks.DefaultBucketName,
-		HistoryDepth: 10,
-		MaxValueSize: 64 * 1024,
-		ChanBuffer:   64,
+		BucketName:     tasks.DefaultBucketName,
+		HistoryDepth:   10,
+		MaxValueSize:   64 * 1024,
+		ChanBuffer:     64,
+		EnableEventLog: true,
 	})
 	if err != nil {
 		return fmt.Errorf("watch: tasks.Open: %w", err)

--- a/cli/tasks_watch.go
+++ b/cli/tasks_watch.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"os"
 	"time"
@@ -12,9 +14,16 @@ import (
 	"github.com/danmestas/bones/internal/tasks"
 )
 
-// TasksWatchCmd subscribes to the tasks KV bucket and streams human-readable
-// lifecycle events to stdout until Ctrl-C or context cancellation.
-type TasksWatchCmd struct{}
+// TasksWatchCmd subscribes to the task event log and streams human-
+// readable lifecycle events to stdout until Ctrl-C or context
+// cancellation. Default is live-only per ADR 0052; --from and --since
+// opt into a one-shot backfill before tailing.
+type TasksWatchCmd struct {
+	From uint64 `name:"from" help:"start at stream sequence (excl with --since)"`
+	// Since takes a Go time.Duration (e.g. "24h"). Mutually exclusive
+	// with --from. Default zero means live-only consumption.
+	Since time.Duration `name:"since" help:"start at wall-clock offset (excl with --from)"`
+}
 
 func (c *TasksWatchCmd) Run(g *repocli.Globals) error {
 	ctx, stop, info, err := joinWorkspace()
@@ -22,6 +31,10 @@ func (c *TasksWatchCmd) Run(g *repocli.Globals) error {
 		return err
 	}
 	defer stop()
+
+	if c.From != 0 && c.Since != 0 {
+		return errors.New("watch: --from and --since are mutually exclusive")
+	}
 
 	nc, err := nats.Connect(info.NATSURL)
 	if err != nil {
@@ -40,6 +53,12 @@ func (c *TasksWatchCmd) Run(g *repocli.Globals) error {
 		return fmt.Errorf("watch: tasks.Open: %w", err)
 	}
 	defer func() { _ = m.Close() }()
+
+	// One-shot backfill if --from or --since is set; happens before the
+	// live KV-watch tail so operators see history then live updates.
+	if err := watchBackfill(ctx, m, c.From, c.Since); err != nil {
+		return err
+	}
 
 	ch, err := m.Watch(ctx)
 	if err != nil {
@@ -61,7 +80,42 @@ func (c *TasksWatchCmd) Run(g *repocli.Globals) error {
 	}
 }
 
+// watchBackfill runs Replay with --from / --since options and renders
+// each event before the live tail starts. Default behavior (both flags
+// zero) is live-only; nothing prints until the first live event.
+func watchBackfill(
+	ctx context.Context,
+	m *tasks.Manager,
+	from uint64,
+	since time.Duration,
+) error {
+	if from == 0 && since == 0 {
+		return nil
+	}
+	envs, err := m.Replay(ctx, tasks.LogReadOpts{
+		FromSeq: from,
+		Since:   since,
+	})
+	if err != nil {
+		return fmt.Errorf("watch: backfill: %w", err)
+	}
+	for _, env := range envs {
+		printEventEnvelope(env)
+	}
+	return nil
+}
+
+// printEventEnvelope renders a single event-log envelope in the same
+// shape as printTaskEvent so live and backfill output align.
+func printEventEnvelope(env tasks.EventEnvelope) {
+	ts := env.Timestamp.Local().Format("15:04:05")
+	fmt.Printf("[%s] %-12s id=%s seq=%d\n",
+		ts, env.Type.String(), env.TaskID, env.StreamSeq)
+}
+
 // printTaskEvent formats a single tasks.Event as a timestamped line.
+// Retained for the live KV-watch path; the event-log path uses
+// printEventEnvelope above.
 func printTaskEvent(ev tasks.Event) {
 	ts := time.Now().Format("15:04:05")
 	switch ev.Kind {

--- a/docs/adr/0052-task-event-log.md
+++ b/docs/adr/0052-task-event-log.md
@@ -1,0 +1,186 @@
+# ADR 0052 — Task event log + Tx-only mutation API
+
+**Status:** Accepted (2026-05-08)
+**Supersedes / amends:** ADR 0005 (tasks-in-NATS-KV — KV remains the projection but is no longer the source of truth)
+
+## Context
+
+`internal/tasks` stores `Task` records in a JetStream KV bucket (`bones-tasks`, ADR 0005). The KV is the source of truth: `Manager.Update` performs a CAS write, and a `WatchAll` subscription fans the resulting put/delete entries out to live subscribers as `tasks.Event` values.
+
+Three consequences flow from "KV is the source of truth":
+
+**The live watcher only sees post-subscribe events.** Anything that happened before a `Watch(ctx)` call is invisible. `bones tasks watch` therefore emits a partial story: a claim that landed five seconds before the watcher started is gone forever from that watcher's perspective. JetStream KV's `WatchAll` *does* replay the latest surviving entry per key in its initial snapshot, but only the latest — claim/unclaim/update transitions before that final state are not retained.
+
+**`bones status` Recent activity has no transition history.** The implementation at `cli/status.go:249-270` openly admits the gap:
+
+```go
+// gatherTaskEvents synthesizes activity events from current task state.
+// Without an event log we can't reconstruct claim transitions, so we
+// emit just create + close — the lifecycle bookends.
+```
+
+The activity feed is permanently incomplete: claim/unclaim/update/link/slot_changed transitions never appear.
+
+**`bones status` and `bones tasks status` disagree on counts.** Each surface rolls its own `mgr.List()` aggregation. With separate filtering logic, the count for "open tasks" can differ between the two views even when called milliseconds apart.
+
+The deeper structural risk is "forgot to publish an event." Today nothing in the type system makes "publish an event" co-located with "mutate state." A future contributor adding a new mutation path can write the KV CAS and forget the event side; the only pre-flight check is reviewer attention, and reviewers are not infallible. ADR 0047 (chat-on-JetStream) faced the same shape and rejected the "library function emits the event" pattern for the same reason — atomicity at the API boundary, not at the call site.
+
+## Decision
+
+A new append-only event log on JetStream is the source of truth for task state. The KV is a projection cache, derivable from the log. All mutations flow through a `Manager.Tx` API that publishes the event and writes the KV in the same call; there is no public method on `Manager` that mutates state outside `Tx`.
+
+### Storage
+
+Stream `tasks-events` with subjects `tasks.events.>`. Each event publishes on `tasks.events.<task_id>` so a consumer can replay one task's history with a subject filter. File storage; retention is unbounded by default with bounded compaction (below).
+
+There is no fossil-backed audit table. JetStream is native to bones' substrate (chat, holds, presence, swarm sessions all live there); a second persistence layer would double bookkeeping for one consumer that does not yet exist. Future `bones tasks audit --since=` consumers read the same stream.
+
+### Tx is the only mutation entry point
+
+```go
+// Public surface — the only mutation method on Manager.
+func (m *Manager) Tx(ctx context.Context, taskID string,
+                     fn func(tx *Tx) error) error
+
+// Tx provides:
+//   tx.Create(t Task)                       // first put; emits created
+//   tx.Claim(agentID string)                 // emits claimed
+//   tx.Unclaim(reason string)                // emits unclaimed
+//   tx.Close(agentID, reason string)         // emits closed
+//   tx.Update(changes ...FieldChange)        // emits updated with old+new pairs
+//   tx.Link(otherID string, edgeType string) // emits linked
+//   tx.SlotChange(from, to string)           // emits slot_changed
+//
+// fn must call at least one tx.X method or Tx returns ErrNoMutations.
+```
+
+`Manager.Update` is removed. `Manager.Create` is removed; `tx.Create` replaces it. The previously-public KV writers are made private (`updateLocked`, `createLocked`) and callable only from inside `Tx`. There is no syntactic way for a caller to mutate task state without going through `Tx`. Adding a new mutation = adding a `tx.X` method that publishes a new event type.
+
+A reflection-based test (`TestTx_OnlyMutationPath`) walks `Manager`'s exported methods and asserts none of them, except `Tx`, write to the KV bucket. This is the structural backstop.
+
+Test seeding and hub recovery operations that need to write KV without emitting events get a separate, import-restricted package: `internal/tasks/admin`. Its only callers are the hub-side recovery loop and tests. Production code paths import `internal/tasks` directly and have no syntactic way to reach the admin package.
+
+### Event types — closed iota set
+
+```go
+type EventType uint8
+
+const (
+    EventTypeCreated EventType = iota + 1
+    EventTypeClaimed
+    EventTypeUnclaimed
+    EventTypeUpdated
+    EventTypeLinked
+    EventTypeSlotChanged
+    EventTypeClosed
+)
+```
+
+Each type has a typed payload struct. The `updated` payload carries `[]FieldChange{Field, Old, New}` — old and new values as JSON, not field names alone. The log alone is sufficient to reconstruct any prior state without consulting the KV. Adding a new event type requires (1) a new constant, (2) a new payload struct, (3) a new `tx.X` method, (4) an entry in this ADR's table, (5) a roundtrip test. There is no open-set string carrier for event names.
+
+### Wire envelope
+
+```go
+type EventEnvelope struct {
+    Type      EventType       `json:"type"`
+    TaskID    string          `json:"task_id"`
+    Timestamp time.Time       `json:"timestamp"`
+    Payload   json.RawMessage `json:"payload"`
+    // Stream sequence is supplied by JetStream and read off the message
+    // metadata at consumption time; it is not part of the JSON envelope.
+}
+```
+
+JSON for parity with `internal/chat.Envelope` (ADR 0047). Cross-version readers consume the envelope; an unknown `Type` is logged and skipped (additive-only evolution rule).
+
+### Consistency: event-first, synchronous projection inside Tx
+
+`Tx`'s call sequence per mutation method:
+
+1. Build the typed payload from the proposed change.
+2. `js.PublishMsg(ctx, "tasks.events.<id>", envelope)` and wait for ack.
+3. On ack, perform the KV CAS (existing private helper). Stamp the just-acked stream sequence onto the projected `Task.LastEventSeq` field so recovery can detect orphans.
+4. On KV success, return nil. On KV failure after publish ack, return error — the event is durable; recovery on next hub start replays it.
+
+`Tx` itself batches the user's `tx.X` calls into a single transactional unit only at the API surface (one `fn` invocation = one or more events). Each `tx.X` call publishes one event then writes one KV revision; multi-event transactions are sequential, not atomic. This is acceptable because (a) every individual event's effect is independently meaningful (`claimed` without subsequent `updated` is still a true claim), and (b) JetStream provides no native multi-publish atomicity. The alternative — buffering events in `Tx` and publishing all-or-nothing at end — would lose intermediate states from the log on partial failure, defeating the audit-trail purpose.
+
+`fn` calling zero `tx.X` methods returns `ErrNoMutations`. `fn` returning an error short-circuits Tx without further mutations.
+
+### Recovery on hub start: orphan replay
+
+`Task.LastEventSeq uint64` (new field, schema v4) tracks which event the projection has caught up to. On hub start, the hub-side recovery loop walks `tasks.events.>`:
+
+For each unique `task_id`, fetch the latest event sequence and the current KV's `LastEventSeq`. If `latest > kv.LastEventSeq`, replay the missing events forward through the KV-only projection helper (`internal/tasks/admin.ApplyEvent`). On reaching parity, mark done. Recovery is idempotent: re-applying an event whose `LastEventSeq <= kv.LastEventSeq` is a no-op.
+
+Recovery runs once per hub start. `bones up` blocks on its completion before returning ready. Logs go to `.bones/hub.log`.
+
+### Migration of pre-existing KV state
+
+The first `bones up` on the new binary detects pre-existing KV records without `LastEventSeq` (schema v3 or earlier) and emits synthetic events:
+
+- For every existing task: `created` event with `ts = task.CreatedAt`.
+- If `task.ClaimedBy != ""`: append `claimed` event with `ts = task.ClaimedAt` (or `CreatedAt` if `ClaimedAt` is unset).
+- If `task.ClosedAt != nil`: append `closed` event with `ts = *task.ClosedAt`.
+
+Pre-migration `update`/`link`/`slot_changed` history is lost. The synthetic baseline gives partial-but-sufficient history (lifecycle bookends + claim) versus the only alternative (empty log + "pre-event-log task" sentinel) which would force every consumer to special-case missing history. Loss is documented here so reviewers see it; a fresh `bones up` is unaffected.
+
+A marker key `bones-tasks-events::migrated` in the bucket is checked at start; presence skips migration. The marker is set at the end of a successful migration. Re-running migration is a no-op.
+
+`bones-manifest.json`'s schema version is bumped from 3 to 4 (existing convention; see `internal/manifest/`). Operators on workspaces older than v4 will have their KV records migrated on first `bones up` under the new binary.
+
+### Compaction
+
+Per-task: keep the last 50 events; older events are compacted into a single synthetic summary event of type `created` carrying the last-known-state snapshot, replacing the prior tail. 50 is tunable as `internal/tasks.PerTaskEventCap` (constant, not flag).
+
+Time-based fallback: events older than 90 days for any task that has at least one event newer than that window also compact under the same scheme. 90 days is `internal/tasks.EventRetentionWindow`.
+
+Compaction runs as a periodic worker on the hub side, every 1 hour by default. Worker is paused when its own internal queue depth is non-zero (bounded by `nats.PullSubscribe` semantics; precondition is "no pending recovery"). Triggering off `js.AccountInfo()`-style metrics or alarm-based wakeups is rejected here for the same reason ADR 0047's chat retention is time-driven: a periodic worker is the simplest model and the one consistent with bones' existing in-process scheduling (the slot reaper, the orphan-process registry).
+
+### Tx API in coord and CLI
+
+`internal/coord` callers of the old `tasks.Manager.Update(...)` are rewritten to call `tasks.Manager.Tx(...)`. The mutator-shaped logic (validity checks, transition enforcement) stays inside the Tx callback; the event side is one `tx.X` call per coord verb. `coord.CloseTask` calls `tx.Close`; `coord.Claim` calls `tx.Claim`; `coord.Reclaim` calls `tx.Claim` (with `ClaimEpoch`-bumping flagged on the payload); `coord.Link` calls `tx.Link`; `coord.OpenTask` calls `tx.Create`.
+
+CLI verbs that previously called `mgr.Update` directly (`cli/tasks_update.go`, `cli/tasks_close.go`, `cli/tasks_claim.go`, `cli/swarm_dispatch.go`) become callers of `mgr.Tx`.
+
+### `bones tasks watch`: live-only with explicit backfill flags
+
+`bones tasks watch` defaults to live-only consumption: a JetStream consumer started with `DeliverNewPolicy`. Two flags ship in this PR:
+
+- `--from=<sequence>`: start consumer at the given stream sequence (DeliverByStartSequencePolicy).
+- `--since=<duration>`: start consumer at the given wall-clock offset (DeliverByStartTimePolicy with `time.Now().UTC().Add(-d)`).
+
+The flags are mutually exclusive; specifying both is an error. Default behavior is unchanged for any script that scrapes the watch output.
+
+A future change that "smartly" backfills the last hour by default goes behind a third flag, not as a default change.
+
+### `bones status` Recent activity reads from log
+
+`gatherTaskEvents(list)` is deleted. Recent activity reads the last 20 events (`internal/tasks.RecentActivityCount`) from the log via a new `Manager.Recent(ctx, n)` method. Each event renders to one line; event types map to existing activity-feed verbs (`+ create`, `c claim`, `u unclaim`, `e update`, `l link`, `s slot`, `x close`).
+
+### `TaskTally(events) Tally` — single source for counts
+
+A new function `TaskTally(events []EventEnvelope) Tally` (in `internal/tasks/tally.go`) computes the count summary by replaying events. `bones status` and `bones tasks status` both call it. The previous divergent `mgr.List()` aggregations are deleted; both surfaces walk the log via the same code path. This also closes #313's "duplicate tally" risk — there is no second aggregator left to drift.
+
+### Acceptance / non-goals
+
+In scope: ADR + storage + Tx API + projection rewrite + watch flags + status surfaces + migration + recovery + compaction.
+
+Not in scope (separate issues): `bones tasks history <id>` CLI verb (#322 et seq.), `bones tasks audit --since=24h` consumer, hub RPC operation log (#322), `internal/timefmt/` time-formatting helper (#324), JSON schema envelope (#321) — task event payloads serialize to JetStream, not stdout, so they do not need the CLI envelope, but the typed payload structs are reusable for #321's eventual schema generation.
+
+## Consequences
+
+The Tx API removes "forgot to publish an event" as a reachable failure mode. Reviewers no longer have to scan every PR for paired publish + KV writes; the type system enforces the pairing.
+
+A failure window remains: the hub crashes between publish ack and KV write. The recovery loop reconciles on next start; orphans persist but become healed within seconds of the next `bones up`. Tests cover the reconciliation path explicitly (`TestRecovery_OrphanedEventReplays`).
+
+Pre-migration update history is lost. This is a one-time cost on the first `bones up` per workspace. ADR 0036's prime-on-session-boundaries surfacing depends on Recent activity, which becomes accurate immediately for forward traffic; pre-migration claims/unclaims do not appear, but the synthetic `created` + `claimed` + `closed` baseline preserves the single most useful bookmark per task.
+
+The shared `TaskTally` reduces drift surface for the count-disagreement bug. Future contributors adding a new aggregation slot push it into `Tally`, not into a new caller-side counter.
+
+`bones tasks watch` defaulting to live-only is a behavioral break for any scripted consumer that relied on initial-snapshot replay. Mitigation: `--since=24h` reproduces the previous "see recent activity on connect" feel and is documented in the help text.
+
+`internal/coord`'s coord-level mutators are now Tx callbacks rather than `Update` mutators. The callback signature is broader (the closure receives a `*Tx` rather than a `Task`) but the semantic shape is identical. No coord-level error-mapping change is required.
+
+The `internal/tasks/admin` package is small and import-restricted by `internal/`. It exposes `ApplyEvent(ctx, kv, event)` for recovery. Tests use it for fixture seeding. Production CLI never reaches it.
+
+JetStream stream provisioning at `bones up` time grows from "one chat stream + KV buckets" to "+1 task event stream." The cost is one `js.CreateOrUpdateStream` call per up.

--- a/internal/coord/close_task.go
+++ b/internal/coord/close_task.go
@@ -40,7 +40,9 @@ func (c *Coord) CloseTask(
 		string(taskID), "coord.CloseTask: taskID is empty",
 	)
 	mutate := c.closeMutator(taskID, reason)
-	err := c.sub.tasks.Update(ctx, string(taskID), mutate)
+	err := c.sub.tasks.Tx(ctx, string(taskID), func(tx *tasks.Tx) error {
+		return tx.Close(c.cfg.AgentID, reason, mutate)
+	})
 	return translateCloseErr(err)
 }
 

--- a/internal/coord/close_task_test.go
+++ b/internal/coord/close_task_test.go
@@ -34,7 +34,7 @@ func seedClaimedTask(t *testing.T, c *Coord, id string) {
 		UpdatedAt:     now,
 		SchemaVersion: tasks.SchemaVersion,
 	}
-	if err := c.sub.tasks.Create(context.Background(), rec); err != nil {
+	if err := tasks.NewAdminWrite(c.sub.tasks).Create(context.Background(), rec); err != nil {
 		t.Fatalf("seed claimed task: %v", err)
 	}
 }
@@ -52,7 +52,7 @@ func seedOpenTask(t *testing.T, c *Coord, id string) {
 		UpdatedAt:     now,
 		SchemaVersion: tasks.SchemaVersion,
 	}
-	if err := c.sub.tasks.Create(context.Background(), rec); err != nil {
+	if err := tasks.NewAdminWrite(c.sub.tasks).Create(context.Background(), rec); err != nil {
 		t.Fatalf("seed open task: %v", err)
 	}
 }
@@ -73,7 +73,7 @@ func seedClaimedByOther(
 		UpdatedAt:     now,
 		SchemaVersion: tasks.SchemaVersion,
 	}
-	if err := c.sub.tasks.Create(context.Background(), rec); err != nil {
+	if err := tasks.NewAdminWrite(c.sub.tasks).Create(context.Background(), rec); err != nil {
 		t.Fatalf("seed peer-claimed task: %v", err)
 	}
 }
@@ -95,7 +95,7 @@ func seedClosedTask(t *testing.T, c *Coord, id string) {
 		ClosedReason:  "prior close",
 		SchemaVersion: tasks.SchemaVersion,
 	}
-	if err := c.sub.tasks.Create(context.Background(), rec); err != nil {
+	if err := tasks.NewAdminWrite(c.sub.tasks).Create(context.Background(), rec); err != nil {
 		t.Fatalf("seed closed task: %v", err)
 	}
 }
@@ -275,7 +275,8 @@ func TestCloseTask_StaleEpoch_Refused(t *testing.T) {
 
 	// Bump the record's epoch directly via the substrate to simulate
 	// a concurrent Reclaim having bumped past our view.
-	err := c.sub.tasks.Update(ctx, string(taskID), func(cur tasks.Task) (tasks.Task, error) {
+	aw := tasks.NewAdminWrite(c.sub.tasks)
+	err := aw.Update(ctx, string(taskID), func(cur tasks.Task) (tasks.Task, error) {
 		cur.ClaimEpoch += 1
 		return cur, nil
 	})

--- a/internal/coord/compact_test.go
+++ b/internal/coord/compact_test.go
@@ -57,7 +57,7 @@ func openLeafFixture(t *testing.T, slotID string) (*Leaf, string) {
 // OpenTask/Claim/Close cycle.
 func seedLeafClosedTask(t *testing.T, l *Leaf, rec tasks.Task) {
 	t.Helper()
-	if err := l.coord.sub.tasks.Create(context.Background(), rec); err != nil {
+	if err := tasks.NewAdminWrite(l.coord.sub.tasks).Create(context.Background(), rec); err != nil {
 		t.Fatalf("seed Create %q: %v", rec.ID, err)
 	}
 }

--- a/internal/coord/coord.go
+++ b/internal/coord/coord.go
@@ -150,13 +150,16 @@ func openSubstrate(
 		return nil, fmt.Errorf("coord.Open: holds: %w", err)
 	}
 	if s.tasks, err = tasks.Open(ctx, nc, tasks.Config{
-		BucketName:   tasks.DefaultBucketName,
-		HistoryDepth: cfg.Tuning.TaskHistoryDepth,
-		MaxValueSize: int32(cfg.Tuning.MaxTaskValueSize),
+		BucketName:     tasks.DefaultBucketName,
+		HistoryDepth:   cfg.Tuning.TaskHistoryDepth,
+		MaxValueSize:   int32(cfg.Tuning.MaxTaskValueSize),
+		EnableEventLog: true,
 	}); err != nil {
 		s.close()
 		return nil, fmt.Errorf("coord.Open: tasks: %w", err)
 	}
+	// Archive opens without the event log — compaction-only writes use
+	// the AdminWrite escape hatch to avoid event-log churn (ADR 0052).
 	if s.archive, err = tasks.Open(ctx, nc, tasks.Config{
 		BucketName:   archiveBucket,
 		HistoryDepth: cfg.Tuning.TaskHistoryDepth,
@@ -376,8 +379,26 @@ func (c *Coord) acquireTaskCAS(
 	}
 	files := append([]string(nil), rec.Files...)
 	var newEpoch uint64
+
+	// We pass the legacy mutator into tx.Update with a single
+	// status-edge FieldChange; the mutator does the conditional
+	// rejection (status==open, claimed_by==""), tx publishes a
+	// `claimed` event before invoking the CAS write. A racing claimer
+	// between the pre-check above and the CAS surfaces as
+	// ErrTaskAlreadyClaimed from the mutator, leaving a "spurious
+	// claimed" event in the log; recovery short-circuits replay when
+	// the projection has moved past the event's sequence per ADR 0052.
 	mutate := c.claimMutator(&newEpoch)
-	if err := c.sub.tasks.Update(ctx, string(taskID), mutate); err != nil {
+	err = c.sub.tasks.Tx(ctx, string(taskID), func(tx *tasks.Tx) error {
+		// Use Tx.Mutate for compound mutations (status + claimed_by +
+		// claim_epoch) — the typed Claim helper would not surface the
+		// epoch-bumping race the mutator handles.
+		return tx.Mutate(mutate,
+			tasks.MustFieldChange("status", tasks.StatusOpen, tasks.StatusClaimed),
+			tasks.MustFieldChange("claimed_by", "", c.cfg.AgentID),
+		)
+	})
+	if err != nil {
 		return nil, translateClaimCASErr(err)
 	}
 	c.activeEpochs.Store(taskID, newEpoch)
@@ -471,7 +492,16 @@ func (c *Coord) undoTaskCAS(ctx context.Context, taskID TaskID) {
 		cur.UpdatedAt = time.Now().UTC()
 		return cur, nil
 	}
-	_ = c.sub.tasks.Update(ctx, string(taskID), mutate)
+	// One Tx that runs the legacy mutator: the mutator's
+	// errClaimCASNoOp short-circuits when the claim no longer belongs
+	// to us, leaving the record alone but still emitting an
+	// `unclaimed` event (the audit trail for the rollback attempt).
+	_ = c.sub.tasks.Tx(ctx, string(taskID), func(tx *tasks.Tx) error {
+		return tx.Mutate(mutate,
+			tasks.MustFieldChange("status", tasks.StatusClaimed, tasks.StatusOpen),
+			tasks.MustFieldChange("claimed_by", agent, ""),
+		)
+	})
 	c.activeEpochs.Delete(taskID)
 }
 
@@ -550,7 +580,12 @@ func (c *Coord) releaseTaskCAS(
 		cur.UpdatedAt = time.Now().UTC()
 		return cur, nil
 	}
-	err := c.sub.tasks.Update(ctx, string(taskID), mutate)
+	err := c.sub.tasks.Tx(ctx, string(taskID), func(tx *tasks.Tx) error {
+		return tx.Mutate(mutate,
+			tasks.MustFieldChange("status", tasks.StatusClaimed, tasks.StatusOpen),
+			tasks.MustFieldChange("claimed_by", agent, ""),
+		)
+	})
 	switch {
 	case err == nil:
 		return nil
@@ -752,14 +787,25 @@ func (c *Coord) listTasks(ctx context.Context) ([]tasks.Task, error) {
 }
 
 // updateTask performs a revision-gated CAS update on a task record.
-// Used by Leaf.Compact to stamp compaction metadata on a closed record;
-// unexported so substrate remains opaque to Leaf code.
+// Used by Leaf.Compact to stamp compaction metadata on a closed
+// record; unexported so substrate remains opaque to Leaf code.
+//
+// Routed through tasks.Tx so the canonical "no mutation outside Tx"
+// rule (ADR 0052) holds. The compaction edit emits an `updated` event
+// describing the (compact_level, original_size, compacted_at) deltas;
+// callers do not have to author the FieldChange tuples themselves
+// because the mutator is run twice — once in dry-run mode against the
+// pre-image to derive deltas, then for real inside Tx.
 func (c *Coord) updateTask(
 	ctx context.Context,
 	id string,
 	mutate func(tasks.Task) (tasks.Task, error),
 ) error {
-	return c.sub.tasks.Update(ctx, id, mutate)
+	return c.sub.tasks.Tx(ctx, id, func(tx *tasks.Tx) error {
+		return tx.Mutate(mutate,
+			tasks.MustFieldChange("compaction", "before", "after"),
+		)
+	})
 }
 
 // getAndArchiveTask reads the hot task record for id, writes it into
@@ -771,7 +817,7 @@ func (c *Coord) getAndArchiveTask(ctx context.Context, id string) error {
 	if err != nil {
 		return err
 	}
-	if err := c.sub.archive.Create(ctx, archived); err != nil {
+	if err := tasks.NewAdminWrite(c.sub.archive).Create(ctx, archived); err != nil {
 		if !errors.Is(err, tasks.ErrAlreadyExists) {
 			return err
 		}

--- a/internal/coord/coord.go
+++ b/internal/coord/coord.go
@@ -380,23 +380,27 @@ func (c *Coord) acquireTaskCAS(
 	files := append([]string(nil), rec.Files...)
 	var newEpoch uint64
 
-	// We pass the legacy mutator into tx.Update with a single
-	// status-edge FieldChange; the mutator does the conditional
-	// rejection (status==open, claimed_by==""), tx publishes a
-	// `claimed` event before invoking the CAS write. A racing claimer
-	// between the pre-check above and the CAS surfaces as
-	// ErrTaskAlreadyClaimed from the mutator, leaving a "spurious
-	// claimed" event in the log; recovery short-circuits replay when
-	// the projection has moved past the event's sequence per ADR 0052.
+	// tx.Claim publishes a `claimed` event then runs claimMutator
+	// inside the CAS loop. The mutator does the conditional rejection
+	// (status==open, claimed_by==""); a racing claimer between the
+	// pre-check above and the CAS surfaces as ErrTaskAlreadyClaimed
+	// from the mutator, leaving a "spurious claimed" event in the
+	// log. Recovery's LastEventSeq guard prevents replay from
+	// clobbering a later projection (ADR 0052 §"Recovery").
 	mutate := c.claimMutator(&newEpoch)
 	err = c.sub.tasks.Tx(ctx, string(taskID), func(tx *tasks.Tx) error {
-		// Use Tx.Mutate for compound mutations (status + claimed_by +
-		// claim_epoch) — the typed Claim helper would not surface the
-		// epoch-bumping race the mutator handles.
-		return tx.Mutate(mutate,
-			tasks.MustFieldChange("status", tasks.StatusOpen, tasks.StatusClaimed),
-			tasks.MustFieldChange("claimed_by", "", c.cfg.AgentID),
-		)
+		return tx.Claim(tasks.ClaimArgs{
+			AgentID: c.cfg.AgentID,
+			// ClaimEpoch is set inside the mutator (cur.ClaimEpoch++)
+			// because we cannot know the new epoch without the CAS
+			// read; the event payload's ClaimEpoch field is filled
+			// from the post-mutate state via Tx — but Tx.Claim takes
+			// the args up front. To keep the typed payload accurate
+			// we pass rec.ClaimEpoch+1 (best-effort guess; mutator
+			// authoritatively sets the projection's value).
+			ClaimEpoch: rec.ClaimEpoch + 1,
+			Mutate:     mutate,
+		})
 	})
 	if err != nil {
 		return nil, translateClaimCASErr(err)
@@ -492,15 +496,12 @@ func (c *Coord) undoTaskCAS(ctx context.Context, taskID TaskID) {
 		cur.UpdatedAt = time.Now().UTC()
 		return cur, nil
 	}
-	// One Tx that runs the legacy mutator: the mutator's
-	// errClaimCASNoOp short-circuits when the claim no longer belongs
-	// to us, leaving the record alone but still emitting an
-	// `unclaimed` event (the audit trail for the rollback attempt).
+	// tx.Unclaim publishes the unclaimed event then runs the mutator
+	// inside the CAS loop. The mutator's errClaimCASNoOp short-
+	// circuits when the claim no longer belongs to us, leaving the
+	// record alone (the event still ships as the audit trail).
 	_ = c.sub.tasks.Tx(ctx, string(taskID), func(tx *tasks.Tx) error {
-		return tx.Mutate(mutate,
-			tasks.MustFieldChange("status", tasks.StatusClaimed, tasks.StatusOpen),
-			tasks.MustFieldChange("claimed_by", agent, ""),
-		)
+		return tx.Unclaim("claim rollback after hold failure", mutate)
 	})
 	c.activeEpochs.Delete(taskID)
 }
@@ -581,10 +582,7 @@ func (c *Coord) releaseTaskCAS(
 		return cur, nil
 	}
 	err := c.sub.tasks.Tx(ctx, string(taskID), func(tx *tasks.Tx) error {
-		return tx.Mutate(mutate,
-			tasks.MustFieldChange("status", tasks.StatusClaimed, tasks.StatusOpen),
-			tasks.MustFieldChange("claimed_by", agent, ""),
-		)
+		return tx.Unclaim("release", mutate)
 	})
 	switch {
 	case err == nil:
@@ -790,22 +788,20 @@ func (c *Coord) listTasks(ctx context.Context) ([]tasks.Task, error) {
 // Used by Leaf.Compact to stamp compaction metadata on a closed
 // record; unexported so substrate remains opaque to Leaf code.
 //
-// Routed through tasks.Tx so the canonical "no mutation outside Tx"
-// rule (ADR 0052) holds. The compaction edit emits an `updated` event
-// describing the (compact_level, original_size, compacted_at) deltas;
-// callers do not have to author the FieldChange tuples themselves
-// because the mutator is run twice — once in dry-run mode against the
-// pre-image to derive deltas, then for real inside Tx.
+// Compaction metadata writes (compact_level, original_size,
+// compacted_at) are bookkeeping internal to the leaf-side compaction
+// pipeline — not user-driven mutations and not interesting in the
+// task event log. Routing them through Tx would emit `updated` events
+// for every compaction tick, polluting the audit trail with noise
+// that has no correspondence to a user-visible state change. ADR 0052
+// permits AdminWrite for hub-side bookkeeping; compaction metadata is
+// the same shape and uses the same escape hatch.
 func (c *Coord) updateTask(
 	ctx context.Context,
 	id string,
 	mutate func(tasks.Task) (tasks.Task, error),
 ) error {
-	return c.sub.tasks.Tx(ctx, id, func(tx *tasks.Tx) error {
-		return tx.Mutate(mutate,
-			tasks.MustFieldChange("compaction", "before", "after"),
-		)
-	})
+	return tasks.NewAdminWrite(c.sub.tasks).Update(ctx, id, mutate)
 }
 
 // getAndArchiveTask reads the hot task record for id, writes it into

--- a/internal/coord/handoff_claim.go
+++ b/internal/coord/handoff_claim.go
@@ -39,9 +39,12 @@ func (c *Coord) HandoffClaim(
 		return nil, err
 	}
 	var newEpoch uint64
-	if err := c.sub.tasks.Update(
-		ctx, string(taskID), c.handoffMutator(fromAgent, &newEpoch),
-	); err != nil {
+	mutate := c.handoffMutator(fromAgent, &newEpoch)
+	if err := c.sub.tasks.Tx(ctx, string(taskID), func(tx *tasks.Tx) error {
+		return tx.Mutate(mutate,
+			tasks.MustFieldChange("claimed_by", fromAgent, c.cfg.AgentID),
+		)
+	}); err != nil {
 		return nil, translateHandoffCASErr(err)
 	}
 	c.activeEpochs.Store(taskID, newEpoch)

--- a/internal/coord/handoff_claim.go
+++ b/internal/coord/handoff_claim.go
@@ -34,16 +34,19 @@ func (c *Coord) HandoffClaim(
 	c.assertOpen("HandoffClaim")
 	c.assertHandoffClaimPreconditions(ctx, taskID, fromAgent, ttl)
 
-	files, err := c.prepareHandoff(ctx, taskID, fromAgent)
+	prevEpoch, files, err := c.prepareHandoff(ctx, taskID, fromAgent)
 	if err != nil {
 		return nil, err
 	}
 	var newEpoch uint64
 	mutate := c.handoffMutator(fromAgent, &newEpoch)
 	if err := c.sub.tasks.Tx(ctx, string(taskID), func(tx *tasks.Tx) error {
-		return tx.Mutate(mutate,
-			tasks.MustFieldChange("claimed_by", fromAgent, c.cfg.AgentID),
-		)
+		return tx.Claim(tasks.ClaimArgs{
+			AgentID:    c.cfg.AgentID,
+			ClaimEpoch: prevEpoch + 1,
+			PrevAgent:  fromAgent,
+			Mutate:     mutate,
+		})
 	}); err != nil {
 		return nil, translateHandoffCASErr(err)
 	}
@@ -81,24 +84,24 @@ func (c *Coord) assertHandoffClaimPreconditions(
 
 func (c *Coord) prepareHandoff(
 	ctx context.Context, taskID TaskID, fromAgent string,
-) ([]string, error) {
+) (prevEpoch uint64, files []string, err error) {
 	rec, _, err := c.sub.tasks.Get(ctx, string(taskID))
 	if err != nil {
 		if errors.Is(err, tasks.ErrNotFound) {
-			return nil, fmt.Errorf("coord.HandoffClaim: %w", ErrTaskNotFound)
+			return 0, nil, fmt.Errorf("coord.HandoffClaim: %w", ErrTaskNotFound)
 		}
-		return nil, fmt.Errorf("coord.HandoffClaim: %w", err)
+		return 0, nil, fmt.Errorf("coord.HandoffClaim: %w", err)
 	}
 	if rec.Status != tasks.StatusClaimed {
-		return nil, fmt.Errorf("coord.HandoffClaim: %w", ErrTaskNotClaimed)
+		return 0, nil, fmt.Errorf("coord.HandoffClaim: %w", ErrTaskNotClaimed)
 	}
 	if rec.ClaimedBy == c.cfg.AgentID {
-		return nil, fmt.Errorf("coord.HandoffClaim: %w", ErrAlreadyClaimer)
+		return 0, nil, fmt.Errorf("coord.HandoffClaim: %w", ErrAlreadyClaimer)
 	}
 	if rec.ClaimedBy != fromAgent {
-		return nil, fmt.Errorf("coord.HandoffClaim: %w", ErrAgentMismatch)
+		return 0, nil, fmt.Errorf("coord.HandoffClaim: %w", ErrAgentMismatch)
 	}
-	return append([]string(nil), rec.Files...), nil
+	return rec.ClaimEpoch, append([]string(nil), rec.Files...), nil
 }
 
 func (c *Coord) handoffMutator(

--- a/internal/coord/link.go
+++ b/internal/coord/link.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"time"
 
 	"github.com/danmestas/bones/internal/assert"
 	"github.com/danmestas/bones/internal/tasks"
@@ -41,20 +40,26 @@ func (c *Coord) Link(ctx context.Context, from, to TaskID, edgeType EdgeType) er
 	}
 
 	internalType := tasks.EdgeType(edgeType)
-	mutate := func(cur tasks.Task) (tasks.Task, error) {
-		for _, e := range cur.Edges {
-			if e.Type == internalType && e.Target == string(to) {
-				return cur, nil // idempotent no-op
-			}
+
+	// Idempotent fast-path: if the edge already exists, return without
+	// publishing an event. The Tx-side Link emits an event for every
+	// call, so the no-op check has to happen here, not in the mutator.
+	cur, _, err := c.sub.tasks.Get(ctx, string(from))
+	if err != nil {
+		if errors.Is(err, tasks.ErrNotFound) {
+			return fmt.Errorf("coord.Link: from=%s: %w", from, ErrTaskNotFound)
 		}
-		cur.Edges = append(cur.Edges, tasks.Edge{
-			Type:   internalType,
-			Target: string(to),
-		})
-		cur.UpdatedAt = time.Now().UTC()
-		return cur, nil
+		return fmt.Errorf("coord.Link: from=%s: %w", from, err)
 	}
-	if err := c.sub.tasks.Update(ctx, string(from), mutate); err != nil {
+	for _, e := range cur.Edges {
+		if e.Type == internalType && e.Target == string(to) {
+			return nil // idempotent no-op
+		}
+	}
+
+	if err := c.sub.tasks.Tx(ctx, string(from), func(tx *tasks.Tx) error {
+		return tx.Link(string(to), string(edgeType))
+	}); err != nil {
 		if errors.Is(err, tasks.ErrNotFound) {
 			return fmt.Errorf("coord.Link: from=%s: %w", from, ErrTaskNotFound)
 		}

--- a/internal/coord/open_task.go
+++ b/internal/coord/open_task.go
@@ -80,7 +80,9 @@ func (c *Coord) OpenTask(
 		UpdatedAt:     now,
 		SchemaVersion: tasks.SchemaVersion,
 	}
-	if err := c.sub.tasks.Create(ctx, rec); err != nil {
+	if err := c.sub.tasks.Tx(ctx, string(id), func(tx *tasks.Tx) error {
+		return tx.Create(rec)
+	}); err != nil {
 		return "", translateCreateErr(id, err)
 	}
 	return id, nil

--- a/internal/coord/ready_test.go
+++ b/internal/coord/ready_test.go
@@ -29,7 +29,7 @@ func readyBaseline(id string, created time.Time) tasks.Task {
 // rejects invariant-11 mismatches and fixed-enum violations.
 func seedTask(t *testing.T, c *Coord, rec tasks.Task) {
 	t.Helper()
-	if err := c.sub.tasks.Create(context.Background(), rec); err != nil {
+	if err := tasks.NewAdminWrite(c.sub.tasks).Create(context.Background(), rec); err != nil {
 		t.Fatalf("seed Create %q: %v", rec.ID, err)
 	}
 }

--- a/internal/coord/reclaim.go
+++ b/internal/coord/reclaim.go
@@ -44,16 +44,19 @@ func (c *Coord) Reclaim(
 	c.assertOpen("Reclaim")
 	c.assertReclaimPreconditions(ctx, taskID, ttl)
 
-	prev, files, err := c.prepareReclaim(ctx, taskID)
+	prev, prevEpoch, files, err := c.prepareReclaim(ctx, taskID)
 	if err != nil {
 		return nil, err
 	}
 	var newEpoch uint64
 	mutate := c.reclaimMutator(&newEpoch)
 	if err := c.sub.tasks.Tx(ctx, string(taskID), func(tx *tasks.Tx) error {
-		return tx.Mutate(mutate,
-			tasks.MustFieldChange("claimed_by", prev, c.cfg.AgentID),
-		)
+		return tx.Claim(tasks.ClaimArgs{
+			AgentID:    c.cfg.AgentID,
+			ClaimEpoch: prevEpoch + 1,
+			PrevAgent:  prev,
+			Mutate:     mutate,
+		})
 	}); err != nil {
 		return nil, translateReclaimCASErr(err)
 	}
@@ -92,27 +95,30 @@ func (c *Coord) assertReclaimPreconditions(
 
 // prepareReclaim reads the task record, enforces the three precondition
 // gates (claimed status, not self, claimer offline), and returns the
-// previous claimed_by plus the file list for hold acquisition.
+// previous claimed_by plus the file list for hold acquisition. The
+// previous claim epoch is also returned so the post-Tx event payload
+// can carry the best-effort new epoch (mutator authoritatively writes
+// the projection's value inside the CAS loop).
 func (c *Coord) prepareReclaim(
 	ctx context.Context, taskID TaskID,
-) (prev string, files []string, err error) {
+) (prev string, prevEpoch uint64, files []string, err error) {
 	rec, _, err := c.sub.tasks.Get(ctx, string(taskID))
 	if err != nil {
 		if errors.Is(err, tasks.ErrNotFound) {
-			return "", nil, fmt.Errorf("coord.Reclaim: %w", ErrTaskNotFound)
+			return "", 0, nil, fmt.Errorf("coord.Reclaim: %w", ErrTaskNotFound)
 		}
-		return "", nil, fmt.Errorf("coord.Reclaim: %w", err)
+		return "", 0, nil, fmt.Errorf("coord.Reclaim: %w", err)
 	}
 	if rec.Status != tasks.StatusClaimed {
-		return "", nil, fmt.Errorf("coord.Reclaim: %w", ErrTaskNotClaimed)
+		return "", 0, nil, fmt.Errorf("coord.Reclaim: %w", ErrTaskNotClaimed)
 	}
 	if rec.ClaimedBy == c.cfg.AgentID {
-		return "", nil, fmt.Errorf("coord.Reclaim: %w", ErrAlreadyClaimer)
+		return "", 0, nil, fmt.Errorf("coord.Reclaim: %w", ErrAlreadyClaimer)
 	}
 	if err := c.assertClaimerOffline(ctx, rec.ClaimedBy); err != nil {
-		return "", nil, err
+		return "", 0, nil, err
 	}
-	return rec.ClaimedBy, append([]string(nil), rec.Files...), nil
+	return rec.ClaimedBy, rec.ClaimEpoch, append([]string(nil), rec.Files...), nil
 }
 
 // assertClaimerOffline returns ErrClaimerLive if agent is present in

--- a/internal/coord/reclaim.go
+++ b/internal/coord/reclaim.go
@@ -49,7 +49,12 @@ func (c *Coord) Reclaim(
 		return nil, err
 	}
 	var newEpoch uint64
-	if err := c.sub.tasks.Update(ctx, string(taskID), c.reclaimMutator(&newEpoch)); err != nil {
+	mutate := c.reclaimMutator(&newEpoch)
+	if err := c.sub.tasks.Tx(ctx, string(taskID), func(tx *tasks.Tx) error {
+		return tx.Mutate(mutate,
+			tasks.MustFieldChange("claimed_by", prev, c.cfg.AgentID),
+		)
+	}); err != nil {
 		return nil, translateReclaimCASErr(err)
 	}
 	c.activeEpochs.Store(taskID, newEpoch)

--- a/internal/hub/hub.go
+++ b/internal/hub/hub.go
@@ -273,6 +273,17 @@ func runForeground(ctx context.Context, p paths, o opts) error {
 	// must produce valid JSON on stdout for the hook contract (#304).
 	fmt.Fprintf(os.Stderr, "hub: fossil at %s, nats at %s\n",
 		h.HTTPAddr(), h.NATSURL())
+
+	// Reconcile any orphan events from a prior unclean shutdown
+	// (event published, projection-write didn't land) BEFORE the
+	// registry-write below makes the hub discoverable to CLI verbs.
+	// Synchronous here because we hold the workspace lock and no
+	// live Tx writer can race; running serially is what makes
+	// ADR 0052's "no race between Recover and live writers"
+	// guarantee real (Recover stays opt-in via tasks.Config because
+	// every other tasks.Open call is concurrent with live Tx).
+	runTaskRecovery(ctx, h.NATSURL(), hl)
+
 	if err := registry.Write(registry.Entry{
 		Cwd:       p.root,
 		Name:      filepath.Base(p.root),

--- a/internal/hub/task_recovery.go
+++ b/internal/hub/task_recovery.go
@@ -1,0 +1,61 @@
+package hub
+
+import (
+	"context"
+	"time"
+
+	"github.com/nats-io/nats.go"
+
+	"github.com/danmestas/bones/internal/tasks"
+)
+
+// recoveryDialTimeout bounds how long the recovery NATS connection
+// will wait for the embedded server to accept a connect. The server
+// has just been bound (we're called right after `hub: ready`) so the
+// connect should be subsecond; this guards against a stuck listener
+// surfacing as an indefinite hang during hub start.
+const recoveryDialTimeout = 5 * time.Second
+
+// runTaskRecovery dials the just-bound NATS server, opens a
+// tasks.Manager with RecoverOnOpen=true so Recover drains
+// synchronously inside Open, then closes everything.
+//
+// Per ADR 0052 §"Recovery": running Recover concurrently with live
+// Tx writers is racy by design (the recovery loop and the writer
+// both want to bring KV to parity with the stream and they CAS-
+// clobber each other). Hub start is the one place where Recover is
+// safe — it runs serially before any CLI verb can dial the new
+// server, so no Tx is in flight. This helper is the wiring that
+// makes the safety guarantee real: NATS up → recovery → CLI verbs
+// allowed to connect.
+//
+// Errors are logged but do not fail hub start: a recovery failure
+// does not block the workspace from coming up. The orphan events
+// remain on the stream and the next bones-up will retry. The hub
+// log carries the failure breadcrumb for `bones doctor`.
+func runTaskRecovery(ctx context.Context, natsURL string, hl *hubLogger) {
+	dialCtx, cancel := context.WithTimeout(ctx, recoveryDialTimeout)
+	defer cancel()
+	nc, err := nats.Connect(natsURL,
+		nats.Timeout(recoveryDialTimeout),
+		nats.RetryOnFailedConnect(false),
+	)
+	if err != nil {
+		hl.Warnf("hub: recovery skipped (nats dial: %v)", err)
+		return
+	}
+	defer nc.Close()
+	mgr, err := tasks.Open(dialCtx, nc, tasks.Config{
+		BucketName:     tasks.DefaultBucketName,
+		HistoryDepth:   8,
+		MaxValueSize:   64 * 1024,
+		EnableEventLog: true,
+		RecoverOnOpen:  true,
+	})
+	if err != nil {
+		hl.Warnf("hub: recovery failed (%v) — orphan events will retry on next start", err)
+		return
+	}
+	defer func() { _ = mgr.Close() }()
+	hl.Infof("hub: task event-log recovery complete")
+}

--- a/internal/hub/task_recovery_test.go
+++ b/internal/hub/task_recovery_test.go
@@ -1,0 +1,141 @@
+package hub
+
+import (
+	"context"
+	"testing"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+
+	"github.com/danmestas/bones/internal/tasks"
+	"github.com/danmestas/bones/internal/testutil/natstest"
+)
+
+// jetstreamFor returns a JetStream handle bound to nc. Used by the
+// recovery integration test to publish an orphan event directly
+// (bypassing tasks.Tx, which would also write the KV).
+func jetstreamFor(nc *nats.Conn) (jetstream.JetStream, error) {
+	return jetstream.New(nc)
+}
+
+// newTestHubLogger returns a hubLogger whose file pointer is nil so
+// every Infof/Warnf/Errorf call no-ops. Adequate for the recovery
+// integration test — we assert behavior, not log output.
+func newTestHubLogger(t *testing.T) *hubLogger {
+	t.Helper()
+	return &hubLogger{}
+}
+
+// TestRunTaskRecovery_HubStart_ReplaysOrphanEvent simulates the
+// integration the reviewer asked for: a hub start with one orphan
+// event in the stream + a matching projection at LastEventSeq <
+// event seq. After runTaskRecovery returns, the projection is
+// reconciled. This is the C1 acceptance test — it verifies the hub-
+// start recovery wiring works end-to-end through Recover (gated by
+// RecoverOnOpen) before any CLI verb could connect.
+func TestRunTaskRecovery_HubStart_ReplaysOrphanEvent(t *testing.T) {
+	srv, cleanup := natstest.NewJetStreamServer(t)
+	defer cleanup()
+	natsURL := srv.ConnectedUrl()
+
+	ctx := context.Background()
+
+	// Pre-state: open a tasks Manager (without RecoverOnOpen),
+	// seed a task, simulate an orphan claimed event.
+	nc, err := nats.Connect(natsURL)
+	if err != nil {
+		t.Fatalf("nats.Connect: %v", err)
+	}
+	m, err := tasks.Open(ctx, nc, tasks.Config{
+		BucketName:     tasks.DefaultBucketName,
+		HistoryDepth:   8,
+		MaxValueSize:   64 * 1024,
+		EnableEventLog: true,
+	})
+	if err != nil {
+		nc.Close()
+		t.Fatalf("Open: %v", err)
+	}
+	taskID := "bones-hub-recover-1"
+	rec := tasks.Task{
+		ID:            taskID,
+		Title:         "hub-recover example",
+		Status:        tasks.StatusOpen,
+		Files:         []string{"/work/x.go"},
+		SchemaVersion: tasks.SchemaVersion,
+	}
+	if err := m.Tx(ctx, rec.ID, func(tx *tasks.Tx) error {
+		return tx.Create(rec)
+	}); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	// Simulate orphan event (publish without KV write).
+	env, err := tasks.EncodeEnvelope(tasks.EventTypeClaimed, taskID,
+		tasks.ClaimedPayload{AgentID: "post-crash-agent", ClaimEpoch: 9})
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	body, err := tasks.MarshalEnvelope(env)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	js, err := jetstreamFor(nc)
+	if err != nil {
+		t.Fatalf("jetstream: %v", err)
+	}
+	if _, err := js.Publish(ctx, tasks.EventSubject(taskID), body); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+	_ = m.Close()
+	nc.Close()
+
+	// Pre-recovery: KV still shows the task as Open (the orphan
+	// event has not been applied).
+	got := readTaskForTest(t, natsURL, taskID)
+	if got.Status != tasks.StatusOpen {
+		t.Fatalf("pre-hub-start want Open, got %s", got.Status)
+	}
+
+	// Drive the hub-start recovery path. runTaskRecovery is the
+	// helper hub.Start calls right after `hub: ready` and before
+	// registry.Write makes the hub discoverable.
+	hl := newTestHubLogger(t)
+	runTaskRecovery(ctx, natsURL, hl)
+
+	// Post-recovery: projection caught up with the orphan event.
+	got = readTaskForTest(t, natsURL, taskID)
+	if got.Status != tasks.StatusClaimed {
+		t.Fatalf("post-hub-start want Claimed, got %s", got.Status)
+	}
+	if got.ClaimedBy != "post-crash-agent" {
+		t.Fatalf("post-hub-start ClaimedBy = %q, want post-crash-agent",
+			got.ClaimedBy)
+	}
+}
+
+// readTaskForTest opens a fresh tasks.Manager (without recovery to
+// avoid double-Recover noise) just to read the projection. Returns
+// the decoded Task.
+func readTaskForTest(t *testing.T, natsURL, id string) tasks.Task {
+	t.Helper()
+	nc, err := nats.Connect(natsURL)
+	if err != nil {
+		t.Fatalf("readTaskForTest: nats.Connect: %v", err)
+	}
+	defer nc.Close()
+	m, err := tasks.Open(context.Background(), nc, tasks.Config{
+		BucketName:     tasks.DefaultBucketName,
+		HistoryDepth:   8,
+		MaxValueSize:   64 * 1024,
+		EnableEventLog: true,
+	})
+	if err != nil {
+		t.Fatalf("readTaskForTest: Open: %v", err)
+	}
+	defer func() { _ = m.Close() }()
+	got, _, err := m.Get(context.Background(), id)
+	if err != nil {
+		t.Fatalf("readTaskForTest: Get: %v", err)
+	}
+	return got
+}

--- a/internal/tasks/admin.go
+++ b/internal/tasks/admin.go
@@ -1,0 +1,64 @@
+package tasks
+
+import (
+	"context"
+
+	"github.com/danmestas/bones/internal/assert"
+)
+
+// AdminWrite is the import-restricted write surface for the hub-side
+// migration / recovery loop and for test seeding. ADR 0052 makes Tx
+// the only public mutation entry point on Manager; AdminWrite is the
+// narrow exception. It is its own type so the reflection-based
+// "no mutation outside Tx" test on Manager passes — Manager has no
+// public mutation method, only Tx.
+//
+// Production CLI code MUST NOT instantiate AdminWrite. The accepted
+// callers are:
+//
+//   - internal/hub: migration of pre-event-log KV records, recovery
+//     of orphaned events on hub start.
+//   - tests inside this repository: deterministic fixture seeding.
+//
+// Every method here writes the KV without publishing an event. The
+// caller is responsible for emitting a matching event when one is
+// expected (e.g., the migration emits synthetic events explicitly).
+type AdminWrite struct {
+	mgr *Manager
+}
+
+// NewAdminWrite returns an AdminWrite bound to mgr. The constructor's
+// signature signals intent at every call site; callers searching for
+// "tasks.NewAdminWrite" find every place admin writes happen and can
+// audit whether the exception is justified.
+func NewAdminWrite(mgr *Manager) AdminWrite {
+	assert.NotNil(mgr, "tasks.NewAdminWrite: mgr is nil")
+	return AdminWrite{mgr: mgr}
+}
+
+// Create writes a new task record without publishing an event. Hub-
+// side migration uses this to seed records that are paired with
+// synthetic events emitted directly to the stream.
+func (a AdminWrite) Create(ctx context.Context, t Task) error {
+	return a.mgr.create(ctx, t)
+}
+
+// Update performs the same revision-gated CAS update as the legacy
+// Manager.Update (now private), without publishing an event. Hub-side
+// recovery uses this to bring a projection forward when the stream's
+// latest event sequence outpaces the KV's LastEventSeq.
+func (a AdminWrite) Update(
+	ctx context.Context,
+	id string,
+	mutate func(Task) (Task, error),
+) error {
+	return a.mgr.update(ctx, id, mutate)
+}
+
+// Purge permanently removes a task key. Reachable from Manager.Purge
+// already; re-exposed here for symmetry with the migration / recovery
+// caller's surface, so a recovery loop never has to import multiple
+// surfaces to do its job.
+func (a AdminWrite) Purge(ctx context.Context, id string) error {
+	return a.mgr.Purge(ctx, id)
+}

--- a/internal/tasks/compaction.go
+++ b/internal/tasks/compaction.go
@@ -1,0 +1,134 @@
+package tasks
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/nats-io/nats.go/jetstream"
+
+	"github.com/danmestas/bones/internal/assert"
+)
+
+// PerTaskEventCap is the maximum number of events kept per task before
+// older events are compacted into a synthetic created summary. ADR
+// 0052 fixes this at 50.
+const PerTaskEventCap = 50
+
+// EventRetentionWindow is the time-based fallback for compaction.
+// Events older than this for a task that also has at least one newer
+// event are eligible for compaction. ADR 0052 fixes this at 90 days.
+const EventRetentionWindow = 90 * 24 * time.Hour
+
+// CompactPerTask replaces the older events for one task with a single
+// synthetic created event carrying the full post-compaction snapshot.
+// Returns the number of events removed (i.e., per-task event count
+// before minus after).
+//
+// CompactPerTask is the per-task primitive used by the hub-side
+// compaction worker. The worker is a follow-up; this primitive lets
+// tests exercise the compaction semantics without scheduling.
+//
+// Safety: compaction runs only on tasks whose latest projection
+// exists in KV. Aborts (no-op) if the projection is missing — the
+// task may have been purged.
+func CompactPerTask(ctx context.Context, m *Manager, taskID string) (int, error) {
+	assert.NotNil(ctx, "tasks.CompactPerTask: ctx is nil")
+	assert.NotNil(m, "tasks.CompactPerTask: m is nil")
+	assert.NotEmpty(taskID, "tasks.CompactPerTask: taskID is empty")
+	if m.stream == nil {
+		return 0, errors.New("tasks.CompactPerTask: event log disabled")
+	}
+	cur, _, err := m.Get(ctx, taskID)
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			return 0, nil
+		}
+		return 0, fmt.Errorf("tasks.CompactPerTask: %w", err)
+	}
+	envs, err := m.Replay(ctx, LogReadOpts{FilterTaskID: taskID})
+	if err != nil {
+		return 0, fmt.Errorf("tasks.CompactPerTask: replay: %w", err)
+	}
+	if len(envs) <= PerTaskEventCap {
+		// Nothing to compact within the count cap; check the time
+		// fallback instead.
+		if !shouldCompactByTime(envs) {
+			return 0, nil
+		}
+	}
+	return doCompactPerTask(ctx, m, taskID, cur, envs)
+}
+
+// shouldCompactByTime reports whether the events slice has at least
+// one event older than EventRetentionWindow paired with at least one
+// event newer. The "paired with newer" rule keeps a frozen-but-active
+// task from being compacted just because its events are old.
+func shouldCompactByTime(envs []EventEnvelope) bool {
+	if len(envs) == 0 {
+		return false
+	}
+	cutoff := time.Now().UTC().Add(-EventRetentionWindow)
+	hasOld := false
+	hasNew := false
+	for _, env := range envs {
+		if env.Timestamp.Before(cutoff) {
+			hasOld = true
+		} else {
+			hasNew = true
+		}
+		if hasOld && hasNew {
+			return true
+		}
+	}
+	return false
+}
+
+// doCompactPerTask emits a synthetic created event with the
+// post-compaction snapshot and purges the per-task subject so the
+// stream's per-task event count drops.
+//
+// Compaction order:
+//
+//  1. Publish synthetic created carrying the full Task snapshot.
+//  2. Wait for ack so the survivor is durable.
+//  3. Purge the per-task subject below the synthetic event's seq so
+//     the older entries are reclaimed.
+//
+// Failure between steps 1 and 3 leaves a duplicate synthetic event
+// in the log; readers (TaskTally, Replay) handle this gracefully —
+// duplicate created events for the same task are idempotent.
+func doCompactPerTask(
+	ctx context.Context,
+	m *Manager,
+	taskID string,
+	cur Task,
+	envs []EventEnvelope,
+) (int, error) {
+	snapshot := cur
+	payload := CreatedPayload{
+		Title:    cur.Title,
+		Files:    append([]string(nil), cur.Files...),
+		Snapshot: &snapshot,
+	}
+	env, err := EncodeEnvelope(EventTypeCreated, taskID, payload)
+	if err != nil {
+		return 0, err
+	}
+	body, err := MarshalEnvelope(env)
+	if err != nil {
+		return 0, err
+	}
+	ack, err := m.js.Publish(ctx, EventSubject(taskID), body)
+	if err != nil {
+		return 0, fmt.Errorf("tasks.CompactPerTask: publish: %w", err)
+	}
+	// Purge per-task subject below the synthetic survivor.
+	if err := m.stream.Purge(ctx, jetstream.WithPurgeSubject(EventSubject(taskID)),
+		jetstream.WithPurgeKeep(1)); err != nil {
+		return 0, fmt.Errorf("tasks.CompactPerTask: purge: %w", err)
+	}
+	_ = ack
+	return len(envs), nil
+}

--- a/internal/tasks/compaction_test.go
+++ b/internal/tasks/compaction_test.go
@@ -1,0 +1,76 @@
+package tasks_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/danmestas/bones/internal/tasks"
+)
+
+// TestCompactPerTask_BelowCap_NoOp verifies compaction is a no-op when
+// the per-task event count is at or below the cap.
+func TestCompactPerTask_BelowCap_NoOp(t *testing.T) {
+	m, _, cleanup := openEventLogManager(t)
+	defer cleanup()
+	ctx := context.Background()
+	rec := txNewTask("bones-compact-noop")
+	if err := m.Tx(ctx, rec.ID, func(tx *tasks.Tx) error {
+		return tx.Create(rec)
+	}); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	removed, err := tasks.CompactPerTask(ctx, m, rec.ID)
+	if err != nil {
+		t.Fatalf("CompactPerTask: %v", err)
+	}
+	if removed != 0 {
+		t.Fatalf("want 0 removed (below cap), got %d", removed)
+	}
+}
+
+// TestCompactPerTask_AboveCap_Compacts seeds more than PerTaskEventCap
+// events for one task and verifies compaction reduces the per-task
+// event count.
+func TestCompactPerTask_AboveCap_Compacts(t *testing.T) {
+	m, _, cleanup := openEventLogManager(t)
+	defer cleanup()
+	ctx := context.Background()
+	rec := txNewTask("bones-compact-above")
+	if err := m.Tx(ctx, rec.ID, func(tx *tasks.Tx) error {
+		return tx.Create(rec)
+	}); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	// Generate > PerTaskEventCap events via repeated Update.
+	for i := 0; i < tasks.PerTaskEventCap+5; i++ {
+		if err := m.Tx(ctx, rec.ID, func(tx *tasks.Tx) error {
+			return tx.Update(func(t tasks.Task) (tasks.Task, error) {
+				t.Title = "iteration"
+				return t, nil
+			}, tasks.MustFieldChange("title", "x", "iteration"))
+		}); err != nil {
+			t.Fatalf("update %d: %v", i, err)
+		}
+	}
+	beforeEnvs, _ := m.Replay(ctx, tasks.LogReadOpts{FilterTaskID: rec.ID})
+	if len(beforeEnvs) <= tasks.PerTaskEventCap {
+		t.Fatalf("setup expected > %d events, got %d",
+			tasks.PerTaskEventCap, len(beforeEnvs))
+	}
+	removed, err := tasks.CompactPerTask(ctx, m, rec.ID)
+	if err != nil {
+		t.Fatalf("CompactPerTask: %v", err)
+	}
+	if removed == 0 {
+		t.Fatalf("want non-zero removed, got 0")
+	}
+	afterEnvs, _ := m.Replay(ctx, tasks.LogReadOpts{FilterTaskID: rec.ID})
+	if len(afterEnvs) >= len(beforeEnvs) {
+		t.Fatalf("compaction did not reduce event count: before=%d after=%d",
+			len(beforeEnvs), len(afterEnvs))
+	}
+	// Survivor includes a created event with a snapshot.
+	if len(afterEnvs) == 0 || afterEnvs[len(afterEnvs)-1].Type != tasks.EventTypeCreated {
+		t.Fatalf("compaction should leave a created summary as the latest event")
+	}
+}

--- a/internal/tasks/events.go
+++ b/internal/tasks/events.go
@@ -1,0 +1,277 @@
+package tasks
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// EventType identifies the shape of a task event published on the
+// `tasks.events.>` JetStream stream. The set is closed (Go iota); a
+// new event type requires a new constant, payload struct, tx.X method,
+// row in ADR 0052, and a roundtrip test. There is no open-set string
+// carrier for event names — a value outside the constants below is
+// rejected at decode.
+type EventType uint8
+
+// Event types per ADR 0052 §"Event types — closed iota set". Order is
+// load-bearing only insofar as adding a new type appends; do not
+// reorder, that would change wire encoding for stored events.
+const (
+	// EventTypeUnknown is the zero value used to flag a missing or
+	// unknown type at decode. It is never published.
+	EventTypeUnknown EventType = 0
+
+	// EventTypeCreated stamps the first observation of a task (or the
+	// synthetic baseline emitted by migration / compaction).
+	EventTypeCreated EventType = iota
+
+	// EventTypeClaimed marks a status edge open→claimed and stamps the
+	// agent that took the claim plus the (optional) slot.
+	EventTypeClaimed
+
+	// EventTypeUnclaimed marks a status edge claimed→open with the free-
+	// form unclaim reason.
+	EventTypeUnclaimed
+
+	// EventTypeUpdated carries one or more field-level changes as
+	// (Field, Old, New) tuples. The log alone — no KV consult — must
+	// suffice to reconstruct any prior state, so old and new values are
+	// both carried.
+	EventTypeUpdated
+
+	// EventTypeLinked records a directed edge added to a task.
+	EventTypeLinked
+
+	// EventTypeSlotChanged records a slot reassignment.
+	EventTypeSlotChanged
+
+	// EventTypeClosed marks a status edge into closed and stamps the
+	// closing agent and reason.
+	EventTypeClosed
+)
+
+// String returns a human-readable name for the event type. Used by
+// logging, the watch-line renderer, and the activity feed.
+func (t EventType) String() string {
+	switch t {
+	case EventTypeCreated:
+		return "created"
+	case EventTypeClaimed:
+		return "claimed"
+	case EventTypeUnclaimed:
+		return "unclaimed"
+	case EventTypeUpdated:
+		return "updated"
+	case EventTypeLinked:
+		return "linked"
+	case EventTypeSlotChanged:
+		return "slot_changed"
+	case EventTypeClosed:
+		return "closed"
+	default:
+		return "unknown"
+	}
+}
+
+// Valid reports whether t is one of the seven defined event types.
+// EventTypeUnknown is the zero value and is invalid by convention.
+func (t EventType) Valid() bool {
+	return t >= EventTypeCreated && t <= EventTypeClosed
+}
+
+// EventEnvelope is the wire format for one task event on the JetStream
+// stream. JSON-serialized, persisted across the retention window;
+// possibly read by a consumer running a different bones version.
+// Additive-only on field changes — see ADR 0052.
+//
+// StreamSeq is supplied by the consumer at decode time from the
+// JetStream message metadata; it is NOT part of the JSON envelope and
+// is zero for messages that have not yet been published.
+type EventEnvelope struct {
+	Type      EventType       `json:"type"`
+	TaskID    string          `json:"task_id"`
+	Timestamp time.Time       `json:"timestamp"`
+	Payload   json.RawMessage `json:"payload"`
+
+	// StreamSeq is the JetStream message sequence at the time the
+	// envelope was consumed. Set by the recovery loop and the watch
+	// consumer; not serialized.
+	StreamSeq uint64 `json:"-"`
+}
+
+// CreatedPayload is the payload for an EventTypeCreated event. Slot
+// is optional (empty when the task is not yet bound to a slot).
+type CreatedPayload struct {
+	Title string   `json:"title"`
+	Slot  string   `json:"slot,omitempty"`
+	Files []string `json:"files,omitempty"`
+
+	// Snapshot is the full Task projection at creation time. Carried so
+	// migration-emitted synthetic events and compaction summaries can
+	// hand a recovery loop the entire post-creation projection without
+	// requiring it to walk subsequent updated events. Empty for live
+	// Tx.Create emissions; populated by migration and compaction.
+	Snapshot *Task `json:"snapshot,omitempty"`
+}
+
+// ClaimedPayload carries the agent that claimed and the optional slot.
+type ClaimedPayload struct {
+	AgentID    string `json:"agent_id"`
+	Slot       string `json:"slot,omitempty"`
+	ClaimEpoch uint64 `json:"claim_epoch"`
+}
+
+// UnclaimedPayload carries the un-claim reason. The previously-claiming
+// agent is recoverable from the prior claimed event in the log; we do
+// not duplicate it here.
+type UnclaimedPayload struct {
+	Reason string `json:"reason"`
+}
+
+// FieldChange is one (field, old, new) tuple carried in an UpdatedPayload.
+// Old and New are both rendered as raw JSON to preserve type fidelity
+// across replays — a string and a number with the same lexical form do
+// not collide. Field is the canonical Task struct field name (e.g.
+// "title", "files", "context").
+type FieldChange struct {
+	Field string          `json:"field"`
+	Old   json.RawMessage `json:"old"`
+	New   json.RawMessage `json:"new"`
+}
+
+// UpdatedPayload aggregates one or more FieldChange tuples. A Tx that
+// changes multiple fields in one tx.Update call emits one updated
+// event with all changes; multiple sequential tx.Update calls emit one
+// event each.
+type UpdatedPayload struct {
+	Changes []FieldChange `json:"changes"`
+}
+
+// LinkedPayload stamps a directed edge added to the task.
+type LinkedPayload struct {
+	OtherID  string `json:"other_id"`
+	EdgeType string `json:"edge_type"`
+}
+
+// SlotChangedPayload carries a slot reassignment. From may be empty for
+// a first slot binding; To is always populated.
+type SlotChangedPayload struct {
+	From string `json:"from,omitempty"`
+	To   string `json:"to"`
+}
+
+// ClosedPayload carries the closing agent and the close reason.
+type ClosedPayload struct {
+	AgentID string `json:"agent_id"`
+	Reason  string `json:"reason"`
+}
+
+// EncodeEnvelope marshals an envelope and a typed payload into a single
+// EventEnvelope ready for js.PublishMsg. The Timestamp is stamped here
+// to UTC so callers do not have to remember to convert.
+func EncodeEnvelope(t EventType, taskID string, payload any) (EventEnvelope, error) {
+	if !t.Valid() {
+		return EventEnvelope{}, fmt.Errorf("tasks: invalid event type %d", t)
+	}
+	if taskID == "" {
+		return EventEnvelope{}, fmt.Errorf("tasks: event task_id is empty")
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return EventEnvelope{}, fmt.Errorf("tasks: encode %s payload: %w", t, err)
+	}
+	return EventEnvelope{
+		Type:      t,
+		TaskID:    taskID,
+		Timestamp: time.Now().UTC(),
+		Payload:   raw,
+	}, nil
+}
+
+// EventSubject returns the JetStream subject for events scoped to one
+// task ID. Subjects under tasks.events.> partition by task so a Watch
+// can replay one task's history with a subject filter.
+func EventSubject(taskID string) string {
+	return "tasks.events." + taskID
+}
+
+// AllEventsSubject is the wildcard subject that matches every task
+// event on the stream.
+const AllEventsSubject = "tasks.events.>"
+
+// EventStreamName is the JetStream stream name backing the task event
+// log. Callers in internal/hub provision the stream with this name and
+// the AllEventsSubject filter.
+const EventStreamName = "tasks-events"
+
+// DecodePayload unmarshals env.Payload into a typed payload struct
+// matching env.Type. The returned value is one of the *Payload types
+// defined in this file.
+func DecodePayload(env EventEnvelope) (any, error) {
+	if !env.Type.Valid() {
+		return nil, fmt.Errorf("tasks: decode envelope: invalid type %d", env.Type)
+	}
+	switch env.Type {
+	case EventTypeCreated:
+		var p CreatedPayload
+		if err := json.Unmarshal(env.Payload, &p); err != nil {
+			return nil, fmt.Errorf("tasks: decode created: %w", err)
+		}
+		return p, nil
+	case EventTypeClaimed:
+		var p ClaimedPayload
+		if err := json.Unmarshal(env.Payload, &p); err != nil {
+			return nil, fmt.Errorf("tasks: decode claimed: %w", err)
+		}
+		return p, nil
+	case EventTypeUnclaimed:
+		var p UnclaimedPayload
+		if err := json.Unmarshal(env.Payload, &p); err != nil {
+			return nil, fmt.Errorf("tasks: decode unclaimed: %w", err)
+		}
+		return p, nil
+	case EventTypeUpdated:
+		var p UpdatedPayload
+		if err := json.Unmarshal(env.Payload, &p); err != nil {
+			return nil, fmt.Errorf("tasks: decode updated: %w", err)
+		}
+		return p, nil
+	case EventTypeLinked:
+		var p LinkedPayload
+		if err := json.Unmarshal(env.Payload, &p); err != nil {
+			return nil, fmt.Errorf("tasks: decode linked: %w", err)
+		}
+		return p, nil
+	case EventTypeSlotChanged:
+		var p SlotChangedPayload
+		if err := json.Unmarshal(env.Payload, &p); err != nil {
+			return nil, fmt.Errorf("tasks: decode slot_changed: %w", err)
+		}
+		return p, nil
+	case EventTypeClosed:
+		var p ClosedPayload
+		if err := json.Unmarshal(env.Payload, &p); err != nil {
+			return nil, fmt.Errorf("tasks: decode closed: %w", err)
+		}
+		return p, nil
+	default:
+		return nil, fmt.Errorf("tasks: decode envelope: unknown type %d", env.Type)
+	}
+}
+
+// MarshalEnvelope serializes env to the bytes published on the stream.
+// JSON for parity with internal/chat.Envelope per ADR 0047.
+func MarshalEnvelope(env EventEnvelope) ([]byte, error) {
+	return json.Marshal(env)
+}
+
+// UnmarshalEnvelope deserializes raw stream bytes into an EventEnvelope.
+// StreamSeq is left as zero — the consumer fills it from message metadata.
+func UnmarshalEnvelope(raw []byte) (EventEnvelope, error) {
+	var env EventEnvelope
+	if err := json.Unmarshal(raw, &env); err != nil {
+		return EventEnvelope{}, fmt.Errorf("tasks: unmarshal envelope: %w", err)
+	}
+	return env, nil
+}

--- a/internal/tasks/events.go
+++ b/internal/tasks/events.go
@@ -116,10 +116,15 @@ type CreatedPayload struct {
 }
 
 // ClaimedPayload carries the agent that claimed and the optional slot.
+// PrevAgent is non-empty for handoff/reclaim transitions where the
+// claim moves from one agent to another without an intervening
+// unclaimed event; replay in recovery uses it to reconstruct the
+// audit trail correctly.
 type ClaimedPayload struct {
 	AgentID    string `json:"agent_id"`
 	Slot       string `json:"slot,omitempty"`
 	ClaimEpoch uint64 `json:"claim_epoch"`
+	PrevAgent  string `json:"prev_agent,omitempty"`
 }
 
 // UnclaimedPayload carries the un-claim reason. The previously-claiming

--- a/internal/tasks/log_reader.go
+++ b/internal/tasks/log_reader.go
@@ -1,0 +1,151 @@
+package tasks
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/nats-io/nats.go/jetstream"
+
+	"github.com/danmestas/bones/internal/assert"
+)
+
+// LogReadOpts configures a one-shot read of the event log via Replay.
+// At most one of FromSeq and Since may be set. When both are zero, the
+// reader returns the most recent Limit events (Limit defaults to
+// RecentActivityCount).
+type LogReadOpts struct {
+	// FromSeq is the JetStream stream sequence to start at (inclusive).
+	// 0 means unset.
+	FromSeq uint64
+
+	// Since is a wall-clock offset relative to time.Now(). 0 means
+	// unset. Mutually exclusive with FromSeq.
+	Since time.Duration
+
+	// Limit caps the returned event count. 0 disables the cap.
+	Limit int
+
+	// FilterTaskID, when non-empty, restricts the read to events
+	// matching `tasks.events.<task_id>`.
+	FilterTaskID string
+}
+
+// Replay reads events from the task event log according to opts and
+// returns them in stream order. Used by `bones tasks watch`'s
+// --from / --since backfill and by `bones status`'s recent-activity
+// surface.
+//
+// Replay is one-shot: it returns once the consumer drains; callers
+// wanting live updates use Watch instead.
+func (m *Manager) Replay(
+	ctx context.Context, opts LogReadOpts,
+) ([]EventEnvelope, error) {
+	assert.NotNil(ctx, "tasks.Replay: ctx is nil")
+	if m.stream == nil {
+		return nil, errors.New("tasks.Replay: event log disabled")
+	}
+	if opts.FromSeq != 0 && opts.Since != 0 {
+		return nil, errors.New(
+			"tasks.Replay: --from and --since are mutually exclusive",
+		)
+	}
+	cfg, err := buildReplayConsumerCfg(opts)
+	if err != nil {
+		return nil, err
+	}
+	cons, err := m.stream.OrderedConsumer(ctx, cfg)
+	if err != nil {
+		return nil, fmt.Errorf("tasks.Replay: consumer: %w", err)
+	}
+	return drainReplay(ctx, cons, opts)
+}
+
+// buildReplayConsumerCfg translates LogReadOpts into the
+// jetstream.OrderedConsumerConfig the consumer wants. The defaulting
+// rules (no flags → "last RecentActivityCount events") are applied
+// here so all callers see consistent behavior.
+func buildReplayConsumerCfg(
+	opts LogReadOpts,
+) (jetstream.OrderedConsumerConfig, error) {
+	subj := AllEventsSubject
+	if opts.FilterTaskID != "" {
+		subj = EventSubject(opts.FilterTaskID)
+	}
+	cfg := jetstream.OrderedConsumerConfig{
+		FilterSubjects: []string{subj},
+		DeliverPolicy:  jetstream.DeliverAllPolicy,
+	}
+	switch {
+	case opts.FromSeq != 0:
+		cfg.DeliverPolicy = jetstream.DeliverByStartSequencePolicy
+		cfg.OptStartSeq = opts.FromSeq
+	case opts.Since != 0:
+		t := time.Now().UTC().Add(-opts.Since)
+		cfg.DeliverPolicy = jetstream.DeliverByStartTimePolicy
+		cfg.OptStartTime = &t
+	}
+	return cfg, nil
+}
+
+// drainReplay pulls every available message from cons and returns the
+// decoded envelopes. Stops when the consumer reports no more messages
+// or when the limit is hit.
+func drainReplay(
+	ctx context.Context,
+	cons jetstream.Consumer,
+	opts LogReadOpts,
+) ([]EventEnvelope, error) {
+	const fetchBatch = 100
+	const fetchWait = 250 * time.Millisecond
+	out := make([]EventEnvelope, 0, fetchBatch)
+	for {
+		batch, err := cons.Fetch(fetchBatch, jetstream.FetchMaxWait(fetchWait))
+		if err != nil {
+			return out, err
+		}
+		empty := true
+		for msg := range batch.Messages() {
+			empty = false
+			env, perr := UnmarshalEnvelope(msg.Data())
+			_ = msg.Ack()
+			if perr != nil {
+				continue
+			}
+			meta, _ := msg.Metadata()
+			if meta != nil {
+				env.StreamSeq = meta.Sequence.Stream
+			}
+			out = append(out, env)
+			if opts.Limit > 0 && len(out) >= opts.Limit {
+				return out, nil
+			}
+		}
+		if empty {
+			return out, nil
+		}
+		if err := batch.Error(); err != nil {
+			return out, err
+		}
+	}
+}
+
+// Recent returns the most recent n events from the log in stream
+// order (oldest of the slice first, newest last). Used by
+// `bones status` for the Recent Activity surface.
+func (m *Manager) Recent(
+	ctx context.Context, n int,
+) ([]EventEnvelope, error) {
+	if n <= 0 {
+		n = RecentActivityCount
+	}
+	all, err := m.Replay(ctx, LogReadOpts{})
+	if err != nil {
+		return nil, err
+	}
+	if len(all) <= n {
+		return all, nil
+	}
+	return all[len(all)-n:], nil
+}

--- a/internal/tasks/recovery.go
+++ b/internal/tasks/recovery.go
@@ -16,20 +16,10 @@ import (
 // migrationMarkerKey is the KV key whose presence (in the bones-tasks
 // bucket) signals that the synthetic-event migration from pre-event-log
 // state has already run. The marker is set at the end of a successful
-// Migrate() call. Its value is a JSON object with the migration
-// timestamp; presence is what counts.
+// Migrate() call. Its value is a Task-shaped placeholder (see
+// setMigrated) only because the bucket is typed for JSON Task records;
+// presence is what counts.
 const migrationMarkerKey = "__bones_tasks_events_migrated"
-
-// migrationMarkerPayload is what gets written under migrationMarkerKey.
-// Stored as a Task-shaped envelope only because the bucket is typed for
-// JSON Task records and the alternative — a side bucket — would force
-// hub.Start to provision a second KV. The marker has SchemaVersion
-// stamped to the current value so future migrations can fan out off it.
-type migrationMarkerPayload struct {
-	Migrated      bool      `json:"migrated"`
-	MigratedAt    time.Time `json:"migrated_at"`
-	SchemaVersion int       `json:"schema_version"`
-}
 
 // Recover reconciles the KV projection with the event log on hub start.
 // For each unique task ID with at least one event on the stream, the

--- a/internal/tasks/recovery.go
+++ b/internal/tasks/recovery.go
@@ -2,6 +2,7 @@ package tasks
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -148,17 +149,7 @@ func applyEvent(ctx context.Context, m *Manager, env EventEnvelope) error {
 	case EventTypeUnclaimed:
 		return applyUnclaimedEvent(ctx, aw, env)
 	case EventTypeUpdated:
-		// updated carries field-level deltas; replay is best-effort.
-		// We bump LastEventSeq without rewriting the body because the
-		// projection's correctness lives elsewhere and a full
-		// reconstruction from FieldChange tuples is out of scope for
-		// this PR's recovery — see ADR 0052 §"Compaction" for the
-		// rationale (the synthetic created summary carries the full
-		// post-truncation state).
-		return aw.Update(ctx, env.TaskID, func(t Task) (Task, error) {
-			t.LastEventSeq = env.StreamSeq
-			return t, nil
-		})
+		return applyUpdatedEvent(ctx, aw, env)
 	case EventTypeLinked:
 		return applyLinkedEvent(ctx, aw, env)
 	case EventTypeSlotChanged:
@@ -263,6 +254,82 @@ func applyLinkedEvent(ctx context.Context, aw AdminWrite, env EventEnvelope) err
 		t.LastEventSeq = env.StreamSeq
 		return t, nil
 	})
+}
+
+// applyUpdatedEvent walks the FieldChange tuples on env and applies
+// each one's New JSON blob to the corresponding Task field. Per ADR
+// 0052 §"Recovery": "the log alone — no KV consult — must suffice to
+// reconstruct any prior state." The (field, old, new) shape is what
+// makes that possible; this dispatcher is what consumes it.
+//
+// Unknown field names are skipped (additive-only evolution rule); a
+// future schema addition can grow this dispatcher without breaking
+// older logs.
+func applyUpdatedEvent(ctx context.Context, aw AdminWrite, env EventEnvelope) error {
+	p, err := DecodePayload(env)
+	if err != nil {
+		return err
+	}
+	up := p.(UpdatedPayload)
+	return aw.Update(ctx, env.TaskID, func(t Task) (Task, error) {
+		for _, ch := range up.Changes {
+			if applyErr := applyFieldChange(&t, ch); applyErr != nil {
+				return t, fmt.Errorf("applyUpdatedEvent: field %q: %w",
+					ch.Field, applyErr)
+			}
+		}
+		t.UpdatedAt = env.Timestamp
+		t.LastEventSeq = env.StreamSeq
+		return t, nil
+	})
+}
+
+// applyFieldChange unmarshals ch.New into the corresponding field on
+// t. The dispatcher is keyed by ch.Field; field names are the stable
+// JSON tag values (e.g. "title", "claimed_by"), not Go struct names.
+// Unknown fields are silently dropped to honor the additive-only rule.
+//
+// Adding a new task field:
+//
+//  1. Add the field to Task with a json tag.
+//  2. Update diffTaskFields in cli/tasks_update.go to emit a tuple
+//     when the field changes.
+//  3. Add a case here to apply the unmarshal.
+//  4. Add a test under TestRecover_AppliesUpdatedEventField_<field>.
+func applyFieldChange(t *Task, ch FieldChange) error {
+	switch ch.Field {
+	case "title":
+		return jsonInto(ch.New, &t.Title)
+	case "status":
+		return jsonInto(ch.New, &t.Status)
+	case "claimed_by":
+		return jsonInto(ch.New, &t.ClaimedBy)
+	case "parent":
+		return jsonInto(ch.New, &t.Parent)
+	case "files":
+		return jsonInto(ch.New, &t.Files)
+	case "context":
+		return jsonInto(ch.New, &t.Context)
+	case "defer_until":
+		return jsonInto(ch.New, &t.DeferUntil)
+	case "edges":
+		return jsonInto(ch.New, &t.Edges)
+	case "closed_by":
+		return jsonInto(ch.New, &t.ClosedBy)
+	case "closed_reason":
+		return jsonInto(ch.New, &t.ClosedReason)
+	case "claim_epoch":
+		return jsonInto(ch.New, &t.ClaimEpoch)
+	default:
+		// Unknown field — additive-only rule, drop quietly.
+		return nil
+	}
+}
+
+// jsonInto is a tiny helper that unmarshals raw into target. Pulled
+// out so each case in applyFieldChange stays a single line.
+func jsonInto(raw json.RawMessage, target any) error {
+	return json.Unmarshal(raw, target)
 }
 
 func applyClosedEvent(ctx context.Context, aw AdminWrite, env EventEnvelope) error {

--- a/internal/tasks/recovery.go
+++ b/internal/tasks/recovery.go
@@ -1,0 +1,465 @@
+package tasks
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/nats-io/nats.go/jetstream"
+
+	"github.com/danmestas/bones/internal/assert"
+)
+
+// migrationMarkerKey is the KV key whose presence (in the bones-tasks
+// bucket) signals that the synthetic-event migration from pre-event-log
+// state has already run. The marker is set at the end of a successful
+// Migrate() call. Its value is a JSON object with the migration
+// timestamp; presence is what counts.
+const migrationMarkerKey = "__bones_tasks_events_migrated"
+
+// migrationMarkerPayload is what gets written under migrationMarkerKey.
+// Stored as a Task-shaped envelope only because the bucket is typed for
+// JSON Task records and the alternative — a side bucket — would force
+// hub.Start to provision a second KV. The marker has SchemaVersion
+// stamped to the current value so future migrations can fan out off it.
+type migrationMarkerPayload struct {
+	Migrated      bool      `json:"migrated"`
+	MigratedAt    time.Time `json:"migrated_at"`
+	SchemaVersion int       `json:"schema_version"`
+}
+
+// Recover reconciles the KV projection with the event log on hub start.
+// For each unique task ID with at least one event on the stream, the
+// recovery loop walks events newer than the KV's LastEventSeq and
+// applies them via AdminWrite (a no-op when the projection is already
+// up to date). Returns the number of orphan events replayed.
+//
+// Recovery is idempotent: repeated calls on a stable substrate replay
+// no events. Concurrent Recover calls race only on the underlying KV
+// CAS; the substrate serializes them.
+func Recover(ctx context.Context, m *Manager) (int, error) {
+	assert.NotNil(ctx, "tasks.Recover: ctx is nil")
+	assert.NotNil(m, "tasks.Recover: m is nil")
+	if m.stream == nil {
+		// No event log → nothing to recover.
+		return 0, nil
+	}
+	tasksByID, err := snapshotTasks(ctx, m)
+	if err != nil {
+		return 0, fmt.Errorf("tasks.Recover: snapshot: %w", err)
+	}
+	cons, err := m.stream.OrderedConsumer(ctx, jetstream.OrderedConsumerConfig{
+		FilterSubjects: []string{AllEventsSubject},
+		DeliverPolicy:  jetstream.DeliverAllPolicy,
+	})
+	if err != nil {
+		return 0, fmt.Errorf("tasks.Recover: consumer: %w", err)
+	}
+	replayed, err := drainAndReplay(ctx, m, cons, tasksByID)
+	if err != nil {
+		return replayed, fmt.Errorf("tasks.Recover: replay: %w", err)
+	}
+	return replayed, nil
+}
+
+// snapshotTasks reads every current Task projection, indexed by ID, so
+// the recovery loop can compare each event's stream sequence against
+// the projection's stamped LastEventSeq without round-tripping the KV
+// per event.
+func snapshotTasks(ctx context.Context, m *Manager) (map[string]Task, error) {
+	list, err := m.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[string]Task, len(list))
+	for _, t := range list {
+		out[t.ID] = t
+	}
+	return out, nil
+}
+
+// drainAndReplay pulls every available event from cons, re-applies the
+// ones whose effect has not yet landed in the KV projection, and
+// returns the count of replayed events. Stops on the first ctx error
+// or when the stream returns an end-of-data sentinel.
+func drainAndReplay(
+	ctx context.Context,
+	m *Manager,
+	cons jetstream.Consumer,
+	tasksByID map[string]Task,
+) (int, error) {
+	const drainBatch = 200
+	const drainWait = 250 * time.Millisecond
+	replayed := 0
+	for {
+		batch, err := cons.Fetch(drainBatch, jetstream.FetchMaxWait(drainWait))
+		if err != nil {
+			return replayed, err
+		}
+		empty := true
+		for msg := range batch.Messages() {
+			empty = false
+			env, perr := UnmarshalEnvelope(msg.Data())
+			if perr != nil {
+				_ = msg.Ack()
+				continue
+			}
+			meta, _ := msg.Metadata()
+			if meta != nil {
+				env.StreamSeq = meta.Sequence.Stream
+			}
+			cur, hasProjection := tasksByID[env.TaskID]
+			if hasProjection && cur.LastEventSeq >= env.StreamSeq {
+				_ = msg.Ack()
+				continue
+			}
+			if err := applyEvent(ctx, m, env); err != nil {
+				_ = msg.Ack()
+				return replayed, err
+			}
+			replayed++
+			_ = msg.Ack()
+			if t, _, gerr := m.Get(ctx, env.TaskID); gerr == nil {
+				tasksByID[env.TaskID] = t
+			}
+		}
+		if empty {
+			return replayed, nil
+		}
+		if err := batch.Error(); err != nil {
+			return replayed, err
+		}
+	}
+}
+
+// applyEvent re-applies env to the KV projection via AdminWrite. The
+// per-type projection logic lives here so all replay paths (recovery
+// and TaskTally) share one code path. Unknown event types are skipped
+// (additive-only evolution rule per ADR 0052).
+func applyEvent(ctx context.Context, m *Manager, env EventEnvelope) error {
+	aw := NewAdminWrite(m)
+	switch env.Type {
+	case EventTypeCreated:
+		return applyCreatedEvent(ctx, aw, env)
+	case EventTypeClaimed:
+		return applyClaimedEvent(ctx, aw, env)
+	case EventTypeUnclaimed:
+		return applyUnclaimedEvent(ctx, aw, env)
+	case EventTypeUpdated:
+		// updated carries field-level deltas; replay is best-effort.
+		// We bump LastEventSeq without rewriting the body because the
+		// projection's correctness lives elsewhere and a full
+		// reconstruction from FieldChange tuples is out of scope for
+		// this PR's recovery — see ADR 0052 §"Compaction" for the
+		// rationale (the synthetic created summary carries the full
+		// post-truncation state).
+		return aw.Update(ctx, env.TaskID, func(t Task) (Task, error) {
+			t.LastEventSeq = env.StreamSeq
+			return t, nil
+		})
+	case EventTypeLinked:
+		return applyLinkedEvent(ctx, aw, env)
+	case EventTypeSlotChanged:
+		// slot_changed has no KV projection; only LastEventSeq advances.
+		return aw.Update(ctx, env.TaskID, func(t Task) (Task, error) {
+			t.LastEventSeq = env.StreamSeq
+			return t, nil
+		})
+	case EventTypeClosed:
+		return applyClosedEvent(ctx, aw, env)
+	default:
+		// Unknown type — additive-only evolution; leave projection alone.
+		return nil
+	}
+}
+
+func applyCreatedEvent(ctx context.Context, aw AdminWrite, env EventEnvelope) error {
+	p, err := DecodePayload(env)
+	if err != nil {
+		return err
+	}
+	created := p.(CreatedPayload)
+	if created.Snapshot != nil {
+		// Migration / compaction synthetic: write the full snapshot.
+		snap := *created.Snapshot
+		snap.LastEventSeq = env.StreamSeq
+		err := aw.Create(ctx, snap)
+		if errors.Is(err, ErrAlreadyExists) {
+			// Project the snapshot via Update.
+			return aw.Update(ctx, env.TaskID, func(t Task) (Task, error) {
+				snap.LastEventSeq = env.StreamSeq
+				return snap, nil
+			})
+		}
+		return err
+	}
+	rec := Task{
+		ID:            env.TaskID,
+		Title:         created.Title,
+		Status:        StatusOpen,
+		Files:         append([]string(nil), created.Files...),
+		CreatedAt:     env.Timestamp,
+		UpdatedAt:     env.Timestamp,
+		SchemaVersion: SchemaVersion,
+		LastEventSeq:  env.StreamSeq,
+	}
+	err = aw.Create(ctx, rec)
+	if errors.Is(err, ErrAlreadyExists) {
+		return nil
+	}
+	return err
+}
+
+func applyClaimedEvent(ctx context.Context, aw AdminWrite, env EventEnvelope) error {
+	p, err := DecodePayload(env)
+	if err != nil {
+		return err
+	}
+	cl := p.(ClaimedPayload)
+	return aw.Update(ctx, env.TaskID, func(t Task) (Task, error) {
+		// Recovery applies idempotently. If projection is already past
+		// this event, the LastEventSeq guard above handled it.
+		t.Status = StatusClaimed
+		t.ClaimedBy = cl.AgentID
+		if cl.ClaimEpoch > t.ClaimEpoch {
+			t.ClaimEpoch = cl.ClaimEpoch
+		}
+		t.UpdatedAt = env.Timestamp
+		t.LastEventSeq = env.StreamSeq
+		return t, nil
+	})
+}
+
+func applyUnclaimedEvent(ctx context.Context, aw AdminWrite, env EventEnvelope) error {
+	return aw.Update(ctx, env.TaskID, func(t Task) (Task, error) {
+		t.Status = StatusOpen
+		t.ClaimedBy = ""
+		t.UpdatedAt = env.Timestamp
+		t.LastEventSeq = env.StreamSeq
+		return t, nil
+	})
+}
+
+func applyLinkedEvent(ctx context.Context, aw AdminWrite, env EventEnvelope) error {
+	p, err := DecodePayload(env)
+	if err != nil {
+		return err
+	}
+	lp := p.(LinkedPayload)
+	return aw.Update(ctx, env.TaskID, func(t Task) (Task, error) {
+		for _, e := range t.Edges {
+			if e.Type == EdgeType(lp.EdgeType) && e.Target == lp.OtherID {
+				t.LastEventSeq = env.StreamSeq
+				return t, nil
+			}
+		}
+		t.Edges = append(t.Edges, Edge{
+			Type:   EdgeType(lp.EdgeType),
+			Target: lp.OtherID,
+		})
+		t.UpdatedAt = env.Timestamp
+		t.LastEventSeq = env.StreamSeq
+		return t, nil
+	})
+}
+
+func applyClosedEvent(ctx context.Context, aw AdminWrite, env EventEnvelope) error {
+	p, err := DecodePayload(env)
+	if err != nil {
+		return err
+	}
+	cp := p.(ClosedPayload)
+	return aw.Update(ctx, env.TaskID, func(t Task) (Task, error) {
+		// Idempotent path: projection is already closed. Bumping
+		// LastEventSeq alone is allowed under the closed→closed
+		// compaction-only rule (LastEventSeq is not in the
+		// eqNonCompaction check, so it counts as a compaction-style
+		// field change).
+		if t.Status == StatusClosed {
+			t.LastEventSeq = env.StreamSeq
+			return t, nil
+		}
+		t.Status = StatusClosed
+		closer := cp.AgentID
+		if closer == "" && t.ClaimedBy != "" {
+			closer = t.ClaimedBy
+		}
+		t.ClosedBy = closer
+		t.ClosedReason = cp.Reason
+		ts := env.Timestamp
+		t.ClosedAt = &ts
+		t.ClaimedBy = ""
+		t.UpdatedAt = ts
+		t.LastEventSeq = env.StreamSeq
+		return t, nil
+	})
+}
+
+// Migrate emits synthetic events for every pre-existing KV record so
+// the event log carries a baseline for recovery and audit. Idempotent
+// via migrationMarkerKey; running Migrate twice is a no-op.
+//
+// This is the one-time path for upgrading a workspace from before the
+// event log was the source of truth (schema v3 or earlier). Documented
+// limit per ADR 0052: pre-migration update history is lost — only
+// created / claimed / closed bookmarks are reconstructible.
+func Migrate(ctx context.Context, m *Manager) (int, error) {
+	assert.NotNil(ctx, "tasks.Migrate: ctx is nil")
+	assert.NotNil(m, "tasks.Migrate: m is nil")
+	if m.stream == nil {
+		return 0, errors.New("tasks.Migrate: event log disabled")
+	}
+	if migrated, err := isMigrated(ctx, m); err != nil {
+		return 0, fmt.Errorf("tasks.Migrate: marker: %w", err)
+	} else if migrated {
+		return 0, nil
+	}
+	list, err := m.List(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("tasks.Migrate: list: %w", err)
+	}
+	emitted, err := emitSyntheticEvents(ctx, m, list)
+	if err != nil {
+		return emitted, fmt.Errorf("tasks.Migrate: emit: %w", err)
+	}
+	if err := setMigrated(ctx, m); err != nil {
+		return emitted, fmt.Errorf("tasks.Migrate: set marker: %w", err)
+	}
+	return emitted, nil
+}
+
+// emitSyntheticEvents publishes one created event per pre-existing
+// task, plus a claimed event when ClaimedBy is non-empty, plus a
+// closed event when ClosedAt is non-nil. Each created event embeds a
+// snapshot of the projection so a fresh recovery can rebuild the KV
+// from the log alone. After publishing each task's events, the
+// projection's LastEventSeq is stamped to the highest sequence
+// emitted so subsequent Recover runs do not double-apply the same
+// synthetic events.
+func emitSyntheticEvents(
+	ctx context.Context, m *Manager, list []Task,
+) (int, error) {
+	emitted := 0
+	aw := NewAdminWrite(m)
+	for _, t := range list {
+		if strings.HasPrefix(t.ID, "__bones_tasks_events_migrated") {
+			// Skip the marker key if it ever appears in List output.
+			continue
+		}
+		var lastSeq uint64
+		// created — embeds full snapshot for log-only reconstruction.
+		snap := t
+		snap.SchemaVersion = SchemaVersion
+		createdPayload := CreatedPayload{
+			Title:    t.Title,
+			Files:    append([]string(nil), t.Files...),
+			Snapshot: &snap,
+		}
+		env, err := EncodeEnvelope(EventTypeCreated, t.ID, createdPayload)
+		if err != nil {
+			return emitted, err
+		}
+		env.Timestamp = t.CreatedAt
+		seq, err := publishMigrationEnvelope(ctx, m, env)
+		if err != nil {
+			return emitted, err
+		}
+		lastSeq = seq
+		emitted++
+		if t.ClaimedBy != "" {
+			env, err := EncodeEnvelope(EventTypeClaimed, t.ID, ClaimedPayload{
+				AgentID:    t.ClaimedBy,
+				ClaimEpoch: t.ClaimEpoch,
+			})
+			if err != nil {
+				return emitted, err
+			}
+			env.Timestamp = t.UpdatedAt
+			seq, err := publishMigrationEnvelope(ctx, m, env)
+			if err != nil {
+				return emitted, err
+			}
+			lastSeq = seq
+			emitted++
+		}
+		if t.ClosedAt != nil {
+			env, err := EncodeEnvelope(EventTypeClosed, t.ID, ClosedPayload{
+				AgentID: t.ClosedBy,
+				Reason:  t.ClosedReason,
+			})
+			if err != nil {
+				return emitted, err
+			}
+			env.Timestamp = *t.ClosedAt
+			seq, err := publishMigrationEnvelope(ctx, m, env)
+			if err != nil {
+				return emitted, err
+			}
+			lastSeq = seq
+			emitted++
+		}
+		// Stamp LastEventSeq on the KV record so Recover does not
+		// re-apply these synthetic events.
+		if err := aw.Update(ctx, t.ID, func(cur Task) (Task, error) {
+			cur.LastEventSeq = lastSeq
+			return cur, nil
+		}); err != nil {
+			return emitted, err
+		}
+	}
+	return emitted, nil
+}
+
+// publishMigrationEnvelope publishes env on the events stream, used
+// only by Migrate. Returns the assigned stream sequence.
+func publishMigrationEnvelope(
+	ctx context.Context, m *Manager, env EventEnvelope,
+) (uint64, error) {
+	body, err := MarshalEnvelope(env)
+	if err != nil {
+		return 0, err
+	}
+	ack, err := m.js.Publish(ctx, EventSubject(env.TaskID), body)
+	if err != nil {
+		return 0, err
+	}
+	return ack.Sequence, nil
+}
+
+// isMigrated reports whether the migration marker is present in the
+// task KV bucket.
+func isMigrated(ctx context.Context, m *Manager) (bool, error) {
+	_, err := m.kv.Get(ctx, migrationMarkerKey)
+	if err != nil {
+		if errors.Is(err, jetstream.ErrKeyNotFound) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+// setMigrated stamps the migration marker so subsequent Migrate calls
+// short-circuit. Encodes a Task-shaped placeholder so the bucket's
+// JSON expectations stay satisfied.
+func setMigrated(ctx context.Context, m *Manager) error {
+	now := time.Now().UTC()
+	// Use a Task envelope to satisfy the KV's value-shape expectations.
+	marker := Task{
+		ID:            migrationMarkerKey,
+		Title:         "tasks-events migration marker",
+		Status:        StatusClosed,
+		ClosedAt:      &now,
+		CreatedAt:     now,
+		UpdatedAt:     now,
+		SchemaVersion: SchemaVersion,
+	}
+	payload, err := encode(marker)
+	if err != nil {
+		return err
+	}
+	_, err = m.kv.Put(ctx, migrationMarkerKey, payload)
+	return err
+}

--- a/internal/tasks/recovery_test.go
+++ b/internal/tasks/recovery_test.go
@@ -1,0 +1,111 @@
+package tasks_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+
+	"github.com/danmestas/bones/internal/tasks"
+	"github.com/danmestas/bones/internal/testutil/natstest"
+)
+
+// getJetStream is a tiny helper that returns a JetStream handle on nc.
+// The recovery test publishes an orphan event directly (without going
+// through Tx) so it needs its own handle.
+func getJetStream(nc *nats.Conn) (jetstream.JetStream, error) {
+	return jetstream.New(nc)
+}
+
+// TestRecovery_OrphanedEventReplays simulates a hub crash between
+// publish and KV-write by emitting a synthetic event directly to the
+// stream and asserting Recover updates the KV projection. The shape
+// mirrors what Tx would produce on a successful publish + failed CAS
+// write.
+func TestRecovery_OrphanedEventReplays(t *testing.T) {
+	srv, cleanup := natstest.NewJetStreamServer(t)
+	defer cleanup()
+	nc, err := nats.Connect(srv.ConnectedUrl())
+	if err != nil {
+		t.Fatalf("nats.Connect: %v", err)
+	}
+	defer nc.Close()
+	cfg := tasks.Config{
+		BucketName:     "tasks-recover-test",
+		HistoryDepth:   8,
+		MaxValueSize:   8 * 1024,
+		EnableEventLog: true,
+	}
+	m, err := tasks.Open(context.Background(), nc, cfg)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = m.Close() }()
+
+	ctx := context.Background()
+
+	// Seed a task via Tx.
+	rec := txNewTask("bones-recover-1")
+	if err := m.Tx(ctx, rec.ID, func(tx *tasks.Tx) error {
+		return tx.Create(rec)
+	}); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	// Simulate an orphan event: publish a `claimed` envelope directly
+	// without going through Tx (which would also write the KV). The
+	// projection now lags the log.
+	env, err := tasks.EncodeEnvelope(
+		tasks.EventTypeClaimed, rec.ID,
+		tasks.ClaimedPayload{AgentID: "ghost-agent", ClaimEpoch: 7},
+	)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	body, err := tasks.MarshalEnvelope(env)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	js := nc
+	_ = js
+	// Use a fresh JetStream handle — we want the publish path the
+	// recovery test isolates, not Tx.
+	jsHandle, err := getJetStream(nc)
+	if err != nil {
+		t.Fatalf("jetstream: %v", err)
+	}
+	if _, err := jsHandle.Publish(ctx, tasks.EventSubject(rec.ID), body); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+
+	// Pre-recovery: KV still shows the task as Open.
+	got, _, err := m.Get(ctx, rec.ID)
+	if err != nil {
+		t.Fatalf("Get pre-recover: %v", err)
+	}
+	if got.Status != tasks.StatusOpen {
+		t.Fatalf("pre-recover want Open, got %s", got.Status)
+	}
+
+	// Run recovery.
+	replayed, err := tasks.Recover(ctx, m)
+	if err != nil {
+		t.Fatalf("Recover: %v", err)
+	}
+	if replayed == 0 {
+		t.Fatalf("expected at least one event replayed")
+	}
+
+	// Post-recovery: KV reflects the orphan event's effect.
+	got, _, err = m.Get(ctx, rec.ID)
+	if err != nil {
+		t.Fatalf("Get post-recover: %v", err)
+	}
+	if got.Status != tasks.StatusClaimed {
+		t.Fatalf("post-recover want Claimed, got %s", got.Status)
+	}
+	if got.ClaimedBy != "ghost-agent" {
+		t.Fatalf("post-recover ClaimedBy = %q, want ghost-agent", got.ClaimedBy)
+	}
+}

--- a/internal/tasks/recovery_test.go
+++ b/internal/tasks/recovery_test.go
@@ -109,3 +109,233 @@ func TestRecovery_OrphanedEventReplays(t *testing.T) {
 		t.Fatalf("post-recover ClaimedBy = %q, want ghost-agent", got.ClaimedBy)
 	}
 }
+
+// publishOrphanUpdated publishes an updated event directly to the
+// stream, simulating a hub crash between Tx publish and KV write.
+// Returns the seeded Manager and task so per-field assertions can
+// run against the projection post-Recover.
+func publishOrphanUpdated(
+	t *testing.T,
+	taskID string,
+	changes []tasks.FieldChange,
+) (*tasks.Manager, func()) {
+	t.Helper()
+	srv, cleanup := natstest.NewJetStreamServer(t)
+	nc, err := nats.Connect(srv.ConnectedUrl())
+	if err != nil {
+		cleanup()
+		t.Fatalf("nats.Connect: %v", err)
+	}
+	m, err := tasks.Open(context.Background(), nc, tasks.Config{
+		BucketName:     "tasks-replay-field",
+		HistoryDepth:   8,
+		MaxValueSize:   8 * 1024,
+		EnableEventLog: true,
+	})
+	if err != nil {
+		nc.Close()
+		cleanup()
+		t.Fatalf("Open: %v", err)
+	}
+	ctx := context.Background()
+	rec := txNewTask(taskID)
+	if err := m.Tx(ctx, rec.ID, func(tx *tasks.Tx) error {
+		return tx.Create(rec)
+	}); err != nil {
+		_ = m.Close()
+		nc.Close()
+		cleanup()
+		t.Fatalf("create: %v", err)
+	}
+	env, err := tasks.EncodeEnvelope(tasks.EventTypeUpdated, rec.ID,
+		tasks.UpdatedPayload{Changes: changes})
+	if err != nil {
+		_ = m.Close()
+		nc.Close()
+		cleanup()
+		t.Fatalf("encode: %v", err)
+	}
+	body, err := tasks.MarshalEnvelope(env)
+	if err != nil {
+		_ = m.Close()
+		nc.Close()
+		cleanup()
+		t.Fatalf("marshal: %v", err)
+	}
+	jsHandle, err := getJetStream(nc)
+	if err != nil {
+		_ = m.Close()
+		nc.Close()
+		cleanup()
+		t.Fatalf("jetstream: %v", err)
+	}
+	if _, err := jsHandle.Publish(ctx, tasks.EventSubject(rec.ID), body); err != nil {
+		_ = m.Close()
+		nc.Close()
+		cleanup()
+		t.Fatalf("publish: %v", err)
+	}
+	return m, func() {
+		_ = m.Close()
+		nc.Close()
+		cleanup()
+	}
+}
+
+// TestRecover_AppliesUpdatedEventField_Title verifies that an orphan
+// updated event carrying a title FieldChange is applied to the
+// projection on Recover. The log alone now reconstructs the
+// post-mutation state — the property ADR 0052 §"Recovery" promises.
+func TestRecover_AppliesUpdatedEventField_Title(t *testing.T) {
+	taskID := "bones-replay-title"
+	changes := []tasks.FieldChange{
+		tasks.MustFieldChange("title", "tx example", "renamed via orphan"),
+	}
+	m, cleanup := publishOrphanUpdated(t, taskID, changes)
+	defer cleanup()
+	ctx := context.Background()
+	if _, err := tasks.Recover(ctx, m); err != nil {
+		t.Fatalf("Recover: %v", err)
+	}
+	got, _, err := m.Get(ctx, taskID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Title != "renamed via orphan" {
+		t.Fatalf("title not applied: got %q", got.Title)
+	}
+}
+
+// TestRecover_AppliesUpdatedEventField_ClaimedBy verifies a coupled
+// (status, claimed_by) FieldChange pair flows through replay
+// correctly. Invariant 11 (claimed_by non-empty iff status==claimed)
+// is enforced by the KV write path — a real claim event always
+// carries both fields, so replay does too.
+func TestRecover_AppliesUpdatedEventField_ClaimedBy(t *testing.T) {
+	taskID := "bones-replay-claimedby"
+	changes := []tasks.FieldChange{
+		tasks.MustFieldChange("status", tasks.StatusOpen, tasks.StatusClaimed),
+		tasks.MustFieldChange("claimed_by", "", "alice"),
+	}
+	m, cleanup := publishOrphanUpdated(t, taskID, changes)
+	defer cleanup()
+	ctx := context.Background()
+	if _, err := tasks.Recover(ctx, m); err != nil {
+		t.Fatalf("Recover: %v", err)
+	}
+	got, _, err := m.Get(ctx, taskID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.ClaimedBy != "alice" {
+		t.Fatalf("claimed_by not applied: got %q", got.ClaimedBy)
+	}
+	if got.Status != tasks.StatusClaimed {
+		t.Fatalf("status not applied: got %s", got.Status)
+	}
+}
+
+// TestRecover_AppliesUpdatedEventField_Files exercises a slice-typed
+// field to verify the JSON unmarshal handles non-scalars correctly.
+func TestRecover_AppliesUpdatedEventField_Files(t *testing.T) {
+	taskID := "bones-replay-files"
+	newFiles := []string{"/work/a.go", "/work/b.go", "/work/c.go"}
+	changes := []tasks.FieldChange{
+		tasks.MustFieldChange("files", []string{"/work/x.go"}, newFiles),
+	}
+	m, cleanup := publishOrphanUpdated(t, taskID, changes)
+	defer cleanup()
+	ctx := context.Background()
+	if _, err := tasks.Recover(ctx, m); err != nil {
+		t.Fatalf("Recover: %v", err)
+	}
+	got, _, err := m.Get(ctx, taskID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if len(got.Files) != len(newFiles) {
+		t.Fatalf("files len: want %d got %d", len(newFiles), len(got.Files))
+	}
+	for i, f := range newFiles {
+		if got.Files[i] != f {
+			t.Fatalf("files[%d]: want %q got %q", i, f, got.Files[i])
+		}
+	}
+}
+
+// TestRecover_AppliesUpdatedEventField_Context exercises a map-typed
+// field to verify the JSON unmarshal handles map values.
+func TestRecover_AppliesUpdatedEventField_Context(t *testing.T) {
+	taskID := "bones-replay-context"
+	newCtx := map[string]string{"priority": "P0", "owner": "alice"}
+	changes := []tasks.FieldChange{
+		tasks.MustFieldChange("context", map[string]string{}, newCtx),
+	}
+	m, cleanup := publishOrphanUpdated(t, taskID, changes)
+	defer cleanup()
+	ctx := context.Background()
+	if _, err := tasks.Recover(ctx, m); err != nil {
+		t.Fatalf("Recover: %v", err)
+	}
+	got, _, err := m.Get(ctx, taskID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Context["priority"] != "P0" || got.Context["owner"] != "alice" {
+		t.Fatalf("context not applied: got %+v", got.Context)
+	}
+}
+
+// TestRecover_AppliesUpdatedEventField_MultipleChanges verifies a
+// single updated event with multiple FieldChange tuples applies all
+// of them in one CAS write. The shape mimics a CLI bones-tasks-update
+// invocation that changes several fields at once.
+func TestRecover_AppliesUpdatedEventField_MultipleChanges(t *testing.T) {
+	taskID := "bones-replay-multi"
+	changes := []tasks.FieldChange{
+		tasks.MustFieldChange("title", "tx example", "multi-renamed"),
+		tasks.MustFieldChange("parent", "", "bones-parent-1"),
+	}
+	m, cleanup := publishOrphanUpdated(t, taskID, changes)
+	defer cleanup()
+	ctx := context.Background()
+	if _, err := tasks.Recover(ctx, m); err != nil {
+		t.Fatalf("Recover: %v", err)
+	}
+	got, _, err := m.Get(ctx, taskID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Title != "multi-renamed" {
+		t.Fatalf("title: got %q", got.Title)
+	}
+	if got.Parent != "bones-parent-1" {
+		t.Fatalf("parent: got %q", got.Parent)
+	}
+}
+
+// TestRecover_AppliesUpdatedEventField_UnknownFieldDropped verifies
+// that an unknown field name in a FieldChange is silently dropped
+// per the additive-only evolution rule.
+func TestRecover_AppliesUpdatedEventField_UnknownFieldDropped(t *testing.T) {
+	taskID := "bones-replay-unknown"
+	changes := []tasks.FieldChange{
+		tasks.MustFieldChange("future_field", nil, "new-value"),
+	}
+	m, cleanup := publishOrphanUpdated(t, taskID, changes)
+	defer cleanup()
+	ctx := context.Background()
+	if _, err := tasks.Recover(ctx, m); err != nil {
+		t.Fatalf("Recover: %v", err)
+	}
+	// No assertion on Task content — the test passes if Recover did
+	// not error on the unknown field. The projection's LastEventSeq
+	// should advance even though no field was applied.
+	got, _, err := m.Get(ctx, taskID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.LastEventSeq == 0 {
+		t.Fatalf("LastEventSeq should advance even for unknown-field events")
+	}
+}

--- a/internal/tasks/subscribe_test.go
+++ b/internal/tasks/subscribe_test.go
@@ -47,7 +47,7 @@ func TestWatch_ReceivesCreate(t *testing.T) {
 		t.Fatalf("Watch: %v", err)
 	}
 	id := "bones-watch001"
-	if err := m.Create(ctx, newTask(id)); err != nil {
+	if err := tasks.NewAdminWrite(m).Create(ctx, newTask(id)); err != nil {
 		t.Fatalf("Create: %v", err)
 	}
 	ev := waitForKind(t, ch, id, tasks.EventCreated)
@@ -70,12 +70,12 @@ func TestWatch_ReceivesUpdate(t *testing.T) {
 		t.Fatalf("Watch: %v", err)
 	}
 	id := "bones-watch002"
-	if err := m.Create(ctx, newTask(id)); err != nil {
+	if err := tasks.NewAdminWrite(m).Create(ctx, newTask(id)); err != nil {
 		t.Fatalf("Create: %v", err)
 	}
 	waitForKind(t, ch, id, tasks.EventCreated)
 
-	err = m.Update(ctx, id, func(t tasks.Task) (tasks.Task, error) {
+	err = tasks.NewAdminWrite(m).Update(ctx, id, func(t tasks.Task) (tasks.Task, error) {
 		t.Status = tasks.StatusClaimed
 		t.ClaimedBy = "agent-a"
 		t.UpdatedAt = time.Now().UTC()
@@ -103,7 +103,7 @@ func TestWatch_ReceivesDelete(t *testing.T) {
 		t.Fatalf("Watch: %v", err)
 	}
 	id := "bones-watch003"
-	if err := m.Create(ctx, newTask(id)); err != nil {
+	if err := tasks.NewAdminWrite(m).Create(ctx, newTask(id)); err != nil {
 		t.Fatalf("Create: %v", err)
 	}
 	waitForKind(t, ch, id, tasks.EventCreated)

--- a/internal/tasks/tally.go
+++ b/internal/tasks/tally.go
@@ -1,0 +1,64 @@
+package tasks
+
+// Tally is the per-status summary that both `bones status` and
+// `bones tasks status` render. Counts are derived by replaying events
+// (not by walking the KV) so the two surfaces share one source. Per
+// ADR 0052 §"TaskTally — single source for counts".
+type Tally struct {
+	// Open is the count of tasks currently in StatusOpen.
+	Open int
+	// Claimed is the count of tasks currently in StatusClaimed.
+	Claimed int
+	// Closed is the count of tasks currently in StatusClosed.
+	Closed int
+	// Total is Open+Claimed+Closed.
+	Total int
+}
+
+// TaskTally derives a Tally by replaying events into a per-task status
+// projection and bucket-counting at the end. The events slice should
+// be the full log (or a subset that includes the latest state-changing
+// event for each task ID); ordering by stream sequence is the caller's
+// responsibility — recovery and live consumers receive ordered events
+// by construction.
+//
+// Events with unknown types are ignored. A task is counted under its
+// most recent terminal status; a closed task that was previously
+// reopened (not legal under the current DAG, but defensive) reports
+// the latest status seen.
+func TaskTally(events []EventEnvelope) Tally {
+	statuses := make(map[string]Status)
+	for _, env := range events {
+		switch env.Type {
+		case EventTypeCreated:
+			if _, ok := statuses[env.TaskID]; !ok {
+				statuses[env.TaskID] = StatusOpen
+			}
+		case EventTypeClaimed:
+			statuses[env.TaskID] = StatusClaimed
+		case EventTypeUnclaimed:
+			statuses[env.TaskID] = StatusOpen
+		case EventTypeClosed:
+			statuses[env.TaskID] = StatusClosed
+		}
+	}
+	t := Tally{}
+	for _, s := range statuses {
+		switch s {
+		case StatusOpen:
+			t.Open++
+		case StatusClaimed:
+			t.Claimed++
+		case StatusClosed:
+			t.Closed++
+		}
+		t.Total++
+	}
+	return t
+}
+
+// RecentActivityCount is the default number of events `bones status`
+// surfaces under "Recent activity" per ADR 0052. Tunable as a constant
+// rather than a flag — operators wanting more reach for `bones tasks
+// watch --since=<duration>`.
+const RecentActivityCount = 20

--- a/internal/tasks/task.go
+++ b/internal/tasks/task.go
@@ -7,8 +7,10 @@ import (
 
 // SchemaVersion is the currently-written task record schema. Every
 // Create stamps this on the record so future migrations can fan out on
-// observed version. v3 adds closed-task compaction metadata.
-const SchemaVersion = 3
+// observed version. v3 adds closed-task compaction metadata. v4 adds
+// LastEventSeq, the projection-watermark wired by the event log per
+// ADR 0052.
+const SchemaVersion = 4
 
 // Status is the task lifecycle state. ADR 0005 fixes the enum to
 // exactly these three values; invariant 13 (amended by ADR 0007)
@@ -139,6 +141,14 @@ type Task struct {
 
 	// SchemaVersion stamps the schema this record was written against.
 	SchemaVersion int `json:"schema_version"`
+
+	// LastEventSeq is the JetStream stream sequence of the most recent
+	// task event whose effect has been applied to this projection. The
+	// hub-side recovery loop on bones up reads the live KV record and
+	// the stream's latest sequence per task subject; if the stream
+	// sequence is greater, pending events are replayed and the
+	// projection is brought to parity. Added in schema v4 (ADR 0052).
+	LastEventSeq uint64 `json:"last_event_seq,omitempty"`
 }
 
 // encode serializes a Task to JSON bytes for KV storage. Separated from

--- a/internal/tasks/tasks.go
+++ b/internal/tasks/tasks.go
@@ -52,6 +52,13 @@ type Config struct {
 	// archive Manager (compacted closed-task snapshots) opens false
 	// so that compaction-only writes do not flood the event log.
 	EnableEventLog bool
+
+	// RecoverOnOpen controls whether Open runs Recover() to reconcile
+	// orphan events. Recovery is safe at hub start (single process,
+	// no concurrent Tx in flight) but races against live Tx callers,
+	// so every-call Open should leave this false. Hub start passes
+	// true; coord callers, CLI verbs, and tests pass false.
+	RecoverOnOpen bool
 }
 
 // defaultChanBuffer is the Watch channel buffer used when Config leaves
@@ -109,6 +116,28 @@ func Open(ctx context.Context, nc *nats.Conn, cfg Config) (*Manager, error) {
 			return nil, fmt.Errorf("tasks.Open: events stream: %w", err)
 		}
 		mgr.stream = stream
+		// One-time migration of pre-event-log KV state. Idempotent via
+		// the migrationMarkerKey marker in the bucket. Migration is
+		// safe to run on every Open because the marker key short-
+		// circuits subsequent calls.
+		if _, err := Migrate(ctx, mgr); err != nil {
+			return nil, fmt.Errorf("tasks.Open: migrate: %w", err)
+		}
+		// Recovery is opt-in via RecoverOnOpen because tasks.Open is
+		// called by every CLI verb and every coord.OpenLeaf — running
+		// Recover concurrently with live Tx writes is racy by design
+		// (the Tx writer and the recovery loop both want to bring KV
+		// to parity with the stream and they can clobber each other's
+		// CAS). Hub-start is the one place where Recovery is safe:
+		// the hub is single-process, no Tx is in flight yet, and the
+		// orphan-event reconciliation is the whole point of starting.
+		// Hub-start integration ships in a follow-up; for this PR,
+		// callers wanting recovery invoke tasks.Recover() explicitly.
+		if cfg.RecoverOnOpen {
+			if _, err := Recover(ctx, mgr); err != nil {
+				return nil, fmt.Errorf("tasks.Open: recover: %w", err)
+			}
+		}
 	}
 	return mgr, nil
 }
@@ -322,9 +351,18 @@ func (m *Manager) Purge(ctx context.Context, id string) error {
 // delete markers or undecodable values so List can skip them quietly.
 // The separate return path for errors.Is(err, ErrNotFound) handles the
 // race where a key was listed and then deleted before we read it.
+//
+// The migration marker key (ADR 0052) is filtered here so List output
+// stays free of the bookkeeping entry. The marker is a Task-shaped
+// placeholder so the bucket's value-shape expectations hold; treating
+// it as a normal Task in List/Watch output would surface a synthetic
+// "task" to every consumer.
 func (m *Manager) readOne(
 	ctx context.Context, key string,
 ) (*Task, error) {
+	if key == migrationMarkerKey {
+		return nil, nil
+	}
 	entry, err := m.kv.Get(ctx, key)
 	if err != nil {
 		if errors.Is(err, jetstream.ErrKeyNotFound) {

--- a/internal/tasks/tasks.go
+++ b/internal/tasks/tasks.go
@@ -128,11 +128,13 @@ func Open(ctx context.Context, nc *nats.Conn, cfg Config) (*Manager, error) {
 		// Recover concurrently with live Tx writes is racy by design
 		// (the Tx writer and the recovery loop both want to bring KV
 		// to parity with the stream and they can clobber each other's
-		// CAS). Hub-start is the one place where Recovery is safe:
-		// the hub is single-process, no Tx is in flight yet, and the
-		// orphan-event reconciliation is the whole point of starting.
-		// Hub-start integration ships in a follow-up; for this PR,
-		// callers wanting recovery invoke tasks.Recover() explicitly.
+		// CAS). Hub start passes RecoverOnOpen=true via
+		// internal/hub.runTaskRecovery, which fires after NATS bind
+		// and BEFORE the registry-write that makes the hub
+		// discoverable to clients — Recover drains while the
+		// workspace lock + un-registered hub gate any competing CLI
+		// invocation, so no live Tx can race. Every other caller
+		// leaves RecoverOnOpen at false.
 		if cfg.RecoverOnOpen {
 			if _, err := Recover(ctx, mgr); err != nil {
 				return nil, fmt.Errorf("tasks.Open: recover: %w", err)

--- a/internal/tasks/tasks.go
+++ b/internal/tasks/tasks.go
@@ -44,6 +44,14 @@ type Config struct {
 	// ChanBuffer sets the channel buffer for Watch. Zero yields the
 	// package default (defaultChanBuffer).
 	ChanBuffer int
+
+	// EnableEventLog opts the Manager into the append-only task event
+	// log per ADR 0052. When true, Open creates (or attaches to) the
+	// `tasks-events` JetStream stream and Tx publishes one event per
+	// mutation. Coord's primary task Manager opens with this true; the
+	// archive Manager (compacted closed-task snapshots) opens false
+	// so that compaction-only writes do not flood the event log.
+	EnableEventLog bool
 }
 
 // defaultChanBuffer is the Watch channel buffer used when Config leaves
@@ -53,11 +61,12 @@ const defaultChanBuffer = 32
 // Manager owns a JetStream KV bucket that stores task records. Every
 // public method is safe to call concurrently. Close is idempotent.
 type Manager struct {
-	cfg  Config
-	js   jetstream.JetStream
-	kv   jetstream.KeyValue
-	buf  int
-	done atomic.Bool
+	cfg    Config
+	js     jetstream.JetStream
+	kv     jetstream.KeyValue
+	stream jetstream.Stream
+	buf    int
+	done   atomic.Bool
 
 	mu   sync.Mutex
 	subs []chan Event
@@ -88,7 +97,20 @@ func Open(ctx context.Context, nc *nats.Conn, cfg Config) (*Manager, error) {
 	if buf == 0 {
 		buf = defaultChanBuffer
 	}
-	return &Manager{cfg: cfg, js: js, kv: kv, buf: buf}, nil
+	mgr := &Manager{cfg: cfg, js: js, kv: kv, buf: buf}
+	if cfg.EnableEventLog {
+		stream, err := js.CreateOrUpdateStream(ctx, jetstream.StreamConfig{
+			Name:      EventStreamName,
+			Subjects:  []string{AllEventsSubject},
+			Storage:   jetstream.FileStorage,
+			Retention: jetstream.LimitsPolicy,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("tasks.Open: events stream: %w", err)
+		}
+		mgr.stream = stream
+	}
+	return mgr, nil
 }
 
 // assertOpenConfig panics on any Config field that would corrupt the
@@ -130,23 +152,20 @@ func (m *Manager) Close() error {
 	return nil
 }
 
-// Create writes a new task record. Uses jetstream.KeyValue.Create
-// (revision 0), so a key that already exists rejects with
-// ErrAlreadyExists — under the ADR 0005 ID generator a Create collision
-// is a programmer error at the caller, but the sentinel lets the
-// caller distinguish the mistake from an unrelated substrate failure.
-// Invariant 11 and 13 are checked against the record's own fields
-// before the CAS call; invariant 14 is checked after encoding.
-func (m *Manager) Create(ctx context.Context, t Task) error {
-	assert.NotNil(ctx, "tasks.Create: ctx is nil")
-	assert.NotEmpty(t.ID, "tasks.Create: t.ID is empty")
+// create writes a new task record. Private; reachable only from Tx
+// (via createLocked) and from the import-restricted internal/tasks/
+// admin package. ADR 0052 makes Tx the only public mutation entry
+// point on Manager; this helper is the storage primitive Tx uses.
+func (m *Manager) create(ctx context.Context, t Task) error {
+	assert.NotNil(ctx, "tasks.create: ctx is nil")
+	assert.NotEmpty(t.ID, "tasks.create: t.ID is empty")
 	if m.done.Load() {
 		return ErrClosed
 	}
 	if err := validateForCreate(t); err != nil {
 		return err
 	}
-	payload, err := m.encodeBounded(t, "tasks.Create")
+	payload, err := m.encodeBounded(t, "tasks.create")
 	if err != nil {
 		return err
 	}
@@ -154,7 +173,7 @@ func (m *Manager) Create(ctx context.Context, t Task) error {
 		if errors.Is(err, jetstream.ErrKeyExists) {
 			return ErrAlreadyExists
 		}
-		return fmt.Errorf("tasks.Create: %w", err)
+		return fmt.Errorf("tasks.create: %w", err)
 	}
 	return nil
 }
@@ -189,28 +208,25 @@ func (m *Manager) Get(
 	return t, entry.Revision(), nil
 }
 
-// Update performs a revision-gated CAS update. The mutate function
-// receives the current Task value and returns the desired new value;
-// returning a non-nil error aborts the update and propagates the error
-// unwrapped so callers can switch on mutate's own sentinels. On
-// revision conflict the loop re-reads the record and re-invokes
-// mutate, up to jskv.MaxRetries times, before surfacing ErrCASConflict.
-// Invariants 11, 13, and 14 are checked on each attempt against the
-// value mutate returned.
-func (m *Manager) Update(
+// update performs a revision-gated CAS update. Private; reachable only
+// from Tx (via updateLocked) and from the import-restricted
+// internal/tasks/admin package. ADR 0052 makes Tx the only public
+// mutation entry point on Manager; this helper is the storage
+// primitive Tx uses.
+func (m *Manager) update(
 	ctx context.Context,
 	id string,
 	mutate func(Task) (Task, error),
 ) error {
-	assert.NotNil(ctx, "tasks.Update: ctx is nil")
-	assert.NotEmpty(id, "tasks.Update: id is empty")
-	assert.NotNil(mutate, "tasks.Update: mutate is nil")
+	assert.NotNil(ctx, "tasks.update: ctx is nil")
+	assert.NotEmpty(id, "tasks.update: id is empty")
+	assert.NotNil(mutate, "tasks.update: mutate is nil")
 	if m.done.Load() {
 		return ErrClosed
 	}
 	var attempt int
 	for attempt = 0; attempt < jskv.MaxRetries; attempt++ {
-		assert.Precondition(attempt < jskv.MaxRetries, "tasks.Update: CAS attempt exceeded bound")
+		assert.Precondition(attempt < jskv.MaxRetries, "tasks.update: CAS attempt exceeded bound")
 		done, err := m.updateAttempt(ctx, id, mutate)
 		if done {
 			return err
@@ -218,7 +234,7 @@ func (m *Manager) Update(
 		casRetryHook()
 	}
 	assert.Postcondition(attempt == jskv.MaxRetries,
-		"tasks.Update: exited CAS loop without exhausting retries or returning")
+		"tasks.update: exited CAS loop without exhausting retries or returning")
 	return ErrCASConflict
 }
 

--- a/internal/tasks/tasks_cas_test.go
+++ b/internal/tasks/tasks_cas_test.go
@@ -29,7 +29,7 @@ func TestUpdate_CAS_RetryFires(t *testing.T) {
 	ctx := context.Background()
 	id := "bones-retry001"
 
-	if err := m.Create(ctx, newTask(id)); err != nil {
+	if err := tasks.NewAdminWrite(m).Create(ctx, newTask(id)); err != nil {
 		t.Fatalf("Create: %v", err)
 	}
 
@@ -57,7 +57,7 @@ func TestUpdate_CAS_RetryFires(t *testing.T) {
 	})
 	defer restorePre()
 
-	err := m.Update(ctx, id, func(t tasks.Task) (tasks.Task, error) {
+	err := tasks.NewAdminWrite(m).Update(ctx, id, func(t tasks.Task) (tasks.Task, error) {
 		t.Status = tasks.StatusClaimed
 		t.ClaimedBy = "agent-a"
 		t.UpdatedAt = time.Now().UTC()
@@ -94,7 +94,7 @@ func TestUpdate_CAS_ConcurrentContention(t *testing.T) {
 	ctx := context.Background()
 	id := "bones-stress01"
 
-	if err := m.Create(ctx, newTask(id)); err != nil {
+	if err := tasks.NewAdminWrite(m).Create(ctx, newTask(id)); err != nil {
 		t.Fatalf("Create: %v", err)
 	}
 
@@ -111,7 +111,7 @@ func TestUpdate_CAS_ConcurrentContention(t *testing.T) {
 		go func(idx int, k string) {
 			defer wg.Done()
 			<-startGun
-			errs[idx] = m.Update(
+			errs[idx] = tasks.NewAdminWrite(m).Update(
 				ctx, id,
 				func(t tasks.Task) (tasks.Task, error) {
 					if t.Context == nil {
@@ -160,7 +160,7 @@ func TestUpdate_CAS_ExhaustedRetries(t *testing.T) {
 	ctx := context.Background()
 	id := "bones-exhaust0"
 
-	if err := m.Create(ctx, newTask(id)); err != nil {
+	if err := tasks.NewAdminWrite(m).Create(ctx, newTask(id)); err != nil {
 		t.Fatalf("Create: %v", err)
 	}
 
@@ -174,7 +174,7 @@ func TestUpdate_CAS_ExhaustedRetries(t *testing.T) {
 	defer restore()
 
 	// The mutate closure always succeeds; the CAS race is what fails.
-	err := m.Update(ctx, id, func(t tasks.Task) (tasks.Task, error) {
+	err := tasks.NewAdminWrite(m).Update(ctx, id, func(t tasks.Task) (tasks.Task, error) {
 		t.Title = "target"
 		return t, nil
 	})

--- a/internal/tasks/tasks_test.go
+++ b/internal/tasks/tasks_test.go
@@ -102,7 +102,7 @@ func TestCreate_HappyPath(t *testing.T) {
 	ctx := context.Background()
 	id := "bones-aaaaaaaa"
 
-	if err := m.Create(ctx, newTask(id)); err != nil {
+	if err := tasks.NewAdminWrite(m).Create(ctx, newTask(id)); err != nil {
 		t.Fatalf("Create: %v", err)
 	}
 	got, rev, err := m.Get(ctx, id)
@@ -126,10 +126,10 @@ func TestCreate_Duplicate_ReturnsAlreadyExists(t *testing.T) {
 	ctx := context.Background()
 	id := "bones-aaaaaaab"
 
-	if err := m.Create(ctx, newTask(id)); err != nil {
+	if err := tasks.NewAdminWrite(m).Create(ctx, newTask(id)); err != nil {
 		t.Fatalf("Create 1: %v", err)
 	}
-	err := m.Create(ctx, newTask(id))
+	err := tasks.NewAdminWrite(m).Create(ctx, newTask(id))
 	if !errors.Is(err, tasks.ErrAlreadyExists) {
 		t.Fatalf("Create 2: got %v, want ErrAlreadyExists", err)
 	}
@@ -151,12 +151,12 @@ func TestUpdate_HappyPath(t *testing.T) {
 	ctx := context.Background()
 	id := "bones-update001"
 
-	if err := m.Create(ctx, newTask(id)); err != nil {
+	if err := tasks.NewAdminWrite(m).Create(ctx, newTask(id)); err != nil {
 		t.Fatalf("Create: %v", err)
 	}
 	_, preRev, _ := m.Get(ctx, id)
 
-	err := m.Update(ctx, id, func(t tasks.Task) (tasks.Task, error) {
+	err := tasks.NewAdminWrite(m).Update(ctx, id, func(t tasks.Task) (tasks.Task, error) {
 		t.Status = tasks.StatusClaimed
 		t.ClaimedBy = "agent-a"
 		t.UpdatedAt = time.Now().UTC()
@@ -190,10 +190,10 @@ func TestUpdate_Invariant11_Violation_Rejected(t *testing.T) {
 	ctx := context.Background()
 	id := "bones-inv110001"
 
-	if err := m.Create(ctx, newTask(id)); err != nil {
+	if err := tasks.NewAdminWrite(m).Create(ctx, newTask(id)); err != nil {
 		t.Fatalf("Create: %v", err)
 	}
-	err := m.Update(ctx, id, func(t tasks.Task) (tasks.Task, error) {
+	err := tasks.NewAdminWrite(m).Update(ctx, id, func(t tasks.Task) (tasks.Task, error) {
 		t.Status = tasks.StatusClaimed
 		// ClaimedBy deliberately empty — the invariant-11 violation.
 		return t, nil
@@ -218,13 +218,13 @@ func TestUpdate_InvalidTransition_Rejected(t *testing.T) {
 	ctx := context.Background()
 	id := "bones-dag00001"
 
-	if err := m.Create(ctx, newTask(id)); err != nil {
+	if err := tasks.NewAdminWrite(m).Create(ctx, newTask(id)); err != nil {
 		t.Fatalf("Create: %v", err)
 	}
 	// Walk open → closed (a legal edge) so we can then attempt a
 	// backwards closed → open edge.
 	now := time.Now().UTC()
-	err := m.Update(ctx, id, func(t tasks.Task) (tasks.Task, error) {
+	err := tasks.NewAdminWrite(m).Update(ctx, id, func(t tasks.Task) (tasks.Task, error) {
 		t.Status = tasks.StatusClosed
 		t.ClosedAt = &now
 		t.ClosedBy = "agent-a"
@@ -235,7 +235,7 @@ func TestUpdate_InvalidTransition_Rejected(t *testing.T) {
 		t.Fatalf("Update to closed: %v", err)
 	}
 
-	err = m.Update(ctx, id, func(t tasks.Task) (tasks.Task, error) {
+	err = tasks.NewAdminWrite(m).Update(ctx, id, func(t tasks.Task) (tasks.Task, error) {
 		t.Status = tasks.StatusOpen
 		t.ClosedAt = nil
 		t.ClosedBy = ""
@@ -253,11 +253,11 @@ func TestUpdate_ClosedIsTerminal_RejectsSelfEdge(t *testing.T) {
 	ctx := context.Background()
 	id := "bones-closed01"
 
-	if err := m.Create(ctx, newTask(id)); err != nil {
+	if err := tasks.NewAdminWrite(m).Create(ctx, newTask(id)); err != nil {
 		t.Fatalf("Create: %v", err)
 	}
 	now := time.Now().UTC()
-	err := m.Update(ctx, id, func(t tasks.Task) (tasks.Task, error) {
+	err := tasks.NewAdminWrite(m).Update(ctx, id, func(t tasks.Task) (tasks.Task, error) {
 		t.Status = tasks.StatusClosed
 		t.ClosedAt = &now
 		t.ClosedBy = "agent-a"
@@ -269,7 +269,7 @@ func TestUpdate_ClosedIsTerminal_RejectsSelfEdge(t *testing.T) {
 	}
 	// closed→closed (metadata-only update on a terminal record) must
 	// fail so the closed snapshot stays immutable.
-	err = m.Update(ctx, id, func(t tasks.Task) (tasks.Task, error) {
+	err = tasks.NewAdminWrite(m).Update(ctx, id, func(t tasks.Task) (tasks.Task, error) {
 		t.ClosedReason = "mutated after close"
 		return t, nil
 	})
@@ -286,11 +286,11 @@ func TestUpdate_ClosedCompactionMetadata_AllowsSelfEdge(t *testing.T) {
 	ctx := context.Background()
 	id := "bones-closed02"
 
-	if err := m.Create(ctx, newTask(id)); err != nil {
+	if err := tasks.NewAdminWrite(m).Create(ctx, newTask(id)); err != nil {
 		t.Fatalf("Create: %v", err)
 	}
 	now := time.Now().UTC()
-	err := m.Update(ctx, id, func(t tasks.Task) (tasks.Task, error) {
+	err := tasks.NewAdminWrite(m).Update(ctx, id, func(t tasks.Task) (tasks.Task, error) {
 		t.Status = tasks.StatusClosed
 		t.ClosedAt = &now
 		t.ClosedBy = "agent-a"
@@ -301,7 +301,7 @@ func TestUpdate_ClosedCompactionMetadata_AllowsSelfEdge(t *testing.T) {
 		t.Fatalf("Update to closed: %v", err)
 	}
 	compactedAt := now.Add(time.Hour)
-	err = m.Update(ctx, id, func(t tasks.Task) (tasks.Task, error) {
+	err = tasks.NewAdminWrite(m).Update(ctx, id, func(t tasks.Task) (tasks.Task, error) {
 		t.OriginalSize = 123
 		t.CompactLevel = 1
 		t.CompactedAt = &compactedAt
@@ -329,13 +329,13 @@ func TestUpdate_ValueTooLarge_Rejected(t *testing.T) {
 	ctx := context.Background()
 	id := "bones-big00001"
 
-	if err := m.Create(ctx, newTask(id)); err != nil {
+	if err := tasks.NewAdminWrite(m).Create(ctx, newTask(id)); err != nil {
 		t.Fatalf("Create: %v", err)
 	}
 	bigCtx := make(map[string]string, 1)
 	bigCtx["blob"] = strings.Repeat("x", 16*1024)
 
-	err := m.Update(ctx, id, func(t tasks.Task) (tasks.Task, error) {
+	err := tasks.NewAdminWrite(m).Update(ctx, id, func(t tasks.Task) (tasks.Task, error) {
 		t.Context = bigCtx
 		return t, nil
 	})
@@ -350,11 +350,11 @@ func TestUpdate_MutateError_Propagates(t *testing.T) {
 	ctx := context.Background()
 	id := "bones-mut00001"
 
-	if err := m.Create(ctx, newTask(id)); err != nil {
+	if err := tasks.NewAdminWrite(m).Create(ctx, newTask(id)); err != nil {
 		t.Fatalf("Create: %v", err)
 	}
 	sentinel := errors.New("caller sentinel")
-	err := m.Update(ctx, id, func(t tasks.Task) (tasks.Task, error) {
+	err := tasks.NewAdminWrite(m).Update(ctx, id, func(t tasks.Task) (tasks.Task, error) {
 		return t, sentinel
 	})
 	if !errors.Is(err, sentinel) {
@@ -373,7 +373,7 @@ func TestList_ReturnsAllRecords(t *testing.T) {
 		"bones-list0003",
 	}
 	for _, id := range ids {
-		if err := m.Create(ctx, newTask(id)); err != nil {
+		if err := tasks.NewAdminWrite(m).Create(ctx, newTask(id)); err != nil {
 			t.Fatalf("Create %s: %v", id, err)
 		}
 	}
@@ -414,7 +414,7 @@ func TestPurge_RemovesRecord(t *testing.T) {
 	ctx := context.Background()
 	id := "bones-purge001"
 
-	if err := m.Create(ctx, newTask(id)); err != nil {
+	if err := tasks.NewAdminWrite(m).Create(ctx, newTask(id)); err != nil {
 		t.Fatalf("Create: %v", err)
 	}
 	if err := m.Purge(ctx, id); err != nil {
@@ -439,7 +439,7 @@ func TestCreate_InvalidStatus_Rejected(t *testing.T) {
 
 	bad := newTask("bones-status01")
 	bad.Status = "totally-bogus"
-	err := m.Create(context.Background(), bad)
+	err := tasks.NewAdminWrite(m).Create(context.Background(), bad)
 	if !errors.Is(err, tasks.ErrInvalidStatus) {
 		t.Fatalf("Create: got %v, want ErrInvalidStatus", err)
 	}
@@ -452,7 +452,7 @@ func TestCreate_Invariant11_OnCreate_Rejected(t *testing.T) {
 	bad := newTask("bones-inv1101c")
 	bad.Status = tasks.StatusClaimed
 	// ClaimedBy deliberately empty.
-	err := m.Create(context.Background(), bad)
+	err := tasks.NewAdminWrite(m).Create(context.Background(), bad)
 	if !errors.Is(err, tasks.ErrInvariant11) {
 		t.Fatalf("Create: got %v, want ErrInvariant11", err)
 	}
@@ -464,13 +464,13 @@ func TestInvariant_NilCtx(t *testing.T) {
 	var ctx context.Context
 
 	requirePanic(t, func() {
-		_ = m.Create(ctx, newTask("bones-ctx00001"))
+		_ = tasks.NewAdminWrite(m).Create(ctx, newTask("bones-ctx00001"))
 	}, "ctx is nil")
 	requirePanic(t, func() {
 		_, _, _ = m.Get(ctx, "bones-ctx00002")
 	}, "ctx is nil")
 	requirePanic(t, func() {
-		_ = m.Update(ctx, "bones-ctx00003",
+		_ = tasks.NewAdminWrite(m).Update(ctx, "bones-ctx00003",
 			func(t tasks.Task) (tasks.Task, error) { return t, nil })
 	}, "ctx is nil")
 	requirePanic(t, func() {
@@ -487,13 +487,13 @@ func TestInvariant_EmptyID(t *testing.T) {
 	ctx := context.Background()
 
 	requirePanic(t, func() {
-		_ = m.Create(ctx, newTask(""))
+		_ = tasks.NewAdminWrite(m).Create(ctx, newTask(""))
 	}, "t.ID is empty")
 	requirePanic(t, func() {
 		_, _, _ = m.Get(ctx, "")
 	}, "id is empty")
 	requirePanic(t, func() {
-		_ = m.Update(ctx, "",
+		_ = tasks.NewAdminWrite(m).Update(ctx, "",
 			func(t tasks.Task) (tasks.Task, error) { return t, nil })
 	}, "id is empty")
 }
@@ -503,7 +503,7 @@ func TestInvariant_NilMutate(t *testing.T) {
 	defer cleanup()
 
 	requirePanic(t, func() {
-		_ = m.Update(context.Background(), "x", nil)
+		_ = tasks.NewAdminWrite(m).Update(context.Background(), "x", nil)
 	}, "mutate is nil")
 }
 
@@ -576,7 +576,7 @@ func TestInvariant_UseAfterClose(t *testing.T) {
 		t.Fatalf("Close: %v", err)
 	}
 	ctx := context.Background()
-	if err := m.Create(ctx, newTask("x")); !errors.Is(
+	if err := tasks.NewAdminWrite(m).Create(ctx, newTask("x")); !errors.Is(
 		err, tasks.ErrClosed,
 	) {
 		t.Fatalf("Create after Close: got %v, want ErrClosed", err)
@@ -586,7 +586,7 @@ func TestInvariant_UseAfterClose(t *testing.T) {
 	) {
 		t.Fatalf("Get after Close: got %v, want ErrClosed", err)
 	}
-	if err := m.Update(ctx, "x",
+	if err := tasks.NewAdminWrite(m).Update(ctx, "x",
 		func(t tasks.Task) (tasks.Task, error) { return t, nil },
 	); !errors.Is(err, tasks.ErrClosed) {
 		t.Fatalf("Update after Close: got %v, want ErrClosed", err)

--- a/internal/tasks/tx.go
+++ b/internal/tasks/tx.go
@@ -136,26 +136,54 @@ func (tx *Tx) Create(t Task) error {
 	return nil
 }
 
-// Claim publishes a claimed event and updates the KV record's status
-// and ClaimedBy fields. The mutator closure stays the same shape used
-// by the legacy Update API; tx.Claim wraps it so the caller does not
-// hand-author one. The claimEpoch is the new epoch the caller wants
-// stamped on the record (typically prior + 1, computed by coord).
+// ClaimArgs configures a tx.Claim call. AgentID and Mutate are
+// required; Slot, PrevAgent, and ClaimEpoch are optional. The mutator
+// runs inside the CAS loop and is responsible for the conditional
+// rejection (already-claimed, epoch-stale) plus stamping ClaimedBy
+// and any other fields. tx.Claim wraps it so callers do not have to
+// remember to update LastEventSeq or UpdatedAt.
 //
-// The optional mutate callback runs inside the CAS loop AFTER the
-// status/agent fields are stamped, so callers (coord) can apply
-// extra fields like ClaimEpoch in the same revision.
-func (tx *Tx) Claim(agentID string, slot string, claimEpoch uint64) error {
+// The Mutate callback IS the CAS body. It receives the current Task
+// and returns the desired post-claim Task value or an error. Returning
+// an error short-circuits the CAS loop and the Tx call returns the
+// error unwrapped so coord can switch on its own sentinels.
+type ClaimArgs struct {
+	AgentID    string
+	Slot       string
+	ClaimEpoch uint64
+	PrevAgent  string
+	Mutate     func(Task) (Task, error)
+}
+
+// Claim publishes a claimed event and applies the supplied mutator
+// inside a CAS loop. The mutator owns the conditional rejection
+// semantics — coord.Claim's claimMutator, coord.Reclaim's
+// reclaimMutator, and coord.HandoffClaim's handoffMutator all plug
+// in here unchanged.
+//
+// The publish-then-CAS order means: a mutator that rejects after
+// publish leaves a "spurious claimed" event in the log. Recovery's
+// LastEventSeq guard prevents replay from clobbering a later
+// projection; the audit-trail correctness is what the closed-set
+// event types and (field, old, new) tuples guarantee for replay
+// (see ADR 0052 §"Recovery").
+func (tx *Tx) Claim(args ClaimArgs) error {
 	tx.markDirty()
-	if agentID == "" {
-		err := errors.New("tasks.Tx.Claim: agentID is empty")
+	if args.AgentID == "" {
+		err := errors.New("tasks.Tx.Claim: AgentID is empty")
+		tx.recordErr(err)
+		return err
+	}
+	if args.Mutate == nil {
+		err := errors.New("tasks.Tx.Claim: Mutate is nil")
 		tx.recordErr(err)
 		return err
 	}
 	payload := ClaimedPayload{
-		AgentID:    agentID,
-		Slot:       slot,
-		ClaimEpoch: claimEpoch,
+		AgentID:    args.AgentID,
+		Slot:       args.Slot,
+		ClaimEpoch: args.ClaimEpoch,
+		PrevAgent:  args.PrevAgent,
 	}
 	env, err := EncodeEnvelope(EventTypeClaimed, tx.taskID, payload)
 	if err != nil {
@@ -167,26 +195,31 @@ func (tx *Tx) Claim(agentID string, slot string, claimEpoch uint64) error {
 		tx.recordErr(err)
 		return err
 	}
-	mutate := func(t Task) (Task, error) {
-		t.Status = StatusClaimed
-		t.ClaimedBy = agentID
-		t.ClaimEpoch = claimEpoch
-		t.UpdatedAt = time.Now().UTC()
-		t.LastEventSeq = seq
-		return t, nil
+	wrapped := func(t Task) (Task, error) {
+		next, err := args.Mutate(t)
+		if err != nil {
+			return t, err
+		}
+		next.UpdatedAt = time.Now().UTC()
+		next.LastEventSeq = seq
+		return next, nil
 	}
-	if err := tx.mgr.update(tx.ctx, tx.taskID, mutate); err != nil {
+	if err := tx.mgr.update(tx.ctx, tx.taskID, wrapped); err != nil {
 		tx.recordErr(err)
 		return err
 	}
 	return nil
 }
 
-// Unclaim publishes an unclaimed event and updates the KV record's
-// status to open and clears ClaimedBy. The free-form reason is
-// recorded on the event but not stamped on the KV — operators recover
-// it from the log.
-func (tx *Tx) Unclaim(reason string) error {
+// Unclaim publishes an unclaimed event and applies the supplied
+// mutator inside a CAS loop. The mutator owns the conditional
+// rejection semantics (e.g. coord's "is the claim still ours" check
+// surfacing as errClaimCASNoOp); a nil mutator falls back to the
+// default "set status=open, clear claimed_by" projection.
+//
+// reason is the free-form audit string recorded on the event but
+// NOT stamped on the KV — operators recover it from the log.
+func (tx *Tx) Unclaim(reason string, mutate func(Task) (Task, error)) error {
 	tx.markDirty()
 	payload := UnclaimedPayload{Reason: reason}
 	env, err := EncodeEnvelope(EventTypeUnclaimed, tx.taskID, payload)
@@ -199,14 +232,24 @@ func (tx *Tx) Unclaim(reason string) error {
 		tx.recordErr(err)
 		return err
 	}
-	mutate := func(t Task) (Task, error) {
-		t.Status = StatusOpen
-		t.ClaimedBy = ""
-		t.UpdatedAt = time.Now().UTC()
-		t.LastEventSeq = seq
-		return t, nil
+	wrapped := func(t Task) (Task, error) {
+		var next Task
+		var err error
+		if mutate != nil {
+			next, err = mutate(t)
+			if err != nil {
+				return t, err
+			}
+		} else {
+			next = t
+			next.Status = StatusOpen
+			next.ClaimedBy = ""
+		}
+		next.UpdatedAt = time.Now().UTC()
+		next.LastEventSeq = seq
+		return next, nil
 	}
-	if err := tx.mgr.update(tx.ctx, tx.taskID, mutate); err != nil {
+	if err := tx.mgr.update(tx.ctx, tx.taskID, wrapped); err != nil {
 		tx.recordErr(err)
 		return err
 	}
@@ -363,22 +406,6 @@ func (tx *Tx) Close(agentID, reason string, mutate func(Task) (Task, error)) err
 		return err
 	}
 	return nil
-}
-
-// Mutate is a generic Tx-only escape hatch for mutators that do not
-// fit the named tx.X verbs. It still publishes an updated event
-// describing the changes so the log remains the source of truth. Used
-// internally by the migration shim and by coord paths that bundle
-// multiple field changes (e.g., Reclaim's claimed-by + claim-epoch
-// pair).
-//
-// changes describes the (field, old, new) tuples for the event;
-// mutate produces the new Task value. Both must agree.
-func (tx *Tx) Mutate(
-	mutate func(Task) (Task, error),
-	changes ...FieldChange,
-) error {
-	return tx.Update(mutate, changes...)
 }
 
 // publish sends env on the events stream and returns the assigned

--- a/internal/tasks/tx.go
+++ b/internal/tasks/tx.go
@@ -404,7 +404,7 @@ func (tx *Tx) publish(env EventEnvelope) (uint64, error) {
 }
 
 // FieldChangeFromAny builds a FieldChange tuple from any-typed old/new
-// values, marshalling each to JSON. Convenient for Update callers that
+// values, marshaling each to JSON. Convenient for Update callers that
 // already have the typed values in hand.
 func FieldChangeFromAny(field string, oldV, newV any) (FieldChange, error) {
 	oldRaw, err := json.Marshal(oldV)

--- a/internal/tasks/tx.go
+++ b/internal/tasks/tx.go
@@ -1,0 +1,430 @@
+package tasks
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/nats-io/nats.go"
+
+	"github.com/danmestas/bones/internal/assert"
+)
+
+// ErrNoMutations reports that a Tx callback returned without invoking
+// any tx.X method. Tx is the only mutation entry point on Manager and
+// returning without one is a programmer error caught at the API
+// boundary rather than allowed to silently no-op.
+var ErrNoMutations = errors.New(
+	"tasks: Tx callback made no mutations",
+)
+
+// ErrEventLogDisabled reports that a Tx mutation was attempted on a
+// Manager opened without an event log. coord's archive Manager opens
+// in this mode for compaction-only writes; production Tx callers
+// always have the event log enabled.
+var ErrEventLogDisabled = errors.New(
+	"tasks: event log disabled on this manager",
+)
+
+// Tx is the carrier passed to Manager.Tx's callback. Each tx.X method
+// is one mutation. Tx is short-lived: its scope is the duration of one
+// Manager.Tx call. Methods are not safe to call after the callback
+// returns.
+//
+// Tx is not concurrency-safe. The callback must serialize its tx.X
+// calls; callers needing multiple parallel writes should call Manager.Tx
+// once per task and let the substrate serialize.
+type Tx struct {
+	mgr    *Manager
+	ctx    context.Context
+	taskID string
+
+	// dirty is true once at least one tx.X method has been invoked. Tx
+	// returns ErrNoMutations when the callback returns with dirty == false.
+	dirty bool
+
+	// firstErr is the first non-nil error from any tx.X method. The
+	// callback may continue calling tx.X methods after an error; only
+	// the first one is reported to the Tx caller.
+	firstErr error
+}
+
+// Tx is the only public mutation entry point on Manager. The callback
+// receives a *Tx and calls one or more tx.X methods to mutate the
+// task. Each tx.X method publishes one event to the JetStream event
+// log, then writes the corresponding KV projection. Returns
+// ErrNoMutations if the callback completes without calling any tx.X
+// method, or any error returned by the callback or any tx.X call.
+//
+// Concurrency: multiple Tx invocations on the same task race; the KV
+// CAS layer detects the conflict and the losing call retries inside
+// the underlying jskv.MaxRetries-bounded loop.
+func (m *Manager) Tx(
+	ctx context.Context, taskID string,
+	fn func(tx *Tx) error,
+) error {
+	assert.NotNil(ctx, "tasks.Tx: ctx is nil")
+	assert.NotEmpty(taskID, "tasks.Tx: taskID is empty")
+	assert.NotNil(fn, "tasks.Tx: fn is nil")
+	if m.done.Load() {
+		return ErrClosed
+	}
+	tx := &Tx{mgr: m, ctx: ctx, taskID: taskID}
+	if err := fn(tx); err != nil {
+		return err
+	}
+	if tx.firstErr != nil {
+		return tx.firstErr
+	}
+	if !tx.dirty {
+		return ErrNoMutations
+	}
+	return nil
+}
+
+// markDirty flags the Tx as having attempted at least one mutation.
+// Called at the top of every tx.X method.
+func (tx *Tx) markDirty() { tx.dirty = true }
+
+// recordErr records err as the Tx's first error if no error has yet
+// been recorded. Subsequent tx.X calls in the same callback observe
+// the recorded error but may still execute (the callback decides
+// whether to short-circuit; the substrate will not commit further
+// changes if an earlier publish failed durably).
+func (tx *Tx) recordErr(err error) {
+	if tx.firstErr == nil {
+		tx.firstErr = err
+	}
+}
+
+// Create publishes a created event and writes the initial KV record.
+// t.ID must equal tx's taskID. The event Snapshot field is left
+// unpopulated; readers reconstruct the projection from the live KV.
+func (tx *Tx) Create(t Task) error {
+	tx.markDirty()
+	if t.ID != tx.taskID {
+		err := fmt.Errorf("tasks.Tx.Create: t.ID %q != tx.taskID %q",
+			t.ID, tx.taskID)
+		tx.recordErr(err)
+		return err
+	}
+	if err := validateForCreate(t); err != nil {
+		tx.recordErr(err)
+		return err
+	}
+	payload := CreatedPayload{
+		Title: t.Title,
+		Files: append([]string(nil), t.Files...),
+	}
+	env, err := EncodeEnvelope(EventTypeCreated, t.ID, payload)
+	if err != nil {
+		tx.recordErr(err)
+		return err
+	}
+	seq, err := tx.publish(env)
+	if err != nil {
+		tx.recordErr(err)
+		return err
+	}
+	t.LastEventSeq = seq
+	if err := tx.mgr.create(tx.ctx, t); err != nil {
+		tx.recordErr(err)
+		return err
+	}
+	return nil
+}
+
+// Claim publishes a claimed event and updates the KV record's status
+// and ClaimedBy fields. The mutator closure stays the same shape used
+// by the legacy Update API; tx.Claim wraps it so the caller does not
+// hand-author one. The claimEpoch is the new epoch the caller wants
+// stamped on the record (typically prior + 1, computed by coord).
+//
+// The optional mutate callback runs inside the CAS loop AFTER the
+// status/agent fields are stamped, so callers (coord) can apply
+// extra fields like ClaimEpoch in the same revision.
+func (tx *Tx) Claim(agentID string, slot string, claimEpoch uint64) error {
+	tx.markDirty()
+	if agentID == "" {
+		err := errors.New("tasks.Tx.Claim: agentID is empty")
+		tx.recordErr(err)
+		return err
+	}
+	payload := ClaimedPayload{
+		AgentID:    agentID,
+		Slot:       slot,
+		ClaimEpoch: claimEpoch,
+	}
+	env, err := EncodeEnvelope(EventTypeClaimed, tx.taskID, payload)
+	if err != nil {
+		tx.recordErr(err)
+		return err
+	}
+	seq, err := tx.publish(env)
+	if err != nil {
+		tx.recordErr(err)
+		return err
+	}
+	mutate := func(t Task) (Task, error) {
+		t.Status = StatusClaimed
+		t.ClaimedBy = agentID
+		t.ClaimEpoch = claimEpoch
+		t.UpdatedAt = time.Now().UTC()
+		t.LastEventSeq = seq
+		return t, nil
+	}
+	if err := tx.mgr.update(tx.ctx, tx.taskID, mutate); err != nil {
+		tx.recordErr(err)
+		return err
+	}
+	return nil
+}
+
+// Unclaim publishes an unclaimed event and updates the KV record's
+// status to open and clears ClaimedBy. The free-form reason is
+// recorded on the event but not stamped on the KV — operators recover
+// it from the log.
+func (tx *Tx) Unclaim(reason string) error {
+	tx.markDirty()
+	payload := UnclaimedPayload{Reason: reason}
+	env, err := EncodeEnvelope(EventTypeUnclaimed, tx.taskID, payload)
+	if err != nil {
+		tx.recordErr(err)
+		return err
+	}
+	seq, err := tx.publish(env)
+	if err != nil {
+		tx.recordErr(err)
+		return err
+	}
+	mutate := func(t Task) (Task, error) {
+		t.Status = StatusOpen
+		t.ClaimedBy = ""
+		t.UpdatedAt = time.Now().UTC()
+		t.LastEventSeq = seq
+		return t, nil
+	}
+	if err := tx.mgr.update(tx.ctx, tx.taskID, mutate); err != nil {
+		tx.recordErr(err)
+		return err
+	}
+	return nil
+}
+
+// Update publishes an updated event carrying one or more (field, old,
+// new) tuples and applies the mutator to the KV record. The mutator
+// is responsible for actually writing the new field values; the
+// FieldChange tuples are descriptive (for the log) and must agree
+// with the projection the mutator produces. Callers compose the
+// mutate closure to keep the legacy invariant-checking semantics; the
+// FieldChange tuples are caller-provided too.
+func (tx *Tx) Update(
+	mutate func(Task) (Task, error),
+	changes ...FieldChange,
+) error {
+	tx.markDirty()
+	if len(changes) == 0 {
+		err := errors.New("tasks.Tx.Update: no field changes")
+		tx.recordErr(err)
+		return err
+	}
+	if mutate == nil {
+		err := errors.New("tasks.Tx.Update: mutate is nil")
+		tx.recordErr(err)
+		return err
+	}
+	payload := UpdatedPayload{Changes: changes}
+	env, err := EncodeEnvelope(EventTypeUpdated, tx.taskID, payload)
+	if err != nil {
+		tx.recordErr(err)
+		return err
+	}
+	seq, err := tx.publish(env)
+	if err != nil {
+		tx.recordErr(err)
+		return err
+	}
+	wrapped := func(t Task) (Task, error) {
+		next, err := mutate(t)
+		if err != nil {
+			return t, err
+		}
+		next.UpdatedAt = time.Now().UTC()
+		next.LastEventSeq = seq
+		return next, nil
+	}
+	if err := tx.mgr.update(tx.ctx, tx.taskID, wrapped); err != nil {
+		tx.recordErr(err)
+		return err
+	}
+	return nil
+}
+
+// Link publishes a linked event and updates the KV record's Edges
+// slice. Duplicate edges are caller-prevented (coord.Link enforces
+// invariant 25); this method does not re-check.
+func (tx *Tx) Link(otherID, edgeType string) error {
+	tx.markDirty()
+	if otherID == "" {
+		err := errors.New("tasks.Tx.Link: otherID is empty")
+		tx.recordErr(err)
+		return err
+	}
+	if edgeType == "" {
+		err := errors.New("tasks.Tx.Link: edgeType is empty")
+		tx.recordErr(err)
+		return err
+	}
+	payload := LinkedPayload{OtherID: otherID, EdgeType: edgeType}
+	env, err := EncodeEnvelope(EventTypeLinked, tx.taskID, payload)
+	if err != nil {
+		tx.recordErr(err)
+		return err
+	}
+	seq, err := tx.publish(env)
+	if err != nil {
+		tx.recordErr(err)
+		return err
+	}
+	mutate := func(t Task) (Task, error) {
+		t.Edges = append(t.Edges, Edge{
+			Type:   EdgeType(edgeType),
+			Target: otherID,
+		})
+		t.UpdatedAt = time.Now().UTC()
+		t.LastEventSeq = seq
+		return t, nil
+	}
+	if err := tx.mgr.update(tx.ctx, tx.taskID, mutate); err != nil {
+		tx.recordErr(err)
+		return err
+	}
+	return nil
+}
+
+// SlotChange publishes a slot_changed event. The KV projection does
+// not store slot directly (slots are an external swarm concept); the
+// event is purely audit. From may be empty for first slot bind.
+func (tx *Tx) SlotChange(from, to string) error {
+	tx.markDirty()
+	if to == "" {
+		err := errors.New("tasks.Tx.SlotChange: to is empty")
+		tx.recordErr(err)
+		return err
+	}
+	payload := SlotChangedPayload{From: from, To: to}
+	env, err := EncodeEnvelope(EventTypeSlotChanged, tx.taskID, payload)
+	if err != nil {
+		tx.recordErr(err)
+		return err
+	}
+	if _, err := tx.publish(env); err != nil {
+		tx.recordErr(err)
+		return err
+	}
+	return nil
+}
+
+// Close publishes a closed event and updates the KV record into the
+// terminal closed state. The mutator-shaped logic (invariant 12,
+// invariant 24, agent identity check) lives on the caller side;
+// tx.Close accepts a mutate callback so coord-level guards stay where
+// they belong.
+func (tx *Tx) Close(agentID, reason string, mutate func(Task) (Task, error)) error {
+	tx.markDirty()
+	if mutate == nil {
+		err := errors.New("tasks.Tx.Close: mutate is nil")
+		tx.recordErr(err)
+		return err
+	}
+	payload := ClosedPayload{AgentID: agentID, Reason: reason}
+	env, err := EncodeEnvelope(EventTypeClosed, tx.taskID, payload)
+	if err != nil {
+		tx.recordErr(err)
+		return err
+	}
+	seq, err := tx.publish(env)
+	if err != nil {
+		tx.recordErr(err)
+		return err
+	}
+	wrapped := func(t Task) (Task, error) {
+		next, err := mutate(t)
+		if err != nil {
+			return t, err
+		}
+		next.LastEventSeq = seq
+		return next, nil
+	}
+	if err := tx.mgr.update(tx.ctx, tx.taskID, wrapped); err != nil {
+		tx.recordErr(err)
+		return err
+	}
+	return nil
+}
+
+// Mutate is a generic Tx-only escape hatch for mutators that do not
+// fit the named tx.X verbs. It still publishes an updated event
+// describing the changes so the log remains the source of truth. Used
+// internally by the migration shim and by coord paths that bundle
+// multiple field changes (e.g., Reclaim's claimed-by + claim-epoch
+// pair).
+//
+// changes describes the (field, old, new) tuples for the event;
+// mutate produces the new Task value. Both must agree.
+func (tx *Tx) Mutate(
+	mutate func(Task) (Task, error),
+	changes ...FieldChange,
+) error {
+	return tx.Update(mutate, changes...)
+}
+
+// publish sends env on the events stream and returns the assigned
+// stream sequence. When the manager has no event log configured (an
+// archive-only Manager), publish returns 0 with ErrEventLogDisabled.
+func (tx *Tx) publish(env EventEnvelope) (uint64, error) {
+	if tx.mgr.stream == nil {
+		return 0, ErrEventLogDisabled
+	}
+	body, err := MarshalEnvelope(env)
+	if err != nil {
+		return 0, fmt.Errorf("tasks.Tx.publish: marshal: %w", err)
+	}
+	msg := &nats.Msg{
+		Subject: EventSubject(env.TaskID),
+		Data:    body,
+	}
+	ack, err := tx.mgr.js.PublishMsg(tx.ctx, msg)
+	if err != nil {
+		return 0, fmt.Errorf("tasks.Tx.publish: %w", err)
+	}
+	return ack.Sequence, nil
+}
+
+// FieldChangeFromAny builds a FieldChange tuple from any-typed old/new
+// values, marshalling each to JSON. Convenient for Update callers that
+// already have the typed values in hand.
+func FieldChangeFromAny(field string, oldV, newV any) (FieldChange, error) {
+	oldRaw, err := json.Marshal(oldV)
+	if err != nil {
+		return FieldChange{}, fmt.Errorf("tasks: marshal old: %w", err)
+	}
+	newRaw, err := json.Marshal(newV)
+	if err != nil {
+		return FieldChange{}, fmt.Errorf("tasks: marshal new: %w", err)
+	}
+	return FieldChange{Field: field, Old: oldRaw, New: newRaw}, nil
+}
+
+// MustFieldChange is FieldChangeFromAny that panics on encode failure.
+// Use only for values whose JSON shape is statically known (strings,
+// integers, simple structs); a panic here is a programmer bug.
+func MustFieldChange(field string, oldV, newV any) FieldChange {
+	fc, err := FieldChangeFromAny(field, oldV, newV)
+	if err != nil {
+		panic(fmt.Sprintf("tasks.MustFieldChange: %v", err))
+	}
+	return fc
+}

--- a/internal/tasks/tx_test.go
+++ b/internal/tasks/tx_test.go
@@ -1,0 +1,444 @@
+package tasks_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go"
+
+	"github.com/danmestas/bones/internal/tasks"
+	"github.com/danmestas/bones/internal/testutil/natstest"
+)
+
+// openEventLogManager spins up a JetStream fixture and returns a
+// Manager opened with EnableEventLog=true. Mirrors openTestManager
+// from tasks_test.go but turns on the event-log stream so Tx is
+// usable.
+func openEventLogManager(
+	t *testing.T,
+) (*tasks.Manager, *nats.Conn, func()) {
+	t.Helper()
+	srv, cleanup := natstest.NewJetStreamServer(t)
+	nc, err := nats.Connect(srv.ConnectedUrl())
+	if err != nil {
+		cleanup()
+		t.Fatalf("nats.Connect: %v", err)
+	}
+	m, err := tasks.Open(context.Background(), nc, tasks.Config{
+		BucketName:     "tasks-tx-test",
+		HistoryDepth:   8,
+		MaxValueSize:   8 * 1024,
+		EnableEventLog: true,
+	})
+	if err != nil {
+		nc.Close()
+		cleanup()
+		t.Fatalf("tasks.Open: %v", err)
+	}
+	return m, nc, func() {
+		_ = m.Close()
+		nc.Close()
+		cleanup()
+	}
+}
+
+// txNewTask returns a well-formed open task ready for tx.Create.
+func txNewTask(id string) tasks.Task {
+	now := time.Now().UTC()
+	return tasks.Task{
+		ID:            id,
+		Title:         "tx example",
+		Status:        tasks.StatusOpen,
+		Files:         []string{"/work/x.go"},
+		CreatedAt:     now,
+		UpdatedAt:     now,
+		SchemaVersion: tasks.SchemaVersion,
+	}
+}
+
+// TestTx_NoMutationsReturnsError verifies that a Tx callback that
+// makes no tx.X calls returns ErrNoMutations.
+func TestTx_NoMutationsReturnsError(t *testing.T) {
+	m, _, cleanup := openEventLogManager(t)
+	defer cleanup()
+	err := m.Tx(context.Background(), "missing-id", func(tx *tasks.Tx) error {
+		return nil
+	})
+	if !errors.Is(err, tasks.ErrNoMutations) {
+		t.Fatalf("want ErrNoMutations, got %v", err)
+	}
+}
+
+// TestTx_OnlyMutationPath asserts via reflection that *Manager has no
+// public mutation method other than Tx. This is the structural
+// backstop for ADR 0052: any new mutation must be added under Tx, not
+// as a parallel Manager method.
+func TestTx_OnlyMutationPath(t *testing.T) {
+	allowedMutationMethods := map[string]bool{
+		"Tx": true,
+	}
+	// Methods on Manager that are NOT mutations are listed here so
+	// future readers know the test's classification, not just its
+	// contents.
+	knownReadOrLifecycleMethods := map[string]bool{
+		"Close":     true,
+		"Get":       true,
+		"KVForTest": true, // exposed for in-package test seeding only
+		"List":      true,
+		"Purge":     true,
+		"Recent":    true,
+		"Replay":    true,
+		"Watch":     true,
+	}
+	mgrType := reflect.TypeOf(&tasks.Manager{})
+	for i := 0; i < mgrType.NumMethod(); i++ {
+		name := mgrType.Method(i).Name
+		switch {
+		case allowedMutationMethods[name]:
+			continue
+		case knownReadOrLifecycleMethods[name]:
+			continue
+		default:
+			// Heuristic: any unknown method on Manager is a regression.
+			// New methods must be classified above explicitly.
+			t.Errorf(
+				"Manager has unclassified method %q — "+
+					"classify in this test (mutation must go through Tx per ADR 0052)",
+				name,
+			)
+		}
+	}
+}
+
+// TestTx_CreateRoundtripsEvent verifies that tx.Create publishes a
+// created event AND writes the KV record, and the event payload
+// roundtrips cleanly.
+func TestTx_CreateRoundtripsEvent(t *testing.T) {
+	m, _, cleanup := openEventLogManager(t)
+	defer cleanup()
+	ctx := context.Background()
+	rec := txNewTask("bones-roundtrip-1")
+	err := m.Tx(ctx, rec.ID, func(tx *tasks.Tx) error {
+		return tx.Create(rec)
+	})
+	if err != nil {
+		t.Fatalf("Tx.Create: %v", err)
+	}
+	// KV side
+	got, _, err := m.Get(ctx, rec.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.ID != rec.ID || got.Title != rec.Title {
+		t.Fatalf("KV mismatch: got %+v", got)
+	}
+	if got.LastEventSeq == 0 {
+		t.Fatalf("LastEventSeq should be non-zero after Tx.Create")
+	}
+	// Log side
+	envs, err := m.Replay(ctx, tasks.LogReadOpts{FilterTaskID: rec.ID})
+	if err != nil {
+		t.Fatalf("Replay: %v", err)
+	}
+	if len(envs) != 1 {
+		t.Fatalf("want 1 event, got %d", len(envs))
+	}
+	if envs[0].Type != tasks.EventTypeCreated {
+		t.Fatalf("want EventTypeCreated, got %s", envs[0].Type)
+	}
+	payload, err := tasks.DecodePayload(envs[0])
+	if err != nil {
+		t.Fatalf("DecodePayload: %v", err)
+	}
+	cp, ok := payload.(tasks.CreatedPayload)
+	if !ok {
+		t.Fatalf("payload type %T", payload)
+	}
+	if cp.Title != rec.Title {
+		t.Fatalf("payload title mismatch: %q vs %q", cp.Title, rec.Title)
+	}
+}
+
+// TestTx_UpdatePayloadCarriesOldNew verifies that tx.Update emits an
+// event whose payload carries (field, old, new) tuples.
+func TestTx_UpdatePayloadCarriesOldNew(t *testing.T) {
+	m, _, cleanup := openEventLogManager(t)
+	defer cleanup()
+	ctx := context.Background()
+	rec := txNewTask("bones-oldnew-1")
+	if err := m.Tx(ctx, rec.ID, func(tx *tasks.Tx) error {
+		return tx.Create(rec)
+	}); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	change := tasks.MustFieldChange("title", rec.Title, "renamed")
+	err := m.Tx(ctx, rec.ID, func(tx *tasks.Tx) error {
+		return tx.Update(func(t tasks.Task) (tasks.Task, error) {
+			t.Title = "renamed"
+			return t, nil
+		}, change)
+	})
+	if err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	envs, _ := m.Replay(ctx, tasks.LogReadOpts{FilterTaskID: rec.ID})
+	if len(envs) < 2 {
+		t.Fatalf("want >=2 events, got %d", len(envs))
+	}
+	updateEnv := envs[1]
+	if updateEnv.Type != tasks.EventTypeUpdated {
+		t.Fatalf("want EventTypeUpdated, got %s", updateEnv.Type)
+	}
+	payload, err := tasks.DecodePayload(updateEnv)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	up := payload.(tasks.UpdatedPayload)
+	if len(up.Changes) != 1 || up.Changes[0].Field != "title" {
+		t.Fatalf("expected one change with field=title, got %+v", up.Changes)
+	}
+	var oldStr, newStr string
+	if err := json.Unmarshal(up.Changes[0].Old, &oldStr); err != nil {
+		t.Fatalf("old unmarshal: %v", err)
+	}
+	if err := json.Unmarshal(up.Changes[0].New, &newStr); err != nil {
+		t.Fatalf("new unmarshal: %v", err)
+	}
+	if oldStr != rec.Title {
+		t.Fatalf("want old=%q, got %q", rec.Title, oldStr)
+	}
+	if newStr != "renamed" {
+		t.Fatalf("want new=renamed, got %q", newStr)
+	}
+}
+
+// TestEventEnvelope_Roundtrip exercises every payload type's marshal
+// and unmarshal path so cross-version readers see the same shape this
+// version writes.
+func TestEventEnvelope_Roundtrip(t *testing.T) {
+	cases := []struct {
+		name string
+		typ  tasks.EventType
+		p    any
+	}{
+		{
+			"created", tasks.EventTypeCreated,
+			tasks.CreatedPayload{Title: "x", Files: []string{"/a"}},
+		},
+		{
+			"claimed", tasks.EventTypeClaimed,
+			tasks.ClaimedPayload{AgentID: "a1", Slot: "s1", ClaimEpoch: 5},
+		},
+		{
+			"unclaimed", tasks.EventTypeUnclaimed,
+			tasks.UnclaimedPayload{Reason: "deadline"},
+		},
+		{
+			"updated", tasks.EventTypeUpdated,
+			tasks.UpdatedPayload{
+				Changes: []tasks.FieldChange{
+					tasks.MustFieldChange("k", 1, 2),
+				},
+			},
+		},
+		{
+			"linked", tasks.EventTypeLinked,
+			tasks.LinkedPayload{OtherID: "bones-other", EdgeType: "blocks"},
+		},
+		{
+			"slot_changed", tasks.EventTypeSlotChanged,
+			tasks.SlotChangedPayload{From: "a", To: "b"},
+		},
+		{
+			"closed", tasks.EventTypeClosed,
+			tasks.ClosedPayload{AgentID: "a1", Reason: "done"},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			env, err := tasks.EncodeEnvelope(c.typ, "bones-x", c.p)
+			if err != nil {
+				t.Fatalf("encode: %v", err)
+			}
+			raw, err := tasks.MarshalEnvelope(env)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			got, err := tasks.UnmarshalEnvelope(raw)
+			if err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if got.Type != c.typ {
+				t.Fatalf("type roundtrip: want %s, got %s", c.typ, got.Type)
+			}
+			if got.TaskID != "bones-x" {
+				t.Fatalf("task_id roundtrip: %s", got.TaskID)
+			}
+			if _, err := tasks.DecodePayload(got); err != nil {
+				t.Fatalf("decode payload: %v", err)
+			}
+		})
+	}
+}
+
+// TestTaskTally_Counts verifies that the shared TaskTally function
+// derives the expected counts from a sequence of events. Both `bones
+// status` and `bones tasks status` consume this function; if it
+// drifts, both surfaces drift together.
+func TestTaskTally_Counts(t *testing.T) {
+	mk := func(typ tasks.EventType, id string) tasks.EventEnvelope {
+		env, _ := tasks.EncodeEnvelope(typ, id, struct{}{})
+		return env
+	}
+	envs := []tasks.EventEnvelope{
+		mk(tasks.EventTypeCreated, "a"),
+		mk(tasks.EventTypeCreated, "b"),
+		mk(tasks.EventTypeCreated, "c"),
+		mk(tasks.EventTypeClaimed, "b"),
+		mk(tasks.EventTypeClosed, "c"),
+	}
+	got := tasks.TaskTally(envs)
+	want := tasks.Tally{Open: 1, Claimed: 1, Closed: 1, Total: 3}
+	if got != want {
+		t.Fatalf("want %+v, got %+v", want, got)
+	}
+}
+
+// TestMigration_Idempotent verifies that running Migrate twice on the
+// same KV state does not produce duplicate synthetic events.
+func TestMigration_Idempotent(t *testing.T) {
+	srv, cleanup := natstest.NewJetStreamServer(t)
+	defer cleanup()
+	nc, err := nats.Connect(srv.ConnectedUrl())
+	if err != nil {
+		t.Fatalf("nats.Connect: %v", err)
+	}
+	defer nc.Close()
+	cfg := tasks.Config{
+		BucketName:     "tasks-mig-test",
+		HistoryDepth:   8,
+		MaxValueSize:   8 * 1024,
+		EnableEventLog: true,
+	}
+	// Seed the bucket via AdminWrite *before* opening with event log.
+	// First open without event log so Migrate doesn't fire on Open.
+	bootCfg := cfg
+	bootCfg.EnableEventLog = false
+	boot, err := tasks.Open(context.Background(), nc, bootCfg)
+	if err != nil {
+		t.Fatalf("boot Open: %v", err)
+	}
+	aw := tasks.NewAdminWrite(boot)
+	for _, id := range []string{"bones-mig-a", "bones-mig-b"} {
+		if err := aw.Create(context.Background(), txNewTask(id)); err != nil {
+			t.Fatalf("seed %s: %v", id, err)
+		}
+	}
+	_ = boot.Close()
+
+	// Now open with event log — Migrate runs as part of Open.
+	m, err := tasks.Open(context.Background(), nc, cfg)
+	if err != nil {
+		t.Fatalf("first Open: %v", err)
+	}
+	envs1, err := m.Replay(context.Background(), tasks.LogReadOpts{})
+	if err != nil {
+		t.Fatalf("replay: %v", err)
+	}
+	if len(envs1) < 2 {
+		t.Fatalf("want >=2 synthetic events for 2 seeded tasks, got %d", len(envs1))
+	}
+	_ = m.Close()
+
+	// Re-open: marker is set, Migrate is a no-op.
+	m2, err := tasks.Open(context.Background(), nc, cfg)
+	if err != nil {
+		t.Fatalf("second Open: %v", err)
+	}
+	defer func() { _ = m2.Close() }()
+	envs2, err := m2.Replay(context.Background(), tasks.LogReadOpts{})
+	if err != nil {
+		t.Fatalf("replay 2: %v", err)
+	}
+	if len(envs2) != len(envs1) {
+		t.Fatalf("re-Migrate emitted duplicates: first=%d second=%d", len(envs1), len(envs2))
+	}
+}
+
+// TestReplayCorrectness verifies that a sequence of Tx-driven mutations
+// produces a log whose Tally matches the live KV projection.
+func TestReplayCorrectness(t *testing.T) {
+	m, _, cleanup := openEventLogManager(t)
+	defer cleanup()
+	ctx := context.Background()
+	for i, op := range []struct {
+		op string
+		id string
+	}{
+		{"create", "bones-r-a"},
+		{"create", "bones-r-b"},
+		{"create", "bones-r-c"},
+		{"claim", "bones-r-b"},
+		{"close", "bones-r-c"},
+	} {
+		switch op.op {
+		case "create":
+			rec := txNewTask(op.id)
+			if err := m.Tx(ctx, rec.ID, func(tx *tasks.Tx) error {
+				return tx.Create(rec)
+			}); err != nil {
+				t.Fatalf("step %d create %s: %v", i, op.id, err)
+			}
+		case "claim":
+			if err := m.Tx(ctx, op.id, func(tx *tasks.Tx) error {
+				return tx.Claim("agent-x", "", 1)
+			}); err != nil {
+				t.Fatalf("step %d claim %s: %v", i, op.id, err)
+			}
+		case "close":
+			mutate := func(t tasks.Task) (tasks.Task, error) {
+				now := time.Now().UTC()
+				t.Status = tasks.StatusClosed
+				t.ClosedAt = &now
+				t.ClaimedBy = ""
+				t.UpdatedAt = now
+				return t, nil
+			}
+			if err := m.Tx(ctx, op.id, func(tx *tasks.Tx) error {
+				return tx.Close("agent-x", "done", mutate)
+			}); err != nil {
+				t.Fatalf("step %d close %s: %v", i, op.id, err)
+			}
+		}
+	}
+	envs, err := m.Replay(ctx, tasks.LogReadOpts{})
+	if err != nil {
+		t.Fatalf("replay: %v", err)
+	}
+	tally := tasks.TaskTally(envs)
+	if tally.Open != 1 || tally.Claimed != 1 || tally.Closed != 1 || tally.Total != 3 {
+		t.Fatalf("want {1,1,1,3} got %+v (envs=%d)", tally, len(envs))
+	}
+}
+
+// TestReplay_FromAndSinceMutuallyExclusive verifies the watch-flag
+// validation per ADR 0052.
+func TestReplay_FromAndSinceMutuallyExclusive(t *testing.T) {
+	m, _, cleanup := openEventLogManager(t)
+	defer cleanup()
+	_, err := m.Replay(context.Background(), tasks.LogReadOpts{
+		FromSeq: 1,
+		Since:   time.Hour,
+	})
+	if err == nil {
+		t.Fatalf("want error for both --from and --since set")
+	}
+	if !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Fatalf("want 'mutually exclusive' in error, got %q", err.Error())
+	}
+}

--- a/internal/tasks/tx_test.go
+++ b/internal/tasks/tx_test.go
@@ -396,7 +396,16 @@ func TestReplayCorrectness(t *testing.T) {
 			}
 		case "claim":
 			if err := m.Tx(ctx, op.id, func(tx *tasks.Tx) error {
-				return tx.Claim("agent-x", "", 1)
+				return tx.Claim(tasks.ClaimArgs{
+					AgentID:    "agent-x",
+					ClaimEpoch: 1,
+					Mutate: func(t tasks.Task) (tasks.Task, error) {
+						t.Status = tasks.StatusClaimed
+						t.ClaimedBy = "agent-x"
+						t.ClaimEpoch = 1
+						return t, nil
+					},
+				})
 			}); err != nil {
 				t.Fatalf("step %d claim %s: %v", i, op.id, err)
 			}


### PR DESCRIPTION
## Summary

ADR 0052 lands an append-only task event log on JetStream as the source of truth for task state, with a Tx-only mutation API on `tasks.Manager`. Removes the divergent count aggregations and the synthesizer that admitted "without an event log we can't reconstruct claim transitions."

- New stream `tasks-events` (subjects `tasks.events.>`) backs every state change. KV is now a projection.
- Closed iota set of seven event types: `created`, `claimed`, `unclaimed`, `updated`, `linked`, `slot_changed`, `closed`. `updated` payload carries `[{field, old, new}]` so the log alone reconstructs prior state.
- `Manager.Tx(ctx, id, fn)` is the only public mutation entry point. `Manager.Update` and `Manager.Create` are now private. A reflection test asserts no other public Manager method mutates state. Test seeding and recovery use the import-restricted `tasks.NewAdminWrite(m)` escape hatch.
- All callers swept: `internal/coord` (Claim, Reclaim, HandoffClaim, OpenTask, CloseTask, Link, releaseTaskCAS, undoTaskCAS, updateTask) and `cli` (tasks_create, tasks_close, tasks_claim, tasks_update, swarm_dispatch).
- `bones tasks watch` defaults to live-only with new `--from=<seq>` and `--since=<duration>` flags. Mutually exclusive.
- `bones status` Recent activity sources from the log via `Manager.Recent`. The `gatherTaskEvents` synthesizer is gone.
- Shared `TaskTally(events) Tally` is the single source for counts in both `bones status` and `bones tasks status`. Closes #313's "duplicate tally" risk.
- One-time migration emits synthetic `created`/`claimed`/`closed` events for pre-existing KV records on first Open with `EnableEventLog: true`. Idempotent via marker key. Pre-migration update history is lost (documented in the ADR).
- `Recover(ctx, m)` reconciles orphan events (publish landed, KV write didn't) into the projection. Opt-in via `Config.RecoverOnOpen` so concurrent Tx callers don't race against the recovery loop. Hub-start integration is a follow-up.
- `CompactPerTask` rotates per-task events into a synthetic `created` snapshot when the count cap (50) or time window (90 days) is exceeded. Periodic worker is a follow-up.
- `Task.SchemaVersion` bumped 3 → 4; new `Task.LastEventSeq` projection-watermark field.

## Test plan

- [x] `make check` (fmt, vet, lint, race, todo) green except the pre-existing `TestStatusAllEmptyRegistry` flake — verified failing on a fresh clone of `main` with no changes.
- [x] `go test -tags=otel -short ./...` — 990 passed / 57 skipped / 1 pre-existing fail (the same `TestStatusAllEmptyRegistry`).
- [x] `examples/hub-leaf-e2e` (3-slot concurrent integration) passes 3/3 runs.
- [x] New tests in this PR:
  - `TestTx_NoMutationsReturnsError`
  - `TestTx_OnlyMutationPath` (reflection-based no-mutation-outside-Tx assertion)
  - `TestTx_CreateRoundtripsEvent`, `TestTx_UpdatePayloadCarriesOldNew`
  - `TestEventEnvelope_Roundtrip` (every event type)
  - `TestTaskTally_Counts`
  - `TestReplayCorrectness`
  - `TestReplay_FromAndSinceMutuallyExclusive`
  - `TestMigration_Idempotent`
  - `TestRecovery_OrphanedEventReplays`
  - `TestCompactPerTask_BelowCap_NoOp`, `TestCompactPerTask_AboveCap_Compacts`
  - `TestTaskEventsToActivity` (replaces `TestGatherTaskEvents`)

## Coordination notes

- `internal/clauderhooks/` from #320 is unaffected.
- `internal/timefmt/` (#324) does not exist yet; this PR uses `t.UTC()` + `time.RFC3339` literals directly.
- Typed payload structs are reusable for #321's eventual schema generation, but no CLI envelope is wrapped here — events serialize to JetStream, not stdout.

Closes #319