### PR TITLE
feat(json): versioned --json schema contract for every emitting verb

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,11 +11,11 @@ SHELL := /usr/bin/env bash
 # bare tree (Phase 1 currently has no .go files); callers must tolerate that.
 GO_PACKAGES := $(shell go list ./... 2>/dev/null)
 
-.PHONY: check fmt fmt-check vet lint test race todo-check install-tools help bones bin
+.PHONY: check fmt fmt-check vet lint test race todo-check install-tools help bones bin schemas schemas-check
 
 help:
 	@echo "Targets:"
-	@echo "  check          — full discipline suite (fmt-check, vet, lint, race, todo-check)"
+	@echo "  check          — full discipline suite (fmt-check, vet, lint, race, todo-check, schemas-check)"
 	@echo "  fmt            — gofmt -w . (writes changes)"
 	@echo "  fmt-check      — gofmt -l . (read-only; exits 1 on drift)"
 	@echo "  vet            — go vet ./..."
@@ -23,9 +23,11 @@ help:
 	@echo "  test           — go test ./..."
 	@echo "  race           — go test -race ./..."
 	@echo "  todo-check     — forbid TODO in non-test .go files"
+	@echo "  schemas        — regenerate schemas/*.json from cli/schemas/*.go (writes)"
+	@echo "  schemas-check  — verify schemas/*.json matches cli/schemas/*.go (read-only; exits 1 on drift)"
 	@echo "  install-tools  — install staticcheck + errcheck for local dev"
 
-check: fmt-check vet lint race todo-check
+check: fmt-check vet lint race todo-check schemas-check
 	@echo "check: OK"
 
 fmt:
@@ -95,6 +97,31 @@ bin:
 
 bones: bin
 	go build -o bin/bones ./cmd/bones
+
+# Regenerate the JSON Schema files under schemas/ from the typed
+# payload structs in cli/schemas/. ADR 0053 makes the Go types the
+# source of truth; this target writes the derived artifacts.
+schemas:
+	go run ./cmd/bones-schemagen -out ./schemas
+
+# CI gate for schema drift. Runs the generator into a tmp directory
+# and diffs against the checked-in schemas/. Same posture as
+# fmt-check: read-only, non-zero exit on any difference. Fails fast
+# with a clear "run make schemas" message so the operator knows the
+# fix path. ADR 0053 forbids hand-edits — every change must round-
+# trip through the generator.
+schemas-check:
+	@tmp=$$(mktemp -d); \
+	go run ./cmd/bones-schemagen -out $$tmp >/dev/null 2>&1 || { \
+		rm -rf $$tmp; echo "schemas-check: generator failed" >&2; exit 1; }; \
+	if ! diff -ru schemas $$tmp >/dev/null 2>&1; then \
+		echo "schemas-check: generated output drifts from checked-in schemas/" >&2; \
+		echo "  run \`make schemas\` to regenerate" >&2; \
+		diff -ru schemas $$tmp >&2 || true; \
+		rm -rf $$tmp; \
+		exit 1; \
+	fi; \
+	rm -rf $$tmp
 
 # CI mirror — runs make check + otel lanes from .github/workflows/ci.yml.
 # Cross-repo leaf-binary integration is CI-only.

--- a/cli/doctor.go
+++ b/cli/doctor.go
@@ -102,7 +102,7 @@ func (c *DoctorCmd) Run(g *repocli.Globals) (err error) {
 func (c *DoctorCmd) runAll(_ *repocli.Globals) error {
 	var exitCode int
 	if c.JSON {
-		exitCode = renderDoctorAllJSON(os.Stdout)
+		exitCode = renderDoctorAllJSON(os.Stdout, os.Stderr)
 	} else {
 		exitCode = renderDoctorAll(os.Stdout, doctorAllOpts{
 			Quiet:  c.Quiet,

--- a/cli/doctor_all.go
+++ b/cli/doctor_all.go
@@ -149,10 +149,17 @@ func isHubAlive(hubURL string) bool {
 
 // renderDoctorAllJSON emits a machine-readable JSON summary of all
 // workspaces wrapped in the ADR 0053 envelope under verb "doctor".
-func renderDoctorAllJSON(w io.Writer) int {
+//
+// Substrate-level failures (e.g. registry.List() returning an error)
+// route to errw and yield exit code 1 with NO bytes on the JSON
+// stdout writer. ADR 0053 is strict: every byte on the JSON channel
+// is enveloped, no exceptions. Errors belong on stderr (the
+// non-structured channel) so consumers parsing stdout never have to
+// detect "envelope or error string?" at the wire level.
+func renderDoctorAllJSON(w, errw io.Writer) int {
 	entries, err := registry.List()
 	if err != nil {
-		_, _ = fmt.Fprintf(w, `{"error":%q}`, err.Error())
+		_, _ = fmt.Fprintf(errw, "doctor --all: registry list: %v\n", err)
 		return 1
 	}
 	results := runDoctorPerWorkspace(entries)

--- a/cli/doctor_all.go
+++ b/cli/doctor_all.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -10,6 +9,7 @@ import (
 	"sync"
 	"text/tabwriter"
 
+	"github.com/danmestas/bones/cli/schemas"
 	"github.com/danmestas/bones/internal/registry"
 )
 
@@ -147,7 +147,8 @@ func isHubAlive(hubURL string) bool {
 	return resp.StatusCode < 500
 }
 
-// renderDoctorAllJSON emits a machine-readable JSON summary of all workspaces.
+// renderDoctorAllJSON emits a machine-readable JSON summary of all
+// workspaces wrapped in the ADR 0053 envelope under verb "doctor".
 func renderDoctorAllJSON(w io.Writer) int {
 	entries, err := registry.List()
 	if err != nil {
@@ -155,24 +156,21 @@ func renderDoctorAllJSON(w io.Writer) int {
 		return 1
 	}
 	results := runDoctorPerWorkspace(entries)
-	type row struct {
-		Name     string `json:"name"`
-		Cwd      string `json:"cwd"`
-		HubAlive bool   `json:"hub_alive"`
-		Issues   int    `json:"issues"`
-	}
-	rows := make([]row, len(results))
+	rows := make([]schemas.DoctorWorkspaceRow, len(results))
 	anyIssue := false
 	for i, r := range results {
-		rows[i] = row{r.Entry.Name, r.Entry.Cwd, r.HubAlive, r.Issues}
+		rows[i] = schemas.DoctorWorkspaceRow{
+			Name:     r.Entry.Name,
+			Cwd:      r.Entry.Cwd,
+			HubAlive: r.HubAlive,
+			Issues:   r.Issues,
+		}
 		if r.Issues > 0 {
 			anyIssue = true
 		}
 	}
-	enc := json.NewEncoder(w)
-	if err := enc.Encode(struct {
-		Workspaces []row `json:"workspaces"`
-	}{rows}); err != nil {
+	if err := emitEnvelope(w, "doctor",
+		schemas.DoctorAllPayload{Workspaces: rows}); err != nil {
 		return 1
 	}
 	if anyIssue {

--- a/cli/doctor_all_test.go
+++ b/cli/doctor_all_test.go
@@ -128,8 +128,8 @@ func TestDoctorAllJSON(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("seed: %v", err)
 	}
-	var buf bytes.Buffer
-	exitCode := renderDoctorAllJSON(&buf)
+	var buf, errBuf bytes.Buffer
+	exitCode := renderDoctorAllJSON(&buf, &errBuf)
 	if exitCode != 0 {
 		t.Fatalf("expected exit 0, got %d\n%s", exitCode, buf.String())
 	}
@@ -260,8 +260,8 @@ func TestDoctorAll_DoesNotRewriteSettings(t *testing.T) {
 
 func TestDoctorAllJSONEmpty(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
-	var buf bytes.Buffer
-	exitCode := renderDoctorAllJSON(&buf)
+	var buf, errBuf bytes.Buffer
+	exitCode := renderDoctorAllJSON(&buf, &errBuf)
 	if exitCode != 0 {
 		t.Fatalf("empty registry should be exit 0")
 	}
@@ -275,5 +275,35 @@ func TestDoctorAllJSONEmpty(t *testing.T) {
 	}
 	if len(env.Data.Workspaces) != 0 {
 		t.Fatalf("expected empty workspaces, got %+v", env.Data.Workspaces)
+	}
+}
+
+// TestDoctorAllJSON_StderrSeamWired guards the ADR 0053 strict-stdout
+// contract: registry-error reports go to the stderr writer, never
+// to the JSON stdout writer. We can't reliably force registry.List
+// to fail in a unit test (the underlying glob swallows missing
+// directories), so this test verifies the seam exists by exercising
+// the happy path — empty registry, both writers passed in — and
+// asserting stdout carries the envelope while stderr stays empty.
+//
+// A reviewer reading the code path can confirm by inspection that
+// the registry-error branch routes to `errw` (cli/doctor_all.go).
+// If a future refactor accidentally swaps the writers, the
+// well-formed envelope on stdout is the visible signal that the
+// happy path still respects the contract; broken-envelope tests
+// elsewhere catch a rebroken happy path.
+func TestDoctorAllJSON_StderrSeamWired(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	var stdout, stderr bytes.Buffer
+	exitCode := renderDoctorAllJSON(&stdout, &stderr)
+	if exitCode != 0 {
+		t.Errorf("happy path exit = %d, want 0", exitCode)
+	}
+	if stdout.Len() == 0 {
+		t.Errorf("stdout should carry envelope on happy path; got empty")
+	}
+	if stderr.Len() != 0 {
+		t.Errorf("stderr should be empty on happy path; got %q",
+			stderr.String())
 	}
 }

--- a/cli/doctor_all_test.go
+++ b/cli/doctor_all_test.go
@@ -133,15 +133,25 @@ func TestDoctorAllJSON(t *testing.T) {
 	if exitCode != 0 {
 		t.Fatalf("expected exit 0, got %d\n%s", exitCode, buf.String())
 	}
-	var got struct {
-		Workspaces []struct {
-			Name   string `json:"name"`
-			Issues int    `json:"issues"`
-		} `json:"workspaces"`
+	var env struct {
+		Schema struct {
+			Verb    string `json:"verb"`
+			Version string `json:"version"`
+		} `json:"schema"`
+		Data struct {
+			Workspaces []struct {
+				Name   string `json:"name"`
+				Issues int    `json:"issues"`
+			} `json:"workspaces"`
+		} `json:"data"`
 	}
-	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+	if err := json.Unmarshal(buf.Bytes(), &env); err != nil {
 		t.Fatalf("unmarshal: %v\n%s", err, buf.String())
 	}
+	if env.Schema.Verb != "doctor" || env.Schema.Version != "v1" {
+		t.Errorf("schema = %+v, want {doctor v1}", env.Schema)
+	}
+	got := env.Data
 	if len(got.Workspaces) != 1 || got.Workspaces[0].Name != "x" {
 		t.Fatalf("unexpected workspaces: %+v", got.Workspaces)
 	}
@@ -255,13 +265,15 @@ func TestDoctorAllJSONEmpty(t *testing.T) {
 	if exitCode != 0 {
 		t.Fatalf("empty registry should be exit 0")
 	}
-	var got struct {
-		Workspaces []interface{} `json:"workspaces"`
+	var env struct {
+		Data struct {
+			Workspaces []interface{} `json:"workspaces"`
+		} `json:"data"`
 	}
-	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+	if err := json.Unmarshal(buf.Bytes(), &env); err != nil {
 		t.Fatalf("unmarshal: %v\n%s", err, buf.String())
 	}
-	if len(got.Workspaces) != 0 {
-		t.Fatalf("expected empty workspaces, got %+v", got.Workspaces)
+	if len(env.Data.Workspaces) != 0 {
+		t.Fatalf("expected empty workspaces, got %+v", env.Data.Workspaces)
 	}
 }

--- a/cli/schemas/envelope.go
+++ b/cli/schemas/envelope.go
@@ -1,0 +1,92 @@
+// Package schemas defines the typed payload structs for every
+// `--json`-emitting bones CLI verb (ADR 0053). Each verb has one Go
+// struct here; the `cmd/bones-schemagen` binary reflects these structs
+// and writes derived JSON Schema files into the repo-root `schemas/`
+// directory.
+//
+// Go types in this package are the source of truth for the external
+// `--json` contract. Types here are intentionally separate from the
+// internal storage types under `internal/tasks`, `internal/swarm`,
+// etc.; the duplication pins the external surface so internal types
+// can evolve freely behind it.
+//
+// The envelope below is universal: every emitter wraps its payload
+// in `Envelope[T]` so consumers can write one parser that handles
+// every verb. The single carve-out (`bones logs --json`, which
+// passthrough-emits substrate event-log NDJSON) is documented in
+// ADR 0053 and uses the substrate's own contract per ADR 0052.
+package schemas
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+// Schema is the meta-block stamped on every bones `--json` emit.
+// Verb is the dotted CLI command path (e.g. "tasks.list",
+// "swarm.dispatch"). Version is "v" followed by an integer
+// (e.g. "v1"); the ADR 0053 hard-cut migration policy means a single
+// version of bones emits exactly one version per verb.
+type Schema struct {
+	Verb    string `json:"verb"`
+	Version string `json:"version"`
+}
+
+// Envelope wraps every `--json` payload. T is the verb-specific
+// typed payload struct defined elsewhere in this package.
+//
+// Generic over T so the compiler enforces that the wrapped payload
+// matches what the schemagen generator reflected for the named
+// verb; a copy/paste mismatch (wrapping a TasksListPayload under a
+// schema verb of "tasks.show") becomes a build error.
+type Envelope[T any] struct {
+	Schema Schema `json:"schema"`
+	Data   T      `json:"data"`
+}
+
+// New builds an Envelope[T] with the given verb name, version
+// string, and typed payload. Used by every emitter so the schema
+// block is constructed in one place — no emitter spells out the
+// verb-name or version-tag literal twice.
+func New[T any](verb, version string, data T) Envelope[T] {
+	return Envelope[T]{
+		Schema: Schema{Verb: verb, Version: version},
+		Data:   data,
+	}
+}
+
+// Emit marshals env as compact JSON to w with a trailing newline.
+// Mirrors the pre-existing `emitJSON` helper's wire shape so a
+// `--json`-emitting verb wrapped by this helper byte-for-byte
+// matches the pre-envelope shape (modulo the wrap).
+//
+// Compact output is the bones default; emitters that previously
+// used indented output (`json.NewEncoder.SetIndent`) keep their
+// indented shape via [EmitIndent]. A future v2 may unify these,
+// but v1 pins today's per-verb shape.
+func Emit[T any](w io.Writer, env Envelope[T]) error {
+	data, err := json.Marshal(env)
+	if err != nil {
+		return fmt.Errorf("marshal envelope: %w", err)
+	}
+	data = append(data, '\n')
+	if _, err := w.Write(data); err != nil {
+		return fmt.Errorf("write envelope: %w", err)
+	}
+	return nil
+}
+
+// EmitIndent marshals env as indented (2-space) JSON to w with a
+// trailing newline emitted by the encoder. Used by verbs whose
+// pre-envelope shape was `json.NewEncoder.SetIndent("","  ")` —
+// `swarm.status`, `workspaces.list`, `workspaces.get` — so v1
+// preserves their human-readable indentation.
+func EmitIndent[T any](w io.Writer, env Envelope[T]) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(env); err != nil {
+		return fmt.Errorf("encode envelope: %w", err)
+	}
+	return nil
+}

--- a/cli/schemas/envelope_test.go
+++ b/cli/schemas/envelope_test.go
@@ -1,0 +1,99 @@
+package schemas
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestEnvelopeRoundtrip exercises Envelope[T] over a tiny payload to
+// prove the marshal/unmarshal pair preserves the schema block and
+// the typed payload byte-for-byte.
+func TestEnvelopeRoundtrip(t *testing.T) {
+	type Payload struct {
+		Foo string `json:"foo"`
+		Bar int    `json:"bar"`
+	}
+	in := New("test.verb", "v1", Payload{Foo: "hi", Bar: 7})
+	data, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var out Envelope[Payload]
+	if err := json.Unmarshal(data, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.Schema.Verb != "test.verb" {
+		t.Errorf("verb: got %q want %q", out.Schema.Verb, "test.verb")
+	}
+	if out.Schema.Version != "v1" {
+		t.Errorf("version: got %q want %q", out.Schema.Version, "v1")
+	}
+	if out.Data.Foo != "hi" || out.Data.Bar != 7 {
+		t.Errorf("data: got %+v", out.Data)
+	}
+}
+
+// TestEmitCompact asserts the wire shape: schema block first, data
+// block second, single trailing newline, compact (no indent).
+func TestEmitCompact(t *testing.T) {
+	type Payload struct {
+		Foo string `json:"foo"`
+	}
+	var buf bytes.Buffer
+	if err := Emit(&buf, New("v.x", "v1", Payload{Foo: "bar"})); err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	got := buf.String()
+	want := `{"schema":{"verb":"v.x","version":"v1"},"data":{"foo":"bar"}}` + "\n"
+	if got != want {
+		t.Errorf("wire shape:\n got: %q\nwant: %q", got, want)
+	}
+}
+
+// TestEmitIndent asserts the indented wire shape used by verbs that
+// previously emitted via SetIndent("","  "): two-space indent, one
+// trailing newline (encoder default).
+func TestEmitIndent(t *testing.T) {
+	type Payload struct {
+		Foo string `json:"foo"`
+	}
+	var buf bytes.Buffer
+	if err := EmitIndent(&buf, New("v.x", "v1", Payload{Foo: "bar"})); err != nil {
+		t.Fatalf("EmitIndent: %v", err)
+	}
+	got := buf.String()
+	if !strings.HasPrefix(got, "{\n") {
+		t.Errorf("expected indented prefix, got %q", got)
+	}
+	if !strings.Contains(got, "  \"schema\": {") {
+		t.Errorf("expected 2-space indent, got %q", got)
+	}
+	if !strings.HasSuffix(got, "\n") {
+		t.Errorf("expected trailing newline, got %q", got)
+	}
+}
+
+// TestEnvelopeStableFieldOrder pins the on-the-wire field order:
+// schema before data. Go's json package iterates struct fields in
+// source order, so this is enforced by the struct layout — but the
+// test guards against an accidental reorder.
+func TestEnvelopeStableFieldOrder(t *testing.T) {
+	type Payload struct {
+		X int `json:"x"`
+	}
+	data, err := json.Marshal(New("a.b", "v1", Payload{X: 1}))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	s := string(data)
+	schemaIdx := strings.Index(s, `"schema"`)
+	dataIdx := strings.Index(s, `"data"`)
+	if schemaIdx < 0 || dataIdx < 0 {
+		t.Fatalf("missing keys in output %q", s)
+	}
+	if schemaIdx >= dataIdx {
+		t.Errorf("schema must come before data; got %q", s)
+	}
+}

--- a/cli/schemas/types.go
+++ b/cli/schemas/types.go
@@ -1,0 +1,42 @@
+package schemas
+
+import "time"
+
+// Edge mirrors the on-the-wire edge shape from internal/tasks.Edge.
+// Re-declared here so cli/schemas owns the external contract; the
+// internal Edge type may evolve behind it.
+type Edge struct {
+	Type   string `json:"type"`
+	Target string `json:"target"`
+}
+
+// Task is the on-the-wire shape every task-emitting verb writes.
+// Mirrors internal/tasks.Task field-for-field including JSON tags
+// (`omitempty` markers preserved); see ADR 0005 and ADR 0014 for
+// the canonical schema.
+//
+// Pointer-time fields (DeferUntil, ClosedAt, CompactedAt) stay
+// pointer-typed so an absent value omits cleanly under omitempty
+// rather than serializing the zero value.
+type Task struct {
+	ID            string            `json:"id"`
+	Title         string            `json:"title"`
+	Status        string            `json:"status"`
+	ClaimedBy     string            `json:"claimed_by,omitempty"`
+	Files         []string          `json:"files"`
+	Parent        string            `json:"parent,omitempty"`
+	Edges         []Edge            `json:"edges,omitempty"`
+	Context       map[string]string `json:"context,omitempty"`
+	CreatedAt     time.Time         `json:"created_at"`
+	UpdatedAt     time.Time         `json:"updated_at"`
+	DeferUntil    *time.Time        `json:"defer_until,omitempty"`
+	ClosedAt      *time.Time        `json:"closed_at,omitempty"`
+	ClosedBy      string            `json:"closed_by,omitempty"`
+	ClosedReason  string            `json:"closed_reason,omitempty"`
+	ClaimEpoch    uint64            `json:"claim_epoch,omitempty"`
+	OriginalSize  uint64            `json:"original_size,omitempty"`
+	CompactLevel  uint8             `json:"compact_level,omitempty"`
+	CompactedAt   *time.Time        `json:"compacted_at,omitempty"`
+	SchemaVersion int               `json:"schema_version"`
+	LastEventSeq  uint64            `json:"last_event_seq,omitempty"`
+}

--- a/cli/schemas/verbs.go
+++ b/cli/schemas/verbs.go
@@ -1,0 +1,255 @@
+package schemas
+
+//go:generate go run ../../cmd/bones-schemagen -out ../../schemas
+
+import "time"
+
+// Verb identifies one CLI emit site. The dotted name matches the
+// command path (`tasks.list` ↔ `bones tasks list`); CurrentVersion is
+// the version this binary emits.
+//
+// All verbs start at "v1" per ADR 0053's hard-cut migration policy.
+type VerbInfo struct {
+	Verb           string
+	CurrentVersion string
+	// PayloadName is the Go type name of the payload struct,
+	// matched against the schemagen reflector's output. Lets the
+	// generator drive entirely off this slice instead of walking
+	// the AST.
+	PayloadName string
+}
+
+// Verbs is the canonical registry. Order is alphabetical by verb
+// name; the generator iterates this slice and writes
+// schemas/<verb>.<version>.json per entry.
+//
+// When adding a new verb: append an entry here, define the payload
+// struct below, run `make schemas`, and add the per-verb test in
+// cli/schemas_test.go.
+var Verbs = []VerbInfo{
+	{Verb: "doctor", CurrentVersion: "v1", PayloadName: "DoctorAllPayload"},
+	{Verb: "status", CurrentVersion: "v1", PayloadName: "StatusAllPayload"},
+	{Verb: "swarm.dispatch", CurrentVersion: "v1", PayloadName: "SwarmDispatchPayload"},
+	{Verb: "swarm.status", CurrentVersion: "v1", PayloadName: "SwarmStatusPayload"},
+	{Verb: "swarm.tasks", CurrentVersion: "v1", PayloadName: "SwarmTasksPayload"},
+	{Verb: "tasks.aggregate", CurrentVersion: "v1", PayloadName: "TasksAggregatePayload"},
+	{Verb: "tasks.bySlot", CurrentVersion: "v1", PayloadName: "TasksBySlotPayload"},
+	{Verb: "tasks.claim", CurrentVersion: "v1", PayloadName: "TasksClaimPayload"},
+	{Verb: "tasks.close", CurrentVersion: "v1", PayloadName: "TasksClosePayload"},
+	{Verb: "tasks.create", CurrentVersion: "v1", PayloadName: "TasksCreatePayload"},
+	{Verb: "tasks.link", CurrentVersion: "v1", PayloadName: "TasksLinkPayload"},
+	{Verb: "tasks.list", CurrentVersion: "v1", PayloadName: "TasksListPayload"},
+	{Verb: "tasks.prime", CurrentVersion: "v1", PayloadName: "TasksPrimePayload"},
+	{Verb: "tasks.ready", CurrentVersion: "v1", PayloadName: "TasksReadyPayload"},
+	{Verb: "tasks.show", CurrentVersion: "v1", PayloadName: "TasksShowPayload"},
+	{Verb: "tasks.update", CurrentVersion: "v1", PayloadName: "TasksUpdatePayload"},
+	{Verb: "workspaces.get", CurrentVersion: "v1", PayloadName: "WorkspacesGetPayload"},
+	{Verb: "workspaces.list", CurrentVersion: "v1", PayloadName: "WorkspacesListPayload"},
+}
+
+// VersionFor returns the current version string for verb. Falls
+// back to "v1" for unknown verbs so the generator and emitters
+// share one lookup. (CI gates that every emitter's verb is in this
+// registry, so the fallback only fires on coding errors.)
+func VersionFor(verb string) string {
+	for _, v := range Verbs {
+		if v.Verb == verb {
+			return v.CurrentVersion
+		}
+	}
+	return "v1"
+}
+
+// --- payload structs (one per verb, alphabetical by verb name) ---
+
+// DoctorAllPayload is the payload for `bones doctor --all --json`.
+// Mirrors the per-workspace row shape `renderDoctorAllJSON` emits.
+type DoctorAllPayload struct {
+	Workspaces []DoctorWorkspaceRow `json:"workspaces"`
+}
+
+// DoctorWorkspaceRow is one row of the doctor --all summary.
+type DoctorWorkspaceRow struct {
+	Name     string `json:"name"`
+	Cwd      string `json:"cwd"`
+	HubAlive bool   `json:"hub_alive"`
+	Issues   int    `json:"issues"`
+}
+
+// StatusAllPayload is the payload for `bones status --all --json`.
+// Mirrors `renderStatusAllJSON`: live registry rows only.
+type StatusAllPayload struct {
+	Workspaces []StatusWorkspaceRow `json:"workspaces"`
+}
+
+// StatusWorkspaceRow is one row of the status --all view.
+type StatusWorkspaceRow struct {
+	Cwd       string    `json:"cwd"`
+	Name      string    `json:"name"`
+	HubURL    string    `json:"hub_url"`
+	Sessions  int       `json:"sessions"`
+	StartedAt time.Time `json:"started_at"`
+}
+
+// SwarmDispatchPayload is the payload for `bones swarm dispatch --json`.
+// Mirrors `dispatchSummaryJSON`: manifest path + plan hash + task
+// count for the just-built dispatch.
+type SwarmDispatchPayload struct {
+	ManifestPath string `json:"manifest_path"`
+	TaskCount    int    `json:"task_count"`
+	PlanSHA256   string `json:"plan_sha256"`
+}
+
+// SwarmStatusPayload is the payload for `bones swarm status --json`.
+// Mirrors `[]statusRow` — every active swarm-session record.
+type SwarmStatusPayload []SwarmStatusRow
+
+// SwarmStatusRow is one swarm-session row.
+type SwarmStatusRow struct {
+	Slot         string    `json:"slot"`
+	TaskID       string    `json:"task_id"`
+	AgentID      string    `json:"agent_id"`
+	Host         string    `json:"host"`
+	LeafPID      int       `json:"leaf_pid"`
+	StartedAt    time.Time `json:"started_at"`
+	LastRenewed  time.Time `json:"last_renewed"`
+	State        string    `json:"state"`
+	StaleSeconds int64     `json:"stale_seconds"`
+}
+
+// SwarmTasksPayload is the payload for `bones swarm tasks --json`.
+// Mirrors the `[]tasks.Task` shape returned by the slot-scoped
+// readiness filter.
+type SwarmTasksPayload []Task
+
+// TasksAggregatePayload is the payload for `bones tasks aggregate --json`.
+// Mirrors `aggregateResult`: window summary + per-slot breakdown.
+type TasksAggregatePayload struct {
+	Since       string                `json:"since"`
+	TotalTasks  int                   `json:"total_tasks"`
+	TotalSlots  int                   `json:"total_slots"`
+	ActiveSlots int                   `json:"active_slots"`
+	Slots       []TasksAggregateSlot  `json:"slots"`
+}
+
+// TasksAggregateSlot is the per-slot summary row inside a tasks.aggregate payload.
+type TasksAggregateSlot struct {
+	SlotID string   `json:"slot_id"`
+	Tasks  int      `json:"tasks"`
+	Files  []string `json:"files"`
+	Status string   `json:"status"`
+}
+
+// TasksBySlotPayload is the payload for `bones tasks list --by-slot --json`.
+// Distinct verb name from `tasks.list` because the shape diverges:
+// `tasks.list` emits `[]Task`; `tasks.bySlot` emits a per-slot
+// grouping with the hot-threshold context.
+type TasksBySlotPayload struct {
+	Slots        []TasksSlotGroup `json:"slots"`
+	HotThreshold int              `json:"hot_threshold"`
+}
+
+// TasksSlotGroup is one slot's grouping row.
+type TasksSlotGroup struct {
+	Slot      string   `json:"slot"`
+	OpenCount int      `json:"open_count"`
+	Hot       bool     `json:"hot"`
+	TaskIDs   []string `json:"task_ids"`
+}
+
+// TasksClaimPayload is the payload for `bones tasks claim --json`.
+// Emits the post-claim Task record.
+type TasksClaimPayload = Task
+
+// TasksClosePayload is the payload for `bones tasks close --json`.
+// Emits the post-close Task record.
+type TasksClosePayload = Task
+
+// TasksCreatePayload is the payload for `bones tasks create --json`.
+// Emits the just-created Task record.
+type TasksCreatePayload = Task
+
+// TasksLinkPayload is the payload for `bones tasks link --json`.
+// Emits a link-confirmation tuple.
+type TasksLinkPayload struct {
+	From string `json:"from"`
+	To   string `json:"to"`
+	Type string `json:"type"`
+}
+
+// TasksListPayload is the payload for `bones tasks list --json`.
+// Emits a (possibly filtered) list of tasks. Default-mode list only;
+// the `--by-slot` mode emits the `tasks.bySlot` shape instead.
+type TasksListPayload []Task
+
+// TasksPrimePayload is the payload for `bones tasks prime --json`.
+// Mirrors `primeResultJSON`: the agent's open/ready/claimed task
+// view + recent threads + online peers.
+type TasksPrimePayload struct {
+	OpenTasks    []TasksPrimeTask     `json:"open_tasks"`
+	ReadyTasks   []TasksPrimeTask     `json:"ready_tasks"`
+	ClaimedTasks []TasksPrimeTask     `json:"claimed_tasks"`
+	Threads      []TasksPrimeThread   `json:"threads"`
+	Peers        []TasksPrimePresence `json:"peers"`
+}
+
+// TasksPrimeTask is the trimmed task shape used inside a tasks.prime
+// payload — coord.Task projection without storage-internal fields.
+type TasksPrimeTask struct {
+	ID        string    `json:"id"`
+	Title     string    `json:"title"`
+	Files     []string  `json:"files,omitempty"`
+	ClaimedBy string    `json:"claimed_by,omitempty"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// TasksPrimeThread is the chat-thread row inside a tasks.prime payload.
+type TasksPrimeThread struct {
+	ThreadShort  string    `json:"thread_short"`
+	LastActivity time.Time `json:"last_activity"`
+	MessageCount int       `json:"message_count"`
+	LastBody     string    `json:"last_body"`
+}
+
+// TasksPrimePresence is the peer-presence row inside a tasks.prime payload.
+type TasksPrimePresence struct {
+	AgentID   string    `json:"agent_id"`
+	Project   string    `json:"project"`
+	StartedAt time.Time `json:"started_at"`
+	LastSeen  time.Time `json:"last_seen"`
+}
+
+// TasksReadyPayload is the payload for `bones tasks ready --json`.
+// Always emits an array (never null); empty result yields `[]`.
+type TasksReadyPayload []Task
+
+// TasksShowPayload is the payload for `bones tasks show --json`.
+// Single Task record.
+type TasksShowPayload = Task
+
+// TasksUpdatePayload is the payload for `bones tasks update --json`.
+// Post-update Task record (or pre-update record when the update was
+// a no-op).
+type TasksUpdatePayload = Task
+
+// WorkspacesGetPayload is the payload for `bones workspaces show <name> --json`.
+// Single registry row.
+type WorkspacesGetPayload = WorkspacesRow
+
+// WorkspacesListPayload is the payload for `bones workspaces ls --json`.
+// All registry rows in the deterministic sort order ListInfo applies.
+type WorkspacesListPayload []WorkspacesRow
+
+// WorkspacesRow is one registry entry as serialized by both
+// `workspaces.list` and `workspaces.get`.
+type WorkspacesRow struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Cwd         string `json:"cwd"`
+	HubStatus   string `json:"hub_status"`
+	LastTouched string `json:"last_touched"`
+	AgentID     string `json:"agent_id"`
+	NATSURL     string `json:"nats_url"`
+	HubURL      string `json:"hub_url"`
+}

--- a/cli/schemas/verbs.go
+++ b/cli/schemas/verbs.go
@@ -125,11 +125,11 @@ type SwarmTasksPayload []Task
 // TasksAggregatePayload is the payload for `bones tasks aggregate --json`.
 // Mirrors `aggregateResult`: window summary + per-slot breakdown.
 type TasksAggregatePayload struct {
-	Since       string                `json:"since"`
-	TotalTasks  int                   `json:"total_tasks"`
-	TotalSlots  int                   `json:"total_slots"`
-	ActiveSlots int                   `json:"active_slots"`
-	Slots       []TasksAggregateSlot  `json:"slots"`
+	Since       string               `json:"since"`
+	TotalTasks  int                  `json:"total_tasks"`
+	TotalSlots  int                  `json:"total_slots"`
+	ActiveSlots int                  `json:"active_slots"`
+	Slots       []TasksAggregateSlot `json:"slots"`
 }
 
 // TasksAggregateSlot is the per-slot summary row inside a tasks.aggregate payload.

--- a/cli/schemas_test.go
+++ b/cli/schemas_test.go
@@ -4,8 +4,13 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"os"
 	"path/filepath"
+	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/santhosh-tekuri/jsonschema/v6"
@@ -211,57 +216,90 @@ func zeroPayloadFor(t *testing.T, name string) any {
 }
 
 // TestEvery_JSONFlag_HasRegistryEntry guards the inverse of
-// TestEveryVerbHasSchemaFile: every `--json` flag in cli/ has a
-// corresponding registry entry in schemas.Verbs (modulo the
-// documented carve-out for `bones logs --json`, which passthrough-
-// emits substrate event-log NDJSON per ADR 0052).
+// TestEveryVerbHasSchemaFile: every `--json` flag declared via a
+// Kong tag in cli/ must map to a known emitter, and the registry
+// must cover every emitter.
 //
-// Implementation: walks the cli/ tree for `name:"json"` Kong tags
-// and resolves each to the verb name via the file path. Failure
-// surfaces both ways: a new emitter without a registry row, OR a
-// renamed verb whose registry entry got out of sync.
+// Implementation: AST-walks every cli/*.go (non-test) file, finds
+// every struct field whose tag contains `name:"json"`, and resolves
+// the file path to its expected dotted verb name via [fileToVerb].
+// Self-maintaining: a new --json emitter without a fileToVerb
+// mapping or registry entry trips this test.
+//
+// The single intentional exemption is `cli/logs.go` — `bones logs
+// --json` passthrough-emits substrate event-log NDJSON per ADR
+// 0052 and is the documented carve-out from the envelope.
 func TestEvery_JSONFlag_HasRegistryEntry(t *testing.T) {
-	// Map: source file → expected dotted verb name. logs is the
-	// documented carve-out and is intentionally absent.
-	wantVerbs := map[string]string{
-		"cli/doctor.go":          "doctor",
-		"cli/status.go":          "status",
-		"cli/swarm_dispatch.go":  "swarm.dispatch",
-		"cli/swarm_status.go":    "swarm.status",
-		"cli/swarm_tasks.go":     "swarm.tasks",
-		"cli/tasks_aggregate.go": "tasks.aggregate",
-		"cli/tasks_claim.go":     "tasks.claim",
-		"cli/tasks_close.go":     "tasks.close",
-		"cli/tasks_create.go":    "tasks.create",
-		"cli/tasks_link.go":      "tasks.link",
-		// tasks_list.go also drives tasks.bySlot via --by-slot
-		"cli/tasks_list.go":   "tasks.list",
-		"cli/tasks_prime.go":  "tasks.prime",
-		"cli/tasks_ready.go":  "tasks.ready",
-		"cli/tasks_show.go":   "tasks.show",
-		"cli/tasks_update.go": "tasks.update",
-		// also drives workspaces.get via WorkspacesShowCmd
-		"cli/workspaces.go": "workspaces.list",
+	cliDir := repoSubdir(t, "cli")
+	emitters := scanJSONFlagEmitters(t, cliDir)
+
+	if len(emitters) == 0 {
+		t.Fatalf("AST walk found zero --json emitters in %s — walker broken",
+			cliDir)
 	}
+
+	// Map every source file to the dotted verb its --json flag
+	// produces. Files not in the map either don't emit JSON
+	// (vacuously true) or are documented carve-outs (logs.go).
+	fileToVerb := map[string]string{
+		"doctor.go":          "doctor",
+		"status.go":          "status",
+		"swarm_dispatch.go":  "swarm.dispatch",
+		"swarm_status.go":    "swarm.status",
+		"swarm_tasks.go":     "swarm.tasks",
+		"tasks_aggregate.go": "tasks.aggregate",
+		"tasks_claim.go":     "tasks.claim",
+		"tasks_close.go":     "tasks.close",
+		"tasks_create.go":    "tasks.create",
+		"tasks_link.go":      "tasks.link",
+		// tasks_list.go also drives tasks.bySlot via --by-slot;
+		// the flag is shared so we map to the primary verb here.
+		"tasks_list.go":   "tasks.list",
+		"tasks_prime.go":  "tasks.prime",
+		"tasks_ready.go":  "tasks.ready",
+		"tasks_show.go":   "tasks.show",
+		"tasks_update.go": "tasks.update",
+		// workspaces.go also drives workspaces.get via WorkspacesShowCmd.
+		"workspaces.go": "workspaces.list",
+	}
+	exempt := map[string]bool{
+		"logs.go": true, // ADR 0053 / ADR 0052 carve-out
+	}
+
 	registered := make(map[string]struct{}, len(schemas.Verbs))
 	for _, v := range schemas.Verbs {
 		registered[v.Verb] = struct{}{}
 	}
-	for path, verb := range wantVerbs {
+
+	// Forward direction: every emitter site must resolve to a
+	// known verb that lives in the registry.
+	for _, file := range emitters {
+		if exempt[file] {
+			continue
+		}
+		verb, ok := fileToVerb[file]
+		if !ok {
+			t.Errorf("%s declares a --json flag but is not in the "+
+				"fileToVerb map; either map it to its dotted verb "+
+				"or add it to the exempt list with an ADR-cited reason",
+				file)
+			continue
+		}
 		if _, ok := registered[verb]; !ok {
 			t.Errorf("%s emits --json for verb %q but registry "+
 				"is missing it; add to cli/schemas/verbs.go",
-				path, verb)
+				file, verb)
 		}
 	}
-	// And every registered verb must have either a known emit site
-	// or be the pseudo-verb (tasks.bySlot, workspaces.get) backed
-	// by a flag combination on a parent command.
+
+	// Reverse direction: every registry entry must be covered by
+	// a known emitter (either a real --json flag or a documented
+	// pseudo-verb backed by a flag combination on a parent command).
 	knownVerbs := map[string]struct{}{
 		"tasks.bySlot":   {}, // tasks list --by-slot --json
 		"workspaces.get": {}, // workspaces show <name> --json
 	}
-	for _, verb := range wantVerbs {
+	for _, verb := range fileToVerb {
 		knownVerbs[verb] = struct{}{}
 	}
 	for v := range registered {
@@ -271,4 +309,86 @@ func TestEvery_JSONFlag_HasRegistryEntry(t *testing.T) {
 				"in TestEvery_JSONFlag_HasRegistryEntry", v)
 		}
 	}
+}
+
+// repoSubdir resolves <repo-root>/<sub> by walking up from the
+// test working directory to find go.mod. Mirrors [schemaPath] but
+// returns a directory instead of a file path.
+func repoSubdir(t *testing.T, sub string) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return filepath.Join(dir, sub)
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("could not find repo root from %s", dir)
+		}
+		dir = parent
+	}
+}
+
+// scanJSONFlagEmitters parses every non-test Go file under dir and
+// returns the basenames whose top-level command struct declares a
+// field with `name:"json"` in its Kong tag. AST-walks rather than
+// greps so a future tag-syntax tweak (spaces, single quotes) keeps
+// matching accurately.
+func scanJSONFlagEmitters(t *testing.T, dir string) []string {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read %s: %v", dir, err)
+	}
+	fset := token.NewFileSet()
+	var hits []string
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		path := filepath.Join(dir, name)
+		file, parseErr := parser.ParseFile(fset, path, nil, parser.ParseComments)
+		if parseErr != nil {
+			t.Fatalf("parse %s: %v", path, parseErr)
+		}
+		if hasJSONFlagField(file) {
+			hits = append(hits, name)
+		}
+	}
+	return hits
+}
+
+// hasJSONFlagField reports whether file contains any struct field
+// whose Kong tag has `name:"json"`. Walks every StructType node so
+// nested or sibling-command structs are caught.
+func hasJSONFlagField(file *ast.File) bool {
+	found := false
+	ast.Inspect(file, func(n ast.Node) bool {
+		st, ok := n.(*ast.StructType)
+		if !ok || st.Fields == nil {
+			return true
+		}
+		for _, f := range st.Fields.List {
+			if f.Tag == nil {
+				continue
+			}
+			// f.Tag.Value is the source-level back-tick literal
+			// including the surrounding quotes; trim them so
+			// reflect.StructTag parses it cleanly.
+			tag := reflect.StructTag(strings.Trim(f.Tag.Value, "`"))
+			if tag.Get("name") == "json" {
+				found = true
+				return false
+			}
+		}
+		return true
+	})
+	return found
 }

--- a/cli/schemas_test.go
+++ b/cli/schemas_test.go
@@ -1,0 +1,274 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/santhosh-tekuri/jsonschema/v6"
+
+	"github.com/danmestas/bones/cli/schemas"
+)
+
+// TestEveryVerbHasSchemaFile pins ADR 0053 acceptance criterion #4:
+// the generator's checked-in artifact set covers every verb in the
+// registry. A new verb appended to schemas.Verbs that hasn't run
+// `make schemas` yet trips here, mirroring the make schemas-check
+// gate at the unit-test layer.
+func TestEveryVerbHasSchemaFile(t *testing.T) {
+	for _, v := range schemas.Verbs {
+		path := schemaPath(t, v.Verb, v.CurrentVersion)
+		if _, err := os.Stat(path); err != nil {
+			t.Errorf("verb %q (%s): missing schema file %s — run `make schemas`",
+				v.Verb, v.CurrentVersion, path)
+		}
+	}
+}
+
+// TestEnvelopeRoundtripPerVerb walks the registry and asserts each
+// verb's payload struct round-trips through the envelope helpers
+// without losing fields. Constructs a zero-value payload, wraps,
+// emits, parses back via Envelope[json.RawMessage] (so we don't
+// have to spell out 17 generic instantiations), and validates the
+// envelope's wire shape and the `data` block against the
+// checked-in JSON Schema file.
+func TestEnvelopeRoundtripPerVerb(t *testing.T) {
+	for _, v := range schemas.Verbs {
+		v := v
+		t.Run(v.Verb, func(t *testing.T) {
+			payload := zeroPayloadFor(t, v.PayloadName)
+			env := schemas.New(v.Verb, v.CurrentVersion, payload)
+
+			var buf bytes.Buffer
+			if err := schemas.Emit(&buf, env); err != nil {
+				t.Fatalf("Emit: %v", err)
+			}
+
+			// Parse the wire bytes back: schema block first, then
+			// data as raw bytes for schema-side validation.
+			var got schemas.Envelope[json.RawMessage]
+			if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+				t.Fatalf("unmarshal envelope: %v\npayload=%s", err, buf.String())
+			}
+			if got.Schema.Verb != v.Verb {
+				t.Errorf("schema.verb = %q, want %q", got.Schema.Verb, v.Verb)
+			}
+			if got.Schema.Version != v.CurrentVersion {
+				t.Errorf("schema.version = %q, want %q",
+					got.Schema.Version, v.CurrentVersion)
+			}
+
+			validateAgainstSchema(t, v.Verb, v.CurrentVersion, got.Data)
+		})
+	}
+}
+
+// TestSchemaFilesParseable asserts every checked-in schema file is
+// valid JSON Schema 2020-12. A hand-edit (forbidden by ADR 0053)
+// that produces invalid JSON Schema would trip here even when
+// schemas-check happens to compare equal byte-for-byte.
+func TestSchemaFilesParseable(t *testing.T) {
+	for _, v := range schemas.Verbs {
+		v := v
+		t.Run(v.Verb, func(t *testing.T) {
+			path := schemaPath(t, v.Verb, v.CurrentVersion)
+			compileSchemaFile(t, path)
+		})
+	}
+}
+
+// schemaPath resolves <repo-root>/schemas/<verb>.<version>.json.
+// Walks up from the test working directory (./cli) to find the
+// repo root by the presence of go.mod.
+func schemaPath(t *testing.T, verb, version string) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return filepath.Join(dir, "schemas",
+				fmt.Sprintf("%s.%s.json", verb, version))
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("could not find repo root from %s", dir)
+		}
+		dir = parent
+	}
+}
+
+// validateAgainstSchema compiles the checked-in schema for verb
+// and validates raw against it. Decoding raw into `any` first is
+// required by santhosh-tekuri/jsonschema's value contract.
+func validateAgainstSchema(t *testing.T, verb, version string, raw json.RawMessage) {
+	t.Helper()
+	compiled := compileSchemaFile(t, schemaPath(t, verb, version))
+	var doc any
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("decode data block: %v", err)
+	}
+	if err := compiled.Validate(doc); err != nil {
+		t.Errorf("data does not validate against %s.%s.json:\n%v",
+			verb, version, err)
+	}
+}
+
+// compileSchemaFile loads + compiles one JSON Schema. Returns the
+// compiled schema; failure is t.Fatal because every verb's schema
+// is supposed to be a buildable artifact.
+func compileSchemaFile(t *testing.T, path string) *jsonschema.Schema {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read schema %s: %v", path, err)
+	}
+	doc, err := jsonschema.UnmarshalJSON(bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("parse schema %s: %v", path, err)
+	}
+	c := jsonschema.NewCompiler()
+	if err := c.AddResource(path, doc); err != nil {
+		t.Fatalf("add schema resource %s: %v", path, err)
+	}
+	compiled, err := c.Compile(path)
+	if err != nil {
+		t.Fatalf("compile schema %s: %v", path, err)
+	}
+	return compiled
+}
+
+// zeroPayloadFor returns a zero-valued payload struct for a given
+// schemas.Verbs entry. The mapping mirrors cmd/bones-schemagen's
+// payloadInstances — duplicated here on purpose so a future
+// generator-side refactor doesn't silently skip a verb in the
+// roundtrip test.
+//
+// Slice and map fields are pre-initialized to non-nil zero values
+// so JSON marshaling emits `[]` / `{}` instead of `null`, matching
+// the runtime emitter behavior (every list-shaped payload's empty
+// case still serializes as an array).
+func zeroPayloadFor(t *testing.T, name string) any {
+	t.Helper()
+	switch name {
+	case "DoctorAllPayload":
+		return schemas.DoctorAllPayload{
+			Workspaces: []schemas.DoctorWorkspaceRow{},
+		}
+	case "StatusAllPayload":
+		return schemas.StatusAllPayload{
+			Workspaces: []schemas.StatusWorkspaceRow{},
+		}
+	case "SwarmDispatchPayload":
+		return schemas.SwarmDispatchPayload{}
+	case "SwarmStatusPayload":
+		return schemas.SwarmStatusPayload{}
+	case "SwarmTasksPayload":
+		return schemas.SwarmTasksPayload{}
+	case "TasksAggregatePayload":
+		return schemas.TasksAggregatePayload{
+			Slots: []schemas.TasksAggregateSlot{},
+		}
+	case "TasksBySlotPayload":
+		return schemas.TasksBySlotPayload{
+			Slots: []schemas.TasksSlotGroup{},
+		}
+	case "TasksClaimPayload":
+		return schemas.TasksClaimPayload{Files: []string{}}
+	case "TasksClosePayload":
+		return schemas.TasksClosePayload{Files: []string{}}
+	case "TasksCreatePayload":
+		return schemas.TasksCreatePayload{Files: []string{}}
+	case "TasksLinkPayload":
+		return schemas.TasksLinkPayload{}
+	case "TasksListPayload":
+		return schemas.TasksListPayload{}
+	case "TasksPrimePayload":
+		return schemas.TasksPrimePayload{
+			OpenTasks:    []schemas.TasksPrimeTask{},
+			ReadyTasks:   []schemas.TasksPrimeTask{},
+			ClaimedTasks: []schemas.TasksPrimeTask{},
+			Threads:      []schemas.TasksPrimeThread{},
+			Peers:        []schemas.TasksPrimePresence{},
+		}
+	case "TasksReadyPayload":
+		return schemas.TasksReadyPayload{}
+	case "TasksShowPayload":
+		return schemas.TasksShowPayload{Files: []string{}}
+	case "TasksUpdatePayload":
+		return schemas.TasksUpdatePayload{Files: []string{}}
+	case "WorkspacesGetPayload":
+		return schemas.WorkspacesGetPayload{}
+	case "WorkspacesListPayload":
+		return schemas.WorkspacesListPayload{}
+	}
+	t.Fatalf("unknown payload type %q — extend zeroPayloadFor", name)
+	return nil
+}
+
+// TestEvery_JSONFlag_HasRegistryEntry guards the inverse of
+// TestEveryVerbHasSchemaFile: every `--json` flag in cli/ has a
+// corresponding registry entry in schemas.Verbs (modulo the
+// documented carve-out for `bones logs --json`, which passthrough-
+// emits substrate event-log NDJSON per ADR 0052).
+//
+// Implementation: walks the cli/ tree for `name:"json"` Kong tags
+// and resolves each to the verb name via the file path. Failure
+// surfaces both ways: a new emitter without a registry row, OR a
+// renamed verb whose registry entry got out of sync.
+func TestEvery_JSONFlag_HasRegistryEntry(t *testing.T) {
+	// Map: source file → expected dotted verb name. logs is the
+	// documented carve-out and is intentionally absent.
+	wantVerbs := map[string]string{
+		"cli/doctor.go":          "doctor",
+		"cli/status.go":          "status",
+		"cli/swarm_dispatch.go":  "swarm.dispatch",
+		"cli/swarm_status.go":    "swarm.status",
+		"cli/swarm_tasks.go":     "swarm.tasks",
+		"cli/tasks_aggregate.go": "tasks.aggregate",
+		"cli/tasks_claim.go":     "tasks.claim",
+		"cli/tasks_close.go":     "tasks.close",
+		"cli/tasks_create.go":    "tasks.create",
+		"cli/tasks_link.go":      "tasks.link",
+		// tasks_list.go also drives tasks.bySlot via --by-slot
+		"cli/tasks_list.go":   "tasks.list",
+		"cli/tasks_prime.go":  "tasks.prime",
+		"cli/tasks_ready.go":  "tasks.ready",
+		"cli/tasks_show.go":   "tasks.show",
+		"cli/tasks_update.go": "tasks.update",
+		// also drives workspaces.get via WorkspacesShowCmd
+		"cli/workspaces.go": "workspaces.list",
+	}
+	registered := make(map[string]struct{}, len(schemas.Verbs))
+	for _, v := range schemas.Verbs {
+		registered[v.Verb] = struct{}{}
+	}
+	for path, verb := range wantVerbs {
+		if _, ok := registered[verb]; !ok {
+			t.Errorf("%s emits --json for verb %q but registry "+
+				"is missing it; add to cli/schemas/verbs.go",
+				path, verb)
+		}
+	}
+	// And every registered verb must have either a known emit site
+	// or be the pseudo-verb (tasks.bySlot, workspaces.get) backed
+	// by a flag combination on a parent command.
+	knownVerbs := map[string]struct{}{
+		"tasks.bySlot":   {}, // tasks list --by-slot --json
+		"workspaces.get": {}, // workspaces show <name> --json
+	}
+	for _, verb := range wantVerbs {
+		knownVerbs[verb] = struct{}{}
+	}
+	for v := range registered {
+		if _, ok := knownVerbs[v]; !ok {
+			t.Errorf("registry entry %q has no documented emit site; "+
+				"either remove from registry or document the verb "+
+				"in TestEvery_JSONFlag_HasRegistryEntry", v)
+		}
+	}
+}

--- a/cli/status.go
+++ b/cli/status.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -15,6 +14,7 @@ import (
 
 	repocli "github.com/danmestas/EdgeSync/cli/repo"
 
+	"github.com/danmestas/bones/cli/schemas"
 	"github.com/danmestas/bones/internal/hub"
 	"github.com/danmestas/bones/internal/registry"
 	"github.com/danmestas/bones/internal/scaffoldver"
@@ -677,7 +677,8 @@ func renderPausedWorkspacesSection(w io.Writer, paused []registry.Entry) error {
 }
 
 // renderStatusAllJSON emits a JSON object with a "workspaces" array
-// covering every live registry entry.
+// covering every live registry entry. Wrapped in the ADR 0053
+// envelope under verb "status".
 func renderStatusAllJSON(w io.Writer) error {
 	entries, err := registry.List()
 	if err != nil {
@@ -691,20 +692,17 @@ func renderStatusAllJSON(w io.Writer) error {
 			_ = registry.Remove(e.Cwd)
 		}
 	}
-	type row struct {
-		Cwd       string    `json:"cwd"`
-		Name      string    `json:"name"`
-		HubURL    string    `json:"hub_url"`
-		Sessions  int       `json:"sessions"`
-		StartedAt time.Time `json:"started_at"`
-	}
-	rows := make([]row, len(live))
+	rows := make([]schemas.StatusWorkspaceRow, len(live))
 	for i, e := range live {
-		rows[i] = row{e.Cwd, e.Name, e.HubURL, sessions.CountByWorkspace(e.Cwd), e.StartedAt}
+		rows[i] = schemas.StatusWorkspaceRow{
+			Cwd:       e.Cwd,
+			Name:      e.Name,
+			HubURL:    e.HubURL,
+			Sessions:  sessions.CountByWorkspace(e.Cwd),
+			StartedAt: e.StartedAt,
+		}
 	}
-	return json.NewEncoder(w).Encode(struct {
-		Workspaces []row `json:"workspaces"`
-	}{rows})
+	return emitEnvelope(w, "status", schemas.StatusAllPayload{Workspaces: rows})
 }
 
 // shortenHome replaces the user's $HOME prefix with ~ for table display.

--- a/cli/status_test.go
+++ b/cli/status_test.go
@@ -583,15 +583,25 @@ func TestStatusAllJSON(t *testing.T) {
 	if err := renderStatusAllJSON(&buf); err != nil {
 		t.Fatalf("renderStatusAllJSON: %v", err)
 	}
-	var got struct {
-		Workspaces []struct {
-			Name string `json:"name"`
-			Cwd  string `json:"cwd"`
-		} `json:"workspaces"`
+	var env struct {
+		Schema struct {
+			Verb    string `json:"verb"`
+			Version string `json:"version"`
+		} `json:"schema"`
+		Data struct {
+			Workspaces []struct {
+				Name string `json:"name"`
+				Cwd  string `json:"cwd"`
+			} `json:"workspaces"`
+		} `json:"data"`
 	}
-	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+	if err := json.Unmarshal(buf.Bytes(), &env); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
+	if env.Schema.Verb != "status" || env.Schema.Version != "v1" {
+		t.Errorf("schema = %+v, want {status v1}", env.Schema)
+	}
+	got := env.Data
 	if len(got.Workspaces) != 1 {
 		t.Fatalf("workspaces len = %d, want 1", len(got.Workspaces))
 	}

--- a/cli/swarm_dispatch.go
+++ b/cli/swarm_dispatch.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -14,6 +13,7 @@ import (
 
 	repocli "github.com/danmestas/EdgeSync/cli/repo"
 
+	"github.com/danmestas/bones/cli/schemas"
 	"github.com/danmestas/bones/internal/dispatch"
 	"github.com/danmestas/bones/internal/tasks"
 	"github.com/danmestas/bones/internal/workspace"
@@ -68,12 +68,10 @@ func (c *SwarmDispatchCmd) Run(g *repocli.Globals) error {
 	}
 }
 
-// dispatchSummaryJSON is the --json output shape for runDispatch.
-type dispatchSummaryJSON struct {
-	ManifestPath string `json:"manifest_path"`
-	TaskCount    int    `json:"task_count"`
-	PlanSHA256   string `json:"plan_sha256"`
-}
+// dispatchSummaryJSON was the pre-ADR-0053 --json output shape; the
+// emitter now constructs schemas.SwarmDispatchPayload directly so
+// the typed struct lives in one place. Kept removed deliberately —
+// reintroducing it would re-fork the contract.
 
 // planSHA256 computes the hex-encoded SHA-256 of a plan file's bytes.
 // Matches the hash BuildManifest stores so re-dispatch detection is consistent.
@@ -199,12 +197,12 @@ func (c *SwarmDispatchCmd) printDispatchResult(
 ) error {
 	manifestPath := dispatch.Path(workspaceDir)
 	if c.JSON {
-		out := dispatchSummaryJSON{
-			ManifestPath: manifestPath,
-			TaskCount:    len(taskIDs),
-			PlanSHA256:   m.PlanSHA256,
-		}
-		return json.NewEncoder(os.Stdout).Encode(out)
+		return emitEnvelope(os.Stdout, "swarm.dispatch",
+			schemas.SwarmDispatchPayload{
+				ManifestPath: manifestPath,
+				TaskCount:    len(taskIDs),
+				PlanSHA256:   m.PlanSHA256,
+			})
 	}
 	fmt.Printf("dispatch: created %d task(s) from %q\n", len(taskIDs), planPath)
 	fmt.Printf("dispatch: manifest written to %s\n", manifestPath)

--- a/cli/swarm_status.go
+++ b/cli/swarm_status.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -12,6 +11,7 @@ import (
 
 	repocli "github.com/danmestas/EdgeSync/cli/repo"
 
+	"github.com/danmestas/bones/cli/schemas"
 	"github.com/danmestas/bones/internal/dispatch"
 	"github.com/danmestas/bones/internal/swarm"
 	"github.com/danmestas/bones/internal/workspace"
@@ -144,9 +144,21 @@ func classifyState(s swarm.Session, host string, staleSec int64) string {
 }
 
 func emitStatusJSON(rows []statusRow) error {
-	enc := json.NewEncoder(os.Stdout)
-	enc.SetIndent("", "  ")
-	return enc.Encode(rows)
+	payload := make(schemas.SwarmStatusPayload, len(rows))
+	for i, r := range rows {
+		payload[i] = schemas.SwarmStatusRow{
+			Slot:         r.Slot,
+			TaskID:       r.TaskID,
+			AgentID:      r.AgentID,
+			Host:         r.Host,
+			LeafPID:      r.LeafPID,
+			StartedAt:    r.StartedAt,
+			LastRenewed:  r.LastRenewed,
+			State:        r.State,
+			StaleSeconds: r.StaleSeconds,
+		}
+	}
+	return emitEnvelopeIndent(os.Stdout, "swarm.status", payload)
 }
 
 func emitStatusTable(rows []statusRow) error {

--- a/cli/swarm_tasks.go
+++ b/cli/swarm_tasks.go
@@ -77,7 +77,7 @@ func (c *SwarmTasksCmd) run(ctx context.Context, info workspace.Info) error {
 		out = append(out, t)
 	}
 	if c.JSON {
-		return emitJSON(os.Stdout, out)
+		return emitEnvelope(os.Stdout, "swarm.tasks", tasksToSchema(out))
 	}
 	for _, t := range out {
 		fmt.Println(formatListLine(t))

--- a/cli/tasks_aggregate.go
+++ b/cli/tasks_aggregate.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"os"
 	"sort"
@@ -11,6 +10,7 @@ import (
 
 	repocli "github.com/danmestas/EdgeSync/cli/repo"
 
+	"github.com/danmestas/bones/cli/schemas"
 	"github.com/danmestas/bones/internal/tasks"
 )
 
@@ -20,21 +20,15 @@ type TasksAggregateCmd struct {
 	JSON  bool          `name:"json" help:"emit JSON"`
 }
 
-// aggregateSlot holds the per-slot summary computed by the aggregate verb.
+// aggregateSlot holds the per-slot summary computed by the aggregate
+// verb. JSON tags mirror the schemas.TasksAggregateSlot wire shape;
+// the fields are name-equal so the struct round-trips cleanly into
+// the envelope payload below.
 type aggregateSlot struct {
 	SlotID string   `json:"slot_id"`
 	Tasks  int      `json:"tasks"`
 	Files  []string `json:"files"`
 	Status string   `json:"status"`
-}
-
-// aggregateResult is the JSON output shape for --json.
-type aggregateResult struct {
-	Since       string          `json:"since"`
-	TotalTasks  int             `json:"total_tasks"`
-	TotalSlots  int             `json:"total_slots"`
-	ActiveSlots int             `json:"active_slots"`
-	Slots       []aggregateSlot `json:"slots"`
 }
 
 func (c *TasksAggregateCmd) Run(g *repocli.Globals) error {
@@ -110,20 +104,23 @@ func emitAggregateOutput(
 	asJSON bool,
 ) error {
 	if asJSON {
-		res := aggregateResult{
+		schemaSlots := make([]schemas.TasksAggregateSlot, len(slots))
+		for i, s := range slots {
+			schemaSlots[i] = schemas.TasksAggregateSlot{
+				SlotID: s.SlotID,
+				Tasks:  s.Tasks,
+				Files:  s.Files,
+				Status: s.Status,
+			}
+		}
+		payload := schemas.TasksAggregatePayload{
 			Since:       since.String(),
 			TotalTasks:  totalTasks,
 			TotalSlots:  len(slots),
 			ActiveSlots: activeSlots,
-			Slots:       slots,
+			Slots:       schemaSlots,
 		}
-		data, err := json.Marshal(res)
-		if err != nil {
-			return fmt.Errorf("aggregate: marshal: %w", err)
-		}
-		data = append(data, '\n')
-		_, err = os.Stdout.Write(data)
-		return err
+		return emitEnvelope(os.Stdout, "tasks.aggregate", payload)
 	}
 	return printAggregateSummary(since, slots, totalTasks, activeSlots)
 }

--- a/cli/tasks_claim.go
+++ b/cli/tasks_claim.go
@@ -72,7 +72,7 @@ func (c *TasksClaimCmd) Run(g *repocli.Globals) error {
 			return err
 		}
 		if c.JSON {
-			return emitJSON(os.Stdout, updated)
+			return emitEnvelope(os.Stdout, "tasks.claim", taskToSchema(updated))
 		}
 		return nil
 	}))

--- a/cli/tasks_close.go
+++ b/cli/tasks_close.go
@@ -123,7 +123,7 @@ func (c *TasksCloseCmd) legacyClose(
 		return err
 	}
 	if c.JSON {
-		return emitJSON(os.Stdout, updated)
+		return emitEnvelope(os.Stdout, "tasks.close", taskToSchema(updated))
 	}
 	return nil
 }
@@ -163,7 +163,7 @@ func (c *TasksCloseCmd) autoReleaseAndClose(
 			if err != nil {
 				return err
 			}
-			return emitJSON(os.Stdout, updated)
+			return emitEnvelope(os.Stdout, "tasks.close", taskToSchema(updated))
 		}
 		return nil
 	}

--- a/cli/tasks_create.go
+++ b/cli/tasks_create.go
@@ -84,7 +84,7 @@ func (c *TasksCreateCmd) Run(g *repocli.Globals) error {
 			}
 		}
 		if c.JSON {
-			return emitJSON(os.Stdout, t)
+			return emitEnvelope(os.Stdout, "tasks.create", taskToSchema(t))
 		}
 		fmt.Println(t.ID)
 		return nil

--- a/cli/tasks_format.go
+++ b/cli/tasks_format.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/danmestas/bones/cli/schemas"
 	"github.com/danmestas/bones/internal/coord"
 	"github.com/danmestas/bones/internal/tasks"
 )
@@ -84,6 +85,11 @@ func formatTime(ts time.Time) string {
 }
 
 // emitJSON marshals v as JSON to w with trailing newline.
+//
+// Pre-ADR-0053 fallback used by tests and the by-slot emitter that
+// already builds its own typed payload. New emit sites should use
+// [emitEnvelope] instead so the ADR 0053 envelope wraps every CLI
+// JSON output.
 func emitJSON(w io.Writer, v any) error {
 	data, err := json.Marshal(v)
 	if err != nil {
@@ -96,41 +102,78 @@ func emitJSON(w io.Writer, v any) error {
 	return nil
 }
 
+// emitEnvelope wraps payload under the ADR 0053 schema envelope and
+// writes it to w as compact JSON with a trailing newline. Centralised
+// so every verb's emit path goes through one helper — consumers can
+// rely on a uniform wire shape across all bones `--json` output.
+//
+// The verb's current version is looked up via [schemas.VersionFor]
+// so the call site does not repeat the version literal — bumping a
+// verb to v2 is a one-line change in cli/schemas/verbs.go.
+func emitEnvelope[T any](w io.Writer, verb string, payload T) error {
+	env := schemas.New(verb, schemas.VersionFor(verb), payload)
+	return schemas.Emit(w, env)
+}
+
+// emitEnvelopeIndent is the indented sibling of emitEnvelope. Used
+// by verbs whose pre-envelope shape was indented (`swarm.status`,
+// `workspaces.list`, `workspaces.get`); v1 preserves their two-space
+// indent so byte-for-byte snapshot tests can pin the shape.
+func emitEnvelopeIndent[T any](w io.Writer, verb string, payload T) error {
+	env := schemas.New(verb, schemas.VersionFor(verb), payload)
+	return schemas.EmitIndent(w, env)
+}
+
+// taskToSchema converts an internal tasks.Task to the cli/schemas
+// wire shape. The two structs are field-for-field identical today;
+// the conversion exists so internal types can evolve without
+// mutating the external contract.
+func taskToSchema(t tasks.Task) schemas.Task {
+	out := schemas.Task{
+		ID:            t.ID,
+		Title:         t.Title,
+		Status:        string(t.Status),
+		ClaimedBy:     t.ClaimedBy,
+		Files:         t.Files,
+		Parent:        t.Parent,
+		Context:       t.Context,
+		CreatedAt:     t.CreatedAt,
+		UpdatedAt:     t.UpdatedAt,
+		DeferUntil:    t.DeferUntil,
+		ClosedAt:      t.ClosedAt,
+		ClosedBy:      t.ClosedBy,
+		ClosedReason:  t.ClosedReason,
+		ClaimEpoch:    t.ClaimEpoch,
+		OriginalSize:  t.OriginalSize,
+		CompactLevel:  t.CompactLevel,
+		CompactedAt:   t.CompactedAt,
+		SchemaVersion: t.SchemaVersion,
+		LastEventSeq:  t.LastEventSeq,
+	}
+	if len(t.Edges) > 0 {
+		out.Edges = make([]schemas.Edge, len(t.Edges))
+		for i, e := range t.Edges {
+			out.Edges[i] = schemas.Edge{Type: string(e.Type), Target: e.Target}
+		}
+	}
+	return out
+}
+
+// tasksToSchema converts a slice of internal tasks.Task into the
+// cli/schemas slice shape. Used by the list/ready/swarm-tasks emit
+// paths.
+func tasksToSchema(in []tasks.Task) []schemas.Task {
+	out := make([]schemas.Task, len(in))
+	for i, t := range in {
+		out[i] = taskToSchema(t)
+	}
+	return out
+}
+
 // --- coord JSON conversions (for ready, prime) ---
 
-type coordTaskJSON struct {
-	ID        string    `json:"id"`
-	Title     string    `json:"title"`
-	Files     []string  `json:"files,omitempty"`
-	ClaimedBy string    `json:"claimed_by,omitempty"`
-	CreatedAt time.Time `json:"created_at"`
-	UpdatedAt time.Time `json:"updated_at"`
-}
-
-type chatThreadJSON struct {
-	ThreadShort  string    `json:"thread_short"`
-	LastActivity time.Time `json:"last_activity"`
-	MessageCount int       `json:"message_count"`
-	LastBody     string    `json:"last_body"`
-}
-
-type presenceJSON struct {
-	AgentID   string    `json:"agent_id"`
-	Project   string    `json:"project"`
-	StartedAt time.Time `json:"started_at"`
-	LastSeen  time.Time `json:"last_seen"`
-}
-
-type primeResultJSON struct {
-	OpenTasks    []coordTaskJSON  `json:"open_tasks"`
-	ReadyTasks   []coordTaskJSON  `json:"ready_tasks"`
-	ClaimedTasks []coordTaskJSON  `json:"claimed_tasks"`
-	Threads      []chatThreadJSON `json:"threads"`
-	Peers        []presenceJSON   `json:"peers"`
-}
-
-func coordTaskToJSON(t coord.Task) coordTaskJSON {
-	return coordTaskJSON{
+func coordTaskToSchema(t coord.Task) schemas.TasksPrimeTask {
+	return schemas.TasksPrimeTask{
 		ID:        string(t.ID()),
 		Title:     t.Title(),
 		Files:     t.Files(),
@@ -140,24 +183,27 @@ func coordTaskToJSON(t coord.Task) coordTaskJSON {
 	}
 }
 
-func coordTasksToJSON(ts []coord.Task) []coordTaskJSON {
-	out := make([]coordTaskJSON, 0, len(ts))
+func coordTasksToSchema(ts []coord.Task) []schemas.TasksPrimeTask {
+	out := make([]schemas.TasksPrimeTask, 0, len(ts))
 	for _, t := range ts {
-		out = append(out, coordTaskToJSON(t))
+		out = append(out, coordTaskToSchema(t))
 	}
 	return out
 }
 
-func primeToJSON(r coord.PrimeResult) primeResultJSON {
-	out := primeResultJSON{
-		OpenTasks:    coordTasksToJSON(r.OpenTasks),
-		ReadyTasks:   coordTasksToJSON(r.ReadyTasks),
-		ClaimedTasks: coordTasksToJSON(r.ClaimedTasks),
-		Threads:      make([]chatThreadJSON, 0, len(r.Threads)),
-		Peers:        make([]presenceJSON, 0, len(r.Peers)),
+// primeToSchema converts the coord-layer PrimeResult into the
+// `tasks.prime` payload shape. Mirrors today's primeResultJSON
+// shape field-for-field; v1 captures it as the external contract.
+func primeToSchema(r coord.PrimeResult) schemas.TasksPrimePayload {
+	out := schemas.TasksPrimePayload{
+		OpenTasks:    coordTasksToSchema(r.OpenTasks),
+		ReadyTasks:   coordTasksToSchema(r.ReadyTasks),
+		ClaimedTasks: coordTasksToSchema(r.ClaimedTasks),
+		Threads:      make([]schemas.TasksPrimeThread, 0, len(r.Threads)),
+		Peers:        make([]schemas.TasksPrimePresence, 0, len(r.Peers)),
 	}
 	for _, t := range r.Threads {
-		out.Threads = append(out.Threads, chatThreadJSON{
+		out.Threads = append(out.Threads, schemas.TasksPrimeThread{
 			ThreadShort:  t.ThreadShort(),
 			LastActivity: t.LastActivity(),
 			MessageCount: t.MessageCount(),
@@ -165,7 +211,7 @@ func primeToJSON(r coord.PrimeResult) primeResultJSON {
 		})
 	}
 	for _, p := range r.Peers {
-		out.Peers = append(out.Peers, presenceJSON{
+		out.Peers = append(out.Peers, schemas.TasksPrimePresence{
 			AgentID:   p.AgentID(),
 			Project:   p.Project(),
 			StartedAt: p.StartedAt(),

--- a/cli/tasks_format.go
+++ b/cli/tasks_format.go
@@ -103,7 +103,7 @@ func emitJSON(w io.Writer, v any) error {
 }
 
 // emitEnvelope wraps payload under the ADR 0053 schema envelope and
-// writes it to w as compact JSON with a trailing newline. Centralised
+// writes it to w as compact JSON with a trailing newline. Centralized
 // so every verb's emit path goes through one helper — consumers can
 // rely on a uniform wire shape across all bones `--json` output.
 //

--- a/cli/tasks_link.go
+++ b/cli/tasks_link.go
@@ -8,6 +8,7 @@ import (
 
 	repocli "github.com/danmestas/EdgeSync/cli/repo"
 
+	"github.com/danmestas/bones/cli/schemas"
 	"github.com/danmestas/bones/internal/coord"
 )
 
@@ -59,10 +60,10 @@ func (c *TasksLinkCmd) Run(g *repocli.Globals) error {
 			return err
 		}
 		if c.JSON {
-			return emitJSON(os.Stdout, map[string]string{
-				"from": string(from),
-				"to":   string(to),
-				"type": string(edgeType),
+			return emitEnvelope(os.Stdout, "tasks.link", schemas.TasksLinkPayload{
+				From: string(from),
+				To:   string(to),
+				Type: string(edgeType),
 			})
 		}
 		return nil

--- a/cli/tasks_list.go
+++ b/cli/tasks_list.go
@@ -216,7 +216,7 @@ func filterOrphans(in []tasks.Task, liveAgents map[string]struct{}) []tasks.Task
 // formatListLine per task. The legacy plain-text format is preserved.
 func emitTasks(out []tasks.Task, asJSON bool) error {
 	if asJSON {
-		return emitJSON(os.Stdout, out)
+		return emitEnvelope(os.Stdout, "tasks.list", tasksToSchema(out))
 	}
 	for _, t := range out {
 		fmt.Println(formatListLine(t))

--- a/cli/tasks_prime.go
+++ b/cli/tasks_prime.go
@@ -98,7 +98,7 @@ func (c *TasksPrimeCmd) Run(g *repocli.Globals) error {
 			// gives the agent zero signal that bones is active,
 			// while an empty-but-present envelope is the "bones is
 			// here, nothing claimed yet" signal (#170).
-			return emitJSON(os.Stdout, primeToJSON(result))
+			return emitEnvelope(os.Stdout, "tasks.prime", primeToSchema(result))
 		default:
 			fmt.Print(formatPrime(result))
 			return nil

--- a/cli/tasks_prime_test.go
+++ b/cli/tasks_prime_test.go
@@ -16,25 +16,42 @@ import (
 // must still emit a non-empty envelope so a downstream operator
 // script reading the bones-shape JSON sees the workspace is active.
 //
-// `--json` is the operator-script surface (separately governed by
-// issue #321) — it stays unchanged by ADR 0051's hook-protocol work.
-//
-// The envelope must round-trip with the documented top-level keys
-// — open_tasks, ready_tasks, claimed_tasks, threads, peers — and
-// each list must be a present empty array (not omitted, not null).
+// `--json` is the operator-script surface (governed by ADR 0053).
+// The wire shape is `{schema:{verb,version},data:{...}}` with the
+// payload under data carrying the documented keys (open_tasks,
+// ready_tasks, claimed_tasks, threads, peers), each as a present
+// empty array (not omitted, not null).
 func TestPrimeJSON_ZeroTasksEnvelope(t *testing.T) {
 	var buf bytes.Buffer
-	if err := emitJSON(&buf, primeToJSON(coord.PrimeResult{})); err != nil {
-		t.Fatalf("emitJSON: %v", err)
+	if err := emitEnvelope(&buf, "tasks.prime",
+		primeToSchema(coord.PrimeResult{})); err != nil {
+		t.Fatalf("emitEnvelope: %v", err)
 	}
 
 	if buf.Len() == 0 {
 		t.Fatalf("zero-tasks prime emitted empty stdout; want envelope")
 	}
 
-	var got map[string]json.RawMessage
-	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+	var top map[string]json.RawMessage
+	if err := json.Unmarshal(buf.Bytes(), &top); err != nil {
 		t.Fatalf("unmarshal envelope: %v\npayload=%q", err, buf.String())
+	}
+
+	// Schema block sanity.
+	var sch struct {
+		Verb    string `json:"verb"`
+		Version string `json:"version"`
+	}
+	if err := json.Unmarshal(top["schema"], &sch); err != nil {
+		t.Fatalf("unmarshal schema block: %v", err)
+	}
+	if sch.Verb != "tasks.prime" || sch.Version != "v1" {
+		t.Errorf("schema = %+v, want {tasks.prime v1}", sch)
+	}
+
+	var got map[string]json.RawMessage
+	if err := json.Unmarshal(top["data"], &got); err != nil {
+		t.Fatalf("unmarshal data block: %v", err)
 	}
 
 	for _, key := range []string{
@@ -42,30 +59,34 @@ func TestPrimeJSON_ZeroTasksEnvelope(t *testing.T) {
 	} {
 		raw, ok := got[key]
 		if !ok {
-			t.Errorf("envelope missing key %q; got=%q", key, buf.String())
+			t.Errorf("data missing key %q; got=%q", key, buf.String())
 			continue
 		}
 		// Each list must serialize as an array (not null) so a
 		// downstream consumer can `.length` without a guard.
 		if string(raw) != "[]" {
-			t.Errorf("envelope key %q = %s, want []", key, raw)
+			t.Errorf("data key %q = %s, want []", key, raw)
 		}
 	}
 }
 
 // TestPrimeJSON_PopulatedEnvelope guards the populated case so a
-// future refactor of primeToJSON keeps the documented keys.
+// future refactor of primeToSchema keeps the documented keys.
 func TestPrimeJSON_PopulatedEnvelope(t *testing.T) {
 	var buf bytes.Buffer
 	r := coord.PrimeResult{
 		OpenTasks: make([]coord.Task, 1),
 	}
-	if err := emitJSON(&buf, primeToJSON(r)); err != nil {
-		t.Fatalf("emitJSON: %v", err)
+	if err := emitEnvelope(&buf, "tasks.prime", primeToSchema(r)); err != nil {
+		t.Fatalf("emitEnvelope: %v", err)
+	}
+	var top map[string]json.RawMessage
+	if err := json.Unmarshal(buf.Bytes(), &top); err != nil {
+		t.Fatalf("unmarshal envelope: %v", err)
 	}
 	var got map[string]json.RawMessage
-	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
-		t.Fatalf("unmarshal envelope: %v", err)
+	if err := json.Unmarshal(top["data"], &got); err != nil {
+		t.Fatalf("unmarshal data: %v", err)
 	}
 	if _, ok := got["open_tasks"]; !ok {
 		t.Errorf("populated envelope missing open_tasks; got=%q", buf.String())

--- a/cli/tasks_ready.go
+++ b/cli/tasks_ready.go
@@ -135,7 +135,7 @@ func emitReady(out io.Writer, ready []tasks.Task, asJSON bool) error {
 		if ready == nil {
 			ready = []tasks.Task{}
 		}
-		return emitJSON(out, ready)
+		return emitEnvelope(out, "tasks.ready", tasksToSchema(ready))
 	}
 	if len(ready) == 0 {
 		_, err := fmt.Fprintln(out, "(no ready tasks)")

--- a/cli/tasks_ready_test.go
+++ b/cli/tasks_ready_test.go
@@ -170,7 +170,8 @@ func TestTasksReady_FIFOWithinPriority(t *testing.T) {
 	}
 }
 
-// TestTasksReady_JSON asserts --json produces a valid JSON array.
+// TestTasksReady_JSON asserts --json produces a valid envelope
+// containing a JSON array under data.
 func TestTasksReady_JSON(t *testing.T) {
 	now := time.Now().UTC()
 	a := readyFixture("a", "alpha", withPriority("P0"))
@@ -182,10 +183,20 @@ func TestTasksReady_JSON(t *testing.T) {
 		t.Fatalf("emitReady: %v", err)
 	}
 
-	var decoded []tasks.Task
-	if err := json.Unmarshal(buf.Bytes(), &decoded); err != nil {
+	var env struct {
+		Schema struct {
+			Verb    string `json:"verb"`
+			Version string `json:"version"`
+		} `json:"schema"`
+		Data []tasks.Task `json:"data"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &env); err != nil {
 		t.Fatalf("unmarshal: %v\noutput=%s", err, buf.String())
 	}
+	if env.Schema.Verb != "tasks.ready" || env.Schema.Version != "v1" {
+		t.Errorf("schema = %+v, want {tasks.ready v1}", env.Schema)
+	}
+	decoded := env.Data
 	if len(decoded) != 2 {
 		t.Fatalf("got %d items want 2; output=%s", len(decoded), buf.String())
 	}
@@ -211,21 +222,24 @@ func TestTasksReady_EmptyEmits(t *testing.T) {
 		t.Fatalf("expected sentinel line; got %q", buf.String())
 	}
 
-	// JSON mode on empty input emits "[]" so consumers see a parseable
-	// array rather than "null".
+	// JSON mode on empty input emits a `data: []` array under the
+	// envelope so consumers see a parseable list rather than "null"
+	// or a missing key.
 	buf.Reset()
 	if err := emitReady(&buf, got, true); err != nil {
 		t.Fatalf("emitReady JSON: %v", err)
 	}
-	if !strings.HasPrefix(strings.TrimSpace(buf.String()), "[") {
-		t.Fatalf("JSON empty must start with [; got %q", buf.String())
+	var env struct {
+		Data []tasks.Task `json:"data"`
 	}
-	var decoded []tasks.Task
-	if err := json.Unmarshal(buf.Bytes(), &decoded); err != nil {
+	if err := json.Unmarshal(buf.Bytes(), &env); err != nil {
 		t.Fatalf("JSON empty unmarshal: %v\nout=%s", err, buf.String())
 	}
-	if len(decoded) != 0 {
-		t.Fatalf("JSON empty: got %d items want 0", len(decoded))
+	if env.Data == nil {
+		t.Fatalf("JSON empty: data must be present array, got nil")
+	}
+	if len(env.Data) != 0 {
+		t.Fatalf("JSON empty: got %d items want 0", len(env.Data))
 	}
 }
 

--- a/cli/tasks_show.go
+++ b/cli/tasks_show.go
@@ -34,7 +34,7 @@ func (c *TasksShowCmd) Run(g *repocli.Globals) error {
 			return err
 		}
 		if c.JSON {
-			return emitJSON(os.Stdout, t)
+			return emitEnvelope(os.Stdout, "tasks.show", taskToSchema(t))
 		}
 		fmt.Print(formatShowBlock(t))
 		return nil

--- a/cli/tasks_slot.go
+++ b/cli/tasks_slot.go
@@ -1,11 +1,11 @@
 package cli
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 	"sort"
 
+	"github.com/danmestas/bones/cli/schemas"
 	"github.com/danmestas/bones/internal/tasks"
 )
 
@@ -93,20 +93,20 @@ func groupBySlot(in []tasks.Task) []slotGroup {
 // know ADR 0023/0028 to act on it.
 func emitBySlot(w io.Writer, groups []slotGroup, asJSON bool) error {
 	if asJSON {
-		payload := struct {
-			Slots     []slotGroup `json:"slots"`
-			Threshold int         `json:"hot_threshold"`
-		}{
-			Slots:     groups,
-			Threshold: HotSlotThreshold,
+		schemaSlots := make([]schemas.TasksSlotGroup, len(groups))
+		for i, g := range groups {
+			schemaSlots[i] = schemas.TasksSlotGroup{
+				Slot:      g.Slot,
+				OpenCount: g.OpenCount,
+				Hot:       g.Hot,
+				TaskIDs:   g.TaskIDs,
+			}
 		}
-		data, err := json.Marshal(payload)
-		if err != nil {
-			return fmt.Errorf("marshal by-slot: %w", err)
+		payload := schemas.TasksBySlotPayload{
+			Slots:        schemaSlots,
+			HotThreshold: HotSlotThreshold,
 		}
-		data = append(data, '\n')
-		_, err = w.Write(data)
-		return err
+		return emitEnvelope(w, "tasks.bySlot", payload)
 	}
 	// Plain-text rendering. The caption is the serialization rule
 	// surfaced inline — operators must not have to read ADRs to

--- a/cli/tasks_update.go
+++ b/cli/tasks_update.go
@@ -86,7 +86,7 @@ func (c *TasksUpdateCmd) Run(g *repocli.Globals) error {
 			// empty event. Idempotent on the CLI side.
 			updated = before
 			if c.JSON {
-				return emitJSON(os.Stdout, updated)
+				return emitEnvelope(os.Stdout, "tasks.update", taskToSchema(updated))
 			}
 			return nil
 		}
@@ -96,7 +96,7 @@ func (c *TasksUpdateCmd) Run(g *repocli.Globals) error {
 			return err
 		}
 		if c.JSON {
-			return emitJSON(os.Stdout, updated)
+			return emitEnvelope(os.Stdout, "tasks.update", taskToSchema(updated))
 		}
 		return nil
 	}))

--- a/cli/testdata/workspaces_ls.json
+++ b/cli/testdata/workspaces_ls.json
@@ -1,22 +1,28 @@
-[
-  {
-    "id": "<id>",
-    "name": "alpha",
-    "cwd": "<cwd>",
-    "hub_status": "stopped",
-    "last_touched": "<time>",
-    "agent_id": "x",
-    "nats_url": "nats://127.0.0.1:1",
-    "hub_url": "http://127.0.0.1:1"
+{
+  "schema": {
+    "verb": "workspaces.list",
+    "version": "v1"
   },
-  {
-    "id": "<id>",
-    "name": "beta",
-    "cwd": "<cwd>",
-    "hub_status": "stopped",
-    "last_touched": "<time>",
-    "agent_id": "x",
-    "nats_url": "nats://127.0.0.1:2",
-    "hub_url": "http://127.0.0.1:2"
-  }
-]
+  "data": [
+    {
+      "id": "<id>",
+      "name": "alpha",
+      "cwd": "<cwd>",
+      "hub_status": "stopped",
+      "last_touched": "<time>",
+      "agent_id": "x",
+      "nats_url": "nats://127.0.0.1:1",
+      "hub_url": "http://127.0.0.1:1"
+    },
+    {
+      "id": "<id>",
+      "name": "beta",
+      "cwd": "<cwd>",
+      "hub_status": "stopped",
+      "last_touched": "<time>",
+      "agent_id": "x",
+      "nats_url": "nats://127.0.0.1:2",
+      "hub_url": "http://127.0.0.1:2"
+    }
+  ]
+}

--- a/cli/workspaces.go
+++ b/cli/workspaces.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"bufio"
-	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -11,6 +10,7 @@ import (
 	"text/tabwriter"
 	"time"
 
+	"github.com/danmestas/bones/cli/schemas"
 	"github.com/danmestas/bones/internal/registry"
 )
 
@@ -183,22 +183,11 @@ func ambiguousNameError(q string, matches []registry.Info) error {
 	return fmt.Errorf("%s", b.String())
 }
 
-// jsonRow is the per-entry shape of `bones workspaces ls --json`. The
-// schema lives in the spec attached to issue #174; please bump the
-// fixture file under cli/testdata/ if you change it.
-type jsonRow struct {
-	ID          string `json:"id"`
-	Name        string `json:"name"`
-	Cwd         string `json:"cwd"`
-	HubStatus   string `json:"hub_status"`
-	LastTouched string `json:"last_touched"`
-	AgentID     string `json:"agent_id"`
-	NATSURL     string `json:"nats_url"`
-	HubURL      string `json:"hub_url"`
-}
-
-func toJSONRow(i registry.Info) jsonRow {
-	return jsonRow{
+// toJSONRow maps a registry.Info into the schemas.WorkspacesRow
+// wire shape. The schemas package owns the external contract; the
+// internal Info type may evolve behind it.
+func toJSONRow(i registry.Info) schemas.WorkspacesRow {
+	return schemas.WorkspacesRow{
 		ID:          i.ID,
 		Name:        i.Name,
 		Cwd:         i.Cwd,
@@ -211,13 +200,11 @@ func toJSONRow(i registry.Info) jsonRow {
 }
 
 func writeWorkspacesJSON(w io.Writer, infos []registry.Info) error {
-	rows := make([]jsonRow, len(infos))
+	rows := make(schemas.WorkspacesListPayload, len(infos))
 	for i, info := range infos {
 		rows[i] = toJSONRow(info)
 	}
-	enc := json.NewEncoder(w)
-	enc.SetIndent("", "  ")
-	return enc.Encode(rows)
+	return emitEnvelopeIndent(w, "workspaces.list", rows)
 }
 
 // writeWorkspacesTable renders the human-readable form. now is injected
@@ -255,10 +242,10 @@ func writeWorkspacesTable(w io.Writer, infos []registry.Info, now time.Time) err
 // avoid pulling yaml.v3 forward as a direct dependency. The flag is
 // kept on the command so scripts can opt in explicitly and so a future
 // switch to YAML-by-default is non-breaking for `--json` callers.
+//
+// Wrapped in the ADR 0053 envelope under verb "workspaces.get".
 func writeWorkspaceOne(w io.Writer, i registry.Info, _ bool) error {
-	enc := json.NewEncoder(w)
-	enc.SetIndent("", "  ")
-	return enc.Encode(toJSONRow(i))
+	return emitEnvelopeIndent(w, "workspaces.get", toJSONRow(i))
 }
 
 const emDash = "—"

--- a/cli/workspaces_test.go
+++ b/cli/workspaces_test.go
@@ -114,10 +114,20 @@ func TestWorkspacesLsJSON(t *testing.T) {
 		t.Fatalf("writeWorkspacesJSON: %v", err)
 	}
 
-	var rows []map[string]any
-	if err := json.Unmarshal(buf.Bytes(), &rows); err != nil {
+	var env struct {
+		Schema struct {
+			Verb    string `json:"verb"`
+			Version string `json:"version"`
+		} `json:"schema"`
+		Data []map[string]any `json:"data"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &env); err != nil {
 		t.Fatalf("decode: %v\n%s", err, buf.String())
 	}
+	if env.Schema.Verb != "workspaces.list" || env.Schema.Version != "v1" {
+		t.Errorf("schema = %+v, want {workspaces.list v1}", env.Schema)
+	}
+	rows := env.Data
 	if len(rows) != 2 {
 		t.Fatalf("rows = %d, want 2", len(rows))
 	}
@@ -160,12 +170,21 @@ func TestWorkspacesShowByName(t *testing.T) {
 	if err := writeWorkspaceOne(&buf, matches[0], true); err != nil {
 		t.Fatal(err)
 	}
-	var got map[string]any
-	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+	var env struct {
+		Schema struct {
+			Verb    string `json:"verb"`
+			Version string `json:"version"`
+		} `json:"schema"`
+		Data map[string]any `json:"data"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &env); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
-	if got["name"] != "beta" {
-		t.Errorf("name = %v, want beta", got["name"])
+	if env.Schema.Verb != "workspaces.get" || env.Schema.Version != "v1" {
+		t.Errorf("schema = %+v, want {workspaces.get v1}", env.Schema)
+	}
+	if env.Data["name"] != "beta" {
+		t.Errorf("name = %v, want beta", env.Data["name"])
 	}
 }
 

--- a/cmd/bones-schemagen/main.go
+++ b/cmd/bones-schemagen/main.go
@@ -1,0 +1,147 @@
+// Command bones-schemagen reflects the typed payload structs in
+// cli/schemas and emits one JSON Schema file per verb under the
+// configured output directory (default: schemas/ at the repo root).
+//
+// The generator is the source-of-truth pipeline for ADR 0053. CI
+// gates drift between the reflected output and the checked-in files
+// via `make schemas-check`.
+//
+// Invocation:
+//
+//	go run ./cmd/bones-schemagen -out ./schemas
+//
+// Or, equivalently, via `go generate ./cli/schemas/...`.
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+
+	"github.com/invopop/jsonschema"
+
+	"github.com/danmestas/bones/cli/schemas"
+)
+
+func main() {
+	out := flag.String("out", "schemas", "output directory for *.json schemas")
+	flag.Parse()
+
+	if err := run(*out); err != nil {
+		fmt.Fprintf(os.Stderr, "bones-schemagen: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+// run is the testable seam: walks schemas.Verbs, reflects each
+// payload type, and writes <verb>.<version>.json under outDir.
+// Idempotent — re-running on a clean tree yields no diffs.
+func run(outDir string) error {
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
+		return fmt.Errorf("mkdir %s: %w", outDir, err)
+	}
+
+	// Build a name → payload-instance map by reflecting the schemas
+	// package. Every entry in schemas.Verbs must resolve here; an
+	// unmapped name is a coding error caught at generation time.
+	payloads := payloadInstances()
+
+	for _, v := range schemas.Verbs {
+		inst, ok := payloads[v.PayloadName]
+		if !ok {
+			return fmt.Errorf("verb %q: payload type %q not found in schemas package",
+				v.Verb, v.PayloadName)
+		}
+
+		ref := &jsonschema.Reflector{
+			// Allow additional properties so a future v2 can add
+			// fields without invalidating consumer-side validation
+			// inside one major version (we hard-cut on bump anyway,
+			// but consumers writing strict validators still see a
+			// clean v1).
+			AllowAdditionalProperties: true,
+			// Inline definitions: emitting one self-contained schema
+			// per verb is friendlier for downstream tools than
+			// $ref-chained docs.
+			DoNotReference: true,
+			// Anonymous structs produce stable output — no random
+			// suffix on their generated names.
+			Anonymous: true,
+		}
+		schema := ref.Reflect(inst)
+		schema.Title = v.PayloadName
+		schema.Description = fmt.Sprintf(
+			"Payload (`data` field) for `bones %s --json` envelope, version %s.",
+			verbToCommand(v.Verb), v.CurrentVersion)
+		// Pin the JSON Schema dialect explicitly so future
+		// invopop/jsonschema upgrades can't shift the spec out from
+		// under us silently.
+		schema.Version = "https://json-schema.org/draft/2020-12/schema"
+
+		data, err := json.MarshalIndent(schema, "", "  ")
+		if err != nil {
+			return fmt.Errorf("marshal %s: %w", v.Verb, err)
+		}
+		data = append(data, '\n')
+
+		path := filepath.Join(outDir,
+			fmt.Sprintf("%s.%s.json", v.Verb, v.CurrentVersion))
+		if err := os.WriteFile(path, data, 0o644); err != nil {
+			return fmt.Errorf("write %s: %w", path, err)
+		}
+	}
+	return nil
+}
+
+// payloadInstances returns a name → zero-value-struct map for every
+// payload type referenced from schemas.Verbs. Hand-maintained so the
+// generator does not need to grow into a Go AST walker; CI gates
+// completeness via the per-verb roundtrip tests.
+//
+// Type aliases (TasksClaimPayload = Task) are listed by alias name
+// here so each verb gets its own schema file even when multiple
+// verbs share the underlying Go type.
+func payloadInstances() map[string]any {
+	return map[string]any{
+		"DoctorAllPayload":      &schemas.DoctorAllPayload{},
+		"StatusAllPayload":      &schemas.StatusAllPayload{},
+		"SwarmDispatchPayload":  &schemas.SwarmDispatchPayload{},
+		"SwarmStatusPayload":    &schemas.SwarmStatusPayload{},
+		"SwarmTasksPayload":     &schemas.SwarmTasksPayload{},
+		"TasksAggregatePayload": &schemas.TasksAggregatePayload{},
+		"TasksBySlotPayload":    &schemas.TasksBySlotPayload{},
+		"TasksClaimPayload":     &schemas.TasksClaimPayload{},
+		"TasksClosePayload":     &schemas.TasksClosePayload{},
+		"TasksCreatePayload":    &schemas.TasksCreatePayload{},
+		"TasksLinkPayload":      &schemas.TasksLinkPayload{},
+		"TasksListPayload":      &schemas.TasksListPayload{},
+		"TasksPrimePayload":     &schemas.TasksPrimePayload{},
+		"TasksReadyPayload":     &schemas.TasksReadyPayload{},
+		"TasksShowPayload":      &schemas.TasksShowPayload{},
+		"TasksUpdatePayload":    &schemas.TasksUpdatePayload{},
+		"WorkspacesGetPayload":  &schemas.WorkspacesGetPayload{},
+		"WorkspacesListPayload": &schemas.WorkspacesListPayload{},
+	}
+}
+
+// verbToCommand maps a dotted verb name back to the human-readable
+// CLI command path used in schema descriptions. `tasks.list` →
+// `tasks list`, `swarm.dispatch` → `swarm dispatch`.
+func verbToCommand(verb string) string {
+	out := make([]rune, 0, len(verb))
+	for _, r := range verb {
+		if r == '.' {
+			out = append(out, ' ')
+			continue
+		}
+		out = append(out, r)
+	}
+	return string(out)
+}
+
+// _ pins the reflect dependency so future generator-side use (e.g.
+// runtime payload-type discovery) remains a one-line addition.
+var _ = reflect.TypeOf

--- a/cmd/bones-schemagen/main.go
+++ b/cmd/bones-schemagen/main.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"reflect"
 
 	"github.com/invopop/jsonschema"
 
@@ -141,7 +140,3 @@ func verbToCommand(verb string) string {
 	}
 	return string(out)
 }
-
-// _ pins the reflect dependency so future generator-side use (e.g.
-// runtime payload-type discovery) remains a one-line addition.
-var _ = reflect.TypeOf

--- a/docs/adr/0053-json-schema-contract.md
+++ b/docs/adr/0053-json-schema-contract.md
@@ -1,0 +1,203 @@
+# ADR 0053 — JSON schema contract for `--json` output
+
+## Context
+
+Every bones CLI verb that emits JSON (`bones tasks list --json`,
+`bones swarm status --json`, `bones tasks prime --json`, …) is consumed by
+operator scripts and external tooling. Today each emitter writes a
+verb-specific JSON shape directly to stdout with no embedded version
+marker, no schema document, and no contract that ties the on-the-wire
+shape to the consumer's expectations. A renamed field in any one verb
+silently breaks every downstream consumer of that verb.
+
+Two concrete pressures forced the issue:
+
+- ADR 0051 (Claude Code hook protocol) introduced a second JSON output
+  surface for `bones tasks prime`. The new envelope (`hookSpecificOutput`)
+  belongs to Claude Code; the older `--json` shape belongs to bones
+  operator scripts. Without an explicit version marker on the bones
+  surface, future evolution of either side risks confusing the wire
+  format of the other.
+- ADR 0052 (task event log) introduced typed event payloads that share
+  the schema-evolution problem at the substrate layer. The CLI
+  `--json` surface is the analogous problem at the operator layer; the
+  same generator-from-Go-types pattern fits both.
+
+This ADR establishes the contract for the CLI `--json` surface only.
+Event-log payloads are out of scope (their stream-level contract lives
+in ADR 0052). The Claude Code hook-protocol envelope is also out of
+scope (it has its own contract in ADR 0051).
+
+## Decision
+
+### Envelope (mandatory)
+
+Every `--json`-emitting verb wraps its output in a fixed envelope:
+
+```json
+{
+  "schema": { "verb": "tasks.list", "version": "v1" },
+  "data": { /* verb-specific payload */ }
+}
+```
+
+`schema.verb` is the dotted CLI-command path (`tasks.list`,
+`swarm.dispatch`, `workspaces.list`). `schema.version` is `v` followed
+by an integer, monotonically increasing per verb. `data` is the
+verb-specific shape; consumers parse the envelope first, validate
+`data` against the version-pinned JSON Schema, and then proceed.
+
+The envelope is universal: it wraps every emitter, including
+single-field outputs like `tasks claim` and `tasks link`. Skipping
+small payloads would defeat the value — every consumer can write one
+parser that handles every bones JSON output, period.
+
+### Carve-out: `bones logs --json`
+
+`bones logs --json` emits the per-line NDJSON event-log entries
+unchanged (passthrough of the upstream substrate-level event-log
+contract; ADR 0052). Wrapping each line individually would convert a
+byte-for-byte passthrough into a transformation layer, breaking the
+ADR 0052 contract. `logs --json` is therefore the single carve-out
+from the envelope rule. Consumers reading `logs --json` are reading
+the substrate event log, not a bones CLI emit; the semantics differ
+and the contract differs.
+
+### Schemas-from-Go-types
+
+Each verb's `data` payload has a typed Go struct under
+`cli/schemas/<verb>.go`. A generator binary
+(`cmd/bones-schemagen`) walks that package, reflects each typed
+payload, and writes `schemas/<verb>.<version>.json` (JSON Schema
+Draft 2020-12) to the repo root. Go types are the source of truth.
+
+The checked-in JSON Schema files are derived artifacts, never
+hand-edited. CI gates this: `make schemas-check` runs the generator
+and fails if the working tree would diverge from the checked-in
+schemas. Same posture as `gofmt -l`.
+
+### Hard-cut migration on version bump
+
+When a verb's schema goes `v1 → v2`, the new bones release emits
+`v2` only. There is no `--schema=v1` opt-out, no dual-emit window,
+no escape hatch. Pre-1.0 latitude justifies the hard cut, and the
+"shims compound" architectural principle keeps the surface lean.
+
+The migration aid is the ADR table row update plus a `CHANGELOG`
+entry describing the shape change per bump. Operators upgrading
+across a `vN → vN+1` bump rewrite their parsers; the version marker
+in the envelope tells them exactly what to expect.
+
+### Initial baseline: every verb starts at `v1`
+
+This ADR's PR captures *today's* emitted shape as `v1` for every
+verb. No payload reshaping, no field renames, no "while we're here"
+cleanups. The goal is to *pin* the existing surface, not redesign
+it. Reshaping happens in follow-up PRs that bump the verb to `v2`.
+
+### Test convention
+
+Per verb (one test or one test case per verb):
+
+1. Invoke the verb's emit path with representative input (zero-state
+   and populated).
+2. Parse output as `Envelope[T]` where `T` is the typed payload struct.
+3. Assert `schema.verb` and `schema.version` match the expected
+   string literals.
+4. Validate `data` against the checked-in JSON Schema file
+   (`schemas/<verb>.<version>.json`) using `santhosh-tekuri/jsonschema`.
+
+A snapshot test pins today's shape byte-for-byte (modulo the envelope
+wrap), so a future "while we're here" cleanup can't sneak through.
+
+## Verb → version mapping
+
+Initial baseline. Every verb starts at `v1`.
+
+| Verb               | Version | Payload struct (Go)                   |
+|--------------------|---------|---------------------------------------|
+| `status`           | v1      | `schemas.StatusAllPayload`            |
+| `doctor`           | v1      | `schemas.DoctorAllPayload`            |
+| `swarm.dispatch`   | v1      | `schemas.SwarmDispatchPayload`        |
+| `swarm.status`     | v1      | `schemas.SwarmStatusPayload`          |
+| `swarm.tasks`      | v1      | `schemas.SwarmTasksPayload`           |
+| `tasks.aggregate`  | v1      | `schemas.TasksAggregatePayload`       |
+| `tasks.claim`      | v1      | `schemas.TasksClaimPayload`           |
+| `tasks.close`      | v1      | `schemas.TasksClosePayload`           |
+| `tasks.create`     | v1      | `schemas.TasksCreatePayload`          |
+| `tasks.link`       | v1      | `schemas.TasksLinkPayload`            |
+| `tasks.list`       | v1      | `schemas.TasksListPayload`            |
+| `tasks.bySlot`     | v1      | `schemas.TasksBySlotPayload`          |
+| `tasks.prime`      | v1      | `schemas.TasksPrimePayload`           |
+| `tasks.ready`      | v1      | `schemas.TasksReadyPayload`           |
+| `tasks.show`       | v1      | `schemas.TasksShowPayload`            |
+| `tasks.update`     | v1      | `schemas.TasksUpdatePayload`          |
+| `workspaces.list`  | v1      | `schemas.WorkspacesListPayload`       |
+| `workspaces.get`   | v1      | `schemas.WorkspacesGetPayload`        |
+
+`bones status --json` and `bones doctor --json` are presently only
+implemented for `--all`; the version mapping above reflects that
+state. When the non-`--all` JSON path is added, it gets a separate
+verb name (e.g. `status.workspace`) and starts at its own `v1`.
+
+`bones tasks list --by-slot --json` is treated as a separate verb
+output (`tasks.bySlot`) because its payload shape diverges from the
+default `tasks.list` shape (`[]Task`). Two emit shapes from one CLI
+flag combination is one verb-name per shape.
+
+## Generator pipeline
+
+```
+cli/schemas/<verb>.go     ← typed payload struct (source of truth)
+            │
+            │ go run ./cmd/bones-schemagen
+            ▼
+schemas/<verb>.<version>.json  ← JSON Schema (derived; checked in)
+```
+
+`make schemas` regenerates. `make schemas-check` regenerates and
+fails if the working tree diverges from the checked-in schemas.
+`make check` runs `schemas-check` so CI gates drift.
+
+Library: `github.com/invopop/jsonschema` (struct reflection).
+Validation in tests uses `github.com/santhosh-tekuri/jsonschema/v6`.
+
+## Consequences
+
+**Good:**
+
+- Every consumer reads the envelope, asserts version, parses payload —
+  one parser shape across every verb.
+- Schema drift is a CI failure, not a quiet contract break.
+- Version bumps are observable (the version field changes), not
+  silent (a field rename a consumer might miss).
+- New verbs join the system by adding one Go struct + one ADR table
+  row + one regenerated schema file — no per-verb plumbing.
+
+**Bad:**
+
+- One-time wire-format change: every existing consumer must be
+  updated to read `data` instead of the top-level payload. Pre-1.0
+  latitude.
+- The `cli/schemas/` package re-declares some types that already
+  exist under `internal/tasks/`, `internal/swarm/`, etc. The
+  duplication is intentional: `cli/schemas` pins the *external*
+  contract; `internal/*` types evolve freely behind it.
+
+## Out of scope (deferred)
+
+- Reshaping any verb's payload. v1 captures today's shape; reshaping
+  happens in v2 PRs.
+- Generating consumer SDKs from the schemas. Possible future work;
+  the JSON Schema files are the API for any SDK generator.
+- Subsuming the Claude Code hook envelope (ADR 0051) or the
+  event-log stream contract (ADR 0052). Different surfaces, different
+  contracts.
+
+## References
+
+- Issue #321 — agent brief that specified this ADR's scope.
+- ADR 0051 — Claude Code hook protocol (separate envelope).
+- ADR 0052 — task event log (separate contract).
+- `github.com/invopop/jsonschema` — generator library.
+- `github.com/santhosh-tekuri/jsonschema/v6` — validator library.

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,8 @@ require (
 
 require (
 	github.com/antithesishq/antithesis-sdk-go v0.6.0-default-no-op // indirect
+	github.com/bahlo/generic-list-go v0.2.0 // indirect
+	github.com/buger/jsonparser v1.1.2 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/danmestas/EdgeSync/bridge v0.0.3 // indirect
@@ -30,19 +32,23 @@ require (
 	github.com/google/go-tpm v0.9.8 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
 	github.com/hexops/gotextdiff v1.0.3 // indirect
+	github.com/invopop/jsonschema v0.14.0 // indirect
 	github.com/klauspost/compress v1.18.5 // indirect
 	github.com/minio/highwayhash v1.0.4-0.20251030100505-070ab1a87a76 // indirect
 	github.com/nats-io/jwt/v2 v2.8.1 // indirect
 	github.com/nats-io/nkeys v0.4.15 // indirect
 	github.com/nats-io/nuid v1.0.1 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
+	github.com/pb33f/ordered-map/v2 v2.3.1 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
 	github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.67.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0 // indirect
 	go.opentelemetry.io/otel/metric v1.43.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
+	go.yaml.in/yaml/v4 v4.0.0-rc.2 // indirect
 	golang.org/x/crypto v0.50.0 // indirect
 	golang.org/x/exp v0.0.0-20251023183803-a4bb9ffd2546 // indirect
 	golang.org/x/net v0.52.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -9,9 +9,11 @@ require (
 	github.com/danmestas/libfossil v0.6.0
 	github.com/danmestas/libfossil/db/driver/modernc v0.1.0
 	github.com/google/uuid v1.6.0
+	github.com/invopop/jsonschema v0.14.0
 	github.com/mattn/go-isatty v0.0.20
 	github.com/nats-io/nats-server/v2 v2.12.8
 	github.com/nats-io/nats.go v1.51.0
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.43.0
 	go.opentelemetry.io/otel/sdk v1.43.0
@@ -32,7 +34,6 @@ require (
 	github.com/google/go-tpm v0.9.8 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
 	github.com/hexops/gotextdiff v1.0.3 // indirect
-	github.com/invopop/jsonschema v0.14.0 // indirect
 	github.com/klauspost/compress v1.18.5 // indirect
 	github.com/minio/highwayhash v1.0.4-0.20251030100505-070ab1a87a76 // indirect
 	github.com/nats-io/jwt/v2 v2.8.1 // indirect
@@ -41,7 +42,6 @@ require (
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/pb33f/ordered-map/v2 v2.3.1 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
-	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
 	github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.67.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,10 @@ github.com/alecthomas/repr v0.5.2 h1:SU73FTI9D1P5UNtvseffFSGmdNci/O6RsqzeXJtP0Qs
 github.com/alecthomas/repr v0.5.2/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
 github.com/antithesishq/antithesis-sdk-go v0.6.0-default-no-op h1:kpBdlEPbRvff0mDD1gk7o9BhI16b9p5yYAXRlidpqJE=
 github.com/antithesishq/antithesis-sdk-go v0.6.0-default-no-op/go.mod h1:IUpT2DPAKh6i/YhSbt6Gl3v2yvUZjmKncl7U91fup7E=
+github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=
+github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
+github.com/buger/jsonparser v1.1.2 h1:frqHqw7otoVbk5M8LlE/L7HTnIq2v9RX6EJ48i9AxJk=
+github.com/buger/jsonparser v1.1.2/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
@@ -51,6 +55,8 @@ github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
 github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
+github.com/invopop/jsonschema v0.14.0 h1:MHQqLhvpNUZfw+hM3AZDYK7jxO8FZoQeQM77g8iyZjg=
+github.com/invopop/jsonschema v0.14.0/go.mod h1:ygm6C2EaVNMBDPpaPlnOA2pFAxBnxGjFlMZABxm9n2I=
 github.com/klauspost/compress v1.18.5 h1:/h1gH5Ce+VWNLSWqPzOVn6XBO+vJbCNGvjoaGBFW2IE=
 github.com/klauspost/compress v1.18.5/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
@@ -75,10 +81,14 @@ github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOF
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
 github.com/ncruces/julianday v1.0.0 h1:fH0OKwa7NWvniGQtxdJRxAgkBMolni2BjDHaWTxqt7M=
 github.com/ncruces/julianday v1.0.0/go.mod h1:Dusn2KvZrrovOMJuOt0TNXL6tB7U2E8kvza5fFc9G7g=
+github.com/pb33f/ordered-map/v2 v2.3.1 h1:5319HDO0aw4DA4gzi+zv4FXU9UlSs3xGZ40wcP1nBjY=
+github.com/pb33f/ordered-map/v2 v2.3.1/go.mod h1:qxFQgd0PkVUtOMCkTapqotNgzRhMPL7VvaHKbd1HnmQ=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e h1:MRM5ITcdelLK2j1vwZ3Je0FKVCfqOLp5zO6trqMLYs0=
 github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e/go.mod h1:XV66xRDqSt+GTGFMVlhk3ULuV0y9ZmzeVGR4mloJI3M=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
@@ -105,6 +115,8 @@ go.opentelemetry.io/proto/otlp v1.10.0 h1:IQRWgT5srOCYfiWnpqUYz9CVmbO8bFmKcwYxpu
 go.opentelemetry.io/proto/otlp v1.10.0/go.mod h1:/CV4QoCR/S9yaPj8utp3lvQPoqMtxXdzn7ozvvozVqk=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
+go.yaml.in/yaml/v4 v4.0.0-rc.2 h1:/FrI8D64VSr4HtGIlUtlFMGsm7H7pWTbj6vOLVZcA6s=
+go.yaml.in/yaml/v4 v4.0.0-rc.2/go.mod h1:aZqd9kCMsGL7AuUv/m/PvWLdg5sjJsZ4oHDEnfPPfY0=
 golang.org/x/crypto v0.50.0 h1:zO47/JPrL6vsNkINmLoo/PH1gcxpls50DNogFvB5ZGI=
 golang.org/x/crypto v0.50.0/go.mod h1:3muZ7vA7PBCE6xgPX7nkzzjiUq87kRItoJQM1Yo8S+Q=
 golang.org/x/exp v0.0.0-20251023183803-a4bb9ffd2546 h1:mgKeJMpvi0yx/sU5GsxQ7p6s2wtOnGAHZWCHUM4KGzY=

--- a/go.sum
+++ b/go.sum
@@ -30,6 +30,8 @@ github.com/danmestas/libfossil/db/driver/ncruces v0.1.0 h1:GWlyrNicyBYSUi68w4G4u
 github.com/danmestas/libfossil/db/driver/ncruces v0.1.0/go.mod h1:fA+18RPKWC5YxA2yimMNtr2YzMvt1yjMYNlc/p56PvY=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
+github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=

--- a/schemas/doctor.v1.json
+++ b/schemas/doctor.v1.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "properties": {
+    "workspaces": {
+      "items": {
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "cwd": {
+            "type": "string"
+          },
+          "hub_alive": {
+            "type": "boolean"
+          },
+          "issues": {
+            "type": "integer"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name",
+          "cwd",
+          "hub_alive",
+          "issues"
+        ]
+      },
+      "type": "array"
+    }
+  },
+  "type": "object",
+  "required": [
+    "workspaces"
+  ],
+  "title": "DoctorAllPayload",
+  "description": "Payload (`data` field) for `bones doctor --json` envelope, version v1."
+}

--- a/schemas/status.v1.json
+++ b/schemas/status.v1.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "properties": {
+    "workspaces": {
+      "items": {
+        "properties": {
+          "cwd": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "hub_url": {
+            "type": "string"
+          },
+          "sessions": {
+            "type": "integer"
+          },
+          "started_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "type": "object",
+        "required": [
+          "cwd",
+          "name",
+          "hub_url",
+          "sessions",
+          "started_at"
+        ]
+      },
+      "type": "array"
+    }
+  },
+  "type": "object",
+  "required": [
+    "workspaces"
+  ],
+  "title": "StatusAllPayload",
+  "description": "Payload (`data` field) for `bones status --json` envelope, version v1."
+}

--- a/schemas/swarm.dispatch.v1.json
+++ b/schemas/swarm.dispatch.v1.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "properties": {
+    "manifest_path": {
+      "type": "string"
+    },
+    "task_count": {
+      "type": "integer"
+    },
+    "plan_sha256": {
+      "type": "string"
+    }
+  },
+  "type": "object",
+  "required": [
+    "manifest_path",
+    "task_count",
+    "plan_sha256"
+  ],
+  "title": "SwarmDispatchPayload",
+  "description": "Payload (`data` field) for `bones swarm dispatch --json` envelope, version v1."
+}

--- a/schemas/swarm.status.v1.json
+++ b/schemas/swarm.status.v1.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "items": {
+    "properties": {
+      "slot": {
+        "type": "string"
+      },
+      "task_id": {
+        "type": "string"
+      },
+      "agent_id": {
+        "type": "string"
+      },
+      "host": {
+        "type": "string"
+      },
+      "leaf_pid": {
+        "type": "integer"
+      },
+      "started_at": {
+        "type": "string",
+        "format": "date-time"
+      },
+      "last_renewed": {
+        "type": "string",
+        "format": "date-time"
+      },
+      "state": {
+        "type": "string"
+      },
+      "stale_seconds": {
+        "type": "integer"
+      }
+    },
+    "type": "object",
+    "required": [
+      "slot",
+      "task_id",
+      "agent_id",
+      "host",
+      "leaf_pid",
+      "started_at",
+      "last_renewed",
+      "state",
+      "stale_seconds"
+    ]
+  },
+  "type": "array",
+  "title": "SwarmStatusPayload",
+  "description": "Payload (`data` field) for `bones swarm status --json` envelope, version v1."
+}

--- a/schemas/swarm.tasks.v1.json
+++ b/schemas/swarm.tasks.v1.json
@@ -1,0 +1,106 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "items": {
+    "properties": {
+      "id": {
+        "type": "string"
+      },
+      "title": {
+        "type": "string"
+      },
+      "status": {
+        "type": "string"
+      },
+      "claimed_by": {
+        "type": "string"
+      },
+      "files": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "parent": {
+        "type": "string"
+      },
+      "edges": {
+        "items": {
+          "properties": {
+            "type": {
+              "type": "string"
+            },
+            "target": {
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "required": [
+            "type",
+            "target"
+          ]
+        },
+        "type": "array"
+      },
+      "context": {
+        "additionalProperties": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "created_at": {
+        "type": "string",
+        "format": "date-time"
+      },
+      "updated_at": {
+        "type": "string",
+        "format": "date-time"
+      },
+      "defer_until": {
+        "type": "string",
+        "format": "date-time"
+      },
+      "closed_at": {
+        "type": "string",
+        "format": "date-time"
+      },
+      "closed_by": {
+        "type": "string"
+      },
+      "closed_reason": {
+        "type": "string"
+      },
+      "claim_epoch": {
+        "type": "integer"
+      },
+      "original_size": {
+        "type": "integer"
+      },
+      "compact_level": {
+        "type": "integer"
+      },
+      "compacted_at": {
+        "type": "string",
+        "format": "date-time"
+      },
+      "schema_version": {
+        "type": "integer"
+      },
+      "last_event_seq": {
+        "type": "integer"
+      }
+    },
+    "type": "object",
+    "required": [
+      "id",
+      "title",
+      "status",
+      "files",
+      "created_at",
+      "updated_at",
+      "schema_version"
+    ]
+  },
+  "type": "array",
+  "title": "SwarmTasksPayload",
+  "description": "Payload (`data` field) for `bones swarm tasks --json` envelope, version v1."
+}

--- a/schemas/tasks.aggregate.v1.json
+++ b/schemas/tasks.aggregate.v1.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "properties": {
+    "since": {
+      "type": "string"
+    },
+    "total_tasks": {
+      "type": "integer"
+    },
+    "total_slots": {
+      "type": "integer"
+    },
+    "active_slots": {
+      "type": "integer"
+    },
+    "slots": {
+      "items": {
+        "properties": {
+          "slot_id": {
+            "type": "string"
+          },
+          "tasks": {
+            "type": "integer"
+          },
+          "files": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "status": {
+            "type": "string"
+          }
+        },
+        "type": "object",
+        "required": [
+          "slot_id",
+          "tasks",
+          "files",
+          "status"
+        ]
+      },
+      "type": "array"
+    }
+  },
+  "type": "object",
+  "required": [
+    "since",
+    "total_tasks",
+    "total_slots",
+    "active_slots",
+    "slots"
+  ],
+  "title": "TasksAggregatePayload",
+  "description": "Payload (`data` field) for `bones tasks aggregate --json` envelope, version v1."
+}

--- a/schemas/tasks.bySlot.v1.json
+++ b/schemas/tasks.bySlot.v1.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "properties": {
+    "slots": {
+      "items": {
+        "properties": {
+          "slot": {
+            "type": "string"
+          },
+          "open_count": {
+            "type": "integer"
+          },
+          "hot": {
+            "type": "boolean"
+          },
+          "task_ids": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object",
+        "required": [
+          "slot",
+          "open_count",
+          "hot",
+          "task_ids"
+        ]
+      },
+      "type": "array"
+    },
+    "hot_threshold": {
+      "type": "integer"
+    }
+  },
+  "type": "object",
+  "required": [
+    "slots",
+    "hot_threshold"
+  ],
+  "title": "TasksBySlotPayload",
+  "description": "Payload (`data` field) for `bones tasks bySlot --json` envelope, version v1."
+}

--- a/schemas/tasks.claim.v1.json
+++ b/schemas/tasks.claim.v1.json
@@ -1,0 +1,103 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "title": {
+      "type": "string"
+    },
+    "status": {
+      "type": "string"
+    },
+    "claimed_by": {
+      "type": "string"
+    },
+    "files": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "parent": {
+      "type": "string"
+    },
+    "edges": {
+      "items": {
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "target": {
+            "type": "string"
+          }
+        },
+        "type": "object",
+        "required": [
+          "type",
+          "target"
+        ]
+      },
+      "type": "array"
+    },
+    "context": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "defer_until": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "closed_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "closed_by": {
+      "type": "string"
+    },
+    "closed_reason": {
+      "type": "string"
+    },
+    "claim_epoch": {
+      "type": "integer"
+    },
+    "original_size": {
+      "type": "integer"
+    },
+    "compact_level": {
+      "type": "integer"
+    },
+    "compacted_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "schema_version": {
+      "type": "integer"
+    },
+    "last_event_seq": {
+      "type": "integer"
+    }
+  },
+  "type": "object",
+  "required": [
+    "id",
+    "title",
+    "status",
+    "files",
+    "created_at",
+    "updated_at",
+    "schema_version"
+  ],
+  "title": "TasksClaimPayload",
+  "description": "Payload (`data` field) for `bones tasks claim --json` envelope, version v1."
+}

--- a/schemas/tasks.close.v1.json
+++ b/schemas/tasks.close.v1.json
@@ -1,0 +1,103 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "title": {
+      "type": "string"
+    },
+    "status": {
+      "type": "string"
+    },
+    "claimed_by": {
+      "type": "string"
+    },
+    "files": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "parent": {
+      "type": "string"
+    },
+    "edges": {
+      "items": {
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "target": {
+            "type": "string"
+          }
+        },
+        "type": "object",
+        "required": [
+          "type",
+          "target"
+        ]
+      },
+      "type": "array"
+    },
+    "context": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "defer_until": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "closed_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "closed_by": {
+      "type": "string"
+    },
+    "closed_reason": {
+      "type": "string"
+    },
+    "claim_epoch": {
+      "type": "integer"
+    },
+    "original_size": {
+      "type": "integer"
+    },
+    "compact_level": {
+      "type": "integer"
+    },
+    "compacted_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "schema_version": {
+      "type": "integer"
+    },
+    "last_event_seq": {
+      "type": "integer"
+    }
+  },
+  "type": "object",
+  "required": [
+    "id",
+    "title",
+    "status",
+    "files",
+    "created_at",
+    "updated_at",
+    "schema_version"
+  ],
+  "title": "TasksClosePayload",
+  "description": "Payload (`data` field) for `bones tasks close --json` envelope, version v1."
+}

--- a/schemas/tasks.create.v1.json
+++ b/schemas/tasks.create.v1.json
@@ -1,0 +1,103 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "title": {
+      "type": "string"
+    },
+    "status": {
+      "type": "string"
+    },
+    "claimed_by": {
+      "type": "string"
+    },
+    "files": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "parent": {
+      "type": "string"
+    },
+    "edges": {
+      "items": {
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "target": {
+            "type": "string"
+          }
+        },
+        "type": "object",
+        "required": [
+          "type",
+          "target"
+        ]
+      },
+      "type": "array"
+    },
+    "context": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "defer_until": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "closed_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "closed_by": {
+      "type": "string"
+    },
+    "closed_reason": {
+      "type": "string"
+    },
+    "claim_epoch": {
+      "type": "integer"
+    },
+    "original_size": {
+      "type": "integer"
+    },
+    "compact_level": {
+      "type": "integer"
+    },
+    "compacted_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "schema_version": {
+      "type": "integer"
+    },
+    "last_event_seq": {
+      "type": "integer"
+    }
+  },
+  "type": "object",
+  "required": [
+    "id",
+    "title",
+    "status",
+    "files",
+    "created_at",
+    "updated_at",
+    "schema_version"
+  ],
+  "title": "TasksCreatePayload",
+  "description": "Payload (`data` field) for `bones tasks create --json` envelope, version v1."
+}

--- a/schemas/tasks.link.v1.json
+++ b/schemas/tasks.link.v1.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "properties": {
+    "from": {
+      "type": "string"
+    },
+    "to": {
+      "type": "string"
+    },
+    "type": {
+      "type": "string"
+    }
+  },
+  "type": "object",
+  "required": [
+    "from",
+    "to",
+    "type"
+  ],
+  "title": "TasksLinkPayload",
+  "description": "Payload (`data` field) for `bones tasks link --json` envelope, version v1."
+}

--- a/schemas/tasks.list.v1.json
+++ b/schemas/tasks.list.v1.json
@@ -1,0 +1,106 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "items": {
+    "properties": {
+      "id": {
+        "type": "string"
+      },
+      "title": {
+        "type": "string"
+      },
+      "status": {
+        "type": "string"
+      },
+      "claimed_by": {
+        "type": "string"
+      },
+      "files": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "parent": {
+        "type": "string"
+      },
+      "edges": {
+        "items": {
+          "properties": {
+            "type": {
+              "type": "string"
+            },
+            "target": {
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "required": [
+            "type",
+            "target"
+          ]
+        },
+        "type": "array"
+      },
+      "context": {
+        "additionalProperties": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "created_at": {
+        "type": "string",
+        "format": "date-time"
+      },
+      "updated_at": {
+        "type": "string",
+        "format": "date-time"
+      },
+      "defer_until": {
+        "type": "string",
+        "format": "date-time"
+      },
+      "closed_at": {
+        "type": "string",
+        "format": "date-time"
+      },
+      "closed_by": {
+        "type": "string"
+      },
+      "closed_reason": {
+        "type": "string"
+      },
+      "claim_epoch": {
+        "type": "integer"
+      },
+      "original_size": {
+        "type": "integer"
+      },
+      "compact_level": {
+        "type": "integer"
+      },
+      "compacted_at": {
+        "type": "string",
+        "format": "date-time"
+      },
+      "schema_version": {
+        "type": "integer"
+      },
+      "last_event_seq": {
+        "type": "integer"
+      }
+    },
+    "type": "object",
+    "required": [
+      "id",
+      "title",
+      "status",
+      "files",
+      "created_at",
+      "updated_at",
+      "schema_version"
+    ]
+  },
+  "type": "array",
+  "title": "TasksListPayload",
+  "description": "Payload (`data` field) for `bones tasks list --json` envelope, version v1."
+}

--- a/schemas/tasks.prime.v1.json
+++ b/schemas/tasks.prime.v1.json
@@ -1,0 +1,181 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "properties": {
+    "open_tasks": {
+      "items": {
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "files": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "claimed_by": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "title",
+          "created_at",
+          "updated_at"
+        ]
+      },
+      "type": "array"
+    },
+    "ready_tasks": {
+      "items": {
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "files": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "claimed_by": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "title",
+          "created_at",
+          "updated_at"
+        ]
+      },
+      "type": "array"
+    },
+    "claimed_tasks": {
+      "items": {
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "files": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "claimed_by": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "title",
+          "created_at",
+          "updated_at"
+        ]
+      },
+      "type": "array"
+    },
+    "threads": {
+      "items": {
+        "properties": {
+          "thread_short": {
+            "type": "string"
+          },
+          "last_activity": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "message_count": {
+            "type": "integer"
+          },
+          "last_body": {
+            "type": "string"
+          }
+        },
+        "type": "object",
+        "required": [
+          "thread_short",
+          "last_activity",
+          "message_count",
+          "last_body"
+        ]
+      },
+      "type": "array"
+    },
+    "peers": {
+      "items": {
+        "properties": {
+          "agent_id": {
+            "type": "string"
+          },
+          "project": {
+            "type": "string"
+          },
+          "started_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "last_seen": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "type": "object",
+        "required": [
+          "agent_id",
+          "project",
+          "started_at",
+          "last_seen"
+        ]
+      },
+      "type": "array"
+    }
+  },
+  "type": "object",
+  "required": [
+    "open_tasks",
+    "ready_tasks",
+    "claimed_tasks",
+    "threads",
+    "peers"
+  ],
+  "title": "TasksPrimePayload",
+  "description": "Payload (`data` field) for `bones tasks prime --json` envelope, version v1."
+}

--- a/schemas/tasks.ready.v1.json
+++ b/schemas/tasks.ready.v1.json
@@ -1,0 +1,106 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "items": {
+    "properties": {
+      "id": {
+        "type": "string"
+      },
+      "title": {
+        "type": "string"
+      },
+      "status": {
+        "type": "string"
+      },
+      "claimed_by": {
+        "type": "string"
+      },
+      "files": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "parent": {
+        "type": "string"
+      },
+      "edges": {
+        "items": {
+          "properties": {
+            "type": {
+              "type": "string"
+            },
+            "target": {
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "required": [
+            "type",
+            "target"
+          ]
+        },
+        "type": "array"
+      },
+      "context": {
+        "additionalProperties": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "created_at": {
+        "type": "string",
+        "format": "date-time"
+      },
+      "updated_at": {
+        "type": "string",
+        "format": "date-time"
+      },
+      "defer_until": {
+        "type": "string",
+        "format": "date-time"
+      },
+      "closed_at": {
+        "type": "string",
+        "format": "date-time"
+      },
+      "closed_by": {
+        "type": "string"
+      },
+      "closed_reason": {
+        "type": "string"
+      },
+      "claim_epoch": {
+        "type": "integer"
+      },
+      "original_size": {
+        "type": "integer"
+      },
+      "compact_level": {
+        "type": "integer"
+      },
+      "compacted_at": {
+        "type": "string",
+        "format": "date-time"
+      },
+      "schema_version": {
+        "type": "integer"
+      },
+      "last_event_seq": {
+        "type": "integer"
+      }
+    },
+    "type": "object",
+    "required": [
+      "id",
+      "title",
+      "status",
+      "files",
+      "created_at",
+      "updated_at",
+      "schema_version"
+    ]
+  },
+  "type": "array",
+  "title": "TasksReadyPayload",
+  "description": "Payload (`data` field) for `bones tasks ready --json` envelope, version v1."
+}

--- a/schemas/tasks.show.v1.json
+++ b/schemas/tasks.show.v1.json
@@ -1,0 +1,103 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "title": {
+      "type": "string"
+    },
+    "status": {
+      "type": "string"
+    },
+    "claimed_by": {
+      "type": "string"
+    },
+    "files": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "parent": {
+      "type": "string"
+    },
+    "edges": {
+      "items": {
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "target": {
+            "type": "string"
+          }
+        },
+        "type": "object",
+        "required": [
+          "type",
+          "target"
+        ]
+      },
+      "type": "array"
+    },
+    "context": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "defer_until": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "closed_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "closed_by": {
+      "type": "string"
+    },
+    "closed_reason": {
+      "type": "string"
+    },
+    "claim_epoch": {
+      "type": "integer"
+    },
+    "original_size": {
+      "type": "integer"
+    },
+    "compact_level": {
+      "type": "integer"
+    },
+    "compacted_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "schema_version": {
+      "type": "integer"
+    },
+    "last_event_seq": {
+      "type": "integer"
+    }
+  },
+  "type": "object",
+  "required": [
+    "id",
+    "title",
+    "status",
+    "files",
+    "created_at",
+    "updated_at",
+    "schema_version"
+  ],
+  "title": "TasksShowPayload",
+  "description": "Payload (`data` field) for `bones tasks show --json` envelope, version v1."
+}

--- a/schemas/tasks.update.v1.json
+++ b/schemas/tasks.update.v1.json
@@ -1,0 +1,103 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "title": {
+      "type": "string"
+    },
+    "status": {
+      "type": "string"
+    },
+    "claimed_by": {
+      "type": "string"
+    },
+    "files": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "parent": {
+      "type": "string"
+    },
+    "edges": {
+      "items": {
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "target": {
+            "type": "string"
+          }
+        },
+        "type": "object",
+        "required": [
+          "type",
+          "target"
+        ]
+      },
+      "type": "array"
+    },
+    "context": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "defer_until": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "closed_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "closed_by": {
+      "type": "string"
+    },
+    "closed_reason": {
+      "type": "string"
+    },
+    "claim_epoch": {
+      "type": "integer"
+    },
+    "original_size": {
+      "type": "integer"
+    },
+    "compact_level": {
+      "type": "integer"
+    },
+    "compacted_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "schema_version": {
+      "type": "integer"
+    },
+    "last_event_seq": {
+      "type": "integer"
+    }
+  },
+  "type": "object",
+  "required": [
+    "id",
+    "title",
+    "status",
+    "files",
+    "created_at",
+    "updated_at",
+    "schema_version"
+  ],
+  "title": "TasksUpdatePayload",
+  "description": "Payload (`data` field) for `bones tasks update --json` envelope, version v1."
+}

--- a/schemas/workspaces.get.v1.json
+++ b/schemas/workspaces.get.v1.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "name": {
+      "type": "string"
+    },
+    "cwd": {
+      "type": "string"
+    },
+    "hub_status": {
+      "type": "string"
+    },
+    "last_touched": {
+      "type": "string"
+    },
+    "agent_id": {
+      "type": "string"
+    },
+    "nats_url": {
+      "type": "string"
+    },
+    "hub_url": {
+      "type": "string"
+    }
+  },
+  "type": "object",
+  "required": [
+    "id",
+    "name",
+    "cwd",
+    "hub_status",
+    "last_touched",
+    "agent_id",
+    "nats_url",
+    "hub_url"
+  ],
+  "title": "WorkspacesGetPayload",
+  "description": "Payload (`data` field) for `bones workspaces get --json` envelope, version v1."
+}

--- a/schemas/workspaces.list.v1.json
+++ b/schemas/workspaces.list.v1.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "items": {
+    "properties": {
+      "id": {
+        "type": "string"
+      },
+      "name": {
+        "type": "string"
+      },
+      "cwd": {
+        "type": "string"
+      },
+      "hub_status": {
+        "type": "string"
+      },
+      "last_touched": {
+        "type": "string"
+      },
+      "agent_id": {
+        "type": "string"
+      },
+      "nats_url": {
+        "type": "string"
+      },
+      "hub_url": {
+        "type": "string"
+      }
+    },
+    "type": "object",
+    "required": [
+      "id",
+      "name",
+      "cwd",
+      "hub_status",
+      "last_touched",
+      "agent_id",
+      "nats_url",
+      "hub_url"
+    ]
+  },
+  "type": "array",
+  "title": "WorkspacesListPayload",
+  "description": "Payload (`data` field) for `bones workspaces list --json` envelope, version v1."
+}


### PR DESCRIPTION
## Summary

Per-verb embedded schema envelope for every bones CLI `--json` output (ADR 0053).

```json
{ "schema": { "verb": "tasks.list", "version": "v1" }, "data": { /* payload */ } }
```

- ADR `docs/adr/0053-json-schema-contract.md` — envelope shape, hard-cut migration policy, schemas-from-Go-types pipeline, verb→version mapping, test convention.
- `cli/schemas/` package — typed payload struct per verb (18 verbs, all at v1 capturing today's emitted shape byte-for-byte).
- `cmd/bones-schemagen` — generator binary that reflects the payload structs and writes `schemas/<verb>.<version>.json`.
- `make schemas` regenerates; `make schemas-check` is the CI no-drift gate (wired into `make check`).
- All 17 envelope-eligible emit sites swept to wrap their payloads via `emitEnvelope` / `emitEnvelopeIndent`.
- Per-verb roundtrip + JSON Schema validation tests in `cli/schemas_test.go` (`santhosh-tekuri/jsonschema/v6`).

`bones logs --json` is the single documented carve-out: it passthrough-emits substrate event-log NDJSON per ADR 0052, so wrapping each line would convert passthrough into transformation. Documented in the ADR.

## Verb registry

`doctor`, `status`, `swarm.dispatch`, `swarm.status`, `swarm.tasks`, `tasks.aggregate`, `tasks.bySlot`, `tasks.claim`, `tasks.close`, `tasks.create`, `tasks.link`, `tasks.list`, `tasks.prime`, `tasks.ready`, `tasks.show`, `tasks.update`, `workspaces.list`, `workspaces.get` — all v1.

`tasks.bySlot` is broken out from `tasks.list` because `--by-slot` produces a divergent payload shape; one verb-name per shape per ADR 0053.

## Judgment calls in scope

- Schema generator library: `github.com/invopop/jsonschema`. Active, lean dep tree, supports Go generics-friendly reflection. Validator: `github.com/santhosh-tekuri/jsonschema/v6` (also active, clean import).
- `tasks.bySlot` carved out as a separate verb name (rather than a discriminated union under `tasks.list`) — keeps each schema file pure.
- `bones status --json` and `bones doctor --json` only emit JSON in `--all` mode today; the registry reflects that. When the non-`--all` JSON path lands (issue #305 for status), it'll get its own verb name.

## Test plan

- [x] `make schemas` is no-op on the committed tree.
- [x] `make check` (incl. `schemas-check` no-drift gate) passes.
- [x] `go build -tags=otel ./...` passes.
- [x] `go test -tags=otel -short ./...` passes (modulo the pre-existing `TestStatusAllEmptyRegistry` flake — issue #305 will fix).
- [x] Per-verb roundtrip + schema validation tests cover all 18 verbs.
- [ ] Spot-check one consumer parser update post-merge to confirm the migration path is clean.

Closes #321