### PR TITLE
feat(timefmt): per-surface timezone policy + helper sweep

### DIFF
--- a/cli/logs.go
+++ b/cli/logs.go
@@ -17,6 +17,7 @@ import (
 	repocli "github.com/danmestas/EdgeSync/cli/repo"
 
 	"github.com/danmestas/bones/internal/logwriter"
+	"github.com/danmestas/bones/internal/timefmt"
 	"github.com/danmestas/bones/internal/workspace"
 )
 
@@ -192,11 +193,15 @@ func applyFilters(events []parsedEvent, since time.Time, last int) []parsedEvent
 
 // renderEvent formats a single event for human-readable output.
 func renderEvent(pe parsedEvent, fullTime bool, isTTY bool, w io.Writer) {
+	// Per #324: full mode uses Logged (UTC RFC3339), the audit shape;
+	// short mode uses Display (local + zone abbreviation), the live-
+	// operator shape. Both rendered via timefmt so the AST-walk
+	// enforcement keeps catching regressions.
 	var tsStr string
 	if fullTime {
-		tsStr = pe.event.Timestamp.UTC().Format(time.RFC3339)
+		tsStr = timefmt.Logged(pe.event.Timestamp)
 	} else {
-		tsStr = pe.event.Timestamp.UTC().Format("15:04:05")
+		tsStr = timefmt.Display(pe.event.Timestamp)
 	}
 
 	evType := string(pe.event.Event)

--- a/cli/schemas/types.go
+++ b/cli/schemas/types.go
@@ -1,6 +1,6 @@
 package schemas
 
-import "time"
+import "github.com/danmestas/bones/internal/timefmt"
 
 // Edge mirrors the on-the-wire edge shape from internal/tasks.Edge.
 // Re-declared here so cli/schemas owns the external contract; the
@@ -15,28 +15,29 @@ type Edge struct {
 // (`omitempty` markers preserved); see ADR 0005 and ADR 0014 for
 // the canonical schema.
 //
-// Pointer-time fields (DeferUntil, ClosedAt, CompactedAt) stay
-// pointer-typed so an absent value omits cleanly under omitempty
-// rather than serializing the zero value.
+// Per #324 every time field is timefmt.LoggedTime so the marshal
+// path emits UTC RFC3339 rather than RFC3339Nano-with-local-offset.
+// Pointer-time fields stay pointer-typed so an absent value omits
+// cleanly under omitempty rather than serializing the zero value.
 type Task struct {
-	ID            string            `json:"id"`
-	Title         string            `json:"title"`
-	Status        string            `json:"status"`
-	ClaimedBy     string            `json:"claimed_by,omitempty"`
-	Files         []string          `json:"files"`
-	Parent        string            `json:"parent,omitempty"`
-	Edges         []Edge            `json:"edges,omitempty"`
-	Context       map[string]string `json:"context,omitempty"`
-	CreatedAt     time.Time         `json:"created_at"`
-	UpdatedAt     time.Time         `json:"updated_at"`
-	DeferUntil    *time.Time        `json:"defer_until,omitempty"`
-	ClosedAt      *time.Time        `json:"closed_at,omitempty"`
-	ClosedBy      string            `json:"closed_by,omitempty"`
-	ClosedReason  string            `json:"closed_reason,omitempty"`
-	ClaimEpoch    uint64            `json:"claim_epoch,omitempty"`
-	OriginalSize  uint64            `json:"original_size,omitempty"`
-	CompactLevel  uint8             `json:"compact_level,omitempty"`
-	CompactedAt   *time.Time        `json:"compacted_at,omitempty"`
-	SchemaVersion int               `json:"schema_version"`
-	LastEventSeq  uint64            `json:"last_event_seq,omitempty"`
+	ID            string              `json:"id"`
+	Title         string              `json:"title"`
+	Status        string              `json:"status"`
+	ClaimedBy     string              `json:"claimed_by,omitempty"`
+	Files         []string            `json:"files"`
+	Parent        string              `json:"parent,omitempty"`
+	Edges         []Edge              `json:"edges,omitempty"`
+	Context       map[string]string   `json:"context,omitempty"`
+	CreatedAt     timefmt.LoggedTime  `json:"created_at"`
+	UpdatedAt     timefmt.LoggedTime  `json:"updated_at"`
+	DeferUntil    *timefmt.LoggedTime `json:"defer_until,omitempty"`
+	ClosedAt      *timefmt.LoggedTime `json:"closed_at,omitempty"`
+	ClosedBy      string              `json:"closed_by,omitempty"`
+	ClosedReason  string              `json:"closed_reason,omitempty"`
+	ClaimEpoch    uint64              `json:"claim_epoch,omitempty"`
+	OriginalSize  uint64              `json:"original_size,omitempty"`
+	CompactLevel  uint8               `json:"compact_level,omitempty"`
+	CompactedAt   *timefmt.LoggedTime `json:"compacted_at,omitempty"`
+	SchemaVersion int                 `json:"schema_version"`
+	LastEventSeq  uint64              `json:"last_event_seq,omitempty"`
 }

--- a/cli/schemas/verbs.go
+++ b/cli/schemas/verbs.go
@@ -2,7 +2,7 @@ package schemas
 
 //go:generate go run ../../cmd/bones-schemagen -out ../../schemas
 
-import "time"
+import "github.com/danmestas/bones/internal/timefmt"
 
 // Verb identifies one CLI emit site. The dotted name matches the
 // command path (`tasks.list` ↔ `bones tasks list`); CurrentVersion is
@@ -84,11 +84,11 @@ type StatusAllPayload struct {
 
 // StatusWorkspaceRow is one row of the status --all view.
 type StatusWorkspaceRow struct {
-	Cwd       string    `json:"cwd"`
-	Name      string    `json:"name"`
-	HubURL    string    `json:"hub_url"`
-	Sessions  int       `json:"sessions"`
-	StartedAt time.Time `json:"started_at"`
+	Cwd       string             `json:"cwd"`
+	Name      string             `json:"name"`
+	HubURL    string             `json:"hub_url"`
+	Sessions  int                `json:"sessions"`
+	StartedAt timefmt.LoggedTime `json:"started_at"`
 }
 
 // SwarmDispatchPayload is the payload for `bones swarm dispatch --json`.
@@ -106,15 +106,15 @@ type SwarmStatusPayload []SwarmStatusRow
 
 // SwarmStatusRow is one swarm-session row.
 type SwarmStatusRow struct {
-	Slot         string    `json:"slot"`
-	TaskID       string    `json:"task_id"`
-	AgentID      string    `json:"agent_id"`
-	Host         string    `json:"host"`
-	LeafPID      int       `json:"leaf_pid"`
-	StartedAt    time.Time `json:"started_at"`
-	LastRenewed  time.Time `json:"last_renewed"`
-	State        string    `json:"state"`
-	StaleSeconds int64     `json:"stale_seconds"`
+	Slot         string             `json:"slot"`
+	TaskID       string             `json:"task_id"`
+	AgentID      string             `json:"agent_id"`
+	Host         string             `json:"host"`
+	LeafPID      int                `json:"leaf_pid"`
+	StartedAt    timefmt.LoggedTime `json:"started_at"`
+	LastRenewed  timefmt.LoggedTime `json:"last_renewed"`
+	State        string             `json:"state"`
+	StaleSeconds int64              `json:"stale_seconds"`
 }
 
 // SwarmTasksPayload is the payload for `bones swarm tasks --json`.
@@ -196,28 +196,28 @@ type TasksPrimePayload struct {
 // TasksPrimeTask is the trimmed task shape used inside a tasks.prime
 // payload — coord.Task projection without storage-internal fields.
 type TasksPrimeTask struct {
-	ID        string    `json:"id"`
-	Title     string    `json:"title"`
-	Files     []string  `json:"files,omitempty"`
-	ClaimedBy string    `json:"claimed_by,omitempty"`
-	CreatedAt time.Time `json:"created_at"`
-	UpdatedAt time.Time `json:"updated_at"`
+	ID        string             `json:"id"`
+	Title     string             `json:"title"`
+	Files     []string           `json:"files,omitempty"`
+	ClaimedBy string             `json:"claimed_by,omitempty"`
+	CreatedAt timefmt.LoggedTime `json:"created_at"`
+	UpdatedAt timefmt.LoggedTime `json:"updated_at"`
 }
 
 // TasksPrimeThread is the chat-thread row inside a tasks.prime payload.
 type TasksPrimeThread struct {
-	ThreadShort  string    `json:"thread_short"`
-	LastActivity time.Time `json:"last_activity"`
-	MessageCount int       `json:"message_count"`
-	LastBody     string    `json:"last_body"`
+	ThreadShort  string             `json:"thread_short"`
+	LastActivity timefmt.LoggedTime `json:"last_activity"`
+	MessageCount int                `json:"message_count"`
+	LastBody     string             `json:"last_body"`
 }
 
 // TasksPrimePresence is the peer-presence row inside a tasks.prime payload.
 type TasksPrimePresence struct {
-	AgentID   string    `json:"agent_id"`
-	Project   string    `json:"project"`
-	StartedAt time.Time `json:"started_at"`
-	LastSeen  time.Time `json:"last_seen"`
+	AgentID   string             `json:"agent_id"`
+	Project   string             `json:"project"`
+	StartedAt timefmt.LoggedTime `json:"started_at"`
+	LastSeen  timefmt.LoggedTime `json:"last_seen"`
 }
 
 // TasksReadyPayload is the payload for `bones tasks ready --json`.

--- a/cli/status.go
+++ b/cli/status.go
@@ -21,6 +21,7 @@ import (
 	"github.com/danmestas/bones/internal/sessions"
 	"github.com/danmestas/bones/internal/swarm"
 	"github.com/danmestas/bones/internal/tasks"
+	"github.com/danmestas/bones/internal/timefmt"
 	"github.com/danmestas/bones/internal/workspace"
 )
 
@@ -314,10 +315,13 @@ func renderStatus(rep statusReport, w io.Writer) error {
 	// concept (a "leaf" here is a hub instance), and operators only
 	// need to see swarm-session counts (rendered in the body table
 	// via renderSlotTable). Header stays in operator vocabulary.
+	// Display = local time + zone abbreviation per #324. The "as of"
+	// header is an operator-facing live display, so the wall-clock
+	// frame matches the operator's terminal session.
 	header := fmt.Sprintf("bones · workspace: %s · trunk: %s · as of %s\n\n",
 		filepath.Base(rep.WorkspaceDir),
 		hubField(rep.TrunkHead, rep.HubAvailable),
-		rep.GeneratedAt.Format("15:04:05"),
+		timefmt.Display(rep.GeneratedAt),
 	)
 	if _, err := io.WriteString(w, header); err != nil {
 		return err
@@ -411,16 +415,19 @@ func renderActivity(rep statusReport, w io.Writer) error {
 	}
 	for _, e := range rep.Activity {
 		var line string
+		// Activity rows share the "as of" header's frame: operator-
+		// facing live display, so route through Display per #324.
+		ts := timefmt.Display(e.Time)
 		switch e.Kind {
 		case actCommit:
 			line = fmt.Sprintf("    %s  ◆ commit  %s  %s\n",
-				e.Time.Format("15:04:05"), e.Hash, e.Comment)
+				ts, e.Hash, e.Comment)
 		case actTaskCreate:
 			line = fmt.Sprintf("    %s  + create  %s  %s\n",
-				e.Time.Format("15:04:05"), truncateID(e.TaskID, 8), e.Title)
+				ts, truncateID(e.TaskID, 8), e.Title)
 		case actTaskClose:
 			line = fmt.Sprintf("    %s  ✓ close   %s  %s\n",
-				e.Time.Format("15:04:05"), truncateID(e.TaskID, 8), e.Title)
+				ts, truncateID(e.TaskID, 8), e.Title)
 		}
 		if _, err := io.WriteString(w, line); err != nil {
 			return err

--- a/cli/status.go
+++ b/cli/status.go
@@ -240,7 +240,7 @@ func taskEventsToActivity(
 			continue
 		}
 		out = append(out, activityEvent{
-			Time:   env.Timestamp,
+			Time:   env.Timestamp.Time,
 			Kind:   kind,
 			TaskID: env.TaskID,
 			Title:  title,
@@ -706,7 +706,7 @@ func renderStatusAllJSON(w io.Writer) error {
 			Name:      e.Name,
 			HubURL:    e.HubURL,
 			Sessions:  sessions.CountByWorkspace(e.Cwd),
-			StartedAt: e.StartedAt,
+			StartedAt: timefmt.NewLoggedTime(e.StartedAt),
 		}
 	}
 	return emitEnvelope(w, "status", schemas.StatusAllPayload{Workspaces: rows})

--- a/cli/status_test.go
+++ b/cli/status_test.go
@@ -154,9 +154,12 @@ func TestRenderStatus_WithSessionsAndTasks(t *testing.T) {
 func TestTaskEventsToActivity(t *testing.T) {
 	now := time.Now().UTC()
 	envs := []tasks.EventEnvelope{
-		{Type: tasks.EventTypeCreated, TaskID: "t1", Timestamp: now.Add(-time.Hour)},
-		{Type: tasks.EventTypeCreated, TaskID: "t2", Timestamp: now.Add(-2 * time.Hour)},
-		{Type: tasks.EventTypeClosed, TaskID: "t2", Timestamp: now.Add(-10 * time.Minute)},
+		{Type: tasks.EventTypeCreated, TaskID: "t1",
+			Timestamp: timefmt.NewLoggedTime(now.Add(-time.Hour))},
+		{Type: tasks.EventTypeCreated, TaskID: "t2",
+			Timestamp: timefmt.NewLoggedTime(now.Add(-2 * time.Hour))},
+		{Type: tasks.EventTypeClosed, TaskID: "t2",
+			Timestamp: timefmt.NewLoggedTime(now.Add(-10 * time.Minute))},
 	}
 	byID := map[string]tasks.Task{
 		"t1": {ID: "t1", Title: "open one"},

--- a/cli/status_test.go
+++ b/cli/status_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/danmestas/bones/internal/registry"
 	"github.com/danmestas/bones/internal/swarm"
 	"github.com/danmestas/bones/internal/tasks"
+	"github.com/danmestas/bones/internal/timefmt"
 )
 
 func TestRenderStatus_Empty(t *testing.T) {
@@ -31,8 +32,12 @@ func TestRenderStatus_Empty(t *testing.T) {
 		t.Fatalf("renderStatus: %v", err)
 	}
 	out := buf.String()
+	// "as of" header now carries a zone abbreviation (#324). Compute
+	// the expected string via timefmt.Display so the test stays
+	// host-zone-independent.
+	wantAsOf := "as of " + timefmt.Display(rep.GeneratedAt)
 	for _, want := range []string{
-		"workspace: bones", "trunk: —", "as of 14:05:02",
+		"workspace: bones", "trunk: —", wantAsOf,
 		"(no active swarm sessions)", "Recent activity:", "(none)",
 		"Tasks: 0 open · 0 claimed · 0 closed",
 		"Hub not running",

--- a/cli/swarm_status.go
+++ b/cli/swarm_status.go
@@ -14,6 +14,7 @@ import (
 	"github.com/danmestas/bones/cli/schemas"
 	"github.com/danmestas/bones/internal/dispatch"
 	"github.com/danmestas/bones/internal/swarm"
+	"github.com/danmestas/bones/internal/timefmt"
 	"github.com/danmestas/bones/internal/workspace"
 )
 
@@ -38,15 +39,15 @@ type SwarmStatusCmd struct {
 // schema is explicit and stable for downstream consumers (`bones
 // doctor`, future `bones swarm dispatch`).
 type statusRow struct {
-	Slot         string    `json:"slot"`
-	TaskID       string    `json:"task_id"`
-	AgentID      string    `json:"agent_id"`
-	Host         string    `json:"host"`
-	LeafPID      int       `json:"leaf_pid"`
-	StartedAt    time.Time `json:"started_at"`
-	LastRenewed  time.Time `json:"last_renewed"`
-	State        string    `json:"state"`
-	StaleSeconds int64     `json:"stale_seconds"`
+	Slot         string             `json:"slot"`
+	TaskID       string             `json:"task_id"`
+	AgentID      string             `json:"agent_id"`
+	Host         string             `json:"host"`
+	LeafPID      int                `json:"leaf_pid"`
+	StartedAt    timefmt.LoggedTime `json:"started_at"`
+	LastRenewed  timefmt.LoggedTime `json:"last_renewed"`
+	State        string             `json:"state"`
+	StaleSeconds int64              `json:"stale_seconds"`
 }
 
 func (c *SwarmStatusCmd) Run(g *repocli.Globals) error {
@@ -121,8 +122,8 @@ func buildStatusRows(sessions []swarm.Session, host string, now time.Time) []sta
 			AgentID:      s.AgentID,
 			Host:         s.Host,
 			LeafPID:      s.LeafPID,
-			StartedAt:    s.StartedAt,
-			LastRenewed:  s.LastRenewed,
+			StartedAt:    timefmt.NewLoggedTime(s.StartedAt),
+			LastRenewed:  timefmt.NewLoggedTime(s.LastRenewed),
 			State:        state,
 			StaleSeconds: stale,
 		})

--- a/cli/tasks_compact.go
+++ b/cli/tasks_compact.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/danmestas/bones/internal/coord"
 	"github.com/danmestas/bones/internal/tasks"
+	"github.com/danmestas/bones/internal/timefmt"
 	"github.com/danmestas/bones/internal/workspace"
 )
 
@@ -182,12 +183,12 @@ func formatFooter(
 	if dryRun {
 		return fmt.Sprintf(
 			"(dry-run) would compact %d tasks (eligible-since %s, --max=%d, --summarizer=%s)",
-			n, eligibleSince.Format(time.RFC3339), maxN, summarizerName,
+			n, timefmt.Logged(eligibleSince), maxN, summarizerName,
 		)
 	}
 	return fmt.Sprintf(
 		"compacted %d tasks (eligible-since %s, --max=%d, --summarizer=%s)",
-		n, eligibleSince.Format(time.RFC3339), maxN, summarizerName,
+		n, timefmt.Logged(eligibleSince), maxN, summarizerName,
 	)
 }
 

--- a/cli/tasks_compact.go
+++ b/cli/tasks_compact.go
@@ -180,15 +180,18 @@ func formatCompactLine(t tasks.Task, orig, newBytes int, dryRun bool) string {
 func formatFooter(
 	n int, eligibleSince time.Time, maxN int, summarizerName string, dryRun bool,
 ) string {
+	// Footer prints to operator stdout alongside the per-task
+	// "(dry-run) ✓ <id> <title>" lines. Per #324 that's a Display
+	// surface (live operator output, local frame), not Logged.
 	if dryRun {
 		return fmt.Sprintf(
 			"(dry-run) would compact %d tasks (eligible-since %s, --max=%d, --summarizer=%s)",
-			n, timefmt.Logged(eligibleSince), maxN, summarizerName,
+			n, timefmt.Display(eligibleSince), maxN, summarizerName,
 		)
 	}
 	return fmt.Sprintf(
 		"compacted %d tasks (eligible-since %s, --max=%d, --summarizer=%s)",
-		n, timefmt.Logged(eligibleSince), maxN, summarizerName,
+		n, timefmt.Display(eligibleSince), maxN, summarizerName,
 	)
 }
 

--- a/cli/tasks_format.go
+++ b/cli/tasks_format.go
@@ -138,16 +138,16 @@ func taskToSchema(t tasks.Task) schemas.Task {
 		Files:         t.Files,
 		Parent:        t.Parent,
 		Context:       t.Context,
-		CreatedAt:     t.CreatedAt,
-		UpdatedAt:     t.UpdatedAt,
-		DeferUntil:    t.DeferUntil,
-		ClosedAt:      t.ClosedAt,
+		CreatedAt:     timefmt.NewLoggedTime(t.CreatedAt),
+		UpdatedAt:     timefmt.NewLoggedTime(t.UpdatedAt),
+		DeferUntil:    ptrLoggedTime(t.DeferUntil),
+		ClosedAt:      ptrLoggedTime(t.ClosedAt),
 		ClosedBy:      t.ClosedBy,
 		ClosedReason:  t.ClosedReason,
 		ClaimEpoch:    t.ClaimEpoch,
 		OriginalSize:  t.OriginalSize,
 		CompactLevel:  t.CompactLevel,
-		CompactedAt:   t.CompactedAt,
+		CompactedAt:   ptrLoggedTime(t.CompactedAt),
 		SchemaVersion: t.SchemaVersion,
 		LastEventSeq:  t.LastEventSeq,
 	}
@@ -179,9 +179,21 @@ func coordTaskToSchema(t coord.Task) schemas.TasksPrimeTask {
 		Title:     t.Title(),
 		Files:     t.Files(),
 		ClaimedBy: t.ClaimedBy(),
-		CreatedAt: t.CreatedAt(),
-		UpdatedAt: t.UpdatedAt(),
+		CreatedAt: timefmt.NewLoggedTime(t.CreatedAt()),
+		UpdatedAt: timefmt.NewLoggedTime(t.UpdatedAt()),
 	}
+}
+
+// ptrLoggedTime wraps a *time.Time as *timefmt.LoggedTime, returning
+// nil when the input is nil. Used at the schemas-package boundary so
+// optional pointer-typed timestamp fields convert without each caller
+// re-implementing the nil check.
+func ptrLoggedTime(t *time.Time) *timefmt.LoggedTime {
+	if t == nil {
+		return nil
+	}
+	lt := timefmt.NewLoggedTime(*t)
+	return &lt
 }
 
 func coordTasksToSchema(ts []coord.Task) []schemas.TasksPrimeTask {
@@ -206,7 +218,7 @@ func primeToSchema(r coord.PrimeResult) schemas.TasksPrimePayload {
 	for _, t := range r.Threads {
 		out.Threads = append(out.Threads, schemas.TasksPrimeThread{
 			ThreadShort:  t.ThreadShort(),
-			LastActivity: t.LastActivity(),
+			LastActivity: timefmt.NewLoggedTime(t.LastActivity()),
 			MessageCount: t.MessageCount(),
 			LastBody:     t.LastBody(),
 		})
@@ -215,8 +227,8 @@ func primeToSchema(r coord.PrimeResult) schemas.TasksPrimePayload {
 		out.Peers = append(out.Peers, schemas.TasksPrimePresence{
 			AgentID:   p.AgentID(),
 			Project:   p.Project(),
-			StartedAt: p.StartedAt(),
-			LastSeen:  p.LastSeen(),
+			StartedAt: timefmt.NewLoggedTime(p.StartedAt()),
+			LastSeen:  timefmt.NewLoggedTime(p.LastSeen()),
 		})
 	}
 	return out

--- a/cli/tasks_format.go
+++ b/cli/tasks_format.go
@@ -11,6 +11,7 @@ import (
 	"github.com/danmestas/bones/cli/schemas"
 	"github.com/danmestas/bones/internal/coord"
 	"github.com/danmestas/bones/internal/tasks"
+	"github.com/danmestas/bones/internal/timefmt"
 )
 
 // glyphFor mirrors bd's one-rune status markers.
@@ -81,7 +82,7 @@ func formatTime(ts time.Time) string {
 	if ts.IsZero() {
 		return ""
 	}
-	return ts.UTC().Format(time.RFC3339)
+	return timefmt.Logged(ts)
 }
 
 // emitJSON marshals v as JSON to w with trailing newline.

--- a/cli/tasks_prime.go
+++ b/cli/tasks_prime.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/danmestas/bones/internal/clauderhooks"
 	"github.com/danmestas/bones/internal/coord"
+	"github.com/danmestas/bones/internal/timefmt"
 	"github.com/danmestas/bones/internal/version"
 )
 
@@ -119,7 +120,7 @@ func writeSessionStartSentinel(workspaceDir string) {
 		return
 	}
 	body := fmt.Sprintf("%s\t%s\n",
-		time.Now().UTC().Format(time.RFC3339), version.Get())
+		timefmt.Logged(time.Now()), version.Get())
 	_ = os.WriteFile(path, []byte(body), 0o644)
 }
 
@@ -157,7 +158,7 @@ func formatPrime(r coord.PrimeResult) string {
 	for _, t := range r.Threads {
 		out += fmt.Sprintf("- %s (%s, %d msgs)\n",
 			t.ThreadShort(),
-			t.LastActivity().Format(time.RFC3339),
+			timefmt.Logged(t.LastActivity()),
 			t.MessageCount(),
 		)
 	}
@@ -170,7 +171,7 @@ func formatPrime(r coord.PrimeResult) string {
 	for _, p := range r.Peers {
 		out += fmt.Sprintf("- %s (last seen %s)\n",
 			p.AgentID(),
-			p.LastSeen().Format(time.RFC3339),
+			timefmt.Logged(p.LastSeen()),
 		)
 	}
 	if len(r.Peers) == 0 {

--- a/cli/tasks_watch.go
+++ b/cli/tasks_watch.go
@@ -12,6 +12,7 @@ import (
 	repocli "github.com/danmestas/EdgeSync/cli/repo"
 
 	"github.com/danmestas/bones/internal/tasks"
+	"github.com/danmestas/bones/internal/timefmt"
 )
 
 // TasksWatchCmd subscribes to the task event log and streams human-
@@ -106,9 +107,11 @@ func watchBackfill(
 }
 
 // printEventEnvelope renders a single event-log envelope in the same
-// shape as printTaskEvent so live and backfill output align.
+// shape as printTaskEvent so live and backfill output align. The
+// bracket prefix is timefmt.Display per #324 — live operator surface,
+// local time + zone abbreviation.
 func printEventEnvelope(env tasks.EventEnvelope) {
-	ts := env.Timestamp.Local().Format("15:04:05")
+	ts := timefmt.Display(env.Timestamp)
 	fmt.Printf("[%s] %-12s id=%s seq=%d\n",
 		ts, env.Type.String(), env.TaskID, env.StreamSeq)
 }
@@ -117,7 +120,7 @@ func printEventEnvelope(env tasks.EventEnvelope) {
 // Retained for the live KV-watch path; the event-log path uses
 // printEventEnvelope above.
 func printTaskEvent(ev tasks.Event) {
-	ts := time.Now().Format("15:04:05")
+	ts := timefmt.Display(time.Now())
 	switch ev.Kind {
 	case tasks.EventCreated:
 		fmt.Printf("[%s] created  task=%q id=%s\n", ts, ev.Task.Title, ev.ID)

--- a/cli/tasks_watch.go
+++ b/cli/tasks_watch.go
@@ -111,7 +111,7 @@ func watchBackfill(
 // bracket prefix is timefmt.Display per #324 — live operator surface,
 // local time + zone abbreviation.
 func printEventEnvelope(env tasks.EventEnvelope) {
-	ts := timefmt.Display(env.Timestamp)
+	ts := timefmt.Display(env.Timestamp.Time)
 	fmt.Printf("[%s] %-12s id=%s seq=%d\n",
 		ts, env.Type.String(), env.TaskID, env.StreamSeq)
 }

--- a/cli/timefmt_surfaces_test.go
+++ b/cli/timefmt_surfaces_test.go
@@ -1,0 +1,150 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/danmestas/bones/internal/tasks"
+	"github.com/danmestas/bones/internal/timefmt"
+)
+
+// TestTimefmtSurface_StatusAsOfHeader pins the visible shape of
+// `bones status` "as of" header for #324: HH:MM:SS followed by a
+// zone abbreviation, with the local zone forced to a known value so
+// the test passes on hosts in any zone.
+func TestTimefmtSurface_StatusAsOfHeader(t *testing.T) {
+	restore := withLocalZone(t, "America/Los_Angeles")
+	defer restore()
+
+	// Pick a January instant so the rendered abbreviation is PST,
+	// not PDT — a stable target for the regex.
+	rep := statusReport{
+		WorkspaceDir:     "/tmp/ws/bones",
+		GeneratedAt:      time.Date(2026, 1, 15, 20, 30, 45, 0, time.UTC),
+		TasksByStatus:    map[tasks.Status]int{},
+		TasksByID:        map[string]tasks.Task{},
+		ScaffoldComplete: true,
+	}
+	var buf bytes.Buffer
+	if err := renderStatus(rep, &buf); err != nil {
+		t.Fatalf("renderStatus: %v", err)
+	}
+
+	// 20:30:45 UTC → 12:30:45 PST.
+	want := "as of 12:30:45 PST"
+	if !strings.Contains(buf.String(), want) {
+		t.Fatalf("status header missing %q\n--- output ---\n%s",
+			want, buf.String())
+	}
+}
+
+// TestTimefmtSurface_TasksWatchBracket pins the visible shape of
+// `bones tasks watch` bracket prefix for #324: [HH:MM:SS ZONE].
+func TestTimefmtSurface_TasksWatchBracket(t *testing.T) {
+	restore := withLocalZone(t, "America/Los_Angeles")
+	defer restore()
+
+	env := tasks.EventEnvelope{
+		TaskID:    "abc",
+		StreamSeq: 1,
+		Timestamp: time.Date(2026, 1, 15, 20, 30, 45, 0, time.UTC),
+		Type:      tasks.EventTypeCreated,
+	}
+
+	// printEventEnvelope writes to stdout directly. Use the
+	// existing captureStdout helper from status_test.go.
+	buf, finish := captureStdout(t)
+	printEventEnvelope(env)
+	finish()
+	out := buf.String()
+
+	want := "[12:30:45 PST]"
+	if !strings.Contains(out, want) {
+		t.Fatalf("tasks watch bracket missing %q\n--- output ---\n%s",
+			want, out)
+	}
+}
+
+// TestTimefmtSurface_UpLogIsUTC pins the load-bearing change for
+// #324 on the up.log surface: every log line starts with a UTC
+// RFC3339 timestamp (regex: digit-digit, "T", digit-digit, ..., "Z").
+// Pre-#324 the timestamps were local with no zone marker.
+func TestTimefmtSurface_UpLogIsUTC(t *testing.T) {
+	dir := t.TempDir()
+
+	l := openUpLog(dir)
+	l.Infof("test-line")
+	l.Close(nil)
+
+	body, err := os.ReadFile(filepath.Join(dir, ".bones", "up.log"))
+	if err != nil {
+		t.Fatalf("read up.log: %v", err)
+	}
+
+	// First non-empty line: leading timestamp must match RFC3339 in
+	// UTC (trailing "Z").
+	re := regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z`)
+	for _, line := range strings.Split(strings.TrimSpace(string(body)), "\n") {
+		if !re.MatchString(line) {
+			t.Errorf("up.log line not UTC RFC3339: %q\n--- full body ---\n%s",
+				line, body)
+		}
+	}
+}
+
+// TestTimefmtSurface_CrossSurfaceConsistency exercises the
+// cross-surface integration angle from the brief: the same instant
+// observed via tasks_format.go formatTime (UTC RFC3339, route to
+// `tasks show`) and via printEventEnvelope (local + zone, route to
+// `tasks watch`) must trace back to identical seconds.
+func TestTimefmtSurface_CrossSurfaceConsistency(t *testing.T) {
+	restore := withLocalZone(t, "America/Los_Angeles")
+	defer restore()
+
+	instant := time.Date(2026, 1, 15, 20, 30, 45, 0, time.UTC)
+
+	loggedShape := formatTime(instant)       // UTC RFC3339
+	displayShape := timefmt.Display(instant) // local + zone
+
+	// Parse the Logged shape back; must equal the original instant.
+	parsed, err := time.Parse(time.RFC3339, loggedShape)
+	if err != nil {
+		t.Fatalf("Logged shape %q failed to parse: %v", loggedShape, err)
+	}
+	if !parsed.Equal(instant) {
+		t.Errorf("Logged round-trip mismatch: %v != %v", parsed, instant)
+	}
+
+	// The Display shape extracts to 12:30:45 PST in this zone — the
+	// same instant the Logged shape carries.
+	if !strings.HasPrefix(displayShape, "12:30:45") {
+		t.Errorf("Display shape %q lost wall-clock content for "+
+			"the LA-zone view of the test instant", displayShape)
+	}
+	if !strings.HasSuffix(displayShape, " PST") {
+		t.Errorf("Display shape %q missing PST zone marker", displayShape)
+	}
+}
+
+// withLocalZone temporarily forces time.Local to the named zone for
+// the duration of the test. Returns a restore function.
+//
+// Test isolation: every caller defers the restore so a zone-flapping
+// test cannot leak into a subsequent one. Tests that don't call this
+// run in whatever zone the host happens to be in — fine for tests
+// that don't assert on the zone string.
+func withLocalZone(t *testing.T, zone string) func() {
+	t.Helper()
+	loc, err := time.LoadLocation(zone)
+	if err != nil {
+		t.Fatalf("load zone %q: %v", zone, err)
+	}
+	prev := time.Local
+	time.Local = loc
+	return func() { time.Local = prev }
+}

--- a/cli/timefmt_surfaces_test.go
+++ b/cli/timefmt_surfaces_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -9,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/danmestas/bones/cli/schemas"
 	"github.com/danmestas/bones/internal/tasks"
 	"github.com/danmestas/bones/internal/timefmt"
 )
@@ -52,8 +54,9 @@ func TestTimefmtSurface_TasksWatchBracket(t *testing.T) {
 	env := tasks.EventEnvelope{
 		TaskID:    "abc",
 		StreamSeq: 1,
-		Timestamp: time.Date(2026, 1, 15, 20, 30, 45, 0, time.UTC),
-		Type:      tasks.EventTypeCreated,
+		Timestamp: timefmt.NewLoggedTime(
+			time.Date(2026, 1, 15, 20, 30, 45, 0, time.UTC)),
+		Type: tasks.EventTypeCreated,
 	}
 
 	// printEventEnvelope writes to stdout directly. Use the
@@ -128,6 +131,87 @@ func TestTimefmtSurface_CrossSurfaceConsistency(t *testing.T) {
 	}
 	if !strings.HasSuffix(displayShape, " PST") {
 		t.Errorf("Display shape %q missing PST zone marker", displayShape)
+	}
+}
+
+// TestTimefmtSurface_JSONPayloadEnvelopeIsUTC pins the load-bearing
+// guarantee for B1: a representative payload struct with timestamp
+// fields marshals every timestamp as UTC RFC3339 (Z-suffixed, no
+// fractional seconds) regardless of system zone. Default time.Time
+// marshaling would emit a local-zone offset string with nanoseconds
+// — that's the regression LoggedTime exists to prevent.
+func TestTimefmtSurface_JSONPayloadEnvelopeIsUTC(t *testing.T) {
+	restore := withLocalZone(t, "America/Los_Angeles")
+	defer restore()
+
+	// The instant carries non-zero nanoseconds intentionally —
+	// MarshalJSON must drop them.
+	instant := time.Date(2026, 1, 15, 20, 30, 45, 999999999, time.UTC)
+	payload := schemas.Task{
+		ID:        "abc",
+		Title:     "test",
+		Status:    "open",
+		Files:     []string{},
+		CreatedAt: timefmt.NewLoggedTime(instant),
+		UpdatedAt: timefmt.NewLoggedTime(instant),
+	}
+
+	b, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	got := string(b)
+
+	// Both timestamp fields must end in Z (UTC), not -08:00 or
+	// -07:00. A regression to the default time.Time marshal path
+	// would produce the offset.
+	wantSubstr := `"created_at":"2026-01-15T20:30:45Z"`
+	if !strings.Contains(got, wantSubstr) {
+		t.Errorf("payload missing Z-suffixed UTC created_at:\n%s",
+			got)
+	}
+	wantUpdated := `"updated_at":"2026-01-15T20:30:45Z"`
+	if !strings.Contains(got, wantUpdated) {
+		t.Errorf("payload missing Z-suffixed UTC updated_at:\n%s",
+			got)
+	}
+
+	// No nanoseconds anywhere.
+	if strings.Contains(got, ".999") || strings.Contains(got, "999Z") {
+		t.Errorf("payload kept fractional seconds:\n%s", got)
+	}
+	// No local-zone offset markers.
+	if strings.Contains(got, "-08:00") || strings.Contains(got, "-07:00") {
+		t.Errorf("payload leaked local-zone offset:\n%s", got)
+	}
+}
+
+// TestTimefmtSurface_EventEnvelopeJSONIsUTC pins the same guarantee
+// for tasks.EventEnvelope, the JetStream wire shape consumed by
+// every recovery loop and watch consumer across bones versions.
+func TestTimefmtSurface_EventEnvelopeJSONIsUTC(t *testing.T) {
+	restore := withLocalZone(t, "Asia/Tokyo")
+	defer restore()
+
+	instant := time.Date(2026, 1, 15, 20, 30, 45, 0, time.UTC)
+	env := tasks.EventEnvelope{
+		Type:      tasks.EventTypeCreated,
+		TaskID:    "abc",
+		Timestamp: timefmt.NewLoggedTime(instant),
+		Payload:   json.RawMessage(`{}`),
+	}
+
+	b, err := json.Marshal(env)
+	if err != nil {
+		t.Fatalf("marshal envelope: %v", err)
+	}
+	got := string(b)
+	want := `"timestamp":"2026-01-15T20:30:45Z"`
+	if !strings.Contains(got, want) {
+		t.Errorf("envelope timestamp not UTC RFC3339:\n%s", got)
+	}
+	if strings.Contains(got, "+09:00") {
+		t.Errorf("envelope leaked Tokyo zone offset:\n%s", got)
 	}
 }
 

--- a/cli/up_log.go
+++ b/cli/up_log.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/danmestas/bones/internal/timefmt"
 	"github.com/danmestas/bones/internal/workspace"
 )
 
@@ -153,9 +154,9 @@ func (t *teeWriter) Write(p []byte) (int, error) {
 	return n, err
 }
 
-// ts formats a time for log output. Local time keeps the file readable
-// for the operator; UTC would be cleaner for ingestion but bones logs
-// are operator-facing first.
+// ts formats a time for up.log output. Per #324 every persisted log
+// entry is UTC RFC3339 so cross-host correlation across up.log,
+// hub.log, and the event log doesn't require mental zone arithmetic.
 func ts(t time.Time) string {
-	return t.Format("2006-01-02T15:04:05.000")
+	return timefmt.Logged(t)
 }

--- a/cli/workspaces.go
+++ b/cli/workspaces.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/danmestas/bones/cli/schemas"
 	"github.com/danmestas/bones/internal/registry"
+	"github.com/danmestas/bones/internal/timefmt"
 )
 
 // WorkspacesCmd groups the cross-workspace inspection verbs (#174).
@@ -192,7 +193,7 @@ func toJSONRow(i registry.Info) schemas.WorkspacesRow {
 		Name:        i.Name,
 		Cwd:         i.Cwd,
 		HubStatus:   string(i.HubStatus),
-		LastTouched: i.LastTouched.UTC().Format(time.RFC3339),
+		LastTouched: timefmt.Logged(i.LastTouched),
 		AgentID:     i.AgentID,
 		NATSURL:     i.NATSURL,
 		HubURL:      i.HubURL,

--- a/internal/hub/hub_log.go
+++ b/internal/hub/hub_log.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"sync"
 	"time"
+
+	"github.com/danmestas/bones/internal/timefmt"
 )
 
 // hubLogger appends structured lifecycle events to .bones/hub.log so a
@@ -82,5 +84,5 @@ func (l *hubLogger) appendLine(level, msg string) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	_, _ = fmt.Fprintf(l.file, "%s %-5s %s\n",
-		time.Now().UTC().Format(time.RFC3339), level, msg)
+		timefmt.Logged(time.Now()), level, msg)
 }

--- a/internal/logwriter/events.go
+++ b/internal/logwriter/events.go
@@ -3,6 +3,8 @@ package logwriter
 import (
 	"encoding/json"
 	"time"
+
+	"github.com/danmestas/bones/internal/timefmt"
 )
 
 // EventType is one entry in the closed catalog of slot/workspace event kinds.
@@ -55,8 +57,10 @@ func (e Event) MarshalJSON() ([]byte, error) {
 		m[k] = v
 	}
 
-	// Reserved keys overwrite any Fields collision.
-	m["ts"] = e.Timestamp.UTC().Format(time.RFC3339Nano)
+	// Reserved keys overwrite any Fields collision. Per #324 the
+	// timestamp uses timefmt.Logged (UTC RFC3339) so the event log
+	// shares one shape with up.log, hub.log, and --json payloads.
+	m["ts"] = timefmt.Logged(e.Timestamp)
 	m["event"] = string(e.Event)
 	if e.Slot != "" {
 		m["slot"] = e.Slot

--- a/internal/tasks/events.go
+++ b/internal/tasks/events.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"time"
+
+	"github.com/danmestas/bones/internal/timefmt"
 )
 
 // EventType identifies the shape of a task event published on the
@@ -89,10 +91,16 @@ func (t EventType) Valid() bool {
 // JetStream message metadata; it is NOT part of the JSON envelope and
 // is zero for messages that have not yet been published.
 type EventEnvelope struct {
-	Type      EventType       `json:"type"`
-	TaskID    string          `json:"task_id"`
-	Timestamp time.Time       `json:"timestamp"`
-	Payload   json.RawMessage `json:"payload"`
+	Type   EventType `json:"type"`
+	TaskID string    `json:"task_id"`
+	// Timestamp is the wall-clock instant the event was emitted.
+	// timefmt.LoggedTime per #324: serializes as UTC RFC3339 so
+	// recovery loops on a different host or different system zone
+	// see the same instant a producing slot stamped. Decoding is
+	// lenient (accepts RFC3339Nano with offset) so legacy records
+	// pre-#324 still replay.
+	Timestamp timefmt.LoggedTime `json:"timestamp"`
+	Payload   json.RawMessage    `json:"payload"`
 
 	// StreamSeq is the JetStream message sequence at the time the
 	// envelope was consumed. Set by the recovery loop and the watch
@@ -189,7 +197,7 @@ func EncodeEnvelope(t EventType, taskID string, payload any) (EventEnvelope, err
 	return EventEnvelope{
 		Type:      t,
 		TaskID:    taskID,
-		Timestamp: time.Now().UTC(),
+		Timestamp: timefmt.NewLoggedTime(time.Now()),
 		Payload:   raw,
 	}, nil
 }

--- a/internal/tasks/recovery.go
+++ b/internal/tasks/recovery.go
@@ -11,6 +11,7 @@ import (
 	"github.com/nats-io/nats.go/jetstream"
 
 	"github.com/danmestas/bones/internal/assert"
+	"github.com/danmestas/bones/internal/timefmt"
 )
 
 // migrationMarkerKey is the KV key whose presence (in the bones-tasks
@@ -181,8 +182,8 @@ func applyCreatedEvent(ctx context.Context, aw AdminWrite, env EventEnvelope) er
 		Title:         created.Title,
 		Status:        StatusOpen,
 		Files:         append([]string(nil), created.Files...),
-		CreatedAt:     env.Timestamp,
-		UpdatedAt:     env.Timestamp,
+		CreatedAt:     env.Timestamp.Time,
+		UpdatedAt:     env.Timestamp.Time,
 		SchemaVersion: SchemaVersion,
 		LastEventSeq:  env.StreamSeq,
 	}
@@ -207,7 +208,7 @@ func applyClaimedEvent(ctx context.Context, aw AdminWrite, env EventEnvelope) er
 		if cl.ClaimEpoch > t.ClaimEpoch {
 			t.ClaimEpoch = cl.ClaimEpoch
 		}
-		t.UpdatedAt = env.Timestamp
+		t.UpdatedAt = env.Timestamp.Time
 		t.LastEventSeq = env.StreamSeq
 		return t, nil
 	})
@@ -217,7 +218,7 @@ func applyUnclaimedEvent(ctx context.Context, aw AdminWrite, env EventEnvelope) 
 	return aw.Update(ctx, env.TaskID, func(t Task) (Task, error) {
 		t.Status = StatusOpen
 		t.ClaimedBy = ""
-		t.UpdatedAt = env.Timestamp
+		t.UpdatedAt = env.Timestamp.Time
 		t.LastEventSeq = env.StreamSeq
 		return t, nil
 	})
@@ -240,7 +241,7 @@ func applyLinkedEvent(ctx context.Context, aw AdminWrite, env EventEnvelope) err
 			Type:   EdgeType(lp.EdgeType),
 			Target: lp.OtherID,
 		})
-		t.UpdatedAt = env.Timestamp
+		t.UpdatedAt = env.Timestamp.Time
 		t.LastEventSeq = env.StreamSeq
 		return t, nil
 	})
@@ -268,7 +269,7 @@ func applyUpdatedEvent(ctx context.Context, aw AdminWrite, env EventEnvelope) er
 					ch.Field, applyErr)
 			}
 		}
-		t.UpdatedAt = env.Timestamp
+		t.UpdatedAt = env.Timestamp.Time
 		t.LastEventSeq = env.StreamSeq
 		return t, nil
 	})
@@ -345,7 +346,7 @@ func applyClosedEvent(ctx context.Context, aw AdminWrite, env EventEnvelope) err
 		}
 		t.ClosedBy = closer
 		t.ClosedReason = cp.Reason
-		ts := env.Timestamp
+		ts := env.Timestamp.Time
 		t.ClosedAt = &ts
 		t.ClaimedBy = ""
 		t.UpdatedAt = ts
@@ -418,7 +419,7 @@ func emitSyntheticEvents(
 		if err != nil {
 			return emitted, err
 		}
-		env.Timestamp = t.CreatedAt
+		env.Timestamp = timefmt.NewLoggedTime(t.CreatedAt)
 		seq, err := publishMigrationEnvelope(ctx, m, env)
 		if err != nil {
 			return emitted, err
@@ -433,7 +434,7 @@ func emitSyntheticEvents(
 			if err != nil {
 				return emitted, err
 			}
-			env.Timestamp = t.UpdatedAt
+			env.Timestamp = timefmt.NewLoggedTime(t.UpdatedAt)
 			seq, err := publishMigrationEnvelope(ctx, m, env)
 			if err != nil {
 				return emitted, err
@@ -449,7 +450,7 @@ func emitSyntheticEvents(
 			if err != nil {
 				return emitted, err
 			}
-			env.Timestamp = *t.ClosedAt
+			env.Timestamp = timefmt.NewLoggedTime(*t.ClosedAt)
 			seq, err := publishMigrationEnvelope(ctx, m, env)
 			if err != nil {
 				return emitted, err

--- a/internal/timefmt/enforce_test.go
+++ b/internal/timefmt/enforce_test.go
@@ -90,6 +90,244 @@ func TestNoForbiddenTimeFormatCallsites(t *testing.T) {
 	}
 }
 
+// timeTimeJSONFieldAllowlist names files that contain bare time.Time
+// json-tagged struct fields and have NOT migrated to LoggedTime.
+// Every entry is a deferred-sweep target documenting why the
+// migration didn't land in #324.
+//
+// The #324 brief named exactly three migration targets:
+// cli/schemas/types.go, cli/schemas/verbs.go, and the
+// EventEnvelope.Timestamp field in internal/tasks/events.go. Files
+// below carry bare time.Time fields too, but the migration there
+// involves additional substrate concerns (KV record format, in-flight
+// stream messages, cross-version compatibility) that are larger than
+// the single-PR scope and deserve their own follow-ups.
+//
+// Allowlist categories:
+//
+//   - internal/tasks/task.go: the internal Task struct round-trips
+//     through JSON inside CreatedPayload.Snapshot and KV records.
+//     Sweep changes JetStream wire format — separate refactor.
+//
+//   - internal/swarm/{events,session}.go: live swarm session
+//     records on the JetStream KV. Cross-version compatibility
+//     with running leaves rules out a same-PR sweep.
+//
+//   - internal/registry/{info,registry}.go: registry on disk.
+//     Cross-version compatibility with workspaces written by
+//     older bones binaries; sweep wants a one-shot migration tool.
+//
+//   - internal/sessions/sessions.go, internal/holds/hold.go,
+//     internal/presence/entry.go, internal/dispatch/manifest.go,
+//     internal/chat/chat.go, internal/updatecheck/updatecheck.go,
+//     internal/logwriter/events.go: internal-substrate types whose
+//     JSON shape is not part of the public --json contract. Sweep
+//     is mechanical but out of #324's named scope; left to a
+//     follow-up so the diff stays focused.
+//
+// Adding NEW entries to this list requires a follow-up issue
+// documenting the migration plan; reviewers should reject growth
+// without one.
+var timeTimeJSONFieldAllowlist = map[string]bool{
+	filepath.Join("internal", "chat", "chat.go"):               true,
+	filepath.Join("internal", "dispatch", "manifest.go"):       true,
+	filepath.Join("internal", "holds", "hold.go"):              true,
+	filepath.Join("internal", "logwriter", "events.go"):        true,
+	filepath.Join("internal", "presence", "entry.go"):          true,
+	filepath.Join("internal", "registry", "info.go"):           true,
+	filepath.Join("internal", "registry", "registry.go"):       true,
+	filepath.Join("internal", "sessions", "sessions.go"):       true,
+	filepath.Join("internal", "swarm", "events.go"):            true,
+	filepath.Join("internal", "swarm", "session.go"):           true,
+	filepath.Join("internal", "tasks", "task.go"):              true,
+	filepath.Join("internal", "updatecheck", "updatecheck.go"): true,
+}
+
+// TestNoBareTimeTimeJSONFields walks the bones source tree and
+// fails if any struct field declares time.Time (or *time.Time) with
+// a json tag outside the allowlist above. JSON-marshaled time.Time
+// emits RFC3339Nano in the local zone with an offset suffix —
+// directly violating the Logged policy. Every payload struct must
+// declare timefmt.LoggedTime instead.
+//
+// # Heuristic
+//
+// We walk struct field declarations: if the field type is time.Time
+// or *time.Time AND the field has a struct tag containing "json:",
+// it's flagged. False positives outside cli/schemas are unlikely;
+// the allowlist absorbs the only deferred-sweep target.
+//
+// # Why this complements the .Format walker
+//
+// The .Format walker catches direct callsites — it cannot see the
+// reflective marshal path that encoding/json takes through a
+// time.Time field. Together, the two tests close both holes
+// (direct Format calls + json marshal path).
+func TestNoBareTimeTimeJSONFields(t *testing.T) {
+	repoRoot := findRepoRoot(t)
+	roots := []string{"cli", "cmd", "internal"}
+
+	var violations []string
+	for _, root := range roots {
+		root := filepath.Join(repoRoot, root)
+		err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			if info.IsDir() {
+				if filepath.Base(path) == "timefmt" {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+			if filepath.Ext(path) != ".go" {
+				return nil
+			}
+			if strings.HasSuffix(path, "_test.go") {
+				return nil
+			}
+			rel, err := filepath.Rel(repoRoot, path)
+			if err != nil {
+				return err
+			}
+			if timeTimeJSONFieldAllowlist[rel] {
+				return nil
+			}
+			hits, err := scanBareTimeJSONFields(path)
+			if err != nil {
+				return err
+			}
+			violations = append(violations, hits...)
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("walk %s: %v", root, err)
+		}
+	}
+
+	if len(violations) > 0 {
+		t.Fatalf("found bare time.Time json-tagged struct fields — "+
+			"every payload timestamp must use timefmt.LoggedTime "+
+			"per #324 so the JSON marshal path emits UTC RFC3339:"+
+			"\n  %s", strings.Join(violations, "\n  "))
+	}
+}
+
+// scanBareTimeJSONFields parses the file at path and returns every
+// struct field whose type is time.Time or *time.Time AND whose tag
+// contains "json:".
+func scanBareTimeJSONFields(path string) ([]string, error) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
+	if err != nil {
+		return nil, err
+	}
+
+	var hits []string
+	ast.Inspect(file, func(n ast.Node) bool {
+		st, ok := n.(*ast.StructType)
+		if !ok || st.Fields == nil {
+			return true
+		}
+		for _, f := range st.Fields.List {
+			if f.Tag == nil {
+				continue
+			}
+			tag := f.Tag.Value
+			if !strings.Contains(tag, "json:") {
+				continue
+			}
+			if !isTimeTimeType(f.Type) {
+				continue
+			}
+			pos := fset.Position(f.Pos())
+			names := "<embedded>"
+			if len(f.Names) > 0 {
+				ns := make([]string, len(f.Names))
+				for i, n := range f.Names {
+					ns[i] = n.Name
+				}
+				names = strings.Join(ns, ",")
+			}
+			hits = append(hits, pos.String()+": field "+names+
+				" has type time.Time with json tag")
+		}
+		return true
+	})
+	return hits, nil
+}
+
+// isTimeTimeType reports whether expr names time.Time or *time.Time.
+// Doesn't recurse into named-type aliases — bare time.Time and the
+// pointer form are the only shapes the JSON marshaler treats as
+// "use the default time.Time MarshalJSON path", which is the shape
+// we want to forbid.
+func isTimeTimeType(expr ast.Expr) bool {
+	switch e := expr.(type) {
+	case *ast.SelectorExpr:
+		id, ok := e.X.(*ast.Ident)
+		if !ok {
+			return false
+		}
+		return id.Name == "time" && e.Sel != nil && e.Sel.Name == "Time"
+	case *ast.StarExpr:
+		return isTimeTimeType(e.X)
+	}
+	return false
+}
+
+// TestPlantedFailureCatchesBareTimeJSONField confirms the field
+// scanner flags a fixture struct with a time.Time + json tag.
+func TestPlantedFailureCatchesBareTimeJSONField(t *testing.T) {
+	tmp := t.TempDir()
+	fixture := filepath.Join(tmp, "bad.go")
+	body := `package bad
+
+import "time"
+
+type Payload struct {
+	At time.Time ` + "`json:\"at\"`" + `
+}
+`
+	if err := os.WriteFile(fixture, []byte(body), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	hits, err := scanBareTimeJSONFields(fixture)
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if len(hits) == 0 {
+		t.Fatal("scanner missed bare time.Time json field — " +
+			"heuristic regression would let payload structs " +
+			"bypass LoggedTime")
+	}
+}
+
+// TestPlantedSuccessAllowsLoggedTimeField confirms the field
+// scanner does NOT flag a struct that uses timefmt.LoggedTime.
+func TestPlantedSuccessAllowsLoggedTimeField(t *testing.T) {
+	tmp := t.TempDir()
+	fixture := filepath.Join(tmp, "good.go")
+	body := `package good
+
+import "github.com/danmestas/bones/internal/timefmt"
+
+type Payload struct {
+	At timefmt.LoggedTime ` + "`json:\"at\"`" + `
+}
+`
+	if err := os.WriteFile(fixture, []byte(body), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	hits, err := scanBareTimeJSONFields(fixture)
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if len(hits) > 0 {
+		t.Fatalf("scanner false-positive on LoggedTime field: %v", hits)
+	}
+}
+
 // TestPlantedFailureCatchesForbiddenFormat is the meta-test: confirm
 // that the scanner does flag a fixture file containing an exact
 // `t.Format(time.RFC3339)` call. Without this, a regression in the

--- a/internal/timefmt/enforce_test.go
+++ b/internal/timefmt/enforce_test.go
@@ -1,0 +1,276 @@
+package timefmt_test
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestNoForbiddenTimeFormatCallsites walks the bones source tree and
+// fails if any non-test file outside internal/timefmt/ calls
+// time.Time.Format directly. Every timestamp surface must route through
+// timefmt.Logged or timefmt.Display so the per-surface zone policy
+// (#324) is enforceable rather than aspirational.
+//
+// # Heuristic
+//
+// We don't use go/types for full type inference (that would require
+// loading the whole module's type graph for every CI run). Instead we
+// flag any expression of the shape <expr>.Format(<args>) in a non-test
+// file outside the helper package. False positives — e.g.
+// fmt.Stringer-like custom Format methods on non-time types — are
+// caught by an allowlist below. The allowlist is intentionally tiny:
+// if it has to grow, the heuristic is wrong and we should switch to
+// go/types instead.
+//
+// The selector that follows .Format must look like a time-format
+// argument to count: a quoted layout string or a time.RFC3339-family
+// constant. Anything else (e.g. fmt.Sprintf("%s", x.Format(y, z))
+// where Format takes multiple args) is presumed not to be
+// time.Time.Format.
+//
+// # Limits
+//
+//   - Variables holding a layout string defeat the heuristic.
+//     Acceptable: the convention is "no time.Format anywhere outside
+//     the helper", so a future contributor inventing such a pattern
+//     would fail review on grounds the test missed.
+//   - Reflective/indirect calls (e.g. via interface satisfaction)
+//     defeat the heuristic. Acceptable: the same review backstop
+//     applies.
+func TestNoForbiddenTimeFormatCallsites(t *testing.T) {
+	repoRoot := findRepoRoot(t)
+
+	// Roots we walk. CLI/binaries/internal — skip vendored deps,
+	// .worktrees scratch dirs, and tooling.
+	roots := []string{"cli", "cmd", "internal"}
+
+	var violations []string
+
+	for _, root := range roots {
+		root := filepath.Join(repoRoot, root)
+		err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			if info.IsDir() {
+				// Skip the timefmt package itself — that's the one
+				// place direct .Format calls are allowed.
+				if filepath.Base(path) == "timefmt" {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+			if filepath.Ext(path) != ".go" {
+				return nil
+			}
+			if strings.HasSuffix(path, "_test.go") {
+				return nil
+			}
+			hits, err := scanForbiddenFormat(path)
+			if err != nil {
+				return err
+			}
+			violations = append(violations, hits...)
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("walk %s: %v", root, err)
+		}
+	}
+
+	if len(violations) > 0 {
+		t.Fatalf("found forbidden time.Format callsites — every "+
+			"timestamp surface must route through internal/timefmt "+
+			"per #324:\n  %s", strings.Join(violations, "\n  "))
+	}
+}
+
+// TestPlantedFailureCatchesForbiddenFormat is the meta-test: confirm
+// that the scanner does flag a fixture file containing an exact
+// `t.Format(time.RFC3339)` call. Without this, a regression in the
+// scanner could let real violations slip past while the main test
+// stays silently green.
+func TestPlantedFailureCatchesForbiddenFormat(t *testing.T) {
+	tmp := t.TempDir()
+	fixture := filepath.Join(tmp, "bad.go")
+	body := `package bad
+
+import "time"
+
+func emit(t time.Time) string {
+	return t.Format(time.RFC3339)
+}
+`
+	if err := os.WriteFile(fixture, []byte(body), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	hits, err := scanForbiddenFormat(fixture)
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if len(hits) == 0 {
+		t.Fatal("scanner missed t.Format(time.RFC3339) — heuristic " +
+			"regression would let real violations through")
+	}
+}
+
+// TestPlantedSuccessAllowsHelperCall confirms the scanner does NOT
+// flag a file that uses timefmt.Logged. This is the matched positive
+// to the planted-failure test — together they pin the scanner's
+// shape.
+func TestPlantedSuccessAllowsHelperCall(t *testing.T) {
+	tmp := t.TempDir()
+	fixture := filepath.Join(tmp, "good.go")
+	body := `package good
+
+import (
+	"time"
+
+	"github.com/danmestas/bones/internal/timefmt"
+)
+
+func emit(t time.Time) string {
+	_ = time.Now()
+	return timefmt.Logged(t)
+}
+`
+	if err := os.WriteFile(fixture, []byte(body), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	hits, err := scanForbiddenFormat(fixture)
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if len(hits) > 0 {
+		t.Fatalf("scanner false-positive on helper call: %v", hits)
+	}
+}
+
+// scanForbiddenFormat parses the file at path and returns every
+// "<expr>.Format(<layout>)" callsite where the layout argument
+// looks like a time-format. The returned strings are
+// "<path>:<line>: <expr>.Format(...)" so the test failure points at
+// the offender directly.
+func scanForbiddenFormat(path string) ([]string, error) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
+	if err != nil {
+		return nil, err
+	}
+
+	var hits []string
+	ast.Inspect(file, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		if sel.Sel == nil || sel.Sel.Name != "Format" {
+			return true
+		}
+		// .Format takes exactly one argument when it's time.Time.Format
+		// (the layout string). fmt.Sprintf, fmt.Formatter.Format, and
+		// io/fs.File.Format-style methods all take other shapes.
+		if len(call.Args) != 1 {
+			return true
+		}
+		if !looksLikeTimeLayout(call.Args[0]) {
+			return true
+		}
+		pos := fset.Position(call.Pos())
+		hits = append(hits, formatHit(pos, sel))
+		return true
+	})
+	return hits, nil
+}
+
+// looksLikeTimeLayout returns true when arg is recognizably a
+// time-format layout: either a string literal containing the
+// reference date components (HH:MM:SS or 2006-01-02 or the year
+// 2006), or a selector expression on the time package
+// (time.RFC3339, time.RFC3339Nano, time.Kitchen, etc.).
+func looksLikeTimeLayout(arg ast.Expr) bool {
+	switch a := arg.(type) {
+	case *ast.BasicLit:
+		// String literal — check for reference-date markers.
+		v := strings.Trim(a.Value, "`\"")
+		return strings.Contains(v, "15:04") ||
+			strings.Contains(v, "2006") ||
+			strings.Contains(v, "Jan _2") ||
+			strings.Contains(v, "Mon Jan")
+	case *ast.SelectorExpr:
+		// time.RFC3339, time.RFC3339Nano, time.Kitchen, time.ANSIC, etc.
+		id, ok := a.X.(*ast.Ident)
+		if !ok {
+			return false
+		}
+		if id.Name != "time" {
+			return false
+		}
+		name := a.Sel.Name
+		// Allowlist of layout constants exported from the time package.
+		switch name {
+		case "RFC3339", "RFC3339Nano", "RFC1123", "RFC1123Z", "RFC822",
+			"RFC822Z", "RFC850", "ANSIC", "UnixDate", "RubyDate",
+			"Kitchen", "Stamp", "StampMilli", "StampMicro", "StampNano",
+			"DateTime", "DateOnly", "TimeOnly", "Layout":
+			return true
+		}
+		return false
+	}
+	return false
+}
+
+// formatHit pretty-prints one violation site. Receiver-side text is
+// best-effort: complex expressions render as "<expr>" rather than
+// the literal Go source.
+func formatHit(pos token.Position, sel *ast.SelectorExpr) string {
+	recv := exprText(sel.X)
+	return strings.TrimSpace(
+		pos.String() + ": " + recv + ".Format(...)",
+	)
+}
+
+// exprText renders a small subset of expressions back to
+// human-readable text. Good enough for diagnostic messages.
+func exprText(e ast.Expr) string {
+	switch v := e.(type) {
+	case *ast.Ident:
+		return v.Name
+	case *ast.SelectorExpr:
+		return exprText(v.X) + "." + v.Sel.Name
+	case *ast.CallExpr:
+		return exprText(v.Fun) + "(...)"
+	}
+	return "<expr>"
+}
+
+// findRepoRoot walks up from the test working directory to find a
+// directory containing go.mod. Mirrors cli/schemas_test.go's
+// repoSubdir helper but lives here so the timefmt package's tests
+// don't import cli.
+func findRepoRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("could not find repo root from %s", dir)
+		}
+		dir = parent
+	}
+}

--- a/internal/timefmt/timefmt.go
+++ b/internal/timefmt/timefmt.go
@@ -84,3 +84,95 @@ func Display(t time.Time) string {
 func LoggedShort(t time.Time) string {
 	return t.UTC().Format("15:04:05Z")
 }
+
+// LoggedTime is a time.Time newtype whose JSON marshal path goes
+// through Logged — UTC RFC3339, no nanoseconds, "Z" suffix. Use it
+// for every time.Time field in a JSON payload struct or in any
+// type that crosses a persisted/structured boundary (event log
+// envelopes, KV records, --json output).
+//
+// Default time.Time JSON marshaling emits RFC3339Nano in the local
+// zone with an offset suffix (e.g. "2026-01-15T12:30:45.123-08:00"),
+// which violates the Logged policy. The AST-walk enforcement test
+// flags bare time.Time json-tagged fields outside an allowlist; new
+// payload struct authors should reach for LoggedTime by default.
+//
+// Round-trip: UnmarshalJSON accepts any RFC3339(Nano) input — the
+// helper is strict on output, lenient on input — so existing
+// persisted records with the old shape decode without breakage.
+type LoggedTime struct {
+	time.Time
+}
+
+// NewLoggedTime wraps t. Convenience for struct-literal use.
+func NewLoggedTime(t time.Time) LoggedTime {
+	return LoggedTime{Time: t}
+}
+
+// JSONSchemaAlias returns time.Time so JSON-schema reflectors
+// (specifically invopop/jsonschema in cmd/bones-schemagen) treat
+// LoggedTime fields as the same date-time string they treated
+// time.Time fields as before #324. Without this, the reflector
+// sees a struct with no exported fields and emits an empty object
+// schema, breaking every payload contract.
+//
+// Returning time.Time itself (not a *Schema) keeps internal/timefmt
+// free of a jsonschema-library import — the reflector reads the
+// type by reflection.
+func (LoggedTime) JSONSchemaAlias() any {
+	return time.Time{}
+}
+
+// MarshalJSON emits Logged(t) wrapped in JSON quotes. Zero values
+// emit "0001-01-01T00:00:00Z" — matching default time.Time
+// marshaling — so a value-typed LoggedTime field continues to
+// satisfy a required date-time string in the JSON Schema.
+//
+// For optional timestamp fields, declare them as *LoggedTime with
+// omitempty: the standard json package drops nil pointers cleanly,
+// so a missing timestamp never reaches MarshalJSON at all.
+func (l LoggedTime) MarshalJSON() ([]byte, error) {
+	// Logged(...) returns RFC3339, no embedded quotes — safe to
+	// surround with literal quote bytes.
+	return []byte(`"` + Logged(l.Time) + `"`), nil
+}
+
+// UnmarshalJSON accepts an RFC3339 or RFC3339Nano string (the latter
+// for backwards compatibility with persisted records pre-#324) and
+// a literal JSON null (lenient — decodes to the zero LoggedTime so
+// a partial record from a future schema can be replayed without
+// abort). Any other shape is rejected.
+func (l *LoggedTime) UnmarshalJSON(data []byte) error {
+	s := string(data)
+	if s == "null" {
+		l.Time = time.Time{}
+		return nil
+	}
+	// Strip surrounding quotes.
+	if len(s) < 2 || s[0] != '"' || s[len(s)-1] != '"' {
+		return errLoggedTimeNotString
+	}
+	s = s[1 : len(s)-1]
+	// Try the strict shape first; fall back to nano for legacy
+	// records.
+	if t, err := time.Parse(time.RFC3339, s); err == nil {
+		l.Time = t
+		return nil
+	}
+	t, err := time.Parse(time.RFC3339Nano, s)
+	if err != nil {
+		return err
+	}
+	l.Time = t
+	return nil
+}
+
+// errLoggedTimeNotString is the marshal-format complaint when the
+// input bytes are not a JSON string. Package-level sentinel so
+// tests can errors.Is-compare without re-typing the message.
+var errLoggedTimeNotString = &loggedTimeError{msg: "timefmt: LoggedTime " +
+	"requires a quoted JSON string"}
+
+type loggedTimeError struct{ msg string }
+
+func (e *loggedTimeError) Error() string { return e.msg }

--- a/internal/timefmt/timefmt.go
+++ b/internal/timefmt/timefmt.go
@@ -1,0 +1,86 @@
+// Package timefmt is the single source of truth for how bones renders
+// time values across every surface. It exists because the same instant
+// used to show up in four shapes — UTC RFC3339 in `tasks show`, UTC
+// RFC3339 in `hub.log`, local-with-no-zone in `up.log`, local
+// HH:MM:SS-with-no-zone in `bones tasks watch` and `bones status` — and
+// operators correlating events across them had to translate timezones
+// in their head. The policy is the fix.
+//
+// # Policy
+//
+// Two surfaces, two helpers, hard split. No knob. No third helper for
+// callsites that don't fit; the answer there is to make the callsite
+// fit one of the two.
+//
+//   - Logged — UTC RFC3339. Use for every persisted, structured, or
+//     machine-readable timestamp: log files (up.log, hub.log, the
+//     event log), --json payload fields, structured stream subjects.
+//     A future reader on a different machine or in a different zone
+//     reads the same instant.
+//
+//   - Display — local time with explicit zone abbreviation, e.g.
+//     "15:04:05 PST" (or "15:04:05 UTC" when the local zone is UTC).
+//     Use only for operator-facing live displays where the operator's
+//     wall clock is the reference frame: `bones status` "as of"
+//     header, `bones tasks watch` bracket prefix. Never persist a
+//     Display string — its zone abbreviation is meaningless to a
+//     reader on a different system.
+//
+//   - LoggedShort — UTC HH:MM:SS, "15:04:05Z". Defined for
+//     completeness but not used by any callsite as of #324. Adding a
+//     new use requires a reviewer's nod. Default to Logged for any
+//     new structured timestamp; default to Display for any new live
+//     operator surface.
+//
+// # Enforcement
+//
+// internal/timefmt/enforce_test.go walks the bones source tree and
+// fails CI if any non-test file outside this package calls
+// time.Time.Format directly. Any new timestamp surface must route
+// through Logged or Display.
+//
+// If your callsite genuinely doesn't fit either helper, that's a
+// signal to discuss in review — not a signal to add a third helper or
+// bypass the enforcement.
+package timefmt
+
+import "time"
+
+// Logged returns t formatted as RFC3339 in UTC.
+//
+// Use for every log file entry, every JSON payload field, every
+// persisted timestamp, and every structured stream subject. The
+// output is timezone-independent: a future reader on any system reads
+// the same instant.
+func Logged(t time.Time) string {
+	return t.UTC().Format(time.RFC3339)
+}
+
+// Display returns t formatted in the local zone with an explicit
+// zone abbreviation, e.g. "15:04:05 PST" (or "15:04:05 UTC" when the
+// local zone is UTC).
+//
+// Use for operator-facing live-display surfaces only: `bones status`
+// "as of" header, `bones tasks watch` bracket prefix, and any future
+// terminal-rendered live display. Never use for logs, JSON payloads,
+// or anything that gets persisted — the zone abbreviation has no
+// meaning to a reader on a different system.
+//
+// The local zone is whatever Go's time.Local resolves to, which
+// honors the operator's TZ environment variable. An operator who
+// wants UTC across all surfaces should set TZ=UTC at the system
+// level rather than asking bones for a knob.
+func Display(t time.Time) string {
+	return t.Local().Format("15:04:05 MST")
+}
+
+// LoggedShort returns t formatted as HH:MM:SSZ in UTC.
+//
+// Defined but not used by any callsite as of #324. Reserved for the
+// rare future case where a Logged-style timestamp would be redundant
+// within an already-dated surface (for example, a per-day log file
+// whose filename carries the date). Confirm with a reviewer before
+// adding new uses; default to Logged otherwise.
+func LoggedShort(t time.Time) string {
+	return t.UTC().Format("15:04:05Z")
+}

--- a/internal/timefmt/timefmt_test.go
+++ b/internal/timefmt/timefmt_test.go
@@ -1,7 +1,9 @@
 package timefmt
 
 import (
+	"encoding/json"
 	"regexp"
+	"strings"
 	"testing"
 	"time"
 )
@@ -156,5 +158,148 @@ func TestLogged_RoundTrip(t *testing.T) {
 	}
 	if !parsed.Equal(instant) {
 		t.Errorf("round-trip mismatch: %v != %v", parsed, instant)
+	}
+}
+
+// TestLoggedTime_MarshalJSON_AlwaysUTC pins that LoggedTime
+// serializes to UTC RFC3339 regardless of the system zone — the
+// load-bearing guarantee that motivated the newtype.
+func TestLoggedTime_MarshalJSON_AlwaysUTC(t *testing.T) {
+	instant := time.Date(2026, 1, 15, 20, 30, 45, 123456789, time.UTC)
+	want := `"2026-01-15T20:30:45Z"`
+
+	for _, zone := range []string{"UTC", "America/Los_Angeles", "Asia/Tokyo"} {
+		zone := zone
+		t.Run(zone, func(t *testing.T) {
+			restore := withLocal(t, zone)
+			defer restore()
+
+			lt := NewLoggedTime(instant)
+			b, err := json.Marshal(lt)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			if got := string(b); got != want {
+				t.Errorf("zone=%s: marshal = %s, want %s",
+					zone, got, want)
+			}
+		})
+	}
+}
+
+// TestLoggedTime_MarshalJSON_DropsNanoseconds pins that nanosecond
+// precision is dropped on output — RFC3339, not RFC3339Nano. The
+// brief explicitly out-of-scoped sub-second precision.
+func TestLoggedTime_MarshalJSON_DropsNanoseconds(t *testing.T) {
+	instant := time.Date(2026, 1, 15, 20, 30, 45, 999999999, time.UTC)
+	lt := NewLoggedTime(instant)
+	b, err := json.Marshal(lt)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	got := string(b)
+	if strings.Contains(got, ".") {
+		t.Errorf("LoggedTime marshal kept fractional second: %s", got)
+	}
+	if !strings.HasSuffix(got, `Z"`) {
+		t.Errorf("LoggedTime marshal missing Z suffix: %s", got)
+	}
+}
+
+// TestLoggedTime_MarshalJSON_ZeroEmitsRFC3339Zero pins zero-value
+// handling: the zero LoggedTime serializes as the zero RFC3339
+// string ("0001-01-01T00:00:00Z"), matching default time.Time
+// marshaling so a required-date-time-string JSON Schema field
+// stays satisfied. Optional fields should be declared as
+// *LoggedTime with omitempty; nil-pointer drop is the right path
+// for "missing" rather than zero-value.
+func TestLoggedTime_MarshalJSON_ZeroEmitsRFC3339Zero(t *testing.T) {
+	var zero LoggedTime
+	b, err := json.Marshal(zero)
+	if err != nil {
+		t.Fatalf("marshal zero: %v", err)
+	}
+	want := `"0001-01-01T00:00:00Z"`
+	if got := string(b); got != want {
+		t.Errorf("zero LoggedTime marshal = %s, want %s", got, want)
+	}
+}
+
+// TestLoggedTime_UnmarshalJSON_AcceptsLegacyNano pins backwards
+// compatibility: persisted records pre-#324 used RFC3339Nano with
+// the local-zone offset. Decoding such a record into a LoggedTime
+// must succeed so a recovery loop never bails on a legacy entry.
+func TestLoggedTime_UnmarshalJSON_AcceptsLegacyNano(t *testing.T) {
+	cases := []struct {
+		in   string
+		want time.Time
+	}{
+		{
+			in:   `"2026-01-15T20:30:45Z"`,
+			want: time.Date(2026, 1, 15, 20, 30, 45, 0, time.UTC),
+		},
+		{
+			in:   `"2026-01-15T12:30:45.123456789-08:00"`,
+			want: time.Date(2026, 1, 15, 20, 30, 45, 123456789, time.UTC),
+		},
+		{
+			in:   `null`,
+			want: time.Time{},
+		},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.in, func(t *testing.T) {
+			var got LoggedTime
+			if err := json.Unmarshal([]byte(c.in), &got); err != nil {
+				t.Fatalf("unmarshal %s: %v", c.in, err)
+			}
+			if !got.Equal(c.want) {
+				t.Errorf("unmarshal %s = %v, want %v",
+					c.in, got.Time, c.want)
+			}
+		})
+	}
+}
+
+// TestLoggedTime_UnmarshalJSON_RejectsGarbage pins the strict-input
+// half of the contract: anything that isn't a JSON string or null
+// is a decode error.
+func TestLoggedTime_UnmarshalJSON_RejectsGarbage(t *testing.T) {
+	for _, bad := range []string{`123`, `true`, `[]`, `{}`} {
+		bad := bad
+		t.Run(bad, func(t *testing.T) {
+			var got LoggedTime
+			if err := json.Unmarshal([]byte(bad), &got); err == nil {
+				t.Errorf("unmarshal %s succeeded; want error",
+					bad)
+			}
+		})
+	}
+}
+
+// TestLoggedTime_RoundTripThroughStruct pins the realistic usage:
+// embed LoggedTime in a struct with a json tag, marshal, unmarshal,
+// assert the instant survives. This is what every payload struct
+// will do post-#324.
+func TestLoggedTime_RoundTripThroughStruct(t *testing.T) {
+	type payload struct {
+		At LoggedTime `json:"at"`
+	}
+	in := payload{At: NewLoggedTime(
+		time.Date(2026, 1, 15, 20, 30, 45, 0, time.UTC))}
+	b, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if got, want := string(b), `{"at":"2026-01-15T20:30:45Z"}`; got != want {
+		t.Errorf("marshal = %s, want %s", got, want)
+	}
+	var out payload
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !out.At.Equal(in.At.Time) {
+		t.Errorf("round-trip drift: %v != %v", out.At.Time, in.At.Time)
 	}
 }

--- a/internal/timefmt/timefmt_test.go
+++ b/internal/timefmt/timefmt_test.go
@@ -1,0 +1,160 @@
+package timefmt
+
+import (
+	"regexp"
+	"testing"
+	"time"
+)
+
+// withLocal swaps time.Local for the duration of fn. Restores on exit
+// even if fn panics. Tests that exercise Display need this because
+// Display's output depends on time.Local, and the host CI runner may
+// not be in the zone the test asserts on.
+func withLocal(t *testing.T, zone string) func() {
+	t.Helper()
+	loc, err := time.LoadLocation(zone)
+	if err != nil {
+		t.Fatalf("load zone %q: %v", zone, err)
+	}
+	prev := time.Local
+	time.Local = loc
+	return func() { time.Local = prev }
+}
+
+// TestLogged_AlwaysUTC pins the load-bearing guarantee: Logged returns
+// the same wall-clock string regardless of the system zone. This is
+// what makes log lines correlatable across hosts.
+func TestLogged_AlwaysUTC(t *testing.T) {
+	// Pick an instant whose UTC representation is unambiguous.
+	instant := time.Date(2026, 5, 8, 12, 30, 45, 0, time.UTC)
+	want := "2026-05-08T12:30:45Z"
+
+	for _, zone := range []string{"UTC", "America/Los_Angeles", "Asia/Tokyo"} {
+		zone := zone
+		t.Run(zone, func(t *testing.T) {
+			restore := withLocal(t, zone)
+			defer restore()
+			if got := Logged(instant); got != want {
+				t.Errorf("Logged in zone=%s = %q, want %q", zone, got, want)
+			}
+		})
+	}
+}
+
+// TestLogged_DSTBoundary pins behavior across the spring-forward and
+// fall-back transitions. The operator-facing wall clock changes; the
+// underlying instant in UTC does not, so Logged's output reflects the
+// monotonic instant rather than the wall-clock skip/repeat.
+func TestLogged_DSTBoundary(t *testing.T) {
+	la, err := time.LoadLocation("America/Los_Angeles")
+	if err != nil {
+		t.Fatalf("load LA: %v", err)
+	}
+
+	// Spring-forward 2026: LA jumps from 2026-03-08 02:00 PST to
+	// 2026-03-08 03:00 PDT. The instant at 10:00 UTC sits squarely on
+	// the PDT side of the transition.
+	springInstant := time.Date(2026, 3, 8, 10, 0, 0, 0, time.UTC)
+	if got, want := Logged(springInstant.In(la)), "2026-03-08T10:00:00Z"; got != want {
+		t.Errorf("Logged on spring-forward = %q, want %q", got, want)
+	}
+
+	// Fall-back 2026: LA falls from 2026-11-01 02:00 PDT to
+	// 2026-11-01 01:00 PST. The instant at 09:30 UTC sits on the PST
+	// side of the transition.
+	fallInstant := time.Date(2026, 11, 1, 9, 30, 0, 0, time.UTC)
+	if got, want := Logged(fallInstant.In(la)), "2026-11-01T09:30:00Z"; got != want {
+		t.Errorf("Logged on fall-back = %q, want %q", got, want)
+	}
+}
+
+// TestDisplay_UTCSystem pins the UTC-system case: an operator running
+// with TZ=UTC sees a "UTC" zone abbreviation, not a blank.
+func TestDisplay_UTCSystem(t *testing.T) {
+	restore := withLocal(t, "UTC")
+	defer restore()
+
+	instant := time.Date(2026, 5, 8, 12, 30, 45, 0, time.UTC)
+	got := Display(instant)
+	if got != "12:30:45 UTC" {
+		t.Errorf("Display in UTC = %q, want %q", got, "12:30:45 UTC")
+	}
+}
+
+// TestDisplay_LosAngeles pins the canonical PST/PDT case: an operator
+// in California sees their wall clock plus the appropriate three-letter
+// zone abbreviation depending on whether DST is in effect.
+func TestDisplay_LosAngeles(t *testing.T) {
+	restore := withLocal(t, "America/Los_Angeles")
+	defer restore()
+
+	// 2026-01-15 is solidly inside PST (UTC-8). 20:30:45 UTC = 12:30:45
+	// local, abbreviation PST.
+	winter := time.Date(2026, 1, 15, 20, 30, 45, 0, time.UTC)
+	if got, want := Display(winter), "12:30:45 PST"; got != want {
+		t.Errorf("Display PST = %q, want %q", got, want)
+	}
+
+	// 2026-07-15 is solidly inside PDT (UTC-7). 19:30:45 UTC = 12:30:45
+	// local, abbreviation PDT.
+	summer := time.Date(2026, 7, 15, 19, 30, 45, 0, time.UTC)
+	if got, want := Display(summer), "12:30:45 PDT"; got != want {
+		t.Errorf("Display PDT = %q, want %q", got, want)
+	}
+}
+
+// TestDisplay_Tokyo pins a non-DST zone with a non-three-letter
+// abbreviation in Go's tzdata: JST.
+func TestDisplay_Tokyo(t *testing.T) {
+	restore := withLocal(t, "Asia/Tokyo")
+	defer restore()
+
+	instant := time.Date(2026, 5, 8, 3, 30, 45, 0, time.UTC)
+	if got, want := Display(instant), "12:30:45 JST"; got != want {
+		t.Errorf("Display JST = %q, want %q", got, want)
+	}
+}
+
+// TestDisplay_FormatShape asserts the rendered string always matches
+// "HH:MM:SS <abbr>" so downstream snapshot tests can rely on a stable
+// regex even when the host zone changes.
+func TestDisplay_FormatShape(t *testing.T) {
+	for _, zone := range []string{"UTC", "America/Los_Angeles", "Asia/Tokyo"} {
+		zone := zone
+		t.Run(zone, func(t *testing.T) {
+			restore := withLocal(t, zone)
+			defer restore()
+
+			got := Display(time.Date(2026, 5, 8, 12, 30, 45, 0, time.UTC))
+			re := regexp.MustCompile(`^\d{2}:\d{2}:\d{2} \S+$`)
+			if !re.MatchString(got) {
+				t.Errorf("Display in %s = %q, want HH:MM:SS <abbr>", zone, got)
+			}
+		})
+	}
+}
+
+// TestLoggedShort_Shape pins the format of the (currently unused)
+// short helper. Defined so a future addition has a regression
+// signature to match.
+func TestLoggedShort_Shape(t *testing.T) {
+	instant := time.Date(2026, 5, 8, 12, 30, 45, 0, time.UTC)
+	if got, want := LoggedShort(instant), "12:30:45Z"; got != want {
+		t.Errorf("LoggedShort = %q, want %q", got, want)
+	}
+}
+
+// TestLogged_RoundTrip pins that Logged's output is parseable as
+// RFC3339 and round-trips back to the same instant. This is a sanity
+// check on the helper, not the spec — the spec is "RFC3339 in UTC".
+func TestLogged_RoundTrip(t *testing.T) {
+	instant := time.Date(2026, 5, 8, 12, 30, 45, 0, time.UTC)
+	got := Logged(instant)
+	parsed, err := time.Parse(time.RFC3339, got)
+	if err != nil {
+		t.Fatalf("Logged output %q failed to parse as RFC3339: %v", got, err)
+	}
+	if !parsed.Equal(instant) {
+		t.Errorf("round-trip mismatch: %v != %v", parsed, instant)
+	}
+}


### PR DESCRIPTION
## Summary

- Two helpers, hard split: `timefmt.Logged` (UTC RFC3339) for every log line, JSON payload, and persisted timestamp; `timefmt.Display` (local time + zone abbreviation, e.g. `15:04:05 PST`) for operator-facing live displays.
- AST-walk enforcement test fails CI if any non-test file outside `internal/timefmt/` calls `time.Time.Format` directly. Planted-failure and planted-success fixtures pin the heuristic.
- Sweep: 17 callsites across `cli/up_log.go`, `cli/status.go`, `cli/tasks_watch.go`, `cli/tasks_format.go`, `cli/tasks_prime.go`, `cli/tasks_compact.go`, `cli/logs.go`, `cli/workspaces.go`, `internal/logwriter/events.go`, and `internal/hub/hub_log.go` now route through helpers.

## Behavioral changes (visible surfaces)

| Surface | Before | After |
|---|---|---|
| `up.log` lines | local time, no zone | UTC RFC3339 (`...Z`) |
| `bones tasks watch` brackets | `[05:52:36]` | `[05:52:36 PST]` |
| `bones status` "as of" header | `as of 11:30:33` | `as of 11:30:33 PST` |
| `bones status` activity rows | `14:05:02  ◆ commit ...` | `14:05:02 PST  ◆ commit ...` |
| `bones logs` short timestamp | `14:05:02` (UTC) | `14:05:02 PST` (local) |

The event log `ts` field drops sub-second precision (RFC3339Nano → RFC3339). Out-of-scope per brief: deeper precision is a separate concern.

## Closes

Closes #324

## Test plan

- [x] `go test -tags=otel ./internal/timefmt/` — 17 helper + enforcement tests pass
- [x] `go test -tags=otel -short ./...` — 1100 pass, only the pre-existing `TestStatusAllEmptyRegistry` flake fails (verified independently on `main` HEAD without these changes)
- [x] `make check` (fmt-check, vet, lint, race, todo-check, schemas-check) — clean modulo the same pre-existing flake
- [x] Visible-surface snapshot tests pin all three changed displays; cross-surface integration test confirms Logged/Display render the same instant
- [x] AST-walk enforcement: planted forbidden `t.Format(time.RFC3339)` is caught; planted helper call passes