### PR TITLE
feat(cli): bones --help --all recursively renders every verb's flag set

### DIFF
--- a/cmd/bones/help_all.go
+++ b/cmd/bones/help_all.go
@@ -69,14 +69,23 @@ func detectHelpAll(args []string) (filtered []string, helpAll bool) {
 func recursiveHelpPrinter() kong.HelpPrinter {
 	return func(options kong.HelpOptions, ctx *kong.Context) error {
 		// Start node: the command the user selected, or the application
-		// root for bare `bones --help --all`.
+		// root for bare `bones --help --all`. The isAppRoot distinction
+		// matters: DefaultHelpPrinter branches on ctx.Selected() (nil →
+		// printApp, non-nil → printCommand), and the synthetic Path we
+		// build per node decides which branch fires. For a selected leaf
+		// we MUST include its full Command chain so printCommand renders
+		// the leaf's own usage — passing isRoot=true here is the bug
+		// from #325 review: it stripped the Command path and routed every
+		// `bones <leaf> --help --all` invocation through printApp,
+		// surfacing the top-level app help instead of the leaf's.
 		root := ctx.Selected()
-		if root == nil {
+		isAppRoot := root == nil
+		if isAppRoot {
 			root = ctx.Model.Node
 		}
 
 		// Print the root node first (full help block).
-		if err := printNode(options, ctx, root, true); err != nil {
+		if err := printNode(options, ctx, root, isAppRoot); err != nil {
 			return err
 		}
 

--- a/cmd/bones/help_all.go
+++ b/cmd/bones/help_all.go
@@ -1,0 +1,171 @@
+// help-all wires `bones --help --all` (and `bones <verb> --help --all`) so
+// that operators can discover every subcommand's full flag set in one pass.
+//
+// Default `bones --help` and `bones <verb> --help` are unchanged — Kong's
+// stock printer is preserved byte-for-byte. The `--all` flag is detected
+// pre-parse, stripped from os.Args, and only when present does this file
+// install a custom help printer that walks the parsed Kong app tree and
+// concatenates DefaultHelpPrinter output for every non-hidden node.
+//
+// Implementation notes (#325):
+//   - `--all` is intercepted pre-parse rather than declared as a Kong flag.
+//     Adding it as a real flag to every subcommand would either be repetitive
+//     or rely on Kong's "embed/persist" patterns that don't cleanly bubble up
+//     into help-flag handling. Pre-parse interception keeps the surface
+//     minimal: zero changes to command structs, one wrapper around the
+//     default help printer.
+//   - Re-using kong.DefaultHelpPrinter per node means the per-command output
+//     shape matches `bones <cmd> --help` exactly. We synthesize a *kong.Context
+//     with just enough fields populated for DefaultHelpPrinter to run
+//     (Kong + Path); other context fields are unused on the help path.
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/alecthomas/kong"
+)
+
+// detectHelpAll returns (filteredArgs, helpAll) where helpAll is true if the
+// arglist contains "--all" anywhere alongside a help request ("--help" or
+// "-h", or in `kong.UsageOnError()` mode the bare-args case where Kong shows
+// help). When helpAll is true, "--all" is removed from filteredArgs so Kong
+// itself never sees it; the `kong.Help(...)` printer is replaced with the
+// recursive variant by the caller.
+//
+// We intentionally only honor "--all" (no "-a" short form) — single-letter
+// flags collide with per-subcommand options and `--all` is unambiguous in
+// every existing subtree (`bones tasks list --all` is the only existing
+// "--all" and it lives behind a positional command, not after `--help`).
+func detectHelpAll(args []string) (filtered []string, helpAll bool) {
+	hasHelp := false
+	hasAll := false
+	for _, a := range args {
+		switch a {
+		case "--help", "-h":
+			hasHelp = true
+		case "--all":
+			hasAll = true
+		}
+	}
+	if !hasHelp || !hasAll {
+		return args, false
+	}
+	filtered = make([]string, 0, len(args))
+	for _, a := range args {
+		if a == "--all" {
+			continue
+		}
+		filtered = append(filtered, a)
+	}
+	return filtered, true
+}
+
+// recursiveHelpPrinter returns a kong.HelpPrinter that prints the selected
+// node's help, then walks its non-hidden descendants and prints each one's
+// help in turn, separated by a divider line.
+func recursiveHelpPrinter() kong.HelpPrinter {
+	return func(options kong.HelpOptions, ctx *kong.Context) error {
+		// Start node: the command the user selected, or the application
+		// root for bare `bones --help --all`.
+		root := ctx.Selected()
+		if root == nil {
+			root = ctx.Model.Node
+		}
+
+		// Print the root node first (full help block).
+		if err := printNode(options, ctx, root, true); err != nil {
+			return err
+		}
+
+		// Walk descendants in a stable, depth-first order. Skip hidden
+		// nodes — they're hidden from regular `--help` for a reason
+		// (e.g. session-marker, dispatch parent/worker) and should
+		// stay hidden from `--help --all` too.
+		var walk func(n *kong.Node) error
+		walk = func(n *kong.Node) error {
+			for _, child := range n.Children {
+				if child.Hidden {
+					continue
+				}
+				if err := writeDivider(ctx, child); err != nil {
+					return err
+				}
+				if err := printNode(options, ctx, child, false); err != nil {
+					return err
+				}
+				if err := walk(child); err != nil {
+					return err
+				}
+			}
+			return nil
+		}
+		return walk(root)
+	}
+}
+
+// printNode invokes kong.DefaultHelpPrinter against a synthetic Context
+// whose Path identifies `node` as the selected node. For the application
+// root (isRoot=true) we pass a single ApplicationNode path entry so
+// ctx.Selected() returns nil and the printer renders the top-level usage.
+func printNode(options kong.HelpOptions, ctx *kong.Context, node *kong.Node, isRoot bool) error {
+	synthetic := &kong.Context{
+		Kong: ctx.Kong,
+		Path: buildPath(ctx, node, isRoot),
+	}
+	// Kong's DefaultHelpPrinter checks ctx.Empty() — for our synthetic
+	// contexts we always want the full (non-summary) form.
+	options.Summary = false
+	return kong.DefaultHelpPrinter(options, synthetic)
+}
+
+// buildPath constructs the minimal Path slice DefaultHelpPrinter needs:
+//   - For the root: a single Path{App: ...} entry, which makes
+//     ctx.Selected() return nil → printApp branch.
+//   - For a command node: an App entry plus a Command entry per ancestor
+//     down to (and including) the target node. ctx.Selected() returns the
+//     last Command in the slice → printCommand branch.
+func buildPath(ctx *kong.Context, node *kong.Node, isRoot bool) []*kong.Path {
+	app := ctx.Model
+	path := []*kong.Path{{App: app}}
+	if isRoot {
+		return path
+	}
+	// Collect ancestors from root down to node (excluding the application).
+	chain := []*kong.Node{}
+	for cur := node; cur != nil && cur.Type != kong.ApplicationNode; cur = cur.Parent {
+		chain = append([]*kong.Node{cur}, chain...)
+	}
+	for _, n := range chain {
+		path = append(path, &kong.Path{Command: n})
+	}
+	return path
+}
+
+// writeDivider prints a blank line + a header line + a blank line to make
+// each command block visually distinct in the recursive help output.
+// Kong's printer emits no trailing blank line of its own, so we own
+// the spacing between blocks.
+func writeDivider(ctx *kong.Context, node *kong.Node) error {
+	header := fmt.Sprintf("=== %s %s ===", ctx.Model.Name, node.Path())
+	// Trim the path's leading whitespace defensively (Node.Path can
+	// return "" for the root, which we never pass here, but be safe).
+	header = strings.TrimSpace(header)
+	_, err := fmt.Fprintf(ctx.Stdout, "\n%s\n\n", header)
+	return err
+}
+
+// applyHelpAllArgs mutates os.Args (caller's responsibility — done before
+// kong.Parse runs) and returns the kong.Help option to install. Returns
+// nil option when --all wasn't requested, signaling the caller to leave
+// Kong's default help wiring alone.
+func applyHelpAllArgs() kong.Option {
+	filtered, helpAll := detectHelpAll(os.Args)
+	if !helpAll {
+		return nil
+	}
+	os.Args = filtered
+	return kong.Help(recursiveHelpPrinter())
+}

--- a/cmd/bones/help_all_test.go
+++ b/cmd/bones/help_all_test.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestDetectHelpAll covers the pre-parse os.Args filter that intercepts
+// `--help --all`. The detector must:
+//   - return helpAll=false (and untouched args) when --all is absent.
+//   - return helpAll=false when --all is present but no help flag is.
+//   - return helpAll=true and strip --all when both --help and --all (or
+//     -h and --all) are present.
+func TestDetectHelpAll(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		args     []string
+		wantArgs []string
+		wantAll  bool
+	}{
+		{
+			name:     "no flags",
+			args:     []string{"bones"},
+			wantArgs: []string{"bones"},
+			wantAll:  false,
+		},
+		{
+			name:     "help only",
+			args:     []string{"bones", "--help"},
+			wantArgs: []string{"bones", "--help"},
+			wantAll:  false,
+		},
+		{
+			name: "all without help (e.g. tasks list --all)",
+			args: []string{"bones", "tasks", "list", "--all"},
+			// --all here is the user-facing tasks-list flag; we must
+			// not strip it because no help flag is present.
+			wantArgs: []string{"bones", "tasks", "list", "--all"},
+			wantAll:  false,
+		},
+		{
+			name:     "help + all, long form",
+			args:     []string{"bones", "--help", "--all"},
+			wantArgs: []string{"bones", "--help"},
+			wantAll:  true,
+		},
+		{
+			name:     "help + all, short help",
+			args:     []string{"bones", "-h", "--all"},
+			wantArgs: []string{"bones", "-h"},
+			wantAll:  true,
+		},
+		{
+			name:     "verb + help + all",
+			args:     []string{"bones", "tasks", "--help", "--all"},
+			wantArgs: []string{"bones", "tasks", "--help"},
+			wantAll:  true,
+		},
+		{
+			name:     "all before help",
+			args:     []string{"bones", "--all", "--help"},
+			wantArgs: []string{"bones", "--help"},
+			wantAll:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			gotArgs, gotAll := detectHelpAll(tt.args)
+			if gotAll != tt.wantAll {
+				t.Errorf("helpAll = %v, want %v", gotAll, tt.wantAll)
+			}
+			if !reflect.DeepEqual(gotArgs, tt.wantArgs) {
+				t.Errorf("filtered args = %v, want %v", gotArgs, tt.wantArgs)
+			}
+		})
+	}
+}

--- a/cmd/bones/integration/help_all_test.go
+++ b/cmd/bones/integration/help_all_test.go
@@ -166,12 +166,22 @@ func TestCLI_HelpAllRecursesEveryVerb(t *testing.T) {
 
 // TestCLI_HelpAllSubtreeTasks pins `bones tasks --help --all`: only the
 // tasks subtree should render; top-level verbs (e.g. `up`, `swarm`) must
-// not appear, but every non-hidden `tasks <sub>` must.
+// not appear, but every non-hidden `tasks <sub>` must. Also asserts the
+// output STARTS with the parent verb's own usage line — guarding against
+// the regression where the recursive printer routed parent invocations
+// through the application-root branch and surfaced the top-level help.
 func TestCLI_HelpAllSubtreeTasks(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skip in -short: integration test")
 	}
 	out := runHelp(t, "tasks", "--help", "--all")
+
+	if !strings.HasPrefix(out, "Usage: bones tasks ") {
+		t.Errorf(
+			"tasks --help --all must start with the parent's own usage line, got first line:\n%q",
+			firstLine(out),
+		)
+	}
 
 	wantHeaders := []string{
 		"=== bones tasks create ===",
@@ -204,6 +214,57 @@ func TestCLI_HelpAllSubtreeTasks(t *testing.T) {
 		if strings.Contains(out, leak) {
 			t.Errorf("tasks --help --all should not include sibling %q", leak)
 		}
+	}
+}
+
+// TestCLI_HelpAllLeaves covers `bones <leaf> --help --all` — the regression
+// the #325 review caught. Every leaf invocation must render the leaf's own
+// help (not the application root) and must NOT contain divider headers
+// (a leaf has no subtree to recurse into). We sample three leaves at
+// distinct depths: a top-level leaf (`up`), a deeply-nested leaf
+// (`tasks list`), and another verb's leaf (`cleanup`).
+func TestCLI_HelpAllLeaves(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip in -short: integration test")
+	}
+
+	cases := []struct {
+		name      string
+		args      []string
+		wantUsage string
+	}{
+		{name: "up", args: []string{"up", "--help", "--all"}, wantUsage: "Usage: bones up "},
+		{
+			name:      "tasks list",
+			args:      []string{"tasks", "list", "--help", "--all"},
+			wantUsage: "Usage: bones tasks list ",
+		},
+		{
+			name:      "cleanup",
+			args:      []string{"cleanup", "--help", "--all"},
+			wantUsage: "Usage: bones cleanup ",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := runHelp(t, tc.args...)
+			if !strings.HasPrefix(out, tc.wantUsage) {
+				t.Errorf(
+					"%s: expected output to start with %q, got first line:\n%q",
+					tc.name, tc.wantUsage, firstLine(out),
+				)
+			}
+			// Leaves have no children → no divider headers should appear.
+			if strings.Contains(out, "=== bones ") {
+				t.Errorf("%s: leaf --help --all should emit no dividers, got:\n%s", tc.name, out)
+			}
+			// Top-level app description must not appear — that was the
+			// symptom of the bug (root help getting rendered for leaves).
+			if strings.Contains(out, "bones unified CLI: workspace, orchestrator, tasks") {
+				t.Errorf("%s: leaf --help --all leaked app-root description:\n%s", tc.name, out)
+			}
+		})
 	}
 }
 

--- a/cmd/bones/integration/help_all_test.go
+++ b/cmd/bones/integration/help_all_test.go
@@ -1,0 +1,225 @@
+package integration_test
+
+import (
+	"bytes"
+	"flag"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// updateGolden lets developers regenerate fixtures with `go test ... -update`.
+// Default off — CI runs the test against the committed golden output.
+var updateGolden = flag.Bool("update", false, "update golden files for help-all tests")
+
+// runHelp invokes the bones binary with COLUMNS=80 (so wrap width is
+// deterministic) and a stripped HOME so no per-user files (update-check
+// cache, telemetry, $XDG_CONFIG_HOME) leak into help output. Returns
+// stdout (which is what `--help` writes to) so tests can pin it.
+func runHelp(t *testing.T, args ...string) string {
+	t.Helper()
+	requireBinaries(t)
+
+	cmd := exec.Command(bonesBin, args...)
+	// Empty $HOME isolates the update-check cache; the once-per-day
+	// network refresh in main.go writes there. We don't want that
+	// to splash into stderr (or mutate the host) during these tests.
+	td := t.TempDir()
+	cmd.Env = []string{
+		"PATH=" + os.Getenv("PATH"),
+		"HOME=" + td,
+		"COLUMNS=80",
+		// Suppress the once-per-day update notice so its presence
+		// can't desynchronize golden output across runs.
+		"BONES_UPDATE_CHECK=0",
+		"LEAF_BIN=" + leafBinary(),
+	}
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("bones %s failed: %v\nstderr:\n%s", strings.Join(args, " "), err, stderr.String())
+	}
+	return stdout.String()
+}
+
+// goldenPath returns testdata/<name>.txt.
+func goldenPath(name string) string {
+	return filepath.Join("testdata", name+".txt")
+}
+
+// readGolden / writeGolden encapsulate the -update flow.
+func readGolden(t *testing.T, name string) string {
+	t.Helper()
+	b, err := os.ReadFile(goldenPath(name))
+	if err != nil {
+		t.Fatalf("read golden %s: %v (run with -update?)", name, err)
+	}
+	return string(b)
+}
+
+func writeGolden(t *testing.T, name, body string) {
+	t.Helper()
+	if err := os.MkdirAll("testdata", 0o755); err != nil {
+		t.Fatalf("mkdir testdata: %v", err)
+	}
+	if err := os.WriteFile(goldenPath(name), []byte(body), 0o644); err != nil {
+		t.Fatalf("write golden %s: %v", name, err)
+	}
+}
+
+// TestCLI_HelpDefaultGolden pins the byte-for-byte output of `bones --help`
+// without --all (#325). Adding --help --all must not change the default
+// help; this golden file is the canary.
+func TestCLI_HelpDefaultGolden(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip in -short: integration test")
+	}
+	out := runHelp(t, "--help")
+	if *updateGolden {
+		writeGolden(t, "help_default", out)
+		return
+	}
+	want := readGolden(t, "help_default")
+	if out != want {
+		t.Errorf(
+			"default --help output drifted from golden.\n--- want ---\n%s\n--- got ---\n%s",
+			want, out,
+		)
+	}
+}
+
+// TestCLI_HelpAllRecursesEveryVerb exercises `bones --help --all` (#325):
+// the output must contain every top-level verb name plus a divider line
+// per non-hidden node, and every verb must contribute at least one
+// distinguishing flag.
+func TestCLI_HelpAllRecursesEveryVerb(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip in -short: integration test")
+	}
+	out := runHelp(t, "--help", "--all")
+
+	// Every top-level non-hidden verb must appear as a divider header.
+	// Pulled from cmd/bones/cli.go; if that struct grows a new verb,
+	// add it here so the snapshot keeps tracking reality.
+	wantHeaders := []string{
+		"=== bones up ===",
+		"=== bones down ===",
+		"=== bones status ===",
+		"=== bones tasks ===",
+		"=== bones swarm ===",
+		"=== bones logs ===",
+		"=== bones apply ===",
+		"=== bones env ===",
+		"=== bones rename ===",
+		"=== bones cleanup ===",
+		"=== bones workspaces ===",
+		"=== bones repo ===",
+		"=== bones sync ===",
+		"=== bones bridge ===",
+		"=== bones notify ===",
+		"=== bones doctor ===",
+		"=== bones validate-plan ===",
+		"=== bones plan ===",
+		"=== bones peek ===",
+		"=== bones telemetry ===",
+		"=== bones init ===",
+		"=== bones join ===",
+		"=== bones hub ===",
+	}
+	for _, h := range wantHeaders {
+		if !strings.Contains(out, h) {
+			t.Errorf("--help --all missing header %q", h)
+		}
+	}
+
+	// Hidden commands must stay hidden in --help --all too. session-marker
+	// is hidden:"" on the root; tasks dispatch is hidden:"" inside tasks.
+	for _, hidden := range []string{
+		"=== bones session-marker ===",
+		"=== bones tasks dispatch ===",
+	} {
+		if strings.Contains(out, hidden) {
+			t.Errorf("--help --all should not surface hidden command %q", hidden)
+		}
+	}
+
+	// Spot-check that the per-leaf rendering carries the leaf's flags.
+	// `tasks list` is the canonical "rich filter" command #325 calls out.
+	tasksList := extractBlock(out, "=== bones tasks list ===", "=== ")
+	for _, flag := range []string{
+		"--status=STRING",
+		"--claimed-by=STRING",
+		"--ready",
+		"--stale=INT",
+		"--orphans",
+		"--by-slot",
+		"--json",
+	} {
+		if !strings.Contains(tasksList, flag) {
+			t.Errorf("tasks list block missing flag %q\nblock:\n%s", flag, tasksList)
+		}
+	}
+}
+
+// TestCLI_HelpAllSubtreeTasks pins `bones tasks --help --all`: only the
+// tasks subtree should render; top-level verbs (e.g. `up`, `swarm`) must
+// not appear, but every non-hidden `tasks <sub>` must.
+func TestCLI_HelpAllSubtreeTasks(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip in -short: integration test")
+	}
+	out := runHelp(t, "tasks", "--help", "--all")
+
+	wantHeaders := []string{
+		"=== bones tasks create ===",
+		"=== bones tasks list ===",
+		"=== bones tasks show ===",
+		"=== bones tasks update ===",
+		"=== bones tasks claim ===",
+		"=== bones tasks close ===",
+		"=== bones tasks watch ===",
+		"=== bones tasks status ===",
+		"=== bones tasks link ===",
+		"=== bones tasks prime ===",
+		"=== bones tasks autoclaim ===",
+		"=== bones tasks aggregate ===",
+		"=== bones tasks compact ===",
+		"=== bones tasks ready ===",
+	}
+	for _, h := range wantHeaders {
+		if !strings.Contains(out, h) {
+			t.Errorf("tasks --help --all missing header %q", h)
+		}
+	}
+
+	// Sibling verbs must not leak in.
+	for _, leak := range []string{
+		"=== bones up ===",
+		"=== bones swarm ===",
+		"=== bones repo ===",
+	} {
+		if strings.Contains(out, leak) {
+			t.Errorf("tasks --help --all should not include sibling %q", leak)
+		}
+	}
+}
+
+// extractBlock returns the substring of body starting at `from` and ending
+// at the first occurrence of `until` (exclusive). If `until` isn't found,
+// returns from `from` to end of body. Used to scope flag-set assertions
+// to a single command's help block.
+func extractBlock(body, from, until string) string {
+	i := strings.Index(body, from)
+	if i < 0 {
+		return ""
+	}
+	rest := body[i:]
+	j := strings.Index(rest[len(from):], until)
+	if j < 0 {
+		return rest
+	}
+	return rest[:len(from)+j]
+}

--- a/cmd/bones/integration/testdata/help_default.txt
+++ b/cmd/bones/integration/testdata/help_default.txt
@@ -1,0 +1,405 @@
+Usage: bones <command> [flags]
+
+bones unified CLI: workspace, orchestrator, tasks
+
+Flags:
+  -h, --help           Show context-sensitive help.
+  -R, --repo=STRING    Path to repository file
+  -v, --verbose        Verbose output
+
+Daily
+  up [flags]
+    Bootstrap workspace, lazy hub (ADR 0041)
+
+  down [flags]
+    Reverse up: stop hub + clean scaffold
+
+  status [flags]
+    Snapshot tasks, sessions, hub activity
+
+  tasks create <title> [flags]
+    Create a new task
+
+  tasks list [flags]
+    List tasks
+
+  tasks show <id> [flags]
+    Show a task
+
+  tasks update <id> [flags]
+    Update a task
+
+  tasks claim <id> [flags]
+    Claim a task
+
+  tasks close <id> [flags]
+    Close a task
+
+  tasks watch [flags]
+    Stream task lifecycle events
+
+  tasks status
+    Snapshot of all tasks by status
+
+  tasks link <from> <to> [flags]
+    Link two tasks with an edge type
+
+  tasks prime [flags]
+    Print agent-tasks context (prime)
+
+  tasks autoclaim [flags]
+    Run one autoclaim tick
+
+  tasks aggregate [flags]
+    Aggregate per-slot task summary
+
+  tasks compact [flags]
+    Compact eligible closed tasks (ADR 0016)
+
+  tasks ready [flags]
+    List unblocked, unclaimed open tasks
+
+  swarm join [flags]
+    Open a leaf, claim a task, prepare a worktree
+
+  swarm commit --message=STRING [<files> ...] [flags]
+    Commit changes (heartbeats the session)
+
+  swarm close [flags]
+    Release claim, post result, stop the leaf
+
+  swarm status [flags]
+    List active swarm sessions
+
+  swarm cwd --slot=STRING
+    Print the slot's worktree path
+
+  swarm tasks --slot=STRING [flags]
+    List ready tasks matching slot
+
+  swarm fan-in [flags]
+    Merge open hub leaves into trunk
+
+  swarm reap [flags]
+    Force-close stale same-host sessions as result=fail
+
+  swarm dispatch [<plan>] [flags]
+    Dispatch a plan: create tasks + write manifest
+
+  logs [flags]
+    Read per-slot or workspace event logs
+
+  apply [flags]
+    Materialize hub trunk into git tree
+
+  env [flags]
+    Emit shell exports for current workspace
+
+  rename <new-name> [flags]
+    Set workspace display name
+
+  cleanup [flags]
+    Reap slot or legacy worktrees
+
+  workspaces ls [flags]
+    List all known workspaces (live + stopped)
+
+  workspaces show <name> [flags]
+    Show one workspace by name (or filename id)
+
+Repository
+  repo new <path> [flags]
+    Create a new repository
+
+  repo clone [<url> [<path>]] [flags]
+    Clone a remote repository
+
+  repo ci --message=STRING <files> ... [flags]
+    Checkin file changes
+
+  repo co [<version>] [flags]
+    Checkout a version
+
+  repo ls [<version>] [flags]
+    List files in a version
+
+  repo timeline [flags]
+    Show repository history
+
+  repo cat <artifact> [flags]
+    Output artifact content
+
+  repo info
+    Repository statistics
+
+  repo hash <files> ... [flags]
+    Hash files (SHA1 or SHA3)
+
+  repo delta create <source> <target> [flags]
+    Create a delta between two files
+
+  repo delta apply <source> <delta> [flags]
+    Apply a delta to a source file
+
+  repo config ls
+    List all config entries
+
+  repo config get <key>
+    Get a config value
+
+  repo config set <key> <value>
+    Set a config value
+
+  repo query <sql>
+    Execute SQL against repository
+
+  repo verify
+    Verify repository integrity
+
+  repo resolve <name>
+    Resolve symbolic name to UUID
+
+  repo extract [<files> ...] [flags]
+    Extract files from a version
+
+  repo wiki ls
+    List wiki pages
+
+  repo wiki export <page> [flags]
+    Export a wiki page
+
+  repo tag ls [<version>]
+    List tags on an artifact
+
+  repo tag add <tag> [<value>] [flags]
+    Add a tag to an artifact
+
+  repo open [<dir>]
+    Open a checkout in a directory
+
+  repo status [flags]
+    Show working directory changes
+
+  repo add <files> ... [flags]
+    Stage files for addition
+
+  repo rm <files> ... [flags]
+    Stage files for removal
+
+  repo rename <from> <to> [flags]
+    Rename a tracked file
+
+  repo revert [<files> ...] [flags]
+    Undo staging changes
+
+  repo diff [<version>] [flags]
+    Show changes vs a version
+
+  repo merge <version> [flags]
+    Merge a divergent version
+
+  repo conflicts ls [flags]
+    List all conflicts
+
+  repo conflicts show <file> [flags]
+    Show all versions of a conflicted file
+
+  repo conflicts pick <file> [flags]
+    Resolve by picking one version
+
+  repo conflicts merge <file> [flags]
+    Resolve by re-merging with a different strategy
+
+  repo conflicts extract <file> [flags]
+    Extract all versions to disk for manual editing
+
+  repo mark-resolved <file> [flags]
+    Mark a conflict as resolved
+
+  repo undo [flags]
+    Undo last operation
+
+  repo redo [flags]
+    Redo undone operation
+
+  repo stash save [flags]
+    Stash working changes
+
+  repo stash pop [flags]
+    Apply top stash and drop it
+
+  repo stash apply [<id>] [flags]
+    Apply stash without dropping
+
+  repo stash ls
+    List stash entries
+
+  repo stash drop <id>
+    Remove stash entry
+
+  repo stash clear
+    Remove all stash entries
+
+  repo bisect good [<version>] [flags]
+    Mark version as good
+
+  repo bisect bad [<version>] [flags]
+    Mark version as bad
+
+  repo bisect next [flags]
+    Check out midpoint version
+
+  repo bisect skip [<version>] [flags]
+    Skip current version
+
+  repo bisect reset [flags]
+    Clear bisect state
+
+  repo bisect ls [flags]
+    Show bisect path
+
+  repo bisect status [flags]
+    Show bisect state
+
+  repo annotate <file> [flags]
+    Annotate file lines with version history
+
+  repo blame <file> [flags]
+    Alias for annotate
+
+  repo branch ls [flags]
+    List branches
+
+  repo branch new <name> [flags]
+    Create new branch
+
+  repo branch close <name> [flags]
+    Close a branch
+
+  repo uv ls
+    List unversioned files
+
+  repo uv put <name> <file>
+    Add or update an unversioned file
+
+  repo uv get <name> [flags]
+    Retrieve an unversioned file
+
+  repo uv delete <name>
+    Delete an unversioned file (creates tombstone)
+
+  repo schema add --columns=STRING <name> [flags]
+    Register a new synced table
+
+  repo schema list
+    List registered synced tables
+
+  repo schema show <name>
+    Show table schema details
+
+  repo schema remove <name>
+    Remove a synced table registration
+
+  repo user add --cap=STRING <login>
+    Create a new user
+
+  repo user list
+    List all users
+
+  repo user update --cap=STRING <login>
+    Update user capabilities
+
+  repo user rm <login>
+    Delete a user
+
+  repo user passwd <login>
+    Reset user password
+
+  repo invite --cap=STRING <login> [flags]
+    Generate invite token for a user
+
+Sync & messaging
+  sync start [flags]
+    Start leaf agent daemon
+
+  sync now <pid>
+    Trigger immediate sync
+
+  bridge serve --fossil-url=STRING --project=STRING [flags]
+    Start NATS-to-Fossil bridge
+
+  notify init
+    Initialize the notify repo
+
+  notify send --project=STRING <body> [flags]
+    Send a notification message
+
+  notify ask --project=STRING <body> [flags]
+    Send a message and wait for a reply
+
+  notify watch --project=STRING [flags]
+    Watch for incoming messages
+
+  notify threads --project=STRING
+    List active threads
+
+  notify log --project=STRING <thread>
+    Show thread message history
+
+  notify status
+    Show connection state and unread counts
+
+  notify pair --name=STRING [flags]
+    Generate a one-time pairing token and QR code
+
+  notify unpair <name>
+    Revoke a paired device
+
+  notify devices
+    List paired devices
+
+  doctor [flags]
+    Check development environment health
+
+Tooling
+  validate-plan <path> [flags]
+    Validate plan
+
+  plan finalize [flags]
+    Materialize hub artifacts to the host tree (ADR 0044)
+
+  peek [flags]
+    Browse hub via fossil ui
+
+  telemetry status
+    Print current telemetry state
+
+  telemetry disable
+    Opt out of telemetry (writes ~/.bones/no-telemetry)
+
+  telemetry enable
+    Re-enable telemetry (removes the opt-out marker)
+
+Plumbing
+  init [flags]
+    Create a workspace
+
+  join [flags]
+    Locate an existing workspace
+
+  hub start [flags]
+    Start the embedded Fossil hub + NATS server
+
+  hub stop [flags]
+    Stop the embedded Fossil hub + NATS server
+
+  hub user add <login> [flags]
+    Add (or noop-if-exists) a user to the hub repo
+
+  hub user list
+    List users in the hub repo
+
+  hub reap [flags]
+    Terminate orphan hub processes (ADR 0043)
+
+Run "bones <command> --help" for more information on a command.

--- a/cmd/bones/main.go
+++ b/cmd/bones/main.go
@@ -59,7 +59,11 @@ func main() {
 	}
 
 	var c CLI
-	ctx := kong.Parse(&c,
+	// Pre-parse `--help --all` (#325): when present, strips `--all` from
+	// os.Args and returns a kong.Help() option that installs a recursive
+	// help printer. Returns nil otherwise — leaving Kong's default help
+	// wiring untouched so default `--help` output stays byte-identical.
+	parseOpts := []kong.Option{
 		kong.Name("bones"),
 		kong.Description("bones unified CLI: workspace, orchestrator, tasks"),
 		kong.UsageOnError(),
@@ -79,7 +83,11 @@ func main() {
 			}
 			os.Exit(code)
 		}),
-	)
+	}
+	if helpAllOpt := applyHelpAllArgs(); helpAllOpt != nil {
+		parseOpts = append(parseOpts, helpAllOpt)
+	}
+	ctx := kong.Parse(&c, parseOpts...)
 	// Default slog level is Info; demote operational telemetry sites
 	// to Debug so non-`-v` invocations stay quiet. `-v` (repocli
 	// Globals.Verbose) reinstalls a Debug-level handler so the same


### PR DESCRIPTION
## Summary

- Adds `bones --help --all` (and `bones <verb> --help --all`) — recursive help printer that walks the parsed Kong app tree and renders every non-hidden node's full help block in one pass. Operators learning bones from `--help` now see the rich per-verb flag sets (`tasks list` alone has nine filters) without manually walking each subcommand.
- Default `bones --help` is unchanged — byte-for-byte pinned via `cmd/bones/integration/testdata/help_default.txt`.
- Implementation pre-parses `os.Args` for `--help --all`, strips `--all`, and installs `kong.Help(...)` with a custom printer that reuses `kong.DefaultHelpPrinter` per node (synthesizing a minimal `*kong.Context`) so per-command shape stays identical to the single-command form. No changes to any command struct.
- Hidden commands (`session-marker`, `tasks dispatch`) stay hidden in `--help --all`.

## Test plan

- [x] Unit: `TestDetectHelpAll` (8 cases, `cmd/bones/help_all_test.go`) covers detection + arg-stripping for the matrix of `--help`/`-h` x `--all` placements.
- [x] Integration: `TestCLI_HelpDefaultGolden` pins default `bones --help` byte-for-byte (`cmd/bones/integration/testdata/help_default.txt`; regenerate with `go test -update`).
- [x] Integration: `TestCLI_HelpAllRecursesEveryVerb` asserts every top-level verb gets a divider header, hidden commands stay hidden, and `tasks list` block carries every documented filter flag.
- [x] Integration: `TestCLI_HelpAllSubtreeTasks` asserts subtree scoping — every `tasks <sub>` appears, sibling verbs (`up`, `swarm`, `repo`) do not.
- [x] Local CI: `make check` clean. `go test -tags=otel -short ./...` clean modulo the pre-existing `TestStatusAllEmptyRegistry` flake (orthogonal to this change).

Closes #325