### PR TITLE
feat(cli): one-line success signatures for state-mutating verbs

### DIFF
--- a/cli/swarm_dispatch.go
+++ b/cli/swarm_dispatch.go
@@ -14,6 +14,7 @@ import (
 	repocli "github.com/danmestas/EdgeSync/cli/repo"
 
 	"github.com/danmestas/bones/cli/schemas"
+	"github.com/danmestas/bones/cli/uxprint"
 	"github.com/danmestas/bones/internal/dispatch"
 	"github.com/danmestas/bones/internal/tasks"
 	"github.com/danmestas/bones/internal/workspace"
@@ -40,6 +41,7 @@ type SwarmDispatchCmd struct {
 	Wave     int    `name:"wave" help:"explicit wave number (rare; for testing)"`
 	JSON     bool   `name:"json" help:"emit manifest path + summary as JSON"`
 	DryRun   bool   `name:"dry-run" help:"validate; don't touch NATS or filesystem"`
+	Quiet    bool   `name:"quiet" help:"suppress success output"`
 }
 
 // Run dispatches to the appropriate subcommand based on which flag is set.
@@ -98,8 +100,10 @@ func (c *SwarmDispatchCmd) runDispatch(
 		return fmt.Errorf("dispatch: plan %q has %d validation error(s)", planPath, len(res.Errors))
 	}
 	if c.DryRun {
-		fmt.Printf("dispatch: --dry-run: %q valid (%d slot(s)); no tasks or manifest written\n",
-			planPath, len(res.Slots))
+		if !c.Quiet {
+			fmt.Printf("dispatch: --dry-run: %q valid (%d slot(s)); no tasks or manifest written\n",
+				planPath, len(res.Slots))
+		}
 		return nil
 	}
 
@@ -204,10 +208,47 @@ func (c *SwarmDispatchCmd) printDispatchResult(
 				PlanSHA256:   m.PlanSHA256,
 			})
 	}
-	fmt.Printf("dispatch: created %d task(s) from %q\n", len(taskIDs), planPath)
+	if c.Quiet {
+		return nil
+	}
+	// Multi-target convention: one line per task, plus a one-line
+	// summary, plus the manifest/next-step lines that aren't a per-
+	// entity success signature but are still operationally useful.
+	// Iterate slots in stable order so the per-task lines are
+	// reproducible across runs.
+	slotNames := make([]string, 0, len(taskIDs))
+	for slot := range taskIDs {
+		slotNames = append(slotNames, slot)
+	}
+	sortStrings(slotNames)
+	for _, slot := range slotNames {
+		uxprint.Created(os.Stdout, truncateID(taskIDs[slot], 8), slot)
+	}
+	uxprint.Summary(os.Stdout, len(taskIDs), pluralize("task", len(taskIDs)), "created")
 	fmt.Printf("dispatch: manifest written to %s\n", manifestPath)
 	fmt.Println("dispatch: next step — run `bones swarm dispatch --advance` after wave 1 completes")
 	return nil
+}
+
+// sortStrings is a small wrapper around sort.Strings kept local to
+// swarm_dispatch.go so the import surface of the file does not grow
+// for a one-line operation. The wider sort already lives in the
+// package via tasks_slot.go's groupBySlot.
+func sortStrings(in []string) {
+	for i := 1; i < len(in); i++ {
+		for j := i; j > 0 && in[j-1] > in[j]; j-- {
+			in[j-1], in[j] = in[j], in[j-1]
+		}
+	}
+}
+
+// pluralize returns "task" or "tasks" depending on count, matching
+// the brief's "2 tasks created" / "1 task created" examples.
+func pluralize(noun string, n int) string {
+	if n == 1 {
+		return noun
+	}
+	return noun + "s"
 }
 
 // runAdvance opens the task manager, wires an isClosed shim, calls
@@ -235,12 +276,16 @@ func (c *SwarmDispatchCmd) runAdvance(ctx context.Context, info workspace.Info) 
 			return fmt.Errorf("dispatch advance: wave not yet complete")
 		}
 		if errors.Is(err, dispatch.ErrAllWavesComplete) {
-			fmt.Println("dispatch: all waves complete — dispatch is finished")
+			if !c.Quiet {
+				fmt.Println("dispatch: all waves complete — dispatch is finished")
+			}
 			return nil
 		}
 		return err
 	}
-	fmt.Printf("dispatch: advanced to wave %d of %d\n", updated.CurrentWave, len(updated.Waves))
+	if !c.Quiet {
+		fmt.Printf("dispatch: advanced to wave %d of %d\n", updated.CurrentWave, len(updated.Waves))
+	}
 	return nil
 }
 
@@ -276,6 +321,8 @@ func (c *SwarmDispatchCmd) runCancel(ctx context.Context, info workspace.Info) e
 	if err := dispatch.Cancel(info.WorkspaceDir, closeTask); err != nil {
 		return err
 	}
-	fmt.Println("dispatch: canceled and manifest removed")
+	if !c.Quiet {
+		fmt.Println("dispatch: canceled and manifest removed")
+	}
 	return nil
 }

--- a/cli/swarm_tasks.go
+++ b/cli/swarm_tasks.go
@@ -8,6 +8,7 @@ import (
 
 	repocli "github.com/danmestas/EdgeSync/cli/repo"
 
+	"github.com/danmestas/bones/cli/uxprint"
 	"github.com/danmestas/bones/internal/coord"
 	"github.com/danmestas/bones/internal/tasks"
 	"github.com/danmestas/bones/internal/workspace"
@@ -78,6 +79,14 @@ func (c *SwarmTasksCmd) run(ctx context.Context, info workspace.Info) error {
 	}
 	if c.JSON {
 		return emitEnvelope(os.Stdout, "swarm.tasks", tasksToSchema(out))
+	}
+	// Filter-emptiness hint: when --slot narrows to zero ready tasks
+	// but the readiness gate produced rows for other slots, surface
+	// the broaden-the-filter hint so the operator distinguishes "no
+	// tasks for THIS slot" from "no tasks at all anywhere".
+	if len(out) == 0 && len(readies) > 0 {
+		uxprint.NoReadyTasks(os.Stdout, len(readies))
+		return nil
 	}
 	for _, t := range out {
 		fmt.Println(formatListLine(t))

--- a/cli/tasks_aggregate.go
+++ b/cli/tasks_aggregate.go
@@ -11,6 +11,7 @@ import (
 	repocli "github.com/danmestas/EdgeSync/cli/repo"
 
 	"github.com/danmestas/bones/cli/schemas"
+	"github.com/danmestas/bones/cli/uxprint"
 	"github.com/danmestas/bones/internal/tasks"
 )
 
@@ -51,7 +52,13 @@ func (c *TasksAggregateCmd) Run(g *repocli.Globals) error {
 			return fmt.Errorf("aggregate: list tasks: %w", err)
 		}
 		slots, totalTasks, activeSlots := buildAggregateSlots(allTasks, c.Since)
-		return emitAggregateOutput(c.Since, slots, totalTasks, activeSlots, c.JSON)
+		// hasOlder distinguishes "your --since hid these rows"
+		// (filter-emptiness hint shown) from "the workspace has no
+		// task history at all" (silent). The hint exists to point
+		// the operator at the escape hatch (--since=) when their
+		// window is the reason for emptiness.
+		hasOlder := totalTasks == 0 && len(allTasks) > 0
+		return emitAggregateOutput(c.Since, slots, totalTasks, activeSlots, c.JSON, hasOlder)
 	}))
 }
 
@@ -101,7 +108,7 @@ func emitAggregateOutput(
 	since time.Duration,
 	slots []aggregateSlot,
 	totalTasks, activeSlots int,
-	asJSON bool,
+	asJSON, hasOlder bool,
 ) error {
 	if asJSON {
 		schemaSlots := make([]schemas.TasksAggregateSlot, len(slots))
@@ -122,20 +129,30 @@ func emitAggregateOutput(
 		}
 		return emitEnvelope(os.Stdout, "tasks.aggregate", payload)
 	}
-	return printAggregateSummary(since, slots, totalTasks, activeSlots)
+	return printAggregateSummary(since, slots, totalTasks, activeSlots, hasOlder)
 }
 
 func printAggregateSummary(
 	since time.Duration,
 	slots []aggregateSlot,
 	totalTasks, activeSlots int,
+	hasOlder bool,
 ) error {
 	sep := strings.Repeat("─", 53)
 	var b strings.Builder
 	fmt.Fprintf(&b, "Run summary (last %s)\n", since)
 	fmt.Fprintln(&b, sep)
 	if len(slots) == 0 {
-		fmt.Fprintln(&b, "(no tasks in window)")
+		// Filter-emptiness hint: if there are older tasks but the
+		// --since window hid them, point the operator at the escape
+		// hatch. When the workspace has no tasks at all, fall back
+		// to the legacy "(no tasks in window)" line so the report
+		// frame is still readable.
+		if hasOlder {
+			uxprint.NoRecentActivity(&b, since.String())
+		} else {
+			fmt.Fprintln(&b, "(no tasks in window)")
+		}
 	}
 	for _, s := range slots {
 		summary := summarizeFiles(s.Files, 3)

--- a/cli/tasks_claim.go
+++ b/cli/tasks_claim.go
@@ -8,13 +8,15 @@ import (
 
 	repocli "github.com/danmestas/EdgeSync/cli/repo"
 
+	"github.com/danmestas/bones/cli/uxprint"
 	"github.com/danmestas/bones/internal/tasks"
 )
 
 // TasksClaimCmd claims a task as the current agent.
 type TasksClaimCmd struct {
-	ID   string `arg:"" help:"task id"`
-	JSON bool   `name:"json" help:"emit JSON"`
+	ID    string `arg:"" help:"task id"`
+	JSON  bool   `name:"json" help:"emit JSON"`
+	Quiet bool   `name:"quiet" help:"suppress success output"`
 }
 
 // errClaimConflict is returned when a task is held by another agent.
@@ -73,6 +75,12 @@ func (c *TasksClaimCmd) Run(g *repocli.Globals) error {
 		}
 		if c.JSON {
 			return emitEnvelope(os.Stdout, "tasks.claim", taskToSchema(updated))
+		}
+		if !c.Quiet {
+			uxprint.Claimed(os.Stdout,
+				truncateID(updated.ID, 8),
+				truncateID(updated.ClaimedBy, 8),
+			)
 		}
 		return nil
 	}))

--- a/cli/tasks_close.go
+++ b/cli/tasks_close.go
@@ -169,14 +169,13 @@ func (c *TasksCloseCmd) autoReleaseAndClose(
 			return emitEnvelope(os.Stdout, "tasks.close", taskToSchema(updated))
 		}
 		if !c.Quiet {
-			// Auto-release path: emit one closed signature plus a
-			// summary line naming the released slot, so a vertical
-			// scan reads both effects of the verb. Per the brief,
-			// the legacy stderr advisory moves to stdout via these
-			// helpers.
+			// Auto-release path: emit one closed signature plus the
+			// released-slot signature so a vertical scan reads both
+			// effects of the verb. Both helpers come from cli/uxprint
+			// — the convention's source of truth for wording.
 			short := truncateID(c.ID, 8)
 			uxprint.Closed(os.Stdout, short)
-			_, _ = fmt.Fprintf(os.Stdout, "released slot %s (was bound to %s)\n", slot, short)
+			uxprint.SlotReleased(os.Stdout, slot, short)
 		}
 		return nil
 	}

--- a/cli/tasks_close.go
+++ b/cli/tasks_close.go
@@ -12,6 +12,7 @@ import (
 
 	repocli "github.com/danmestas/EdgeSync/cli/repo"
 
+	"github.com/danmestas/bones/cli/uxprint"
 	"github.com/danmestas/bones/internal/swarm"
 	"github.com/danmestas/bones/internal/tasks"
 	"github.com/danmestas/bones/internal/workspace"
@@ -34,6 +35,7 @@ type TasksCloseCmd struct {
 	Reason   string `name:"reason" help:"close reason (optional)"`
 	KeepSlot bool   `name:"keep-slot" help:"close the task; leave the swarm slot intact"`
 	JSON     bool   `name:"json" help:"emit JSON"`
+	Quiet    bool   `name:"quiet" help:"suppress success output"`
 }
 
 func (c *TasksCloseCmd) Run(g *repocli.Globals) error {
@@ -125,6 +127,9 @@ func (c *TasksCloseCmd) legacyClose(
 	if c.JSON {
 		return emitEnvelope(os.Stdout, "tasks.close", taskToSchema(updated))
 	}
+	if !c.Quiet {
+		uxprint.Closed(os.Stdout, truncateID(updated.ID, 8))
+	}
 	return nil
 }
 
@@ -154,8 +159,6 @@ func (c *TasksCloseCmd) autoReleaseAndClose(
 	}
 	closeErr := lease.Close(ctx, swarm.CloseOpts{CloseTaskOnSuccess: true})
 	if closeErr == nil {
-		fmt.Fprintf(os.Stderr,
-			"tasks close: closed task %s and released slot %s\n", c.ID, slot)
 		if c.JSON {
 			// Re-read the task so the JSON shape includes the close
 			// fields the lease/coord layer just wrote.
@@ -164,6 +167,16 @@ func (c *TasksCloseCmd) autoReleaseAndClose(
 				return err
 			}
 			return emitEnvelope(os.Stdout, "tasks.close", taskToSchema(updated))
+		}
+		if !c.Quiet {
+			// Auto-release path: emit one closed signature plus a
+			// summary line naming the released slot, so a vertical
+			// scan reads both effects of the verb. Per the brief,
+			// the legacy stderr advisory moves to stdout via these
+			// helpers.
+			short := truncateID(c.ID, 8)
+			uxprint.Closed(os.Stdout, short)
+			_, _ = fmt.Fprintf(os.Stdout, "released slot %s (was bound to %s)\n", slot, short)
 		}
 		return nil
 	}

--- a/cli/tasks_create.go
+++ b/cli/tasks_create.go
@@ -9,6 +9,7 @@ import (
 	repocli "github.com/danmestas/EdgeSync/cli/repo"
 	"github.com/google/uuid"
 
+	"github.com/danmestas/bones/cli/uxprint"
 	"github.com/danmestas/bones/internal/tasks"
 )
 
@@ -21,6 +22,7 @@ type TasksCreateCmd struct {
 	Slot       string   `name:"slot" help:"slot name; stamps Context[slot]"`
 	Context    []string `name:"context" help:"key=value (repeatable)" sep:"none"`
 	JSON       bool     `name:"json" help:"emit JSON"`
+	Quiet      bool     `name:"quiet" help:"suppress success output"`
 }
 
 func (c *TasksCreateCmd) Run(g *repocli.Globals) error {
@@ -86,7 +88,9 @@ func (c *TasksCreateCmd) Run(g *repocli.Globals) error {
 		if c.JSON {
 			return emitEnvelope(os.Stdout, "tasks.create", taskToSchema(t))
 		}
-		fmt.Println(t.ID)
+		if !c.Quiet {
+			uxprint.Created(os.Stdout, truncateID(t.ID, 8), t.Title)
+		}
 		return nil
 	}))
 }

--- a/cli/tasks_link.go
+++ b/cli/tasks_link.go
@@ -9,15 +9,17 @@ import (
 	repocli "github.com/danmestas/EdgeSync/cli/repo"
 
 	"github.com/danmestas/bones/cli/schemas"
+	"github.com/danmestas/bones/cli/uxprint"
 	"github.com/danmestas/bones/internal/coord"
 )
 
 // TasksLinkCmd links two tasks with a typed edge.
 type TasksLinkCmd struct {
-	From string `arg:"" help:"from task id"`
-	To   string `arg:"" help:"to task id"`
-	Type string `name:"type" help:"edge type: blocks|supersedes|duplicates|discovered-from"`
-	JSON bool   `name:"json" help:"emit JSON"`
+	From  string `arg:"" help:"from task id"`
+	To    string `arg:"" help:"to task id"`
+	Type  string `name:"type" help:"edge type: blocks|supersedes|duplicates|discovered-from"`
+	JSON  bool   `name:"json" help:"emit JSON"`
+	Quiet bool   `name:"quiet" help:"suppress success output"`
 }
 
 func (c *TasksLinkCmd) Run(g *repocli.Globals) error {
@@ -65,6 +67,13 @@ func (c *TasksLinkCmd) Run(g *repocli.Globals) error {
 				To:   string(to),
 				Type: string(edgeType),
 			})
+		}
+		if !c.Quiet {
+			uxprint.Linked(os.Stdout,
+				truncateID(string(from), 8),
+				truncateID(string(to), 8),
+				string(edgeType),
+			)
 		}
 		return nil
 	}))

--- a/cli/tasks_list.go
+++ b/cli/tasks_list.go
@@ -9,6 +9,7 @@ import (
 
 	repocli "github.com/danmestas/EdgeSync/cli/repo"
 
+	"github.com/danmestas/bones/cli/uxprint"
 	"github.com/danmestas/bones/internal/coord"
 	"github.com/danmestas/bones/internal/tasks"
 	"github.com/danmestas/bones/internal/workspace"
@@ -103,18 +104,54 @@ func (c *TasksListCmd) Run(g *repocli.Globals) error {
 			out = filterOrphans(out, liveAgentSet(peers))
 		}
 
-		// --by-slot replaces the per-task rendering with the per-slot
-		// summary (issue #214). Composes with the other filters: e.g.
-		// `--by-slot --claimed-by=-` shows hot slots among unclaimed
-		// open work. groupBySlot drops closed tasks even when --all is
-		// set — closed tasks free the slot, so counting them would
-		// misrepresent the serialization depth.
-		if c.BySlot {
-			return emitBySlot(os.Stdout, groupBySlot(out), c.JSON)
-		}
-
-		return emitTasks(out, c.JSON)
+		return c.render(out, allTasks)
 	}))
+}
+
+// render handles the final per-mode emission for `tasks list`:
+// --by-slot, the filter-emptiness hint, and the legacy plain/JSON
+// rendering. Pulled out of Run so the orchestration body stays under
+// the funlen budget while the rendering logic remains adjacent to
+// the filter pipeline that produced its inputs.
+func (c *TasksListCmd) render(out, allTasks []tasks.Task) error {
+	// --by-slot replaces the per-task rendering with the per-slot
+	// summary (issue #214). Composes with the other filters: e.g.
+	// `--by-slot --claimed-by=-` shows hot slots among unclaimed
+	// open work. groupBySlot drops closed tasks even when --all is
+	// set — closed tasks free the slot, so counting them would
+	// misrepresent the serialization depth.
+	if c.BySlot {
+		return emitBySlot(os.Stdout, groupBySlot(out), c.JSON)
+	}
+
+	// Filter-emptiness hint: when the human-mode result is empty
+	// but closed tasks exist, point the operator at --all so they
+	// can tell "the filter hid closed rows" from "there is nothing
+	// to list at all". JSON output skips the hint — JSON consumers
+	// see the empty array; the hint is human-only by design (issue
+	// #323's read-verb rule).
+	if !c.JSON && len(out) == 0 && !c.All {
+		closedCount := countClosed(allTasks)
+		if closedCount > 0 {
+			uxprint.NoOpenTasks(os.Stdout, closedCount)
+			return nil
+		}
+	}
+
+	return emitTasks(out, c.JSON)
+}
+
+// countClosed returns the number of closed tasks in in. Used by the
+// filter-emptiness hint logic in tasks_list.go to decide whether to
+// emit the (no open tasks; N closed — pass --all) line.
+func countClosed(in []tasks.Task) int {
+	n := 0
+	for _, t := range in {
+		if t.Status == tasks.StatusClosed {
+			n++
+		}
+	}
+	return n
 }
 
 // filterTasks applies the always-on list filters (closed-vs-all, status,

--- a/cli/tasks_ready.go
+++ b/cli/tasks_ready.go
@@ -9,6 +9,7 @@ import (
 
 	repocli "github.com/danmestas/EdgeSync/cli/repo"
 
+	"github.com/danmestas/bones/cli/uxprint"
 	"github.com/danmestas/bones/internal/tasks"
 	"github.com/danmestas/bones/internal/workspace"
 )
@@ -61,7 +62,32 @@ func (c *TasksReadyCmd) run(
 	}
 
 	ready := selectReady(all, c.Slot, c.Mine, info.AgentID, c.Limit, time.Now().UTC())
+	// Filter-emptiness hint: when no ready tasks survive the filter
+	// pipeline but the workspace has open tasks, point the operator
+	// at the broaden-the-filter escape hatch. Silent when the
+	// workspace truly has no open tasks at all.
+	if !c.JSON && len(ready) == 0 {
+		openCount := countOpen(all)
+		if openCount > 0 {
+			uxprint.NoReadyTasks(out, openCount)
+			return nil
+		}
+	}
 	return emitReady(out, ready, c.JSON)
+}
+
+// countOpen returns the number of non-closed tasks. Used by the
+// filter-emptiness hint logic in tasks_ready.go to distinguish "the
+// readiness/slot/mine filter hid all rows" from "there is nothing
+// open to be ready".
+func countOpen(in []tasks.Task) int {
+	n := 0
+	for _, t := range in {
+		if t.Status != tasks.StatusClosed {
+			n++
+		}
+	}
+	return n
 }
 
 // selectReady runs the full filter pipeline used by `bones tasks

--- a/cli/tasks_update.go
+++ b/cli/tasks_update.go
@@ -2,12 +2,14 @@ package cli
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"time"
 
 	repocli "github.com/danmestas/EdgeSync/cli/repo"
 
+	"github.com/danmestas/bones/cli/uxprint"
 	"github.com/danmestas/bones/internal/tasks"
 )
 
@@ -24,6 +26,7 @@ type TasksUpdateCmd struct {
 	Context    []string `name:"context" help:"key=value (repeatable; merges)" sep:"none"`
 	ClaimedBy  *string  `name:"claimed-by" help:"agent id to claim as"`
 	JSON       bool     `name:"json" help:"emit JSON"`
+	Quiet      bool     `name:"quiet" help:"suppress success output"`
 }
 
 func (c *TasksUpdateCmd) Run(g *repocli.Globals) error {
@@ -63,43 +66,96 @@ func (c *TasksUpdateCmd) Run(g *repocli.Globals) error {
 			return err
 		}
 
-		// Pre-read so we can author real (field, old, new) tuples for
-		// the updated event payload. The CAS retry loop inside Tx
-		// handles racing writers; the tuples we emit reflect the
-		// pre-image we observed plus the mutator's intent.
-		before, _, err := mgr.Get(ctx, c.ID)
-		if err != nil {
-			return err
-		}
-		var updated tasks.Task
-		mutate := buildUpdateMutator(c, statusUpdate, parsedDeferUntil, &updated)
-		// Run the mutator against a copy to derive the post-image for
-		// the event payload. The same closure runs again inside Tx's
-		// CAS loop; both invocations are idempotent.
-		afterPreview, mErr := mutate(before)
-		if mErr != nil {
-			return mErr
-		}
-		changes := diffTaskFields(before, afterPreview)
-		if len(changes) == 0 {
-			// Nothing changed — short-circuit so we do not emit an
-			// empty event. Idempotent on the CLI side.
-			updated = before
-			if c.JSON {
-				return emitEnvelope(os.Stdout, "tasks.update", taskToSchema(updated))
-			}
-			return nil
-		}
-		if err := mgr.Tx(ctx, c.ID, func(tx *tasks.Tx) error {
-			return tx.Update(mutate, changes...)
-		}); err != nil {
-			return err
-		}
+		return c.applyAndEmit(ctx, mgr, statusUpdate, parsedDeferUntil)
+	}))
+}
+
+// applyAndEmit runs the read-modify-write update sequence and emits
+// the per-mode output (JSON envelope, uxprint.Updated signature, or
+// silent --quiet). Pulled out of Run so the orchestration body fits
+// the funlen budget; the CAS-retry loop and idempotent short-circuit
+// stay grouped here where they're easiest to reason about together.
+func (c *TasksUpdateCmd) applyAndEmit(
+	ctx context.Context,
+	mgr *tasks.Manager,
+	statusUpdate tasks.Status,
+	parsedDeferUntil *time.Time,
+) error {
+	// Pre-read so we can author real (field, old, new) tuples for
+	// the updated event payload. The CAS retry loop inside Tx
+	// handles racing writers; the tuples we emit reflect the
+	// pre-image we observed plus the mutator's intent.
+	before, _, err := mgr.Get(ctx, c.ID)
+	if err != nil {
+		return err
+	}
+	var updated tasks.Task
+	mutate := buildUpdateMutator(c, statusUpdate, parsedDeferUntil, &updated)
+	// Run the mutator against a copy to derive the post-image for
+	// the event payload. The same closure runs again inside Tx's
+	// CAS loop; both invocations are idempotent.
+	afterPreview, mErr := mutate(before)
+	if mErr != nil {
+		return mErr
+	}
+	changes := diffTaskFields(before, afterPreview)
+	if len(changes) == 0 {
+		// Nothing changed — short-circuit so we do not emit an
+		// empty event. Idempotent on the CLI side.
+		updated = before
 		if c.JSON {
 			return emitEnvelope(os.Stdout, "tasks.update", taskToSchema(updated))
 		}
+		if !c.Quiet {
+			uxprint.Updated(os.Stdout, truncateID(updated.ID, 8), nil)
+		}
 		return nil
-	}))
+	}
+	if err := mgr.Tx(ctx, c.ID, func(tx *tasks.Tx) error {
+		return tx.Update(mutate, changes...)
+	}); err != nil {
+		return err
+	}
+	if c.JSON {
+		return emitEnvelope(os.Stdout, "tasks.update", taskToSchema(updated))
+	}
+	if !c.Quiet {
+		fields := changeFieldsMap(changes)
+		uxprint.Updated(os.Stdout, truncateID(updated.ID, 8), fields)
+	}
+	return nil
+}
+
+// changeFieldsMap converts a slice of tasks.FieldChange into the
+// flat map[string]any shape uxprint.Updated consumes. Each change's
+// New JSON is decoded into a Go value (string for primitives, the
+// raw JSON shape for arrays/objects) so the rendered signature reads
+// naturally — a title of "X" prints as title=X, a slot of "beta"
+// prints as slot=beta, and a structural change (files, context)
+// prints with the JSON literal for context.
+func changeFieldsMap(changes []tasks.FieldChange) map[string]any {
+	out := make(map[string]any, len(changes))
+	for _, ch := range changes {
+		// Try to decode into a generic any so strings render as
+		// strings, numbers as numbers, etc. Failing that, fall back
+		// to the raw JSON literal.
+		var v any
+		if err := json.Unmarshal(ch.New, &v); err == nil {
+			switch typed := v.(type) {
+			case string:
+				out[ch.Field] = typed
+			case float64:
+				// json.Unmarshal into any uses float64 for all
+				// numbers; render as %v which trims trailing zeros.
+				out[ch.Field] = typed
+			default:
+				out[ch.Field] = string(ch.New)
+			}
+			continue
+		}
+		out[ch.Field] = string(ch.New)
+	}
+	return out
 }
 
 // diffTaskFields returns the FieldChange tuples describing the

--- a/cli/uxprint/uxprint.go
+++ b/cli/uxprint/uxprint.go
@@ -75,6 +75,21 @@ func SlotChanged(w io.Writer, shortID, to string) {
 	_, _ = fmt.Fprintf(w, "slot     %s  to=%s\n", shortID, to)
 }
 
+// SlotReleased prints the one-line "released" signature emitted by
+// the `tasks close --auto-release` path when the swarm slot bound to
+// the closed task is released as part of the same operation.
+//
+//	released <slot>  was=<shortID>
+//
+// Shape mirrors Claimed's `by=<agent>` key=value tail so the
+// convention's "verb first, then key=value pairs" pattern stays
+// consistent across helpers. The slot name takes the verb-column
+// because the slot is the entity being released; the released-from
+// task short id is the attribution attached to it.
+func SlotReleased(w io.Writer, slot, shortID string) {
+	_, _ = fmt.Fprintf(w, "released %s  was=%s\n", slot, shortID)
+}
+
 // Updated prints the one-line "updated" signature, listing the
 // fields that changed as `key=value` pairs in stable (sorted) order.
 //

--- a/cli/uxprint/uxprint.go
+++ b/cli/uxprint/uxprint.go
@@ -1,0 +1,169 @@
+// Package uxprint is the single source of truth for one-line success
+// signatures emitted by bones state-mutating CLI verbs.
+//
+// Issue #323 establishes a CLI-wide convention: every state-mutating
+// verb prints a one-line success signature ("verb shortID key=value
+// pairs") on the human stdout path unless --quiet is passed. Read
+// verbs stay silent on success, but emit a filter-emptiness hint when
+// the user's filter hid existing rows. The helpers in this package
+// pin the wording so the convention can not drift verb-by-verb.
+//
+// Helpers are intentionally plain io.Writer + string wrappers around
+// fmt.Fprintf — not rich types over Task / Edge / Slot structs. The
+// per-verb call site decides what to pass; the helper only fixes the
+// format. ADR 0053's --json output paths bypass uxprint entirely (the
+// envelope wraps the typed payload; uxprint is human stdout only).
+package uxprint
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+)
+
+// Created prints the one-line "created" signature.
+//
+//	created  <shortID>  "<title>"
+//
+// shortID is the human-mode 8-char id; title is quoted with %q so
+// embedded spaces and quotes round-trip safely.
+func Created(w io.Writer, shortID, title string) {
+	_, _ = fmt.Fprintf(w, "created  %s  %q\n", shortID, title)
+}
+
+// Claimed prints the one-line "claimed" signature.
+//
+//	claimed  <shortID>  by=<agentShort>
+func Claimed(w io.Writer, shortID, agentShort string) {
+	_, _ = fmt.Fprintf(w, "claimed  %s  by=%s\n", shortID, agentShort)
+}
+
+// Unclaimed prints the one-line "unclaimed" signature, used when a
+// task transitions out of the claimed state (auto-release, manual
+// unclaim).
+//
+//	unclaimed  <shortID>  reason="<reason>"
+func Unclaimed(w io.Writer, shortID, reason string) {
+	_, _ = fmt.Fprintf(w, "unclaimed  %s  reason=%q\n", shortID, reason)
+}
+
+// Closed prints the one-line "closed" signature.
+//
+//	closed   <shortID>
+//
+// Reason is intentionally NOT in the default signature — the
+// majority of closes carry no reason. Callers needing a richer
+// breakdown should compose their own line; the convention's job
+// here is the minimum readable signal.
+func Closed(w io.Writer, shortID string) {
+	_, _ = fmt.Fprintf(w, "closed   %s\n", shortID)
+}
+
+// Linked prints the one-line "linked" signature for `tasks link`.
+//
+//	linked   <fromShort> → <toShort> (<edgeType>)
+func Linked(w io.Writer, fromShort, toShort, edgeType string) {
+	_, _ = fmt.Fprintf(w, "linked   %s → %s (%s)\n", fromShort, toShort, edgeType)
+}
+
+// SlotChanged prints the one-line "slot" signature, used by any verb
+// that changes a task's slot annotation.
+//
+//	slot     <shortID>  to=<slotName>
+func SlotChanged(w io.Writer, shortID, to string) {
+	_, _ = fmt.Fprintf(w, "slot     %s  to=%s\n", shortID, to)
+}
+
+// Updated prints the one-line "updated" signature, listing the
+// fields that changed as `key=value` pairs in stable (sorted) order.
+//
+//	updated  <shortID>  title="X" slot=beta status=closed
+//
+// Values are quoted with %q when they contain whitespace or special
+// characters; everything else is rendered bare so machine-friendly
+// values (uuid, status enum) read cleanly.
+func Updated(w io.Writer, shortID string, fields map[string]any) {
+	if len(fields) == 0 {
+		_, _ = fmt.Fprintf(w, "updated  %s\n", shortID)
+		return
+	}
+	keys := make([]string, 0, len(fields))
+	for k := range fields {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, k := range keys {
+		parts = append(parts, fmt.Sprintf("%s=%s", k, formatValue(fields[k])))
+	}
+	_, _ = fmt.Fprintf(w, "updated  %s  %s\n", shortID, strings.Join(parts, " "))
+}
+
+// Summary prints the one-line "<n> <noun> <verb>" tail used by
+// multi-target mutating verbs. Pluralization is the caller's job —
+// "task" vs "tasks" is supplied via the noun argument.
+//
+//	2 tasks created
+//	1 wave advanced
+func Summary(w io.Writer, n int, noun, verb string) {
+	_, _ = fmt.Fprintf(w, "%d %s %s\n", n, noun, verb)
+}
+
+// NoOpenTasks prints the filter-emptiness hint emitted by `tasks
+// list` (and read verbs that gate on open/closed) when the filter
+// hid existing closed rows.
+//
+//	(no open tasks; <n> closed — pass --all to include)
+//
+// Caller must only invoke this when (closedCount > 0). When the
+// underlying set is genuinely empty, the verb stays silent — the
+// hint exists to disambiguate "your filter hid these" from "there
+// is nothing here", not to add chatter.
+func NoOpenTasks(w io.Writer, closedCount int) {
+	_, _ = fmt.Fprintf(w, "(no open tasks; %d closed — pass --all to include)\n", closedCount)
+}
+
+// NoPeersOnline prints the filter-emptiness hint for swarm/peers
+// listings when the filter hid stale presences.
+//
+//	(no peers online; <n> stale presences shown — pass --all to include)
+func NoPeersOnline(w io.Writer, stalePresences int) {
+	_, _ = fmt.Fprintf(w,
+		"(no peers online; %d stale presences shown — pass --all to include)\n",
+		stalePresences)
+}
+
+// NoRecentActivity prints the filter-emptiness hint for activity
+// windows when the --since cutoff hid older rows.
+//
+//	(no recent activity in last <since>; older history available with --since=)
+func NoRecentActivity(w io.Writer, sinceDuration string) {
+	_, _ = fmt.Fprintf(w,
+		"(no recent activity in last %s; older history available with --since=)\n",
+		sinceDuration)
+}
+
+// NoReadyTasks prints the filter-emptiness hint for `tasks ready`
+// when the readiness gate or slot/mine filter hid existing rows.
+//
+//	(no ready tasks matching filter; <n> open tasks total — broaden filter)
+func NoReadyTasks(w io.Writer, openCount int) {
+	_, _ = fmt.Fprintf(w,
+		"(no ready tasks matching filter; %d open tasks total — broaden filter)\n",
+		openCount)
+}
+
+// formatValue renders a fields-map value for Updated. Strings with
+// whitespace get %q quotation; everything else is rendered with %v.
+// Kept private so callers can not bypass the quoting choice — the
+// convention's whole point is that one wording lives in one place.
+func formatValue(v any) string {
+	if s, ok := v.(string); ok {
+		if strings.ContainsAny(s, " \t\"\\") {
+			return fmt.Sprintf("%q", s)
+		}
+		return s
+	}
+	return fmt.Sprintf("%v", v)
+}

--- a/cli/uxprint/uxprint_test.go
+++ b/cli/uxprint/uxprint_test.go
@@ -1,0 +1,183 @@
+package uxprint
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// Each test pins the exact format string the verb sweep depends on.
+// The point of the helpers is that no one verb gets to invent its own
+// wording; the tests document the wording so a careless edit trips
+// here before it ships in a verb.
+
+func TestCreated(t *testing.T) {
+	var buf bytes.Buffer
+	Created(&buf, "e075b52a", "spy-phase-4 smoke test")
+	want := "created  e075b52a  \"spy-phase-4 smoke test\"\n"
+	if got := buf.String(); got != want {
+		t.Fatalf("Created: got %q want %q", got, want)
+	}
+}
+
+func TestClaimed(t *testing.T) {
+	var buf bytes.Buffer
+	Claimed(&buf, "e075b52a", "dc584303")
+	want := "claimed  e075b52a  by=dc584303\n"
+	if got := buf.String(); got != want {
+		t.Fatalf("Claimed: got %q want %q", got, want)
+	}
+}
+
+func TestUnclaimed(t *testing.T) {
+	var buf bytes.Buffer
+	Unclaimed(&buf, "e075b52a", "manual")
+	want := "unclaimed  e075b52a  reason=\"manual\"\n"
+	if got := buf.String(); got != want {
+		t.Fatalf("Unclaimed: got %q want %q", got, want)
+	}
+}
+
+func TestClosed(t *testing.T) {
+	var buf bytes.Buffer
+	Closed(&buf, "e075b52a")
+	want := "closed   e075b52a\n"
+	if got := buf.String(); got != want {
+		t.Fatalf("Closed: got %q want %q", got, want)
+	}
+}
+
+func TestLinked(t *testing.T) {
+	var buf bytes.Buffer
+	Linked(&buf, "e075b52a", "b1c2d3e4", "blocks")
+	want := "linked   e075b52a → b1c2d3e4 (blocks)\n"
+	if got := buf.String(); got != want {
+		t.Fatalf("Linked: got %q want %q", got, want)
+	}
+}
+
+func TestSlotChanged(t *testing.T) {
+	var buf bytes.Buffer
+	SlotChanged(&buf, "e075b52a", "alpha")
+	want := "slot     e075b52a  to=alpha\n"
+	if got := buf.String(); got != want {
+		t.Fatalf("SlotChanged: got %q want %q", got, want)
+	}
+}
+
+// TestUpdated covers the three shapes of the updated signature:
+// no-fields, single field, multi-field with sorted keys, and value
+// quoting for whitespace / quote-bearing strings.
+func TestUpdated(t *testing.T) {
+	cases := []struct {
+		name   string
+		fields map[string]any
+		want   string
+	}{
+		{
+			"no_fields",
+			nil,
+			"updated  e075b52a\n",
+		},
+		{
+			"single_field",
+			map[string]any{"slot": "beta"},
+			"updated  e075b52a  slot=beta\n",
+		},
+		{
+			"multi_field_sorted",
+			map[string]any{"title": "X", "slot": "beta"},
+			"updated  e075b52a  slot=beta title=X\n",
+		},
+		{
+			"title_with_space_quoted",
+			map[string]any{"title": "Hello World"},
+			"updated  e075b52a  title=\"Hello World\"\n",
+		},
+		{
+			"int_value_renders_bare",
+			map[string]any{"priority": 3},
+			"updated  e075b52a  priority=3\n",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			Updated(&buf, "e075b52a", tc.fields)
+			if got := buf.String(); got != tc.want {
+				t.Fatalf("Updated: got %q want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestSummary round-trips the multi-target summary line. The brief's
+// example "2 tasks created" is the canonical shape.
+func TestSummary(t *testing.T) {
+	var buf bytes.Buffer
+	Summary(&buf, 2, "tasks", "created")
+	want := "2 tasks created\n"
+	if got := buf.String(); got != want {
+		t.Fatalf("Summary: got %q want %q", got, want)
+	}
+}
+
+func TestNoOpenTasks(t *testing.T) {
+	var buf bytes.Buffer
+	NoOpenTasks(&buf, 1)
+	want := "(no open tasks; 1 closed — pass --all to include)\n"
+	if got := buf.String(); got != want {
+		t.Fatalf("NoOpenTasks: got %q want %q", got, want)
+	}
+}
+
+func TestNoPeersOnline(t *testing.T) {
+	var buf bytes.Buffer
+	NoPeersOnline(&buf, 0)
+	want := "(no peers online; 0 stale presences shown — pass --all to include)\n"
+	if got := buf.String(); got != want {
+		t.Fatalf("NoPeersOnline: got %q want %q", got, want)
+	}
+}
+
+func TestNoRecentActivity(t *testing.T) {
+	var buf bytes.Buffer
+	NoRecentActivity(&buf, "24h")
+	want := "(no recent activity in last 24h; older history available with --since=)\n"
+	if got := buf.String(); got != want {
+		t.Fatalf("NoRecentActivity: got %q want %q", got, want)
+	}
+}
+
+func TestNoReadyTasks(t *testing.T) {
+	var buf bytes.Buffer
+	NoReadyTasks(&buf, 5)
+	want := "(no ready tasks matching filter; 5 open tasks total — broaden filter)\n"
+	if got := buf.String(); got != want {
+		t.Fatalf("NoReadyTasks: got %q want %q", got, want)
+	}
+}
+
+// TestVerbAlignment: the brief specifies "verb first" so that lines
+// align in vertical scans of `bones tasks watch`. The verbs use a
+// padding column to vertically align the short-id; this test asserts
+// the column position so a future drift in spacing is caught.
+func TestVerbAlignment(t *testing.T) {
+	var buf bytes.Buffer
+	Created(&buf, "01234567", "x")
+	Claimed(&buf, "01234567", "abcd")
+	Closed(&buf, "01234567")
+	Linked(&buf, "01234567", "76543210", "blocks")
+	SlotChanged(&buf, "01234567", "beta")
+	Updated(&buf, "01234567", map[string]any{"slot": "beta"})
+
+	lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
+	// Each line's id starts at the same byte offset because every verb
+	// pads its column to the same width with two trailing spaces.
+	for _, ln := range lines {
+		idx := strings.Index(ln, "01234567")
+		if idx != 9 {
+			t.Errorf("short-id misaligned in %q (idx=%d, want 9)", ln, idx)
+		}
+	}
+}

--- a/cli/uxprint/uxprint_test.go
+++ b/cli/uxprint/uxprint_test.go
@@ -65,6 +65,19 @@ func TestSlotChanged(t *testing.T) {
 	}
 }
 
+// TestSlotReleased pins the auto-release secondary line emitted by
+// tasks_close.go's --auto-release path. The `was=<short>` tail
+// mirrors Claimed's `by=<agent>` shape so the convention's
+// "verb first, then key=value" pattern stays consistent.
+func TestSlotReleased(t *testing.T) {
+	var buf bytes.Buffer
+	SlotReleased(&buf, "alpha", "e075b52a")
+	want := "released alpha  was=e075b52a\n"
+	if got := buf.String(); got != want {
+		t.Fatalf("SlotReleased: got %q want %q", got, want)
+	}
+}
+
 // TestUpdated covers the three shapes of the updated signature:
 // no-fields, single field, multi-field with sorted keys, and value
 // quoting for whitespace / quote-bearing strings.

--- a/cli/uxprint_enforce_test.go
+++ b/cli/uxprint_enforce_test.go
@@ -1,0 +1,186 @@
+package cli
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// mutatingVerbs is the curated allowlist of state-mutating CLI verbs
+// per issue #323. Every entry is the dotted verb name plus the source
+// file containing its `*Cmd` struct and Run method. The AST walk
+// asserts each Run method (or a helper it directly calls) reaches
+// either a `uxprint.X` call or a `c.Quiet` short-circuit so the verb
+// either prints the success signature or has explicitly opted out.
+//
+// Adding a new mutating verb means adding a row here AND wiring an
+// uxprint helper into its Run method — the test enforces both halves
+// of the convention.
+var mutatingVerbs = []struct {
+	verb string
+	file string
+}{
+	{"tasks.claim", "tasks_claim.go"},
+	{"tasks.close", "tasks_close.go"},
+	{"tasks.create", "tasks_create.go"},
+	{"tasks.update", "tasks_update.go"},
+	{"tasks.link", "tasks_link.go"},
+	{"swarm.dispatch", "swarm_dispatch.go"},
+}
+
+// TestEveryMutatingVerbCallsUxprint walks each entry in mutatingVerbs
+// and asserts the file's AST contains at least one `uxprint.X` call
+// reachable from a Run method (directly, or transitively via a
+// helper inside the same file). A `c.Quiet` reference satisfies the
+// rule too — that's the explicit short-circuit guard the convention
+// permits — so a fixture verb that consults `c.Quiet` and never calls
+// uxprint still passes structurally even though the runtime would
+// stay silent.
+//
+// This is the structural backstop. Per-verb integration tests pin the
+// runtime stdout shape; this test catches a future verb that ships
+// without ever hooking the helper at all.
+func TestEveryMutatingVerbCallsUxprint(t *testing.T) {
+	cliDir := repoSubdir(t, "cli")
+	fset := token.NewFileSet()
+
+	for _, mv := range mutatingVerbs {
+		mv := mv
+		t.Run(mv.verb, func(t *testing.T) {
+			path := filepath.Join(cliDir, mv.file)
+			file, err := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
+			if err != nil {
+				t.Fatalf("parse %s: %v", path, err)
+			}
+			if !fileReferencesUxprintOrQuiet(file) {
+				t.Errorf("%s (%s) does not reference uxprint.* nor c.Quiet — "+
+					"every state-mutating verb must call a uxprint helper "+
+					"on its success path or explicitly short-circuit on "+
+					"--quiet (see issue #323 / cli/uxprint)",
+					mv.verb, mv.file)
+			}
+		})
+	}
+}
+
+// TestPlantedFailureCatchesMissingUxprint is the meta-test that proves
+// the enforcement walker actually fails when its precondition is
+// violated. We synthesize a Go source string that defines a Run method
+// with no uxprint reference and no Quiet field, parse it, and assert
+// fileReferencesUxprintOrQuiet returns false.
+//
+// The brief asks for "a fixture-only command that mutates state but
+// doesn't call uxprint; confirm test catches it." We build the fixture
+// in-memory rather than in a real file so we don't have to add and
+// remove a stub command from the real cli package.
+func TestPlantedFailureCatchesMissingUxprint(t *testing.T) {
+	src := `package cli
+
+type FixtureNoUxprintCmd struct {
+	ID string ` + "`arg:\"\" help:\"task id\"`" + `
+}
+
+func (c *FixtureNoUxprintCmd) Run() error {
+	// Mutates state, prints nothing, no Quiet flag.
+	return nil
+}
+`
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "fixture.go", src, parser.SkipObjectResolution)
+	if err != nil {
+		t.Fatalf("parse fixture: %v", err)
+	}
+	if fileReferencesUxprintOrQuiet(file) {
+		t.Fatalf("fixture without uxprint or Quiet should fail enforcement, but passed")
+	}
+}
+
+// TestPlantedSuccessAllowsUxprintCall is the matched positive: a
+// fixture that calls uxprint.Created passes enforcement.
+func TestPlantedSuccessAllowsUxprintCall(t *testing.T) {
+	src := `package cli
+
+import "github.com/danmestas/bones/cli/uxprint"
+
+type FixtureWithUxprintCmd struct {
+	Quiet bool
+}
+
+func (c *FixtureWithUxprintCmd) Run() error {
+	if !c.Quiet {
+		uxprint.Created(nil, "shortid", "title")
+	}
+	return nil
+}
+`
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "fixture.go", src, parser.SkipObjectResolution)
+	if err != nil {
+		t.Fatalf("parse fixture: %v", err)
+	}
+	if !fileReferencesUxprintOrQuiet(file) {
+		t.Fatalf("fixture with uxprint call must pass enforcement, but failed")
+	}
+}
+
+// fileReferencesUxprintOrQuiet returns true when the file contains
+// either a `uxprint.<Name>(...)` call or any reference to a Quiet
+// field on a receiver named `c`. Either is sufficient evidence that
+// the convention has been considered.
+//
+// Implementation detail: we don't try to walk only the `Run` method
+// — a verb is allowed to delegate the print to a helper inside the
+// same file (e.g. tasks_aggregate.go's emitAggregateOutput, called
+// from Run). Searching the whole file catches the helper-delegated
+// case without false negatives.
+func fileReferencesUxprintOrQuiet(file *ast.File) bool {
+	hasUxprintImport := false
+	for _, imp := range file.Imports {
+		if imp.Path == nil {
+			continue
+		}
+		// imp.Path.Value is quoted; trim and compare.
+		path := strings.Trim(imp.Path.Value, `"`)
+		if path == "github.com/danmestas/bones/cli/uxprint" ||
+			strings.HasSuffix(path, "/cli/uxprint") {
+			hasUxprintImport = true
+			break
+		}
+	}
+
+	found := false
+	ast.Inspect(file, func(n ast.Node) bool {
+		if found {
+			return false
+		}
+		// Match `uxprint.X(...)` selector calls.
+		if call, ok := n.(*ast.CallExpr); ok {
+			if sel, ok := call.Fun.(*ast.SelectorExpr); ok {
+				if id, ok := sel.X.(*ast.Ident); ok && id.Name == "uxprint" {
+					found = true
+					return false
+				}
+			}
+		}
+		// Match `c.Quiet` field references on a receiver named c.
+		if sel, ok := n.(*ast.SelectorExpr); ok {
+			if sel.Sel != nil && sel.Sel.Name == "Quiet" {
+				if id, ok := sel.X.(*ast.Ident); ok && id.Name == "c" {
+					found = true
+					return false
+				}
+			}
+		}
+		return true
+	})
+	if found {
+		return true
+	}
+	// If the file imports uxprint, treat that as evidence — covers
+	// the rare case where the call is constructed via an intermediate
+	// (e.g. `print := uxprint.Created; print(...)`).
+	return hasUxprintImport
+}

--- a/cli/uxprint_filter_hint_test.go
+++ b/cli/uxprint_filter_hint_test.go
@@ -1,0 +1,179 @@
+package cli
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/danmestas/bones/internal/tasks"
+)
+
+// TestCountClosedFilterHintPredicate asserts that countClosed produces
+// the count tasks_list.go drives the (no open tasks; N closed —
+// pass --all to include) hint with. The hint is gated on this count
+// being > 0 — when the count is zero, the verb stays silent (no
+// tasks at all is genuine emptiness, not filter-induced).
+func TestCountClosedFilterHintPredicate(t *testing.T) {
+	all := []tasks.Task{
+		{ID: "a", Status: tasks.StatusOpen},
+		{ID: "b", Status: tasks.StatusClaimed},
+		{ID: "c", Status: tasks.StatusClosed},
+		{ID: "d", Status: tasks.StatusClosed},
+	}
+	if got := countClosed(all); got != 2 {
+		t.Errorf("countClosed: got %d want 2", got)
+	}
+	if got := countClosed(nil); got != 0 {
+		t.Errorf("countClosed(nil): got %d want 0", got)
+	}
+	if got := countClosed([]tasks.Task{
+		{ID: "x", Status: tasks.StatusOpen},
+	}); got != 0 {
+		t.Errorf("countClosed all-open: got %d want 0", got)
+	}
+}
+
+// TestCountOpenFilterHintPredicate asserts that countOpen produces
+// the count tasks_ready.go uses to decide whether "(no ready tasks
+// matching filter; N open tasks total — broaden filter)" should
+// fire. Closed tasks must not count — they are not candidates for
+// readiness.
+func TestCountOpenFilterHintPredicate(t *testing.T) {
+	all := []tasks.Task{
+		{ID: "a", Status: tasks.StatusOpen},
+		{ID: "b", Status: tasks.StatusClaimed},
+		{ID: "c", Status: tasks.StatusClosed},
+	}
+	if got := countOpen(all); got != 2 {
+		t.Errorf("countOpen: got %d want 2", got)
+	}
+	if got := countOpen(nil); got != 0 {
+		t.Errorf("countOpen(nil): got %d want 0", got)
+	}
+}
+
+// TestChangeFieldsMapDecodesJSONValues asserts that the
+// FieldChange-to-fields-map helper used by `tasks update` renders
+// JSON-encoded values as plain Go primitives so uxprint.Updated
+// produces "title=X" rather than 'title="\"X\""'.
+func TestChangeFieldsMapDecodesJSONValues(t *testing.T) {
+	mustJSON := func(v any) json.RawMessage {
+		b, err := json.Marshal(v)
+		if err != nil {
+			t.Fatalf("marshal %v: %v", v, err)
+		}
+		return b
+	}
+	changes := []tasks.FieldChange{
+		{Field: "title", Old: mustJSON("old"), New: mustJSON("new title")},
+		{Field: "status", Old: mustJSON("open"), New: mustJSON("claimed")},
+	}
+	got := changeFieldsMap(changes)
+
+	// Strings should land as Go strings (so uxprint quotes whitespace
+	// only when present, not unconditionally).
+	if v, ok := got["title"].(string); !ok || v != "new title" {
+		t.Errorf("title decoded incorrectly: got %#v", got["title"])
+	}
+	if v, ok := got["status"].(string); !ok || v != "claimed" {
+		t.Errorf("status decoded incorrectly: got %#v", got["status"])
+	}
+}
+
+// TestChangeFieldsMapStructuralValuesFallbackToJSON: when a
+// FieldChange.New is a non-primitive (object, array), the helper
+// falls back to the raw JSON literal. uxprint.Updated then renders
+// it bare via %v — readable, even if not as terse as a primitive.
+func TestChangeFieldsMapStructuralValuesFallbackToJSON(t *testing.T) {
+	mustJSON := func(v any) json.RawMessage {
+		b, err := json.Marshal(v)
+		if err != nil {
+			t.Fatalf("marshal %v: %v", v, err)
+		}
+		return b
+	}
+	changes := []tasks.FieldChange{
+		{Field: "files", Old: mustJSON([]string{"a"}), New: mustJSON([]string{"a", "b"})},
+	}
+	got := changeFieldsMap(changes)
+	if v, ok := got["files"].(string); !ok {
+		t.Errorf("files should decode to its JSON literal string; got %#v", got["files"])
+	} else if !strings.Contains(v, `"a"`) {
+		t.Errorf("files JSON literal should contain quoted strings; got %q", v)
+	}
+}
+
+// TestPluralizeForDispatchSummary pins the helper used by the
+// swarm.dispatch multi-target summary line. "1 task created" is the
+// brief's canonical singular shape; counts above 1 are pluralized.
+func TestPluralizeForDispatchSummary(t *testing.T) {
+	if got := pluralize("task", 1); got != "task" {
+		t.Errorf("pluralize task 1: got %q want %q", got, "task")
+	}
+	if got := pluralize("task", 2); got != "tasks" {
+		t.Errorf("pluralize task 2: got %q want %q", got, "tasks")
+	}
+	if got := pluralize("task", 0); got != "tasks" {
+		t.Errorf("pluralize task 0: got %q want %q", got, "tasks")
+	}
+}
+
+// TestSortStringsLocalHelper asserts the local sortStrings helper in
+// swarm_dispatch.go produces lexical order so the per-task
+// "created <id> <slot>" lines are reproducible across runs (taskIDs
+// is a Go map; iteration order is unstable without an explicit
+// sort).
+func TestSortStringsLocalHelper(t *testing.T) {
+	in := []string{"gamma", "alpha", "beta"}
+	sortStrings(in)
+	want := []string{"alpha", "beta", "gamma"}
+	if !equalSlices(in, want) {
+		t.Errorf("sortStrings: got %v want %v", in, want)
+	}
+}
+
+// equalSlices is a one-purpose helper for the sort test above. The
+// project has filesEqual in tasks_update.go; duplicating here keeps
+// this test file independent of unrelated diff helpers.
+func equalSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// TestPrintAggregateSummaryFilterHint asserts that
+// printAggregateSummary emits NoRecentActivity when hasOlder is true
+// (filter-induced empty window) and the legacy "(no tasks in
+// window)" line when hasOlder is false (genuine empty workspace).
+//
+// Reuses captureStdout from status_test.go in the same package (the
+// helper takes (t) and returns the buffer + a finish closure).
+func TestPrintAggregateSummaryFilterHint(t *testing.T) {
+	buf, finish := captureStdout(t)
+	if err := printAggregateSummary(0, nil, 0, 0, true); err != nil {
+		t.Fatalf("printAggregateSummary hasOlder=true: %v", err)
+	}
+	finish()
+	if !strings.Contains(buf.String(), "no recent activity") {
+		t.Errorf("hasOlder=true must emit NoRecentActivity hint; got %q", buf.String())
+	}
+
+	buf2, finish2 := captureStdout(t)
+	if err := printAggregateSummary(0, nil, 0, 0, false); err != nil {
+		t.Fatalf("printAggregateSummary hasOlder=false: %v", err)
+	}
+	finish2()
+	got := buf2.String()
+	if strings.Contains(got, "no recent activity") {
+		t.Errorf("hasOlder=false must NOT emit hint; got %q", got)
+	}
+	if !strings.Contains(got, "no tasks in window") {
+		t.Errorf("hasOlder=false must emit legacy line; got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

- Establish a CLI-wide convention via a new `cli/uxprint` helpers package: every state-mutating verb prints a one-line success signature (`verb shortID key=value`) unless `--quiet` is passed; read verbs stay silent on success EXCEPT for a one-line filter-emptiness hint when filtering hid existing rows.
- Sweep six mutating verbs (`tasks claim/close/create/update/link`, `swarm dispatch`) to use the helpers, gain a `--quiet` flag, and produce the documented signature shapes (`created e075b52a "title"`, `claimed e075b52a by=dc584303`, `linked e075b52a → b1c2d3e4 (blocks)`, etc.). `swarm dispatch` adopts the multi-target shape: one `created` line per slot in stable order plus a `<n> tasks created` summary.
- Add filter-emptiness hints to four read verbs (`tasks list/ready`, `swarm tasks`, `tasks aggregate`) so an empty result frame distinguishes "your filter hid existing rows" from "there is nothing here."
- Add an AST-walk enforcement test (`cli/uxprint_enforce_test.go`) with a curated allowlist of mutating verbs plus a planted-failure meta-test, so a future verb that ships without hooking the helper trips CI rather than silently regressing.

JSON output paths and the wire shape are unchanged — `--json` bypasses `uxprint` entirely (the ADR 0053 envelope wraps the typed payload; uxprint is human stdout only).

> **Note:** `tasks close --auto-release` now emits the release advisory on stdout (was stderr in v0.12). Scripts that filtered the old advisory off `2>/dev/null` will now see two lines on stdout (`closed <id>` plus `released <slot> was=<id>`). Pass `--quiet` to suppress.

Closes #323
Closes #313

## Test plan

- [x] `go test ./cli/uxprint/...` — 19 helper format tests pass (incl. `SlotReleased`), including the verb-alignment test that pins the byte offset of the short-id column.
- [x] AST enforcement test (`TestEveryMutatingVerbCallsUxprint` + `TestPlantedFailureCatchesMissingUxprint` + `TestPlantedSuccessAllowsUxprintCall`) — passes for the six allowlisted verbs; planted-failure meta-test demonstrates the walker actually fails when its precondition is violated.
- [x] Filter-hint predicate tests (`countClosed`, `countOpen`, `changeFieldsMap`, `pluralize`, `sortStrings`) and a `printAggregateSummary` captured-stdout test pin the read-verb hint behavior.
- [x] `make check` — passes except for the pre-existing `TestStatusAllEmptyRegistry` flake tracked in #305.
- [x] `go build -tags=otel ./...` — clean.
- [x] `go test -tags=otel -short ./...` — 1079 pass, 1 pre-existing flake (#305), 57 skipped (long integration tests).
