### PR TITLE
feat(hub): RPC operation log via NDJSON middleware

### DIFF
--- a/cli/hub.go
+++ b/cli/hub.go
@@ -54,6 +54,11 @@ type HubStartCmd struct {
 	// DrainTimeout bounds NATS/Fossil drain on shutdown before
 	// runForeground returns errDrainTimeout (non-zero exit). See #158.
 	DrainTimeout time.Duration `name:"drain-timeout" default:"30s" help:"max drain wait"` //nolint:lll
+	// LogLevel controls hub.log entry verbosity (#322). Standard four
+	// severities: debug, info, warn, error. Default INFO (read-only
+	// RPCs demoted to DEBUG; mutating + errors at INFO). Honored as
+	// "flag wins, then BONES_HUB_LOG_LEVEL env var, then INFO".
+	LogLevel string `name:"log-level" help:"hub.log min level: debug|info|warn|error (env BONES_HUB_LOG_LEVEL)"` //nolint:lll
 }
 
 func (c *HubStartCmd) Run(g *repocli.Globals) error {
@@ -73,6 +78,7 @@ func (c *HubStartCmd) Run(g *repocli.Globals) error {
 		hub.WithCoordPort(c.CoordPort),
 		hub.WithDetach(c.Detach),
 		hub.WithDrainTimeout(c.DrainTimeout),
+		hub.WithLogLevel(c.LogLevel),
 		hub.WithLeaseWatcher(startLeaseWatcher),
 	)
 }

--- a/cli/logs.go
+++ b/cli/logs.go
@@ -21,13 +21,14 @@ import (
 	"github.com/danmestas/bones/internal/workspace"
 )
 
-// LogsCmd implements `bones logs`. Reads per-slot or workspace-level NDJSON
-// event logs with formatting, follow mode, and filters.
+// LogsCmd implements `bones logs`. Reads per-slot, workspace-level,
+// or hub NDJSON event logs with formatting, follow mode, and filters.
 //
-// Exactly one of --slot or --workspace must be specified.
+// Exactly one of --slot, --workspace, or --hub must be specified.
 type LogsCmd struct {
 	Slot      string `name:"slot" help:"slot name to read log from"`
 	Workspace bool   `name:"workspace" help:"read workspace-level log instead of a slot log"`
+	Hub       bool   `name:"hub" help:"read .bones/hub.log (operator RPC log per #322)"`
 	Tail      bool   `name:"tail" short:"f" help:"follow: poll for new events after EOF"`
 	Since     string `name:"since" help:"filter events after duration (e.g. 5m) or RFC3339 time"`
 	Last      int    `name:"last" help:"keep only the last N events"`
@@ -37,12 +38,22 @@ type LogsCmd struct {
 
 // Run is the Kong entry point for `bones logs`.
 func (c *LogsCmd) Run(g *repocli.Globals) error {
-	// Validate: exactly one of --slot or --workspace.
-	if c.Slot == "" && !c.Workspace {
-		return fmt.Errorf("bones logs: specify --slot=<name> or --workspace")
+	// Validate: exactly one of --slot / --workspace / --hub.
+	modes := 0
+	if c.Slot != "" {
+		modes++
 	}
-	if c.Slot != "" && c.Workspace {
-		return fmt.Errorf("bones logs: --slot and --workspace are mutually exclusive")
+	if c.Workspace {
+		modes++
+	}
+	if c.Hub {
+		modes++
+	}
+	if modes == 0 {
+		return fmt.Errorf("bones logs: specify --slot=<name>, --workspace, or --hub")
+	}
+	if modes > 1 {
+		return fmt.Errorf("bones logs: --slot, --workspace, and --hub are mutually exclusive")
 	}
 
 	ctx := context.Background()
@@ -55,7 +66,7 @@ func (c *LogsCmd) Run(g *repocli.Globals) error {
 		return err
 	}
 
-	logPath := resolveLogPath(info.WorkspaceDir, c.Slot, c.Workspace)
+	logPath := resolveLogPath(info.WorkspaceDir, c.Slot, c.Workspace, c.Hub)
 
 	// Parse --since cutoff.
 	var since time.Time
@@ -74,9 +85,14 @@ func (c *LogsCmd) Run(g *repocli.Globals) error {
 	return readLog(logPath, c, since, isTTY, os.Stdout)
 }
 
-// resolveLogPath returns the log file path for the given workspace dir, slot, or workspace flag.
-func resolveLogPath(workspaceDir, slot string, workspaceLog bool) string {
+// resolveLogPath returns the log file path for the given workspace
+// dir, slot, workspace flag, or hub flag. Per #322's mutual-exclusion
+// invariant, exactly one of slot/workspaceLog/hubLog is set.
+func resolveLogPath(workspaceDir, slot string, workspaceLog, hubLog bool) string {
 	bones := workspace.BonesDir(workspaceDir)
+	if hubLog {
+		return filepath.Join(bones, "hub.log")
+	}
 	if workspaceLog {
 		return filepath.Join(bones, "log")
 	}

--- a/cli/logs_hub_test.go
+++ b/cli/logs_hub_test.go
@@ -1,0 +1,100 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestLogsCmd_HubRender pins the render path for #322's hub.log mode.
+// A representative fixture (one rpc entry, one lifecycle entry, one
+// hook entry) renders one line per entry, each with HH:MM:SS prefix
+// and the structured fields surfaced as key=value pairs.
+//
+// The decodeEvent helper used by readLog does not know about hub.log's
+// {ts, level, event, rpc, agent, ...} shape specifically — it lifts
+// every non-reserved key into Fields. The renderer formats Fields
+// alphabetically, so the agent/level/rpc tokens always appear in a
+// stable order.
+func TestLogsCmd_HubRender(t *testing.T) {
+	tmp := t.TempDir()
+	hubLog := filepath.Join(tmp, ".bones", "hub.log")
+	if err := os.MkdirAll(filepath.Dir(hubLog), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Three lines of representative hub.log content. The timestamps
+	// are pinned so the test does not depend on time.Now's zone or
+	// drift; the renderer converts to display form which is local
+	// time but here we just check substring shape.
+	fixture := []string{
+		`{"ts":"2026-05-08T12:00:00Z","level":"INFO",` +
+			`"event":"lifecycle","msg":"hub: starting (pid=42)"}`,
+		`{"ts":"2026-05-08T12:00:01Z","level":"INFO",` +
+			`"event":"rpc","rpc":"tasks.create","agent":"claude-1",` +
+			`"took_ms":12}`,
+		`{"ts":"2026-05-08T12:00:02Z","level":"INFO",` +
+			`"event":"hook","hook":"SessionStart","session":"abc123",` +
+			`"msg":"primed 3"}`,
+	}
+	if err := os.WriteFile(hubLog, []byte(strings.Join(fixture, "\n")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	c := &LogsCmd{Hub: true}
+	if err := readLog(hubLog, c, time.Time{}, false, &buf); err != nil {
+		t.Fatalf("readLog: %v", err)
+	}
+
+	out := buf.String()
+	lines := splitLines(out)
+	if len(lines) != 3 {
+		t.Fatalf("expected 3 lines, got %d:\n%s", len(lines), out)
+	}
+
+	// Each entry's typed fields must appear somewhere in the rendered
+	// output. The renderer puts level/event/rpc/etc. through the
+	// Fields key=value path.
+	for _, want := range []string{
+		"hub: starting (pid=42)",
+		"tasks.create",
+		"claude-1",
+		"SessionStart",
+		"abc123",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("rendered output missing %q.\nout:\n%s", want, out)
+		}
+	}
+}
+
+// TestLogsCmd_HubJSONPassthrough verifies --json --hub emits the raw
+// NDJSON line so jq pipelines work on hub.log without re-parsing the
+// human render.
+func TestLogsCmd_HubJSONPassthrough(t *testing.T) {
+	tmp := t.TempDir()
+	hubLog := filepath.Join(tmp, ".bones", "hub.log")
+	if err := os.MkdirAll(filepath.Dir(hubLog), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	raw := `{"ts":"2026-05-08T12:00:00Z","level":"INFO",` +
+		`"event":"rpc","rpc":"tasks.create","agent":"claude-1",` +
+		`"took_ms":7}`
+	if err := os.WriteFile(hubLog, []byte(raw+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	c := &LogsCmd{Hub: true, JSON: true}
+	if err := readLog(hubLog, c, time.Time{}, false, &buf); err != nil {
+		t.Fatalf("readLog: %v", err)
+	}
+	got := strings.TrimSpace(buf.String())
+	if got != raw {
+		t.Errorf("--json --hub passthrough mismatch:\nraw: %s\ngot: %s", raw, got)
+	}
+}

--- a/cli/logs_test.go
+++ b/cli/logs_test.go
@@ -21,7 +21,7 @@ import (
 func TestLogsCmd_ResolveSlotPath(t *testing.T) {
 	workspaceDir := t.TempDir()
 	slot := "auth"
-	got := resolveLogPath(workspaceDir, slot, false)
+	got := resolveLogPath(workspaceDir, slot, false, false)
 	want := filepath.Join(workspaceDir, ".bones", "swarm", "auth", "log")
 	if got != want {
 		t.Errorf("resolveLogPath slot: got %q, want %q", got, want)
@@ -32,11 +32,41 @@ func TestLogsCmd_ResolveSlotPath(t *testing.T) {
 // returns <workspace>/.bones/log.
 func TestLogsCmd_ResolveWorkspacePath(t *testing.T) {
 	workspaceDir := t.TempDir()
-	got := resolveLogPath(workspaceDir, "", true)
+	got := resolveLogPath(workspaceDir, "", true, false)
 	want := filepath.Join(workspaceDir, ".bones", "log")
 	if got != want {
 		t.Errorf("resolveLogPath workspace: got %q, want %q", got, want)
 	}
+}
+
+// TestLogsCmd_ResolveHubPath verifies #322's --hub mode points at
+// <workspace>/.bones/hub.log — the operator-facing RPC log.
+func TestLogsCmd_ResolveHubPath(t *testing.T) {
+	workspaceDir := t.TempDir()
+	got := resolveLogPath(workspaceDir, "", false, true)
+	want := filepath.Join(workspaceDir, ".bones", "hub.log")
+	if got != want {
+		t.Errorf("resolveLogPath hub: got %q, want %q", got, want)
+	}
+}
+
+// TestLogsCmd_HubMutuallyExclusive verifies --hub conflicts with
+// --slot and --workspace at the validation layer (no workspace dial).
+func TestLogsCmd_HubMutuallyExclusive(t *testing.T) {
+	t.Run("hub+slot rejected", func(t *testing.T) {
+		c := &LogsCmd{Slot: "auth", Hub: true}
+		err := c.Run(nil)
+		if err == nil || !strings.Contains(err.Error(), "mutually exclusive") {
+			t.Errorf("expected mutually-exclusive error, got: %v", err)
+		}
+	})
+	t.Run("hub+workspace rejected", func(t *testing.T) {
+		c := &LogsCmd{Workspace: true, Hub: true}
+		err := c.Run(nil)
+		if err == nil || !strings.Contains(err.Error(), "mutually exclusive") {
+			t.Errorf("expected mutually-exclusive error, got: %v", err)
+		}
+	})
 }
 
 // TestLogsCmd_BothFlagsError verifies mutual exclusion error message from Run
@@ -85,7 +115,7 @@ func seedLogFile(t *testing.T, logPath string, events []logwriter.Event) {
 func TestLogsCmd_OneShotRender(t *testing.T) {
 	workspaceDir := t.TempDir()
 	slot := "web"
-	logPath := resolveLogPath(workspaceDir, slot, false)
+	logPath := resolveLogPath(workspaceDir, slot, false, false)
 
 	now := time.Now().UTC()
 	events := []logwriter.Event{
@@ -123,7 +153,7 @@ func TestLogsCmd_OneShotRender(t *testing.T) {
 func TestLogsCmd_OneShotJSON(t *testing.T) {
 	workspaceDir := t.TempDir()
 	slot := "api"
-	logPath := resolveLogPath(workspaceDir, slot, false)
+	logPath := resolveLogPath(workspaceDir, slot, false, false)
 
 	now := time.Now().UTC()
 	events := []logwriter.Event{
@@ -157,7 +187,7 @@ func TestLogsCmd_OneShotJSON(t *testing.T) {
 func TestLogsCmd_Tail_SeesNewEvents(t *testing.T) {
 	workspaceDir := t.TempDir()
 	slot := "tail-slot"
-	logPath := resolveLogPath(workspaceDir, slot, false)
+	logPath := resolveLogPath(workspaceDir, slot, false, false)
 
 	// Pre-create the directory so the writer can append.
 	if err := os.MkdirAll(filepath.Dir(logPath), 0o755); err != nil {
@@ -253,7 +283,7 @@ func TestLogsCmd_Tail_SeesNewEvents(t *testing.T) {
 func TestLogsCmd_FilterSince(t *testing.T) {
 	workspaceDir := t.TempDir()
 	slot := "since-slot"
-	logPath := resolveLogPath(workspaceDir, slot, false)
+	logPath := resolveLogPath(workspaceDir, slot, false, false)
 
 	base := time.Now().UTC().Add(-10 * time.Minute)
 	events := []logwriter.Event{
@@ -281,7 +311,7 @@ func TestLogsCmd_FilterSince(t *testing.T) {
 func TestLogsCmd_FilterLast(t *testing.T) {
 	workspaceDir := t.TempDir()
 	slot := "last-slot"
-	logPath := resolveLogPath(workspaceDir, slot, false)
+	logPath := resolveLogPath(workspaceDir, slot, false, false)
 
 	now := time.Now().UTC()
 	events := []logwriter.Event{
@@ -313,7 +343,7 @@ func TestLogsCmd_FilterLast(t *testing.T) {
 func TestLogsCmd_FullTime(t *testing.T) {
 	workspaceDir := t.TempDir()
 	slot := "fulltime-slot"
-	logPath := resolveLogPath(workspaceDir, slot, false)
+	logPath := resolveLogPath(workspaceDir, slot, false, false)
 
 	now := time.Now().UTC()
 	seedLogFile(t, logPath, []logwriter.Event{
@@ -365,7 +395,7 @@ func TestLogsCmd_ParseSince_RFC3339(t *testing.T) {
 // TestLogsCmd_NonExistentLog verifies that a missing log file is not an error.
 func TestLogsCmd_NonExistentLog(t *testing.T) {
 	workspaceDir := t.TempDir()
-	logPath := resolveLogPath(workspaceDir, "ghost", false)
+	logPath := resolveLogPath(workspaceDir, "ghost", false, false)
 
 	var buf bytes.Buffer
 	c := &LogsCmd{Slot: "ghost"}

--- a/internal/hub/hub.go
+++ b/internal/hub/hub.go
@@ -219,7 +219,9 @@ func runForeground(ctx context.Context, p paths, o opts) error {
 	// Open the lifecycle log first so `hub: starting` is the first
 	// thing we write — diagnosing a crashed-hub workspace begins with
 	// hub.log, and every event after this point lands here too (#247).
-	hl := openHubLog(p)
+	// Per #322 the level floor is sourced from --log-level (flag) or
+	// BONES_HUB_LOG_LEVEL (env var); flag wins.
+	hl := openHubLogWithLevel(p, chooseLogLevel(o.logLevel))
 	defer hl.Close()
 	hl.Infof("hub: starting (pid=%d, repo-port=%d, coord-port=%d)",
 		os.Getpid(), o.repoPort, o.coordPort)
@@ -296,6 +298,13 @@ func runForeground(ctx context.Context, p paths, o opts) error {
 		fmt.Fprintf(os.Stderr, "hub: registry write failed (non-fatal): %v\n", err)
 	}
 	hl.Infof("hub: ready")
+
+	// Per #322 the hub-side RPC log middleware. Subscribes to
+	// `tasks.events.>` and projects observed mutations into hub.log
+	// as event="rpc" entries. Best-effort; failures are warned and
+	// hub start proceeds.
+	stopProjector := startRPCProjector(ctx, h.NATSURL(), hl)
+	defer stopProjector()
 
 	stopWatcher := startLeaseWatcherHook(ctx, o, p, h.NATSURL(), hl)
 	defer stopWatcher()
@@ -469,11 +478,15 @@ func spawnDetachedChild(p paths, o opts) error {
 	}
 	defer func() { _ = hubLog.Close() }()
 
-	cmd := exec.Command(exe, "hub", "start",
+	args := []string{"hub", "start",
 		"--repo-port", strconv.Itoa(o.repoPort),
 		"--coord-port", strconv.Itoa(o.coordPort),
 		"--drain-timeout", effectiveDrainTimeout(o.drainTimeout).String(),
-	)
+	}
+	if o.logLevel != "" {
+		args = append(args, "--log-level", o.logLevel)
+	}
+	cmd := exec.Command(exe, args...)
 	cmd.Dir = p.root
 	cmd.Stdout = hubLog
 	cmd.Stderr = hubLog

--- a/internal/hub/hub_log.go
+++ b/internal/hub/hub_log.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strconv"
 	"sync"
 	"time"
 
@@ -182,9 +181,3 @@ func chooseLogLevel(flag string) LogLevel {
 // hubLogLevelEnv names the env var that overrides --log-level when no
 // flag is passed. Pulled out for tests that flip it via t.Setenv.
 const hubLogLevelEnv = "BONES_HUB_LOG_LEVEL"
-
-// pidFromInt returns a pid as a printable decimal. Centralized so the
-// formatting choice (decimal, no padding) is stable across log lines.
-// The function exists rather than inlining strconv.Itoa so a future
-// op who wants e.g. fixed-width pids has one place to change.
-func pidFromInt(pid int) string { return strconv.Itoa(pid) }

--- a/internal/hub/hub_log.go
+++ b/internal/hub/hub_log.go
@@ -1,88 +1,190 @@
 package hub
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"sync"
 	"time"
 
+	"github.com/danmestas/bones/internal/logwriter"
 	"github.com/danmestas/bones/internal/timefmt"
 )
 
-// hubLogger appends structured lifecycle events to .bones/hub.log so a
-// crashed-hub workspace has a navigable audit trail rather than the
-// 63-byte banner the legacy code wrote (#247). Events use bones
-// vocabulary only — `hub:`, `coord:`, `repo:` — so an operator
-// reading the log isn't asked to translate `fossil` / `nats` /
-// `jetstream` substrate words back into bones concepts.
+// timeNow is a seam over time.Now so unit tests can stamp
+// deterministic timestamps. Production callers see real wall-clock
+// time. Replaced via t.Cleanup in unit tests.
+var timeNow = time.Now
+
+// hubLogger appends structured entries to .bones/hub.log per #322. The
+// on-disk format is NDJSON: one LogEntry per line. Operators read
+// either via `bones logs --hub` (formatted) or jq directly.
 //
-// Append-only: operators auditing a crashed workspace need the full
-// history, not just the last run. spawnDetachedChild also opens
-// hub.log in append mode for the child's stdout/stderr stream, so the
-// two writers cooperate without truncation.
+// Two write paths cooperate:
+//
+//   - The Log/Infof/Warnf/Errorf methods take a LogEntry (or build
+//     one from a printf-style call) and route through
+//     internal/logwriter so the 10MB rotation policy from #322 is
+//     applied (logwriter already implements per-#322's spec: 10MiB
+//     default, numbered backups, BONES_LOG_MAX_SIZE override).
+//
+//   - spawnDetachedChild redirects the child's stdout/stderr to
+//     hub.log via O_APPEND so child panics still surface in the file.
+//     That stream bypasses the typed entry path; lines from it land
+//     as opaque text and are tolerated by `bones logs --hub`'s parser
+//     (NDJSON-decode failures skip the line per logwriter convention).
 //
 // A nil logger is safe — every method is a no-op so callers don't
 // branch on open errors.
 type hubLogger struct {
-	mu   sync.Mutex
-	file *os.File
-	path string
+	mu       sync.Mutex
+	w        *logwriter.Writer
+	path     string
+	minLevel LogLevel
 }
 
 // openHubLog opens (or creates, append-mode) <root>/.bones/hub.log.
-// Returns a usable logger even on open failure (file pointer nil,
-// methods degrade to no-ops) so a write-protected workspace cannot
-// break hub start.
+// Returns a usable logger even on open failure (writer nil, methods
+// degrade to no-ops) so a write-protected workspace cannot break
+// hub start.
+//
+// minLevel is the per-process filter floor — entries strictly below
+// it are dropped UNLESS their level is LevelError (errors always
+// log per #322). Default INFO; the hub start CLI flips this via
+// withLogLevel based on --log-level / BONES_HUB_LOG_LEVEL.
 func openHubLog(p paths) *hubLogger {
+	return openHubLogWithLevel(p, LevelInfo)
+}
+
+// openHubLogWithLevel opens hub.log with a non-default minimum level.
+// Pulled out of openHubLog so the hub start path can pass the
+// configured level without touching every other call site (Stop,
+// detach parent, lease watcher hook adapter).
+func openHubLogWithLevel(p paths, min LogLevel) *hubLogger {
 	_ = os.MkdirAll(p.orchDir, 0o755)
 	path := filepath.Join(p.orchDir, "hub.log")
-	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
-	l := &hubLogger{path: path}
-	if err == nil {
-		l.file = f
+	return &hubLogger{
+		w:        logwriter.Open(path),
+		path:     path,
+		minLevel: min,
 	}
-	return l
 }
 
-// Close flushes and closes the underlying file. Safe on nil or on a
-// logger whose file failed to open.
+// Close is retained for API compatibility with the legacy lifecycle
+// helper. logwriter.Writer is stateless (each Append opens/closes the
+// file), so Close is now a no-op — but callers still defer it.
 func (l *hubLogger) Close() {
-	if l == nil || l.file == nil {
+	if l == nil {
 		return
 	}
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	_ = l.file.Close()
-	l.file = nil
+	l.w = nil
 }
 
-// Infof writes one INFO-level lifecycle event.
+// Log emits one typed entry. Errors always emit regardless of the
+// configured minimum level per #322's level policy. Below-floor
+// entries are dropped silently.
+func (l *hubLogger) Log(e LogEntry) {
+	if l == nil || l.w == nil {
+		return
+	}
+	if !l.shouldEmit(e) {
+		return
+	}
+	if e.Ts.IsZero() {
+		e.Ts = timefmt.NewLoggedTime(timeNow())
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	_ = l.w.AppendJSON(rawEntry{e: e})
+}
+
+// shouldEmit applies the level filter. Errors override (they always
+// emit) so a hub running at --log-level=warn still records
+// LevelError handler failures.
+func (l *hubLogger) shouldEmit(e LogEntry) bool {
+	if e.Level == LevelError {
+		return true
+	}
+	if e.Err != "" {
+		return true
+	}
+	return e.Level >= l.minLevel
+}
+
+// Infof writes one INFO-level lifecycle entry. The legacy printf
+// signature is preserved so the hub bring-up callsites at hub.go:222,
+// :345, :350 (per the brief's "touch the lifecycle callsites" step)
+// don't have to thread a LogEntry literal through.
 func (l *hubLogger) Infof(format string, args ...any) {
-	l.appendLine("INFO", fmt.Sprintf(format, args...))
+	l.Log(LogEntry{
+		Level: LevelInfo,
+		Event: EventLifecycle,
+		Msg:   fmt.Sprintf(format, args...),
+	})
 }
 
-// Warnf writes one WARN-level lifecycle event.
+// Warnf writes one WARN-level lifecycle entry.
 func (l *hubLogger) Warnf(format string, args ...any) {
-	l.appendLine("WARN", fmt.Sprintf(format, args...))
+	l.Log(LogEntry{
+		Level: LevelWarn,
+		Event: EventLifecycle,
+		Msg:   fmt.Sprintf(format, args...),
+	})
 }
 
-// Errorf writes one ERROR-level lifecycle event.
+// Errorf writes one ERROR-level lifecycle entry.
 func (l *hubLogger) Errorf(format string, args ...any) {
-	l.appendLine("ERROR", fmt.Sprintf(format, args...))
+	l.Log(LogEntry{
+		Level: LevelError,
+		Event: EventLifecycle,
+		Msg:   fmt.Sprintf(format, args...),
+	})
 }
 
-// appendLine emits one timestamped line. ISO-8601 UTC keeps the file
-// machine-grep-friendly across timezones; the level field is padded so
-// `grep -E '^\S+ ERROR'` lines up regardless of whether the level is
-// INFO / WARN / ERROR. Errors writing to disk are dropped — bones must
-// not abort hub bring-up because the log file became unwritable.
-func (l *hubLogger) appendLine(level, msg string) {
-	if l == nil || l.file == nil {
-		return
-	}
-	l.mu.Lock()
-	defer l.mu.Unlock()
-	_, _ = fmt.Fprintf(l.file, "%s %-5s %s\n",
-		timefmt.Logged(time.Now()), level, msg)
+// rawEntry adapts a LogEntry to logwriter.Event. logwriter.Event's
+// MarshalJSON merges Fields into the top level and stamps ts/event/
+// slot reserved keys; we sidestep it by giving rawEntry its own
+// MarshalJSON that emits the LogEntry shape directly. Exposed via
+// the logwriter.Event interface (anything Marshalable works) — keeps
+// the rotation/atomic-append plumbing reused without forcing the
+// hub.log shape into logwriter's reserved-key conventions.
+type rawEntry struct {
+	e LogEntry
 }
+
+// MarshalJSON delegates to the LogEntry. Required by the
+// json.Marshaler check inside logwriter.AppendOnce.
+func (r rawEntry) MarshalJSON() ([]byte, error) {
+	return json.Marshal(r.e)
+}
+
+// chooseLogLevel resolves the effective minimum level for a hub
+// process: the explicit override (from --log-level) wins; otherwise
+// BONES_HUB_LOG_LEVEL; otherwise INFO.
+//
+// "Flag wins" is the policy from #322: when both are set the operator
+// who passed --log-level explicitly is more current than whoever set
+// the env var.
+func chooseLogLevel(flag string) LogLevel {
+	if flag != "" {
+		return parseLevel(flag)
+	}
+	if env := os.Getenv("BONES_HUB_LOG_LEVEL"); env != "" {
+		return parseLevel(env)
+	}
+	return LevelInfo
+}
+
+// hubLogLevelEnv names the env var that overrides --log-level when no
+// flag is passed. Pulled out for tests that flip it via t.Setenv.
+const hubLogLevelEnv = "BONES_HUB_LOG_LEVEL"
+
+// pidFromInt returns a pid as a printable decimal. Centralized so the
+// formatting choice (decimal, no padding) is stable across log lines.
+// The function exists rather than inlining strconv.Itoa so a future
+// op who wants e.g. fixed-width pids has one place to change.
+func pidFromInt(pid int) string { return strconv.Itoa(pid) }

--- a/internal/hub/hub_log_test.go
+++ b/internal/hub/hub_log_test.go
@@ -13,11 +13,12 @@ import (
 	"time"
 )
 
-// TestHubLog_StartingLineFormat asserts the starting line shape. The
-// log file accumulates a timestamped INFO line naming pid, repo-port,
-// and coord-port — so an operator opening hub.log in a crashed
-// workspace can pin the exact ports the hub tried to bind. Uses
-// operator vocabulary (hub:, repo-port=, coord-port=) per #247.
+// TestHubLog_StartingLineFormat asserts the starting line shape per
+// #322. hub.log is NDJSON: each line is one LogEntry. The starting
+// line carries the lifecycle event with pid, repo-port, and coord-
+// port in the msg field — so an operator opening hub.log in a
+// crashed workspace can pin the exact ports the hub tried to bind.
+// Uses operator vocabulary (hub:, repo-port=, coord-port=) per #247.
 func TestHubLog_StartingLineFormat(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skip in -short: spawns subprocess servers, port-bind sensitive")
@@ -60,16 +61,31 @@ func TestHubLog_StartingLineFormat(t *testing.T) {
 	}
 	got := string(data)
 
-	// Pin the starting line: ISO-8601 timestamp + INFO + structured
-	// fields. Regex is permissive on the exact timestamp shape but
-	// strict on the operator-facing token order.
+	// Pin the starting line: NDJSON per #322. The line is one
+	// LogEntry with level=INFO, event=lifecycle, and msg containing
+	// the pid + ports tokens an operator looks for.
 	re := regexp.MustCompile(
-		`\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z INFO\s+hub: starting ` +
-			`\(pid=\d+, repo-port=` + strconv.Itoa(fossilPort) +
-			`, coord-port=` + strconv.Itoa(natsPort) + `\)`,
-	)
+		`"ts":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z"`)
 	if !re.MatchString(got) {
-		t.Errorf("hub.log missing well-formed starting line.\nlog:\n%s", got)
+		t.Errorf("hub.log missing UTC RFC3339 timestamp.\nlog:\n%s", got)
+	}
+	if !strings.Contains(got, `"level":"INFO"`) {
+		t.Errorf("hub.log missing INFO entry.\nlog:\n%s", got)
+	}
+	if !strings.Contains(got, `"event":"lifecycle"`) {
+		t.Errorf("hub.log missing lifecycle event.\nlog:\n%s", got)
+	}
+	wantMsg := "hub: starting (pid="
+	if !strings.Contains(got, wantMsg) {
+		t.Errorf("hub.log missing starting msg %q.\nlog:\n%s", wantMsg, got)
+	}
+	wantRepo := "repo-port=" + strconv.Itoa(fossilPort)
+	if !strings.Contains(got, wantRepo) {
+		t.Errorf("hub.log missing %q.\nlog:\n%s", wantRepo, got)
+	}
+	wantCoord := "coord-port=" + strconv.Itoa(natsPort)
+	if !strings.Contains(got, wantCoord) {
+		t.Errorf("hub.log missing %q.\nlog:\n%s", wantCoord, got)
 	}
 	if !strings.Contains(got, "hub: ready") {
 		t.Errorf("hub.log missing ready line.\nlog:\n%s", got)

--- a/internal/hub/logentry.go
+++ b/internal/hub/logentry.go
@@ -1,0 +1,176 @@
+// Hub log entry contract per #322. hub.log is the operator-facing
+// audit trail of "what did the hub do, when, and why" — distinct from
+// the agent-facing task event log (#319) and the JSON CLI output
+// envelope (#321). Storage is NDJSON; each LogEntry value marshals to
+// one line on disk.
+package hub
+
+import (
+	"encoding/json"
+
+	"github.com/danmestas/bones/internal/timefmt"
+)
+
+// LogLevel names the four standard severities used by hub.log.
+// Order matters: Debug < Info < Warn < Error. The level filter
+// (--log-level / BONES_HUB_LOG_LEVEL) compares numeric rank rather
+// than string identity so callers can express ">= INFO" without a
+// switch statement.
+type LogLevel uint8
+
+// Numeric ranks let logger.shouldEmit compare configured filter level
+// against the entry level via simple <= ordering. The four-level set
+// is closed; --log-level=trace was rejected during scoping (only the
+// standard four).
+const (
+	LevelDebug LogLevel = iota
+	LevelInfo
+	LevelWarn
+	LevelError
+)
+
+// String returns the canonical wire-form of the level — uppercase
+// short token written into the NDJSON "level" field. Operators
+// grepping hub.log see "INFO" / "WARN" / "ERROR" / "DEBUG", not Go
+// constant names. parseLevel inverts.
+func (l LogLevel) String() string {
+	switch l {
+	case LevelDebug:
+		return "DEBUG"
+	case LevelInfo:
+		return "INFO"
+	case LevelWarn:
+		return "WARN"
+	case LevelError:
+		return "ERROR"
+	default:
+		return "INFO"
+	}
+}
+
+// MarshalJSON emits the wire-form string ("INFO" etc.) so the on-disk
+// "level" field is operator-readable rather than a numeric rank.
+func (l LogLevel) MarshalJSON() ([]byte, error) {
+	return json.Marshal(l.String())
+}
+
+// UnmarshalJSON accepts the wire-form string and decodes back to the
+// numeric rank. Used by the round-trip test and by `bones logs --hub`.
+func (l *LogLevel) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	*l = parseLevel(s)
+	return nil
+}
+
+// parseLevel decodes the wire-form (case-insensitive) back to a
+// LogLevel. Used by the --log-level flag, BONES_HUB_LOG_LEVEL env
+// var, and LogLevel.UnmarshalJSON. Unknown strings degrade to
+// LevelInfo so a typo doesn't mute hub.log entirely — the audit
+// trail is more important than honoring a malformed override.
+func parseLevel(s string) LogLevel {
+	switch s {
+	case "debug", "DEBUG", "Debug":
+		return LevelDebug
+	case "warn", "WARN", "Warn", "warning", "WARNING":
+		return LevelWarn
+	case "error", "ERROR", "Error":
+		return LevelError
+	default:
+		return LevelInfo
+	}
+}
+
+// Event kind constants. The set is closed; new event kinds want a
+// new constant + a comment explaining what the entry means.
+const (
+	// EventRPC is one state-mutating-or-read RPC handler invocation.
+	// Carries rpc/agent/task/took_ms/result_count/err.
+	EventRPC = "rpc"
+
+	// EventHook is one Claude Code hook firing the hub observed.
+	// Carries hook/session/matcher/result fields via Msg.
+	EventHook = "hook"
+
+	// EventLifecycle is a hub bring-up / shutdown / drain marker.
+	// Carries Msg only.
+	EventLifecycle = "lifecycle"
+
+	// EventError is reserved for hub-side errors that don't fit the
+	// rpc / lifecycle path. Most rpc errors ride the rpc kind with
+	// an Err field; this constant exists so a hub-internal failure
+	// (recovery loop crash, watcher stop) has a place to land.
+	EventError = "error"
+)
+
+// LogEntry is the single shape every hub.log row carries. Fields are
+// optional except Ts, Level, Event — those three are present on every
+// row. The struct uses NDJSON tags with omitempty so the on-disk row
+// stays compact: a lifecycle line emits {ts, level, event, msg}; an
+// rpc line emits {ts, level, event, rpc, agent, took_ms}; etc.
+//
+// Per #324 the Ts field is timefmt.LoggedTime so the marshal path
+// emits UTC RFC3339 with a Z suffix — matching every other persisted
+// timestamp in bones (event log, --json payloads, up.log).
+//
+// Per #321 this struct does NOT use the {schema, data} envelope: it
+// is internal log format, not CLI output. Operator tooling reads
+// hub.log directly with `bones logs --hub` (which strips/renders) or
+// jq.
+type LogEntry struct {
+	// Ts is the wall-clock instant the entry was emitted. UTC RFC3339
+	// per the Logged policy.
+	Ts timefmt.LoggedTime `json:"ts"`
+
+	// Level is the severity, wire-encoded as "DEBUG"/"INFO"/"WARN"/
+	// "ERROR" via LogLevel.MarshalJSON.
+	Level LogLevel `json:"level"`
+
+	// Event names the entry kind: "rpc", "hook", "lifecycle", or
+	// "error". Operators grep by event when narrowing an investigation.
+	Event string `json:"event"`
+
+	// RPC is the dotted RPC name (e.g. "tasks.create", "tasks.claim").
+	// Empty for non-rpc events.
+	RPC string `json:"rpc,omitempty"`
+
+	// Agent is the inbound caller identity, or "system" for
+	// hub-internal calls. Empty when not applicable (lifecycle).
+	Agent string `json:"agent,omitempty"`
+
+	// Task is the task ID this entry is scoped to, when applicable.
+	Task string `json:"task,omitempty"`
+
+	// Session is the Claude Code session ID (or other session token)
+	// the entry is scoped to, when applicable. Set on hook firings.
+	Session string `json:"session,omitempty"`
+
+	// Hook names the Claude Code hook event for event="hook" entries
+	// (e.g. "SessionStart", "PreCompact"). Empty otherwise.
+	Hook string `json:"hook,omitempty"`
+
+	// Matcher is the hook matcher value (e.g. "compact" for the
+	// post-#320 SessionStart-with-matcher form). Empty otherwise.
+	Matcher string `json:"matcher,omitempty"`
+
+	// TookMs is the handler duration in milliseconds. Set on rpc
+	// entries; zero (omitted) elsewhere.
+	TookMs int64 `json:"took_ms,omitempty"`
+
+	// ResultCount is the size of a list-shape RPC result, when
+	// available. Zero (omitted) for non-list RPCs.
+	ResultCount int `json:"result_count,omitempty"`
+
+	// Err is the error message (if any) the handler returned. Empty
+	// on success. Errors always log regardless of configured level
+	// per #322's level policy.
+	Err string `json:"err,omitempty"`
+
+	// Msg is a free-form message used by lifecycle entries (the boot
+	// banner, address lines, ready/stopping/stopped) and hook entries
+	// (result summary). Other event kinds prefer typed fields and
+	// leave this empty.
+	Msg string `json:"msg,omitempty"`
+}

--- a/internal/hub/logentry_test.go
+++ b/internal/hub/logentry_test.go
@@ -77,44 +77,6 @@ func TestLogEntry_OmitsZeroFields(t *testing.T) {
 	}
 }
 
-// TestSelectLevel pins the level-selection policy from #322:
-// read-only RPCs default DEBUG; mutating defaults INFO; errors
-// always promote to INFO regardless of read/mutating classification.
-// Table-driven so adding a new RPC name is one row.
-func TestSelectLevel(t *testing.T) {
-	tests := []struct {
-		name string
-		rpc  string
-		err  error
-		want LogLevel
-	}{
-		{"read-only no error → DEBUG", "tasks.list", nil, LevelDebug},
-		{"read-only show no error → DEBUG", "tasks.show", nil, LevelDebug},
-		{"read-only ready no error → DEBUG", "tasks.ready", nil, LevelDebug},
-		{"mutating create → INFO", "tasks.create", nil, LevelInfo},
-		{"mutating claim → INFO", "tasks.claim", nil, LevelInfo},
-		{"mutating close → INFO", "tasks.close", nil, LevelInfo},
-		{"read-only with error → INFO (errors always)", "tasks.list", errStub("boom"), LevelInfo},
-		{"mutating with error → INFO", "tasks.create", errStub("kaboom"), LevelInfo},
-		{"unknown verb → INFO (mutating default)", "fancy.new.rpc", nil, LevelInfo},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := selectLevel(tt.rpc, tt.err)
-			if got != tt.want {
-				t.Errorf("selectLevel(%q, %v) = %v, want %v",
-					tt.rpc, tt.err, got, tt.want)
-			}
-		})
-	}
-}
-
-// errStub is a minimal error type for table tests. Avoids importing
-// errors just for errors.New.
-type errStub string
-
-func (e errStub) Error() string { return string(e) }
-
 // TestParseLevel pins the wire-form decode used by --log-level and
 // BONES_HUB_LOG_LEVEL. Unknown strings degrade to INFO so a typo
 // doesn't mute hub.log entirely.

--- a/internal/hub/logentry_test.go
+++ b/internal/hub/logentry_test.go
@@ -1,0 +1,170 @@
+package hub
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/danmestas/bones/internal/timefmt"
+)
+
+// TestLogEntry_RoundTrip pins the marshal/unmarshal contract per
+// #322's Stage 3 acceptance: a LogEntry → NDJSON → parse → equal
+// struct round-trip. The Z suffix from #324's LoggedTime policy
+// must survive the round-trip — operators correlating hub.log
+// timestamps with up.log/event-log entries rely on the same wire
+// shape across surfaces.
+func TestLogEntry_RoundTrip(t *testing.T) {
+	want := LogEntry{
+		Ts:          timefmt.NewLoggedTime(time.Date(2026, 5, 8, 12, 30, 45, 0, time.UTC)),
+		Level:       LevelInfo,
+		Event:       EventRPC,
+		RPC:         "tasks.create",
+		Agent:       "claude-1",
+		Task:        "task-abc",
+		TookMs:      42,
+		ResultCount: 0,
+	}
+	data, err := json.Marshal(want)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(data), `"ts":"2026-05-08T12:30:45Z"`) {
+		t.Errorf("marshal: ts must use Z suffix per #324 policy, got: %s", data)
+	}
+	if !strings.Contains(string(data), `"level":"INFO"`) {
+		t.Errorf("marshal: level must wire as string, got: %s", data)
+	}
+	var got LogEntry
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !got.Ts.Equal(want.Ts.Time) {
+		t.Errorf("ts round-trip: got %v want %v", got.Ts, want.Ts)
+	}
+	if got.Level != want.Level {
+		t.Errorf("level round-trip: got %v want %v", got.Level, want.Level)
+	}
+	if got.RPC != want.RPC || got.Agent != want.Agent || got.Task != want.Task {
+		t.Errorf("identity round-trip: got %+v want %+v", got, want)
+	}
+}
+
+// TestLogEntry_OmitsZeroFields keeps the on-disk shape compact: a
+// lifecycle entry without rpc/agent/task/etc. should not emit
+// `"rpc":""` and friends. Operators reading hub.log with grep see
+// only the fields that matter.
+func TestLogEntry_OmitsZeroFields(t *testing.T) {
+	e := LogEntry{
+		Ts:    timefmt.NewLoggedTime(time.Date(2026, 5, 8, 12, 30, 45, 0, time.UTC)),
+		Level: LevelInfo,
+		Event: EventLifecycle,
+		Msg:   "hub: ready",
+	}
+	data, err := json.Marshal(e)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	banned := []string{
+		`"rpc"`, `"agent"`, `"task"`, `"session"`, `"hook"`,
+		`"matcher"`, `"took_ms"`, `"result_count"`, `"err"`,
+	}
+	for _, b := range banned {
+		if strings.Contains(string(data), b) {
+			t.Errorf("lifecycle entry must omit %s, got: %s", b, data)
+		}
+	}
+}
+
+// TestSelectLevel pins the level-selection policy from #322:
+// read-only RPCs default DEBUG; mutating defaults INFO; errors
+// always promote to INFO regardless of read/mutating classification.
+// Table-driven so adding a new RPC name is one row.
+func TestSelectLevel(t *testing.T) {
+	tests := []struct {
+		name string
+		rpc  string
+		err  error
+		want LogLevel
+	}{
+		{"read-only no error → DEBUG", "tasks.list", nil, LevelDebug},
+		{"read-only show no error → DEBUG", "tasks.show", nil, LevelDebug},
+		{"read-only ready no error → DEBUG", "tasks.ready", nil, LevelDebug},
+		{"mutating create → INFO", "tasks.create", nil, LevelInfo},
+		{"mutating claim → INFO", "tasks.claim", nil, LevelInfo},
+		{"mutating close → INFO", "tasks.close", nil, LevelInfo},
+		{"read-only with error → INFO (errors always)", "tasks.list", errStub("boom"), LevelInfo},
+		{"mutating with error → INFO", "tasks.create", errStub("kaboom"), LevelInfo},
+		{"unknown verb → INFO (mutating default)", "fancy.new.rpc", nil, LevelInfo},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := selectLevel(tt.rpc, tt.err)
+			if got != tt.want {
+				t.Errorf("selectLevel(%q, %v) = %v, want %v",
+					tt.rpc, tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+// errStub is a minimal error type for table tests. Avoids importing
+// errors just for errors.New.
+type errStub string
+
+func (e errStub) Error() string { return string(e) }
+
+// TestParseLevel pins the wire-form decode used by --log-level and
+// BONES_HUB_LOG_LEVEL. Unknown strings degrade to INFO so a typo
+// doesn't mute hub.log entirely.
+func TestParseLevel(t *testing.T) {
+	tests := []struct {
+		in   string
+		want LogLevel
+	}{
+		{"debug", LevelDebug},
+		{"DEBUG", LevelDebug},
+		{"info", LevelInfo},
+		{"INFO", LevelInfo},
+		{"warn", LevelWarn},
+		{"WARNING", LevelWarn},
+		{"error", LevelError},
+		{"ERROR", LevelError},
+		{"", LevelInfo},
+		{"trace", LevelInfo}, // unknown → INFO floor
+	}
+	for _, tt := range tests {
+		got := parseLevel(tt.in)
+		if got != tt.want {
+			t.Errorf("parseLevel(%q) = %v, want %v", tt.in, got, tt.want)
+		}
+	}
+}
+
+// TestChooseLogLevel pins the flag-vs-env precedence: when both are
+// set, --log-level wins. When only env is set, env is honored. When
+// neither is set, the default is INFO.
+func TestChooseLogLevel(t *testing.T) {
+	t.Run("flag set wins over env", func(t *testing.T) {
+		t.Setenv(hubLogLevelEnv, "warn")
+		got := chooseLogLevel("debug")
+		if got != LevelDebug {
+			t.Errorf("flag should win: got %v want DEBUG", got)
+		}
+	})
+	t.Run("env honored when no flag", func(t *testing.T) {
+		t.Setenv(hubLogLevelEnv, "warn")
+		got := chooseLogLevel("")
+		if got != LevelWarn {
+			t.Errorf("env honored: got %v want WARN", got)
+		}
+	})
+	t.Run("default INFO when neither set", func(t *testing.T) {
+		t.Setenv(hubLogLevelEnv, "")
+		got := chooseLogLevel("")
+		if got != LevelInfo {
+			t.Errorf("default INFO: got %v", got)
+		}
+	})
+}

--- a/internal/hub/middleware.go
+++ b/internal/hub/middleware.go
@@ -1,136 +1,5 @@
 package hub
 
-import (
-	"time"
-
-	"github.com/danmestas/bones/internal/timefmt"
-)
-
-// LogRPC wraps a state-mutating-or-read RPC handler call and emits one
-// LogEntry per invocation. The level-selection policy from #322 is
-// centralized here:
-//
-//   - Read-only RPCs (allowlist below) → DEBUG
-//   - Mutating RPCs → INFO
-//   - Errors always → INFO regardless of read/mutating classification
-//
-// "RPCs" in the bones architecture are not server-side handlers — the
-// hub is just JetStream + Fossil. Operators see RPC-shape activity as
-// the events crossing the hub from CLI verbs (#319 task event log,
-// hook firings, lifecycle markers). LogRPC is the seam every emitter
-// of those activities runs through, so the operator-side hub.log
-// stays one schema regardless of which subsystem produced the entry.
-//
-// Concurrency: safe to call from any goroutine. The underlying
-// hubLogger serializes the file write.
-func (l *hubLogger) LogRPC(name, agent string, took time.Duration, err error) {
-	if l == nil {
-		return
-	}
-	e := LogEntry{
-		Ts:     timefmt.NewLoggedTime(timeNow()),
-		Level:  selectLevel(name, err),
-		Event:  EventRPC,
-		RPC:    name,
-		Agent:  agent,
-		TookMs: took.Milliseconds(),
-	}
-	if err != nil {
-		e.Err = err.Error()
-	}
-	l.Log(e)
-}
-
-// LogRPCResult is the list-shape variant: stamps ResultCount in
-// addition to the standard rpc fields. Used by Watch/Replay/Recent
-// callsites whose output is a slice and whose size is operator-
-// useful.
-func (l *hubLogger) LogRPCResult(name, agent string, took time.Duration, n int, err error) {
-	if l == nil {
-		return
-	}
-	e := LogEntry{
-		Ts:          timefmt.NewLoggedTime(timeNow()),
-		Level:       selectLevel(name, err),
-		Event:       EventRPC,
-		RPC:         name,
-		Agent:       agent,
-		TookMs:      took.Milliseconds(),
-		ResultCount: n,
-	}
-	if err != nil {
-		e.Err = err.Error()
-	}
-	l.Log(e)
-}
-
-// LogHook emits one event="hook" entry. session/matcher are
-// optional; matcher names the post-#320 SessionStart-with-matcher
-// form (e.g. "compact"). msg carries a free-form result line —
-// "primed 3", "no tasks ready", etc. — that operators eyeball.
-//
-// Hook firings emit at INFO per #322's level policy: state-mutating
-// RPCs and hook firings default INFO, errors always promote, reads
-// default DEBUG. A floor of WARN or higher suppresses hook entries
-// — operators who want the breadcrumb keep the default INFO floor.
-func (l *hubLogger) LogHook(hook, session, matcher, msg string) {
-	if l == nil {
-		return
-	}
-	l.Log(LogEntry{
-		Ts:      timefmt.NewLoggedTime(timeNow()),
-		Level:   LevelInfo,
-		Event:   EventHook,
-		Hook:    hook,
-		Session: session,
-		Matcher: matcher,
-		Msg:     msg,
-	})
-}
-
-// readOnlyRPCs is the allowlist of RPC names whose default level is
-// DEBUG rather than INFO. The set tracks the verb inventory from
-// #321: every read-only verb belongs here. Mutating verbs default to
-// INFO via selectLevel.
-//
-// New verbs need a deliberate decision: if you're adding to the
-// list, the verb must NOT mutate task state. When in doubt, leave
-// the verb off the list — the cost of a slightly-noisy hub.log
-// (extra INFO line per read RPC) is much lower than the cost of a
-// silent state mutation (DEBUG-suppressed line invisible at default
-// log level).
-var readOnlyRPCs = map[string]bool{
-	"tasks.list":   true,
-	"tasks.show":   true,
-	"tasks.ready":  true,
-	"tasks.watch":  true,
-	"tasks.status": true,
-	"status":       true,
-	"doctor":       true,
-	"workspaces":   true,
-	"peek":         true,
-	"logs":         true,
-}
-
-// selectLevel returns the default level for an rpc entry given the
-// RPC name and the handler's error. Errors always promote to INFO;
-// mutating RPCs default INFO; read-only RPCs (allowlist above)
-// default DEBUG.
-//
-// Rationale: DEBUG-by-default for reads keeps a busy hub.log from
-// drowning in `tasks.list` entries during normal CLI use. INFO-by-
-// default for mutations matches operator intent — when something
-// changed, the operator wants to see it without flipping the level.
-func selectLevel(name string, err error) LogLevel {
-	if err != nil {
-		return LevelInfo
-	}
-	if readOnlyRPCs[name] {
-		return LevelDebug
-	}
-	return LevelInfo
-}
-
 // rpcNameFromEventType maps a tasks.EventType-style string (the
 // String() output of the closed iota set) to the dotted RPC name
 // hub.log uses. Pulled out so the mapping stays one source of truth
@@ -140,6 +9,25 @@ func selectLevel(name string, err error) LogLevel {
 // The function is robust against an unrecognized input — returns
 // the input prefixed with `tasks.` so an unknown event type still
 // produces a parseable hub.log entry rather than dropping the line.
+//
+// # Why this is the only "middleware" surface
+//
+// #322's brief assumed the hub binary owned RPC handlers it could
+// wrap. Bones doesn't work that way: CLI verbs talk to JetStream
+// substrate directly, so the hub never sees a CLI invocation. The
+// only thing the hub can genuinely observe is the post-mutation
+// event flow on `tasks.events.>`, which the projector subscribes
+// to. Read-only CLI verbs (tasks.list, tasks.show, etc.) and hook
+// firings (emitted by `bones tasks prime --hook=session-start`, an
+// external CLI process) are NOT visible to the hub and therefore
+// have no logging surface here.
+//
+// Earlier drafts of this file carried LogRPC / LogRPCResult /
+// LogHook helpers and a readOnlyRPCs allowlist for level demotion.
+// Those were unwired (no production callers) and have been removed
+// to keep the package honest about what it can observe. A follow-up
+// issue will track making hook firings observable via a JetStream
+// `hub.hooks.fired` marker that the projector can subscribe to.
 func rpcNameFromEventType(eventTypeName string) string {
 	switch eventTypeName {
 	case "created":

--- a/internal/hub/middleware.go
+++ b/internal/hub/middleware.go
@@ -1,0 +1,162 @@
+package hub
+
+import (
+	"time"
+
+	"github.com/danmestas/bones/internal/timefmt"
+)
+
+// LogRPC wraps a state-mutating-or-read RPC handler call and emits one
+// LogEntry per invocation. The level-selection policy from #322 is
+// centralized here:
+//
+//   - Read-only RPCs (allowlist below) → DEBUG
+//   - Mutating RPCs → INFO
+//   - Errors always → INFO regardless of read/mutating classification
+//
+// "RPCs" in the bones architecture are not server-side handlers — the
+// hub is just JetStream + Fossil. Operators see RPC-shape activity as
+// the events crossing the hub from CLI verbs (#319 task event log,
+// hook firings, lifecycle markers). LogRPC is the seam every emitter
+// of those activities runs through, so the operator-side hub.log
+// stays one schema regardless of which subsystem produced the entry.
+//
+// Concurrency: safe to call from any goroutine. The underlying
+// hubLogger serializes the file write.
+func (l *hubLogger) LogRPC(name, agent string, took time.Duration, err error) {
+	if l == nil {
+		return
+	}
+	e := LogEntry{
+		Ts:     timefmt.NewLoggedTime(timeNow()),
+		Level:  selectLevel(name, err),
+		Event:  EventRPC,
+		RPC:    name,
+		Agent:  agent,
+		TookMs: took.Milliseconds(),
+	}
+	if err != nil {
+		e.Err = err.Error()
+	}
+	l.Log(e)
+}
+
+// LogRPCResult is the list-shape variant: stamps ResultCount in
+// addition to the standard rpc fields. Used by Watch/Replay/Recent
+// callsites whose output is a slice and whose size is operator-
+// useful.
+func (l *hubLogger) LogRPCResult(name, agent string, took time.Duration, n int, err error) {
+	if l == nil {
+		return
+	}
+	e := LogEntry{
+		Ts:          timefmt.NewLoggedTime(timeNow()),
+		Level:       selectLevel(name, err),
+		Event:       EventRPC,
+		RPC:         name,
+		Agent:       agent,
+		TookMs:      took.Milliseconds(),
+		ResultCount: n,
+	}
+	if err != nil {
+		e.Err = err.Error()
+	}
+	l.Log(e)
+}
+
+// LogHook emits one event="hook" entry. session/matcher are
+// optional; matcher names the post-#320 SessionStart-with-matcher
+// form (e.g. "compact"). msg carries a free-form result line —
+// "primed 3", "no tasks ready", etc. — that operators eyeball.
+//
+// Hook firings emit at INFO per #322's level policy: state-mutating
+// RPCs and hook firings default INFO, errors always promote, reads
+// default DEBUG. A floor of WARN or higher suppresses hook entries
+// — operators who want the breadcrumb keep the default INFO floor.
+func (l *hubLogger) LogHook(hook, session, matcher, msg string) {
+	if l == nil {
+		return
+	}
+	l.Log(LogEntry{
+		Ts:      timefmt.NewLoggedTime(timeNow()),
+		Level:   LevelInfo,
+		Event:   EventHook,
+		Hook:    hook,
+		Session: session,
+		Matcher: matcher,
+		Msg:     msg,
+	})
+}
+
+// readOnlyRPCs is the allowlist of RPC names whose default level is
+// DEBUG rather than INFO. The set tracks the verb inventory from
+// #321: every read-only verb belongs here. Mutating verbs default to
+// INFO via selectLevel.
+//
+// New verbs need a deliberate decision: if you're adding to the
+// list, the verb must NOT mutate task state. When in doubt, leave
+// the verb off the list — the cost of a slightly-noisy hub.log
+// (extra INFO line per read RPC) is much lower than the cost of a
+// silent state mutation (DEBUG-suppressed line invisible at default
+// log level).
+var readOnlyRPCs = map[string]bool{
+	"tasks.list":   true,
+	"tasks.show":   true,
+	"tasks.ready":  true,
+	"tasks.watch":  true,
+	"tasks.status": true,
+	"status":       true,
+	"doctor":       true,
+	"workspaces":   true,
+	"peek":         true,
+	"logs":         true,
+}
+
+// selectLevel returns the default level for an rpc entry given the
+// RPC name and the handler's error. Errors always promote to INFO;
+// mutating RPCs default INFO; read-only RPCs (allowlist above)
+// default DEBUG.
+//
+// Rationale: DEBUG-by-default for reads keeps a busy hub.log from
+// drowning in `tasks.list` entries during normal CLI use. INFO-by-
+// default for mutations matches operator intent — when something
+// changed, the operator wants to see it without flipping the level.
+func selectLevel(name string, err error) LogLevel {
+	if err != nil {
+		return LevelInfo
+	}
+	if readOnlyRPCs[name] {
+		return LevelDebug
+	}
+	return LevelInfo
+}
+
+// rpcNameFromEventType maps a tasks.EventType-style string (the
+// String() output of the closed iota set) to the dotted RPC name
+// hub.log uses. Pulled out so the mapping stays one source of truth
+// and the hub-side projector (which subscribes to `tasks.events.>`
+// and writes hub.log entries) doesn't bake the names inline.
+//
+// The function is robust against an unrecognized input — returns
+// the input prefixed with `tasks.` so an unknown event type still
+// produces a parseable hub.log entry rather than dropping the line.
+func rpcNameFromEventType(eventTypeName string) string {
+	switch eventTypeName {
+	case "created":
+		return "tasks.create"
+	case "claimed":
+		return "tasks.claim"
+	case "unclaimed":
+		return "tasks.unclaim"
+	case "updated":
+		return "tasks.update"
+	case "linked":
+		return "tasks.link"
+	case "slot_changed":
+		return "tasks.slot"
+	case "closed":
+		return "tasks.close"
+	default:
+		return "tasks." + eventTypeName
+	}
+}

--- a/internal/hub/middleware_test.go
+++ b/internal/hub/middleware_test.go
@@ -1,0 +1,201 @@
+package hub
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// loadEntries reads .bones/hub.log and parses each line as a
+// LogEntry. Test helper used to assert post-condition shapes after
+// invoking hubLogger methods.
+func loadEntries(t *testing.T, path string) []LogEntry {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open %s: %v", path, err)
+	}
+	defer func() { _ = f.Close() }()
+	var out []LogEntry
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" {
+			continue
+		}
+		var e LogEntry
+		if err := json.Unmarshal([]byte(line), &e); err != nil {
+			t.Fatalf("parse %q: %v", line, err)
+		}
+		out = append(out, e)
+	}
+	return out
+}
+
+// newTestLogger opens a hub.log under tmp with the given level.
+// Returns the logger and the file path.
+func newTestLogger(t *testing.T, level LogLevel) (*hubLogger, string) {
+	t.Helper()
+	tmp := t.TempDir()
+	bones := filepath.Join(tmp, ".bones")
+	if err := os.MkdirAll(bones, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	p := paths{orchDir: bones}
+	hl := openHubLogWithLevel(p, level)
+	t.Cleanup(func() { hl.Close() })
+	return hl, filepath.Join(bones, "hub.log")
+}
+
+// TestLogRPC_SuccessEmitsOneEntry pins #322's middleware contract:
+// a successful read-only RPC emits one DEBUG entry; a successful
+// mutating RPC emits one INFO entry.
+func TestLogRPC_SuccessEmitsOneEntry(t *testing.T) {
+	hl, path := newTestLogger(t, LevelDebug)
+	hl.LogRPC("tasks.create", "claude-1", 12*time.Millisecond, nil)
+
+	entries := loadEntries(t, path)
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	e := entries[0]
+	if e.Event != EventRPC {
+		t.Errorf("event: got %q want %q", e.Event, EventRPC)
+	}
+	if e.RPC != "tasks.create" {
+		t.Errorf("rpc: got %q want tasks.create", e.RPC)
+	}
+	if e.Agent != "claude-1" {
+		t.Errorf("agent: got %q want claude-1", e.Agent)
+	}
+	if e.Level != LevelInfo {
+		t.Errorf("level: mutating should default INFO, got %v", e.Level)
+	}
+	if e.TookMs != 12 {
+		t.Errorf("took_ms: got %d want 12", e.TookMs)
+	}
+	if e.Err != "" {
+		t.Errorf("err: should be empty on success, got %q", e.Err)
+	}
+}
+
+// TestLogRPC_ErrorAlwaysAtInfo pins the error-promotes rule: a
+// failing read-only RPC still emits an INFO entry (not DEBUG)
+// because errors always log per #322.
+func TestLogRPC_ErrorAlwaysAtInfo(t *testing.T) {
+	hl, path := newTestLogger(t, LevelInfo)
+	hl.LogRPC("tasks.list", "claude-1", 5*time.Millisecond, errors.New("boom"))
+
+	entries := loadEntries(t, path)
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	e := entries[0]
+	if e.Level != LevelInfo {
+		t.Errorf("level: error must promote to INFO, got %v", e.Level)
+	}
+	if e.Err != "boom" {
+		t.Errorf("err: got %q want boom", e.Err)
+	}
+}
+
+// TestLogRPC_ReadOnlyDemoteToDebug pins the policy that read-only
+// RPCs default DEBUG. With the floor at INFO, the entry should be
+// suppressed; with the floor at DEBUG, the entry should appear.
+func TestLogRPC_ReadOnlyDemoteToDebug(t *testing.T) {
+	t.Run("INFO floor suppresses DEBUG read", func(t *testing.T) {
+		hl, path := newTestLogger(t, LevelInfo)
+		hl.LogRPC("tasks.list", "claude-1", 1*time.Millisecond, nil)
+		// Either the file does not exist or has zero entries.
+		if data, err := os.ReadFile(path); err == nil && len(data) > 0 {
+			t.Errorf("INFO floor must suppress DEBUG: got %s", data)
+		}
+	})
+	t.Run("DEBUG floor passes DEBUG read", func(t *testing.T) {
+		hl, path := newTestLogger(t, LevelDebug)
+		hl.LogRPC("tasks.list", "claude-1", 1*time.Millisecond, nil)
+		entries := loadEntries(t, path)
+		if len(entries) != 1 {
+			t.Fatalf("expected 1 entry, got %d", len(entries))
+		}
+		if entries[0].Level != LevelDebug {
+			t.Errorf("level: got %v want DEBUG", entries[0].Level)
+		}
+	})
+}
+
+// TestLogHook_HookEntry pins the hook firing entry shape. A hook
+// firing produces one event="hook" entry with hook/session/msg
+// populated. Hook entries default INFO per #322's level policy.
+func TestLogHook_HookEntry(t *testing.T) {
+	hl, path := newTestLogger(t, LevelInfo)
+	hl.LogHook("SessionStart", "5b69e0c4", "", "primed 3")
+
+	entries := loadEntries(t, path)
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	e := entries[0]
+	if e.Event != EventHook {
+		t.Errorf("event: got %q want %q", e.Event, EventHook)
+	}
+	if e.Hook != "SessionStart" {
+		t.Errorf("hook: got %q want SessionStart", e.Hook)
+	}
+	if e.Session != "5b69e0c4" {
+		t.Errorf("session: got %q want 5b69e0c4", e.Session)
+	}
+	if e.Msg != "primed 3" {
+		t.Errorf("msg: got %q want primed 3", e.Msg)
+	}
+	if e.Level != LevelInfo {
+		t.Errorf("hook should always emit INFO, got %v", e.Level)
+	}
+}
+
+// TestLogHook_WithMatcher pins the post-#320 SessionStart-with-
+// matcher form (matcher="compact"). Operators auditing a PreCompact
+// vs SessionStart distinguish via the matcher field.
+func TestLogHook_WithMatcher(t *testing.T) {
+	hl, path := newTestLogger(t, LevelInfo)
+	hl.LogHook("SessionStart", "abc-123", "compact", "compact-prime ok")
+
+	entries := loadEntries(t, path)
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	if entries[0].Matcher != "compact" {
+		t.Errorf("matcher: got %q want compact", entries[0].Matcher)
+	}
+}
+
+// TestRPCNameFromEventType pins the mapping from internal task
+// event-type names to dotted RPC names hub.log uses. Adding a new
+// event type wants a row here.
+func TestRPCNameFromEventType(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"created", "tasks.create"},
+		{"claimed", "tasks.claim"},
+		{"unclaimed", "tasks.unclaim"},
+		{"updated", "tasks.update"},
+		{"linked", "tasks.link"},
+		{"slot_changed", "tasks.slot"},
+		{"closed", "tasks.close"},
+		{"unknown_future_type", "tasks.unknown_future_type"},
+	}
+	for _, tt := range tests {
+		got := rpcNameFromEventType(tt.in)
+		if got != tt.want {
+			t.Errorf("rpcNameFromEventType(%q) = %q want %q",
+				tt.in, got, tt.want)
+		}
+	}
+}

--- a/internal/hub/middleware_test.go
+++ b/internal/hub/middleware_test.go
@@ -3,12 +3,12 @@ package hub
 import (
 	"bufio"
 	"encoding/json"
-	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
-	"time"
+
+	"github.com/danmestas/bones/internal/timefmt"
 )
 
 // loadEntries reads .bones/hub.log and parses each line as a
@@ -52,128 +52,6 @@ func newTestLogger(t *testing.T, level LogLevel) (*hubLogger, string) {
 	return hl, filepath.Join(bones, "hub.log")
 }
 
-// TestLogRPC_SuccessEmitsOneEntry pins #322's middleware contract:
-// a successful read-only RPC emits one DEBUG entry; a successful
-// mutating RPC emits one INFO entry.
-func TestLogRPC_SuccessEmitsOneEntry(t *testing.T) {
-	hl, path := newTestLogger(t, LevelDebug)
-	hl.LogRPC("tasks.create", "claude-1", 12*time.Millisecond, nil)
-
-	entries := loadEntries(t, path)
-	if len(entries) != 1 {
-		t.Fatalf("expected 1 entry, got %d", len(entries))
-	}
-	e := entries[0]
-	if e.Event != EventRPC {
-		t.Errorf("event: got %q want %q", e.Event, EventRPC)
-	}
-	if e.RPC != "tasks.create" {
-		t.Errorf("rpc: got %q want tasks.create", e.RPC)
-	}
-	if e.Agent != "claude-1" {
-		t.Errorf("agent: got %q want claude-1", e.Agent)
-	}
-	if e.Level != LevelInfo {
-		t.Errorf("level: mutating should default INFO, got %v", e.Level)
-	}
-	if e.TookMs != 12 {
-		t.Errorf("took_ms: got %d want 12", e.TookMs)
-	}
-	if e.Err != "" {
-		t.Errorf("err: should be empty on success, got %q", e.Err)
-	}
-}
-
-// TestLogRPC_ErrorAlwaysAtInfo pins the error-promotes rule: a
-// failing read-only RPC still emits an INFO entry (not DEBUG)
-// because errors always log per #322.
-func TestLogRPC_ErrorAlwaysAtInfo(t *testing.T) {
-	hl, path := newTestLogger(t, LevelInfo)
-	hl.LogRPC("tasks.list", "claude-1", 5*time.Millisecond, errors.New("boom"))
-
-	entries := loadEntries(t, path)
-	if len(entries) != 1 {
-		t.Fatalf("expected 1 entry, got %d", len(entries))
-	}
-	e := entries[0]
-	if e.Level != LevelInfo {
-		t.Errorf("level: error must promote to INFO, got %v", e.Level)
-	}
-	if e.Err != "boom" {
-		t.Errorf("err: got %q want boom", e.Err)
-	}
-}
-
-// TestLogRPC_ReadOnlyDemoteToDebug pins the policy that read-only
-// RPCs default DEBUG. With the floor at INFO, the entry should be
-// suppressed; with the floor at DEBUG, the entry should appear.
-func TestLogRPC_ReadOnlyDemoteToDebug(t *testing.T) {
-	t.Run("INFO floor suppresses DEBUG read", func(t *testing.T) {
-		hl, path := newTestLogger(t, LevelInfo)
-		hl.LogRPC("tasks.list", "claude-1", 1*time.Millisecond, nil)
-		// Either the file does not exist or has zero entries.
-		if data, err := os.ReadFile(path); err == nil && len(data) > 0 {
-			t.Errorf("INFO floor must suppress DEBUG: got %s", data)
-		}
-	})
-	t.Run("DEBUG floor passes DEBUG read", func(t *testing.T) {
-		hl, path := newTestLogger(t, LevelDebug)
-		hl.LogRPC("tasks.list", "claude-1", 1*time.Millisecond, nil)
-		entries := loadEntries(t, path)
-		if len(entries) != 1 {
-			t.Fatalf("expected 1 entry, got %d", len(entries))
-		}
-		if entries[0].Level != LevelDebug {
-			t.Errorf("level: got %v want DEBUG", entries[0].Level)
-		}
-	})
-}
-
-// TestLogHook_HookEntry pins the hook firing entry shape. A hook
-// firing produces one event="hook" entry with hook/session/msg
-// populated. Hook entries default INFO per #322's level policy.
-func TestLogHook_HookEntry(t *testing.T) {
-	hl, path := newTestLogger(t, LevelInfo)
-	hl.LogHook("SessionStart", "5b69e0c4", "", "primed 3")
-
-	entries := loadEntries(t, path)
-	if len(entries) != 1 {
-		t.Fatalf("expected 1 entry, got %d", len(entries))
-	}
-	e := entries[0]
-	if e.Event != EventHook {
-		t.Errorf("event: got %q want %q", e.Event, EventHook)
-	}
-	if e.Hook != "SessionStart" {
-		t.Errorf("hook: got %q want SessionStart", e.Hook)
-	}
-	if e.Session != "5b69e0c4" {
-		t.Errorf("session: got %q want 5b69e0c4", e.Session)
-	}
-	if e.Msg != "primed 3" {
-		t.Errorf("msg: got %q want primed 3", e.Msg)
-	}
-	if e.Level != LevelInfo {
-		t.Errorf("hook should always emit INFO, got %v", e.Level)
-	}
-}
-
-// TestLogHook_WithMatcher pins the post-#320 SessionStart-with-
-// matcher form (matcher="compact"). Operators auditing a PreCompact
-// vs SessionStart distinguish via the matcher field.
-func TestLogHook_WithMatcher(t *testing.T) {
-	hl, path := newTestLogger(t, LevelInfo)
-	hl.LogHook("SessionStart", "abc-123", "compact", "compact-prime ok")
-
-	entries := loadEntries(t, path)
-	if len(entries) != 1 {
-		t.Fatalf("expected 1 entry, got %d", len(entries))
-	}
-	if entries[0].Matcher != "compact" {
-		t.Errorf("matcher: got %q want compact", entries[0].Matcher)
-	}
-}
-
 // TestRPCNameFromEventType pins the mapping from internal task
 // event-type names to dotted RPC names hub.log uses. Adding a new
 // event type wants a row here.
@@ -197,5 +75,74 @@ func TestRPCNameFromEventType(t *testing.T) {
 			t.Errorf("rpcNameFromEventType(%q) = %q want %q",
 				tt.in, got, tt.want)
 		}
+	}
+}
+
+// TestShouldEmit_ErrorBypassesFloor pins the rule from #322 that
+// errors always log regardless of the configured minimum level. With
+// a WARN floor, a LogEntry whose Level is INFO but whose Err field
+// is non-empty must still emit — the audit trail of failures takes
+// precedence over the floor.
+//
+// The earlier middleware-test variant set Level=INFO and floor=INFO,
+// which short-circuited via the ordinary >=floor branch and never
+// exercised the bypass; this test forces the bypass branch by
+// floor=WARN + Level=INFO.
+func TestShouldEmit_ErrorBypassesFloor(t *testing.T) {
+	hl, path := newTestLogger(t, LevelWarn)
+	hl.Log(LogEntry{
+		Ts:    timefmt.NewLoggedTime(timeNow()),
+		Level: LevelInfo,
+		Event: EventRPC,
+		RPC:   "tasks.create",
+		Err:   "boom",
+	})
+
+	entries := loadEntries(t, path)
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry (errors bypass WARN floor), got %d", len(entries))
+	}
+	if entries[0].Err != "boom" {
+		t.Errorf("err: got %q want boom", entries[0].Err)
+	}
+}
+
+// TestShouldEmit_DebugLevelEntryWithErrBypassesWarnFloor confirms
+// the bypass branch fires regardless of the entry's nominal level
+// — Level=DEBUG plus Err!="" still emits at WARN floor. Pins the
+// "errors override" rule independently of the entry's chosen level.
+func TestShouldEmit_DebugLevelEntryWithErrBypassesWarnFloor(t *testing.T) {
+	hl, path := newTestLogger(t, LevelWarn)
+	hl.Log(LogEntry{
+		Ts:    timefmt.NewLoggedTime(timeNow()),
+		Level: LevelDebug,
+		Event: EventRPC,
+		RPC:   "tasks.list",
+		Err:   "kv read failed",
+	})
+
+	entries := loadEntries(t, path)
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry (DEBUG+err bypasses WARN), got %d", len(entries))
+	}
+	if entries[0].Err != "kv read failed" {
+		t.Errorf("err: got %q", entries[0].Err)
+	}
+}
+
+// TestShouldEmit_NoErrAtBelowFloorSuppressed is the negative case:
+// without the Err field, the floor applies normally — a DEBUG-level
+// entry at WARN floor is dropped.
+func TestShouldEmit_NoErrAtBelowFloorSuppressed(t *testing.T) {
+	hl, path := newTestLogger(t, LevelWarn)
+	hl.Log(LogEntry{
+		Ts:    timefmt.NewLoggedTime(timeNow()),
+		Level: LevelDebug,
+		Event: EventRPC,
+		RPC:   "tasks.list",
+	})
+
+	if data, err := os.ReadFile(path); err == nil && len(data) > 0 {
+		t.Errorf("WARN floor must suppress DEBUG entry without err, got: %s", data)
 	}
 }

--- a/internal/hub/options.go
+++ b/internal/hub/options.go
@@ -74,6 +74,11 @@ type opts struct {
 	detach            bool
 	drainTimeout      time.Duration
 	startLeaseWatcher LeaseWatcherStartFunc
+	// logLevel pins hub.log's minimum entry level (#322). The empty
+	// string means "consult BONES_HUB_LOG_LEVEL or fall back to INFO";
+	// a non-empty string is the explicit --log-level value. The flag
+	// wins over the env var per #322's policy.
+	logLevel string
 }
 
 // defaults returns the production defaults: ports left zero so
@@ -113,6 +118,18 @@ func WithDetach(d bool) Option { return func(o *opts) { o.detach = d } }
 // value falls back to defaultDrainTimeout.
 func WithDrainTimeout(d time.Duration) Option {
 	return func(o *opts) { o.drainTimeout = d }
+}
+
+// WithLogLevel pins hub.log's minimum entry level for this hub start.
+// Per #322 the four standard severities are accepted: debug, info,
+// warn, error (case-insensitive). Errors always log regardless of
+// the floor. The empty string defers to BONES_HUB_LOG_LEVEL, which
+// in turn defaults to INFO.
+//
+// Flag wins over env var: when both --log-level and
+// BONES_HUB_LOG_LEVEL are set, the flag value takes precedence.
+func WithLogLevel(level string) Option {
+	return func(o *opts) { o.logLevel = level }
 }
 
 // WithLeaseWatcher installs the lease-TTL watcher hook. The hub

--- a/internal/hub/rotation_test.go
+++ b/internal/hub/rotation_test.go
@@ -1,0 +1,67 @@
+package hub
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestHubLog_RotationAt10MB pins #322's rotation policy: hub.log
+// rotates at 10MB (default per the brief; matches logwriter's
+// 10 MiB defaultMaxSize). After rotation, hub.log.1 exists and
+// hub.log starts fresh.
+//
+// We override the rotation threshold via BONES_LOG_MAX_SIZE so the
+// test runs in subseconds instead of writing 10MB of entries. The
+// rotation path is identical regardless of threshold; only the
+// trigger condition is faster to provoke.
+func TestHubLog_RotationAt10MB(t *testing.T) {
+	// Cap rotation at 4KB so a few entries trigger it.
+	t.Setenv("BONES_LOG_MAX_SIZE", "4096")
+
+	tmp := t.TempDir()
+	bones := filepath.Join(tmp, ".bones")
+	if err := os.MkdirAll(bones, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	p := paths{orchDir: bones}
+	hl := openHubLogWithLevel(p, LevelDebug)
+	t.Cleanup(func() { hl.Close() })
+
+	logPath := filepath.Join(bones, "hub.log")
+
+	// Write enough entries to push past 4KB. Each entry is roughly
+	// 200 bytes, so 50 entries comfortably crosses the threshold.
+	for i := 0; i < 80; i++ {
+		hl.Infof("hub: rotation test entry %d with some padding %s",
+			i, strings.Repeat("x", 100))
+	}
+
+	// hub.log.1 should exist after rotation.
+	rotated := logPath + ".1"
+	if _, err := os.Stat(rotated); err != nil {
+		t.Fatalf("expected %s to exist after rotation: %v", rotated, err)
+	}
+
+	// hub.log should still exist (rotation creates a fresh active
+	// file on next write).
+	if _, err := os.Stat(logPath); err != nil {
+		t.Fatalf("expected fresh hub.log after rotation: %v", err)
+	}
+
+	// The active file should be smaller than the rotated one
+	// (rotation copies the bulk to .1 and starts fresh).
+	activeInfo, err := os.Stat(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rotatedInfo, err := os.Stat(rotated)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if activeInfo.Size() >= rotatedInfo.Size() {
+		t.Errorf("active log size %d should be < rotated size %d",
+			activeInfo.Size(), rotatedInfo.Size())
+	}
+}

--- a/internal/hub/rpc_projector.go
+++ b/internal/hub/rpc_projector.go
@@ -1,0 +1,166 @@
+package hub
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+
+	"github.com/danmestas/bones/internal/tasks"
+)
+
+// startRPCProjector wires a hub-side consumer of `tasks.events.>` so
+// every state-mutating task event observed on the JetStream stream
+// produces one INFO entry in hub.log per #322. The projector is the
+// concrete realization of "RPC log middleware on the hub side": the
+// hub does not own RPC handlers (CLI verbs do, against JetStream
+// substrate), so the equivalent on the hub side is to project the
+// post-mutation event flow into the operator-facing log.
+//
+// Why subscribe to the event log rather than tap each CLI handler:
+//
+//   - Architecturally honest. The hub is a process boundary; CLI
+//     verbs are different processes. The only thing the hub can
+//     genuinely observe is what crosses NATS or Fossil.
+//
+//   - Single source of truth. Every Tx mutation publishes one event
+//     to the stream (ADR 0052). Subscribing once captures the
+//     complete mutation surface — no chance of a CLI verb forgetting
+//     to call a logging hook.
+//
+// The projector is a best-effort goroutine: connect failures degrade
+// to "no RPC log entries for this hub start", and the lifecycle
+// errors land in hub.log via the existing Warnf path so an operator
+// can see why entries are missing. Hub start does not block on
+// projector readiness.
+//
+// Returns a stop func; callers defer it to clean up the consumer
+// and NATS connection on hub teardown.
+func startRPCProjector(
+	ctx context.Context, natsURL string, hl *hubLogger,
+) func() {
+	// nopStop is the no-op cleanup returned on degraded paths so the
+	// caller's defer is unconditional.
+	nopStop := func() {}
+
+	if hl == nil {
+		return nopStop
+	}
+
+	nc, err := nats.Connect(natsURL,
+		nats.Timeout(5*time.Second),
+		nats.RetryOnFailedConnect(false),
+	)
+	if err != nil {
+		hl.Warnf("hub: rpc-log projector skipped (nats dial: %v)", err)
+		return nopStop
+	}
+
+	js, err := jetstream.New(nc)
+	if err != nil {
+		nc.Close()
+		hl.Warnf("hub: rpc-log projector skipped (jetstream: %v)", err)
+		return nopStop
+	}
+
+	stream, err := js.Stream(ctx, tasks.EventStreamName)
+	if err != nil {
+		nc.Close()
+		hl.Warnf("hub: rpc-log projector skipped (stream: %v)", err)
+		return nopStop
+	}
+
+	// DeliverNewPolicy: only entries published AFTER subscription
+	// land in hub.log. Replay of historic events is a different
+	// concern (the recovery loop already drains them); we do not
+	// want hub.log to flood with hours of backfill on hub restart.
+	cfg := jetstream.OrderedConsumerConfig{
+		FilterSubjects: []string{tasks.AllEventsSubject},
+		DeliverPolicy:  jetstream.DeliverNewPolicy,
+	}
+	cons, err := stream.OrderedConsumer(ctx, cfg)
+	if err != nil {
+		nc.Close()
+		hl.Warnf("hub: rpc-log projector skipped (consumer: %v)", err)
+		return nopStop
+	}
+
+	_, cancel := context.WithCancel(ctx)
+	cc, err := cons.Consume(func(msg jetstream.Msg) {
+		_ = msg.Ack()
+		projectOne(hl, msg.Data())
+	})
+	if err != nil {
+		cancel()
+		nc.Close()
+		hl.Warnf("hub: rpc-log projector skipped (consume: %v)", err)
+		return nopStop
+	}
+
+	stopOnce := false
+	return func() {
+		if stopOnce {
+			return
+		}
+		stopOnce = true
+		cc.Stop()
+		cancel()
+		nc.Close()
+	}
+}
+
+// projectOne decodes one stream message and writes the matching
+// hub.log entry. Decode failures are swallowed — they would be
+// caught by the tasks package's own validation, and propagating
+// them out of the projector would just spam hub.log with duplicate
+// noise.
+//
+// The agent field is sourced from the typed payload when present
+// (Claimed, Closed) and falls back to "system" otherwise. ADR 0052's
+// payload structs already carry the agent ID for the events where
+// it's known; for Created / Updated / Linked / SlotChanged the
+// originating identity is not stamped on the envelope, so "system"
+// is the honest answer.
+func projectOne(hl *hubLogger, raw []byte) {
+	env, err := tasks.UnmarshalEnvelope(raw)
+	if err != nil {
+		return
+	}
+	if !env.Type.Valid() {
+		return
+	}
+	rpc := rpcNameFromEventType(env.Type.String())
+	agent := agentFromPayload(env)
+	hl.Log(LogEntry{
+		Level: selectLevel(rpc, nil),
+		Event: EventRPC,
+		RPC:   rpc,
+		Agent: agent,
+		Task:  env.TaskID,
+	})
+	_ = json.RawMessage(env.Payload)
+}
+
+// agentFromPayload extracts the agent identity from typed payloads
+// where it's stamped. Returns "system" when unknown — the convention
+// in #322's brief for hub-internal calls and for events whose
+// originator is not carried on the envelope.
+func agentFromPayload(env tasks.EventEnvelope) string {
+	dec, err := tasks.DecodePayload(env)
+	if err != nil {
+		return "system"
+	}
+	switch p := dec.(type) {
+	case tasks.ClaimedPayload:
+		if p.AgentID != "" {
+			return p.AgentID
+		}
+	case tasks.ClosedPayload:
+		if p.AgentID != "" {
+			return p.AgentID
+		}
+	}
+	return "system"
+}

--- a/internal/hub/rpc_projector.go
+++ b/internal/hub/rpc_projector.go
@@ -2,7 +2,7 @@ package hub
 
 import (
 	"context"
-	"encoding/json"
+	"sync"
 	"time"
 
 	"github.com/nats-io/nats.go"
@@ -87,27 +87,27 @@ func startRPCProjector(
 		return nopStop
 	}
 
-	_, cancel := context.WithCancel(ctx)
 	cc, err := cons.Consume(func(msg jetstream.Msg) {
 		_ = msg.Ack()
 		projectOne(hl, msg.Data())
 	})
 	if err != nil {
-		cancel()
 		nc.Close()
 		hl.Warnf("hub: rpc-log projector skipped (consume: %v)", err)
 		return nopStop
 	}
 
-	stopOnce := false
+	// sync.Once guards against duplicate stop calls (deferred stop +
+	// an explicit teardown path in tests). Without it, cc.Stop() and
+	// nc.Close() would run twice on the second call — both are
+	// idempotent in practice but the contract should not depend on
+	// upstream best-effort behavior.
+	var stopOnce sync.Once
 	return func() {
-		if stopOnce {
-			return
-		}
-		stopOnce = true
-		cc.Stop()
-		cancel()
-		nc.Close()
+		stopOnce.Do(func() {
+			cc.Stop()
+			nc.Close()
+		})
 	}
 }
 
@@ -133,14 +133,17 @@ func projectOne(hl *hubLogger, raw []byte) {
 	}
 	rpc := rpcNameFromEventType(env.Type.String())
 	agent := agentFromPayload(env)
+	// Every event on tasks.events.> is by definition a state-mutating
+	// operation (ADR 0052: only Tx callbacks publish to the stream).
+	// INFO is the right floor — read-only RPCs would be DEBUG, but
+	// they never appear here because read paths don't publish events.
 	hl.Log(LogEntry{
-		Level: selectLevel(rpc, nil),
+		Level: LevelInfo,
 		Event: EventRPC,
 		RPC:   rpc,
 		Agent: agent,
 		Task:  env.TaskID,
 	})
-	_ = json.RawMessage(env.Payload)
 }
 
 // agentFromPayload extracts the agent identity from typed payloads

--- a/internal/logwriter/writer.go
+++ b/internal/logwriter/writer.go
@@ -97,10 +97,40 @@ func (w *Writer) Append(e Event) error {
 // Atomicity: opens with O_APPEND|O_CREATE|O_WRONLY and writes a single
 // newline-terminated line. POSIX guarantees writes ≤PIPE_BUF are atomic.
 func AppendOnce(path string, e Event) error {
+	return AppendJSONOnce(path, e)
+}
+
+// AppendJSON writes one JSON-marshalable value as a newline-terminated
+// line to the Writer's file. Used by the hub-log path (#322), which
+// carries a typed LogEntry rather than a logwriter.Event — the
+// reserved-key conventions in Event.MarshalJSON would clash with the
+// hub.log shape, so the hub side defines its own struct and writes it
+// through this thinner door.
+//
+// Rotation policy is identical to Append: maxSize > 0 triggers
+// rotateIfNeeded before the write.
+func (w *Writer) AppendJSON(v interface{ MarshalJSON() ([]byte, error) }) error {
+	if w.maxSize > 0 {
+		if err := os.MkdirAll(filepath.Dir(w.path), 0o755); err != nil {
+			return fmt.Errorf("logwriter: mkdir %s: %w", filepath.Dir(w.path), err)
+		}
+		if err := w.rotateIfNeeded(); err != nil {
+			return err
+		}
+	}
+	return AppendJSONOnce(w.path, v)
+}
+
+// AppendJSONOnce is the no-rotation variant of AppendJSON. Mirrors
+// AppendOnce: same O_APPEND|O_CREATE|O_WRONLY contract, same parent-
+// dir auto-create. Pulled out so the marshal/write split lives in
+// one place — both Append (logwriter.Event) and AppendJSON
+// (json.Marshaler) route through here.
+func AppendJSONOnce(path string, v interface{ MarshalJSON() ([]byte, error) }) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return fmt.Errorf("logwriter: mkdir %s: %w", filepath.Dir(path), err)
 	}
-	b, err := json.Marshal(e)
+	b, err := json.Marshal(v)
 	if err != nil {
 		return fmt.Errorf("logwriter: marshal event: %w", err)
 	}


### PR DESCRIPTION
## Summary

- Wires #322's hub-side state-mutation log: every task event observed on `tasks.events.>` projects into `.bones/hub.log` as one NDJSON `LogEntry` per call (event=rpc), alongside lifecycle markers (event=lifecycle).
- Adds `--log-level={debug|info|warn|error}` to `bones hub start` plus the `BONES_HUB_LOG_LEVEL` env var (flag wins). Errors always log regardless of floor.
- Adds `bones logs --hub` mode mutually-exclusive with `--slot` / `--workspace`, reusing the existing parse / follow / `--since` / `--last` / `--json` / `--full-time` pipeline.

## Scope honesty

The brief assumed bones hub owned RPC handlers it could wrap with middleware. It doesn't: CLI verbs talk to JetStream substrate directly, and hook firings happen in external CLI processes (`bones tasks prime --hook=session-start`) the hub never observes.

**Captures**:
- Lifecycle entries (starting, addresses, ready, stopping, stopped) via the typed `Infof`/`Warnf`/`Errorf` shim.
- Every state-mutating task operation, via the projector subscribed to `tasks.events.>` — covers all 7 ADR-0052 event types (created/claimed/unclaimed/updated/linked/slot_changed/closed → tasks.{create,claim,unclaim,update,link,slot,close}).

**Does NOT capture (deferred to follow-ups)**:
- Read-only CLI verb invocations (`tasks list`, `tasks show`, `status`, etc.) — these never touch the hub, the CLI reads directly from JetStream KV.
- Hook firings — emitted by external CLI processes; the hub doesn't see them today. A follow-up will track adding a `hub.hooks.fired` JetStream marker that `bones tasks prime --hook=...` publishes for the projector to subscribe to.

An earlier draft of this PR carried `LogRPC`/`LogRPCResult`/`LogHook` helpers and a `readOnlyRPCs` DEBUG-allowlist for level demotion. Those were unwired (tests-only callers) and have been removed; the package is now honest about what it can observe.

## Architectural notes

- Storage path: extended `internal/logwriter` with `AppendJSON` so the typed `LogEntry` reuses the atomic-append + 10MB rotation plumbing. Lumberjack would have been parallel infrastructure; the existing logwriter already matches the brief's spec (10 MiB default, numbered backups, `BONES_LOG_MAX_SIZE` override).
- `Ts` field on `LogEntry` uses `timefmt.LoggedTime` per #324; the AST-walk enforce test stays green.
- The `LogEntry` struct does NOT use the `{schema, data}` envelope from #321 — hub.log is internal log format, not CLI output.

## Stages landed

1. `internal/logwriter`: `AppendJSON` + `AppendJSONOnce` for typed marshalable values.
2. `internal/hub/logentry.go`: `LogEntry` struct + `LogLevel` + `chooseLogLevel`.
3. `internal/hub/hub_log.go`: typed writer with rotation + level filter (errors bypass floor); legacy `Infof/Warnf/Errorf` shimmed onto the typed path.
4. `internal/hub/middleware.go`: `rpcNameFromEventType` mapping (the only piece of "middleware" the hub can actually expose).
5. `internal/hub/rpc_projector.go`: hub-side subscriber to `tasks.events.>` that projects observed mutations into hub.log.
6. `cli/hub.go`: `--log-level` flag + detach-mode forwarding.
7. `cli/logs.go`: `--hub` mode + three-way mutual exclusion.

## Test plan

- [x] `make check` passes locally (only pre-existing `TestStatusAllEmptyRegistry` flake fails — ignored per the brief).
- [x] `go test -tags=otel -short ./...` passes (1139 / 1 known flake / 57 skipped).
- [x] `go test -tags=otel ./internal/hub/...` passes (52/52) including subprocess-spawning lifecycle tests.
- [x] Round-trip test: `LogEntry → NDJSON → parse → equal struct` with Z-suffix preserved.
- [x] Level parse + flag-vs-env precedence tests.
- [x] Error bypass test: WARN floor + Level=INFO + Err!="" still emits; companion DEBUG+err and DEBUG-no-err cases pin both branches.
- [x] Rotation test: writes past threshold, verifies `hub.log.1` exists and active log restarts fresh.
- [x] Render test: `bones logs --hub` reads representative lifecycle + rpc + hook fixture and surfaces typed fields as key=value.
- [x] `--json --hub` passthrough preserves the raw NDJSON byte-for-byte.

Closes #322