### PR TITLE
fix(down): non-zero abort exit + plan accuracy + remove empty settings stub

### DIFF
--- a/cli/down.go
+++ b/cli/down.go
@@ -59,6 +59,15 @@ func (c *DownCmd) Run(g *repocli.Globals) error {
 	return runDown(root, c, os.Stdin)
 }
 
+// errAborted signals an operator-initiated cancellation: stdin EOF,
+// non-TTY without --yes, or an explicit "n" at the y/N prompt. Surfaced
+// as a sentinel so callers (and the kong runner) can distinguish operator
+// cancellation from a teardown step that genuinely failed. Both still
+// translate to a non-zero exit code via main.go's ctx.Run handler — the
+// typed error keeps the semantics auditable in scripts and tests
+// (errors.Is(err, errAborted) instead of string-matching the message).
+var errAborted = errors.New("down: aborted")
+
 // runAll iterates the workspace registry and tears each down. Prints
 // a summary, prompts unless --yes, then invokes runDown per workspace.
 func (c *DownCmd) runAll() error {
@@ -79,7 +88,7 @@ func (c *DownCmd) runAll() error {
 
 	if !c.Yes {
 		if !confirm(os.Stdin, "Continue?") {
-			return errors.New("down --all: aborted")
+			return fmt.Errorf("down --all: %w", errAborted)
 		}
 	}
 
@@ -140,7 +149,7 @@ func runDown(root string, c *DownCmd, confirmIn interface {
 
 	if !c.Yes {
 		if !confirm(confirmIn, "Proceed?") {
-			return errors.New("down: aborted")
+			return errAborted
 		}
 	}
 
@@ -339,9 +348,18 @@ func planStopHub(root string, c *DownCmd) []downAction {
 	if c.KeepHub {
 		return nil
 	}
-	// Always queue the stop — hub.Stop is best-effort and idempotent
-	// (no-op when hub isn't running), so unconditional inclusion is
-	// both correct and self-documenting in the dry-run output.
+	// Plan accuracy (#307): only queue the stop-hub action when
+	// .bones/hub.pid actually exists on disk. Pre-fix the line was
+	// always rendered with the comment "hub.Stop is idempotent so
+	// unconditional inclusion is self-documenting" — but a `bones
+	// down --dry-run` run on a workspace that never ran the hub
+	// printed "stop hub (.bones/hub.pid)" referencing a file that
+	// doesn't exist. The plan should reflect what will actually
+	// happen, not the full surface bones knows how to teardown.
+	pidFile := filepath.Join(workspace.BonesDir(root), "hub.pid")
+	if !fileExists(pidFile) {
+		return nil
+	}
 	return []downAction{{
 		description: "stop hub (.bones/hub.pid)",
 		do: func() error {
@@ -458,9 +476,16 @@ func planRemoveHooks(root string, c *DownCmd) []downAction {
 	if !fileExists(settings) {
 		return nil
 	}
+	// Snapshot the manifest's SettingsCreatedByUp bit at plan-build
+	// time. The action thunk runs after planRemoveSkills, which
+	// removes the manifest as part of clearing .claude/skills/, so by
+	// the time removeBonesHooks executes the manifest is gone.
+	// Capturing the provenance now keeps the empty-stub branch (#307)
+	// reachable on real `bones up` → `bones down` cycles.
+	bonesCreated := bonesCreatedSettings(settings)
 	return []downAction{{
 		description: "remove bones hooks from " + settings,
-		do:          func() error { return removeBonesHooks(settings) },
+		do:          func() error { return removeBonesHooksWith(settings, bonesCreated) },
 	}}
 }
 
@@ -495,14 +520,40 @@ func planRemoveFossilMarkers(root string) []downAction {
 // "hooks" top-level key are pruned when removal leaves them empty.
 //
 // Per #256: bones owns specific hook entries inside settings.json,
-// not the file itself. When stripping leaves the JSON object as `{}`,
-// the file is rewritten as `{}\n` rather than unlinked — operator
-// owns file existence, bones only owns the keys it installed. This
-// supersedes the prior #235 symmetry-with-up behavior, which deleted
-// the file when it became bones-only-empty. User-authored keys (theme,
-// env, permissions, etc.) at the top level are preserved byte-for-byte
-// alongside the bones-owned hook stripping.
+// not the file itself by default. When stripping leaves the JSON
+// object as `{}` AND bones did not create the file (operator-authored
+// pre-up content lived alongside the bones hooks), the file is
+// rewritten as `{}\n` rather than unlinked — operator owns file
+// existence in that case.
+//
+// Per #307: when `bones up` originally created the settings.json (no
+// pre-existing file), bones owns its existence too. After stripping
+// leaves the file effectively empty (`{}` or `{"hooks": {}}`), the
+// file is removed so the parent "remove .claude/ if empty" pass can
+// succeed. The provenance bit lives in the manifest as
+// SettingsCreatedByUp; absent / false → preserve-stub semantics
+// from #256 wins (conservative default for legacy / hand-authored
+// installs).
+//
+// User-authored keys (theme, env, permissions, etc.) at the top level
+// are preserved byte-for-byte either way.
+//
+// Convenience wrapper that resolves the bones-created provenance from
+// the on-disk manifest. Production callers from `bones down` use
+// removeBonesHooksWith directly so they can capture the provenance bit
+// at plan-build time (the manifest is removed by planRemoveSkills
+// before this action's thunk runs). Tests that exercise the trim
+// behavior in isolation use this entry point.
 func removeBonesHooks(path string) error {
+	return removeBonesHooksWith(path, bonesCreatedSettings(path))
+}
+
+// removeBonesHooksWith is the core trim implementation, parameterized
+// on whether the caller has determined bones owns the file's
+// existence (per the #307 manifest provenance bit). When true, an
+// empty post-trim file is removed; when false, it falls through to
+// the preserve-as-`{}` branch (#256).
+func removeBonesHooksWith(path string, bonesCreated bool) error {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -522,10 +573,21 @@ func removeBonesHooks(path string) error {
 	}
 	hooks, _ := rootObj["hooks"].(map[string]any)
 	if hooks != nil {
-		pruneHookEvent(hooks, "SessionStart", "hub-bootstrap.sh")         // legacy
-		pruneHookEvent(hooks, "SessionStart", "bones hub start")          // current (ADR 0041)
-		pruneHookEvent(hooks, "SessionStart", "bones tasks prime --json") // task priming
-		pruneHookEvent(hooks, "PreCompact", "bones tasks prime --json")   // task priming
+		pruneHookEvent(hooks, "SessionStart", "hub-bootstrap.sh") // legacy
+		pruneHookEvent(hooks, "SessionStart", "bones hub start")  // current (ADR 0041)
+		// Task priming: substring needle "bones tasks prime" matches
+		// every variant bones up has shipped — `--json` (v0.12 legacy),
+		// `--hook=session-start` (current ADR 0051 form), and any bare
+		// invocation. Pre-#307 the needle was the literal `--json`
+		// string, which silently no-op'd against the canonical
+		// `--hook=session-start` entry written by mergeSettings — every
+		// `bones up`-then-`bones down` cycle stranded a prime hook in
+		// settings.json. The broader substring is intentional: every
+		// shipping variant is bones-owned. User scripts that happen to
+		// invoke `bones tasks prime` from these events are exceptional
+		// and were never bones-supported.
+		pruneHookEvent(hooks, "SessionStart", "bones tasks prime")
+		pruneHookEvent(hooks, "PreCompact", "bones tasks prime")
 		// Current installs land under SessionEnd; the legacy Stop event
 		// is also pruned so workspaces installed before the migration
 		// are still cleaned up by `bones down`.
@@ -537,17 +599,54 @@ func removeBonesHooks(path string) error {
 			rootObj["hooks"] = hooks
 		}
 	}
+	// Empty-stub branch (#307): if the post-trim object is `{}` and
+	// the manifest recorded that bones created this file, remove it.
+	// Operator-created files (no manifest, or SettingsCreatedByUp=false)
+	// fall through to the preserve-as-`{}` branch from #256.
+	if len(rootObj) == 0 && bonesCreated {
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+		return nil
+	}
 	// Per #256: bones owns specific keys, not the file. If no top-level
-	// keys remain after stripping, write `{}\n` back rather than
-	// unlinking — operator owns file existence. Supersedes #235's
-	// empty-object deletion. User-authored top-level keys (theme,
-	// model, env, permissions, includeCoAuthoredBy, …) are preserved
-	// verbatim either way.
+	// keys remain after stripping (and bones did not create the file),
+	// write `{}\n` back rather than unlinking — operator owns file
+	// existence. User-authored top-level keys (theme, model, env,
+	// permissions, includeCoAuthoredBy, …) are preserved verbatim
+	// either way.
 	out, err := json.MarshalIndent(rootObj, "", "  ")
 	if err != nil {
 		return err
 	}
 	return os.WriteFile(path, append(out, '\n'), 0o644)
+}
+
+// bonesCreatedSettings reports whether the manifest at the workspace
+// root containing settingsPath records that `bones up` created
+// .claude/settings.json from scratch (#307). False when:
+//   - settingsPath is not under a recognized .claude/settings.json
+//     position (manifest cannot be located);
+//   - no manifest exists (legacy install pre-#307);
+//   - the manifest exists but SettingsCreatedByUp is false (operator
+//     pre-existed the file before bones merged into it).
+//
+// Conservative default: if anything fails to parse cleanly, return
+// false so the caller falls into the preserve-`{}` branch (#256). The
+// down operator never loses a file the manifest doesn't claim.
+func bonesCreatedSettings(settingsPath string) bool {
+	// Expect <root>/.claude/settings.json. Walk up two parents to
+	// recover the workspace root, then read the manifest there.
+	claudeDir := filepath.Dir(settingsPath)
+	if filepath.Base(claudeDir) != ".claude" {
+		return false
+	}
+	root := filepath.Dir(claudeDir)
+	m, err := readManifest(root)
+	if err != nil || m == nil {
+		return false
+	}
+	return m.SettingsCreatedByUp
 }
 
 // pruneHookEvent removes hook entries under hooks[event] whose

--- a/cli/down_test.go
+++ b/cli/down_test.go
@@ -284,23 +284,52 @@ func TestRemoveBonesHooks_MissingFile(t *testing.T) {
 	}
 }
 
-// TestPlanDown_EmptyTree: on a tree without bones state, the always-on
-// actions are hub stop and registry removal (both best-effort, no-ops when
-// nothing is running). Per ADR 0041, planStopHub no longer probes for a
-// script — it always queues hub.Stop.
+// TestPlanDown_EmptyTree: on a tree without bones state, registry
+// removal is the always-on action (best-effort no-op when no entry
+// exists). The hub-stop action is gated on .bones/hub.pid actually
+// existing (#307 plan accuracy): the line previously rendered even
+// against workspaces that never started a hub, claiming to act on a
+// file that wasn't there. With no .bones/ at all in this test, no
+// hub.pid is possible, so the plan reflects only the registry remove.
 func TestPlanDown_EmptyTree(t *testing.T) {
 	dir := t.TempDir()
 	plan := planDown(dir, &DownCmd{})
-	if len(plan) != 2 {
-		t.Fatalf("empty tree plan: got %d actions, want 2 (hub stop + registry remove):\n%+v",
+	if len(plan) != 1 {
+		t.Fatalf("empty tree plan: got %d actions, want 1 (registry remove "+
+			"only — no hub.pid means no stop-hub line per #307):\n%+v",
 			len(plan), plan)
 	}
-	descs := plan[0].description + "\n" + plan[1].description
-	if !strings.Contains(descs, "stop hub") {
-		t.Errorf("plan missing hub stop; got:\n%s", descs)
+	if !strings.Contains(plan[0].description, "registry entry") {
+		t.Errorf("plan missing registry remove; got: %s", plan[0].description)
 	}
-	if !strings.Contains(descs, "registry entry") {
-		t.Errorf("plan missing registry remove; got:\n%s", descs)
+	for _, a := range plan {
+		if strings.Contains(a.description, "stop hub") {
+			t.Errorf("stop hub line present despite no .bones/hub.pid (#307); "+
+				"got: %s", a.description)
+		}
+	}
+}
+
+// TestPlanDown_HubPidPresentQueuesStop pins the inverse of #307's plan
+// accuracy fix: when .bones/hub.pid exists on disk, the stop-hub line
+// is in the plan. Without this companion test, the empty-tree fix
+// could regress to "always skip" and pass silently.
+func TestPlanDown_HubPidPresentQueuesStop(t *testing.T) {
+	dir := t.TempDir()
+	mkdir(t, filepath.Join(dir, ".bones"))
+	if err := os.WriteFile(filepath.Join(dir, ".bones", "hub.pid"),
+		[]byte("999999\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	plan := planDown(dir, &DownCmd{})
+	descs := make([]string, len(plan))
+	for i, a := range plan {
+		descs[i] = a.description
+	}
+	joined := strings.Join(descs, "\n")
+	if !strings.Contains(joined, "stop hub") {
+		t.Errorf("plan missing stop-hub line despite .bones/hub.pid present "+
+			"(#307 plan accuracy):\n%s", joined)
 	}
 }
 
@@ -329,6 +358,11 @@ func TestPlanDown_EmptyTree_KeepHub(t *testing.T) {
 func TestPlanDown_FullInstall(t *testing.T) {
 	dir := t.TempDir()
 	mkdir(t, filepath.Join(dir, ".bones"))
+	// hub.pid must be present for the stop-hub line to appear in the
+	// plan post-#307 (plan accuracy: lines for nonexistent files are
+	// dropped). Pre-#307 the line rendered unconditionally; the test
+	// previously relied on that and didn't seed hub.pid.
+	writeFile(t, filepath.Join(dir, ".bones", "hub.pid"), "999999\n")
 	mkdir(t, filepath.Join(dir, ".orchestrator", "scripts"))
 	for _, name := range []string{"orchestrator", "subagent", "uninstall-bones"} {
 		mkdir(t, filepath.Join(dir, ".claude", "skills", name))
@@ -1105,6 +1139,144 @@ func TestRunDown_PreservesNonEmptyClaudeDir(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(dir, ".claude", "user-notes.md")); err != nil {
 		t.Errorf("user file should be preserved: %v", err)
+	}
+}
+
+// TestRunDown_AbortIsTypedSentinel pins issue #307: canceling the
+// teardown via "n" at the y/N prompt returns the typed errAborted
+// sentinel, not a generic errors.New error. Scripts and the kong
+// runner branch on the typed identity (errors.Is) so the abort path
+// is distinguishable from a teardown step that genuinely failed.
+// Pre-fix runDown returned errors.New("down: aborted"), forcing
+// callers to substring-match the message.
+func TestRunDown_AbortIsTypedSentinel(t *testing.T) {
+	dir := t.TempDir()
+	mkdir(t, filepath.Join(dir, ".bones"))
+
+	// "n" answer.
+	err := runDown(dir, &DownCmd{}, strings.NewReader("n\n"))
+	if !errors.Is(err, errAborted) {
+		t.Errorf("answer-N: expected errors.Is(err, errAborted) = true; got err=%v", err)
+	}
+
+	// Closed stdin (no TTY): confirm reads EOF, treats as N.
+	err = runDown(dir, &DownCmd{}, strings.NewReader(""))
+	if !errors.Is(err, errAborted) {
+		t.Errorf("EOF-stdin: expected errors.Is(err, errAborted) = true; got err=%v", err)
+	}
+}
+
+// TestPlanDown_NoHubPidNoStopLine pins #307 fix 2 in isolation: a
+// workspace whose .bones/ exists but has no hub.pid (i.e. the hub
+// was never started in this lifecycle) produces a plan with no
+// stop-hub line. The dry-run output should not claim to act on a
+// file that doesn't exist.
+func TestPlanDown_NoHubPidNoStopLine(t *testing.T) {
+	dir := t.TempDir()
+	mkdir(t, filepath.Join(dir, ".bones"))
+	writeFile(t, filepath.Join(dir, ".bones", "agent.id"), "test-agent\n")
+
+	plan := planDown(dir, &DownCmd{})
+	for _, a := range plan {
+		if strings.Contains(a.description, "stop hub") {
+			t.Errorf("stop-hub line present despite no hub.pid (#307); "+
+				"got: %s", a.description)
+		}
+	}
+}
+
+// TestRunDown_RemovesEmptyStubWhenBonesCreated pins #307 fix 3: on a
+// workspace where bones up created .claude/settings.json from
+// scratch (manifest records SettingsCreatedByUp=true), trimming
+// bones-owned hooks leaves the file as `{}` and bones removes it so
+// the parent "remove .claude/ if empty" pass can succeed.
+//
+// Distinct from TestRunDown_PreservesClaudeWithStubSettings (#256)
+// which seeds settings.json directly without writing the manifest.
+// The provenance bit is what differentiates the two: bones owns
+// file existence iff bones created the file.
+func TestRunDown_RemovesEmptyStubWhenBonesCreated(t *testing.T) {
+	dir := t.TempDir()
+	mkdir(t, filepath.Join(dir, ".bones"))
+	writeFile(t, filepath.Join(dir, ".bones", "agent.id"), "test-agent\n")
+	// Drive scaffoldOrchestrator so the manifest is written with
+	// SettingsCreatedByUp=true (no pre-existing settings.json).
+	if _, err := scaffoldOrchestrator(dir, scaffoldOpts{}); err != nil {
+		t.Fatalf("scaffoldOrchestrator: %v", err)
+	}
+	// Sanity: manifest has the provenance bit set after a fresh
+	// scaffold against a workspace with no pre-existing .claude/.
+	m, err := readManifest(dir)
+	if err != nil || m == nil {
+		t.Fatalf("readManifest: m=%v err=%v", m, err)
+	}
+	if !m.SettingsCreatedByUp {
+		t.Fatalf("manifest.SettingsCreatedByUp = false; want true after " +
+			"fresh scaffold (no pre-existing settings.json)")
+	}
+
+	if err := runDown(dir, &DownCmd{Yes: true, KeepHub: true},
+		strings.NewReader("")); err != nil {
+		t.Fatalf("runDown: %v", err)
+	}
+
+	settingsPath := filepath.Join(dir, ".claude", "settings.json")
+	if _, err := os.Stat(settingsPath); !errors.Is(err, fs.ErrNotExist) {
+		t.Errorf("settings.json should be removed (#307 bones-created stub); "+
+			"got err=%v", err)
+	}
+	claudeDir := filepath.Join(dir, ".claude")
+	if _, err := os.Stat(claudeDir); !errors.Is(err, fs.ErrNotExist) {
+		t.Errorf(".claude/ should be removed (empty after settings.json removal); "+
+			"got err=%v", err)
+	}
+}
+
+// TestRunDown_PreservesUserKeysWhenBonesCreated pins the
+// non-clobber half of #307: even when bones created the file, any
+// user-authored top-level keys (theme, env, …) added later survive
+// trim. The empty-stub branch only fires when the post-trim object
+// is literally `{}`.
+func TestRunDown_PreservesUserKeysWhenBonesCreated(t *testing.T) {
+	dir := t.TempDir()
+	mkdir(t, filepath.Join(dir, ".bones"))
+	writeFile(t, filepath.Join(dir, ".bones", "agent.id"), "test-agent\n")
+	if _, err := scaffoldOrchestrator(dir, scaffoldOpts{}); err != nil {
+		t.Fatalf("scaffoldOrchestrator: %v", err)
+	}
+	// Operator adds a user key alongside the bones-installed hooks.
+	settingsPath := filepath.Join(dir, ".claude", "settings.json")
+	data, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("read settings.json: %v", err)
+	}
+	var obj map[string]any
+	if err := json.Unmarshal(data, &obj); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	obj["theme"] = "dark"
+	out, err := json.MarshalIndent(obj, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(settingsPath, append(out, '\n'), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	if err := runDown(dir, &DownCmd{Yes: true, KeepHub: true},
+		strings.NewReader("")); err != nil {
+		t.Fatalf("runDown: %v", err)
+	}
+
+	if _, err := os.Stat(settingsPath); err != nil {
+		t.Fatalf("settings.json should survive (user key present): %v", err)
+	}
+	got := readJSON(t, settingsPath)
+	if got["theme"] != "dark" {
+		t.Errorf("theme: got %v, want dark", got["theme"])
+	}
+	if _, ok := got["hooks"]; ok {
+		t.Errorf("bones hooks should be stripped; got %+v", got["hooks"])
 	}
 }
 

--- a/cli/orchestrator.go
+++ b/cli/orchestrator.go
@@ -54,6 +54,15 @@ type scaffoldFootprint struct {
 	// surfaces them so the operator knows their edits are persistent
 	// but won't get fresh skill content on bones release upgrades.
 	SkillsModified []string
+
+	// SettingsCreatedByUp records whether mergeSettings created
+	// .claude/settings.json from scratch (no file pre-existed) or
+	// merged into a user-authored file. Persisted into the manifest
+	// so `bones down` can decide whether the post-trim empty stub
+	// belongs to bones (safe to remove) or to the operator (preserve
+	// per #256). Sticky across re-scaffolds: once true on disk,
+	// writeManifest carries it forward.
+	SettingsCreatedByUp bool
 }
 
 // hooksAdded returns the total count of new hook entries written, summed
@@ -110,7 +119,9 @@ func scaffoldOrchestrator(root string, opts scaffoldOpts) (scaffoldFootprint, er
 	// .bones/scaffold_version, .bones/agent.id, and the bones-owned
 	// hook subset of .claude/settings.json. doctor uses these to
 	// detect tamper / partial-scaffold drift in `bones doctor`.
-	if err := writeManifest(root); err != nil {
+	// Footprint is passed so writeManifest can stamp the
+	// SettingsCreatedByUp provenance bit (#307).
+	if err := writeManifest(root, &fp); err != nil {
 		return fp, fmt.Errorf("manifest: %w", err)
 	}
 	return fp, nil
@@ -179,14 +190,24 @@ func removeLegacyBonesSkills(root string) error {
 // migrated away.
 func mergeSettings(path string, fp *scaffoldFootprint) error {
 	root := map[string]any{}
+	// Provenance signal for #307: if no file exists pre-merge, bones
+	// is creating it. The flag is sticky across re-scaffold via the
+	// manifest read in writeManifest, so a file that bones created
+	// originally stays "bones-created" even on subsequent up runs.
+	preExisted := true
 	if data, err := os.ReadFile(path); err == nil {
 		if len(data) > 0 {
 			if err := json.Unmarshal(data, &root); err != nil {
 				return fmt.Errorf("parse %s: %w", path, err)
 			}
 		}
-	} else if !os.IsNotExist(err) {
+	} else if os.IsNotExist(err) {
+		preExisted = false
+	} else {
 		return err
+	}
+	if !preExisted && fp != nil {
+		fp.SettingsCreatedByUp = true
 	}
 
 	hooks, _ := root["hooks"].(map[string]any)

--- a/cli/skills.go
+++ b/cli/skills.go
@@ -114,6 +114,16 @@ type skillManifest struct {
 	// bones's are NOT tamper-detected (they aren't bones's to claim).
 	// Empty on legacy manifests.
 	SettingsHooksSHA256 string `json:"settings_hooks_sha256,omitempty"`
+
+	// SettingsCreatedByUp records whether `bones up` created
+	// .claude/settings.json from scratch (true) versus merged into a
+	// pre-existing user-authored file (false). Read by `bones down`
+	// to decide whether the post-trim empty stub is safe to remove
+	// (#307: bones owns file existence iff bones created the file).
+	// Sticky across re-scaffold: once true, stays true. Empty on
+	// legacy manifests; absent / false → preserve-stub semantics
+	// (#256) wins, matching the conservative default for upgraders.
+	SettingsCreatedByUp bool `json:"settings_created_by_up,omitempty"`
 }
 
 // bonesOwnedHookCommands lists the (event, command) pairs bones
@@ -200,7 +210,7 @@ func writeBonesSkills(root string, fp *scaffoldFootprint) error {
 //     before bones did and stay out of the manifest entirely.
 //
 // The manifest itself is excluded from its own contents.
-func writeManifest(root string) error {
+func writeManifest(root string, fp *scaffoldFootprint) error {
 	prev, err := readManifest(root)
 	if err != nil {
 		return err
@@ -222,11 +232,25 @@ func writeManifest(root string) error {
 	if err != nil {
 		return err
 	}
+	// Sticky provenance for #307: SettingsCreatedByUp stays true once
+	// set. mergeSettings only flips it true on the call that actually
+	// created the file from scratch — subsequent up runs never see
+	// "no file pre-existed" again, but the flag must persist so down
+	// can still recognize bones-owned file existence. Inherit from
+	// previous manifest unless this run flipped it true.
+	createdByUp := false
+	if prev != nil {
+		createdByUp = prev.SettingsCreatedByUp
+	}
+	if fp != nil && fp.SettingsCreatedByUp {
+		createdByUp = true
+	}
 	m := skillManifest{
 		Version:             bonesVersion(),
 		Files:               files,
 		Scaffolded:          scaff,
 		SettingsHooksSHA256: hooksHash,
+		SettingsCreatedByUp: createdByUp,
 	}
 
 	out, err := json.MarshalIndent(m, "", "  ")


### PR DESCRIPTION
## Summary

Three small compounding defects in `bones down`:

1. **Aborted teardown**: returns a typed `errAborted` sentinel so scripts and the kong runner can branch on `errors.Is(err, errAborted)` instead of substring-matching the message. (Exit code already non-zero via main.go's `ctx.Run` handler — the typed error makes the abort path auditable.)
2. **Plan accuracy**: the "stop hub (.bones/hub.pid)" plan line is gated on hub.pid actually existing. Pre-fix the line rendered against workspaces that never ran a hub.
3. **Empty stub removal**: when `bones up` created `.claude/settings.json` from scratch and `bones down` strips its hooks to `{}`, the file is removed so the parent "remove `.claude/` if empty" pass can succeed. Provenance is tracked via a new sticky `settings_created_by_up` field in `.claude/skills/.bones-manifest.json`. Operator-pre-existing files keep #256's preserve-as-`{}` semantics — bones never removes a file the manifest doesn't claim.

Side fix folded in: the `bones tasks prime` prune needle is broadened from the literal `--json` to the bare `bones tasks prime` substring so the canonical ADR 0051 `--hook=session-start` form is also stripped on down. Pre-fix every up→down cycle stranded a prime hook in settings.json, which blocked the empty-stub branch even on bones-created files.

## Reconciliation with #256

#256 said: don't nuke `.claude/settings.json` if the operator had pre-up content. #307 says: if bones created the file, remove the empty stub on teardown. These are different cases — distinguished by the new manifest provenance bit.

- bones-created file (manifest `SettingsCreatedByUp=true`) + post-trim `{}` → remove (this PR).
- operator-created file (no manifest, or `SettingsCreatedByUp=false`) → preserve as `{}` (existing #256 behavior, unchanged).

## Test plan

- [x] `go test -short ./cli/` — passes (one pre-existing flake `TestStatusAllEmptyRegistry` unrelated).
- [x] `make check` — passes (same flake).
- [x] `go test -tags=otel -short ./...` — passes (same flake).
- [x] Manual repro of all three defects on a real workspace, all three now pass.
- [x] New regression tests:
  - `TestRunDown_AbortIsTypedSentinel` — `errors.Is(err, errAborted)` on N answer and EOF stdin.
  - `TestPlanDown_NoHubPidNoStopLine` + `TestPlanDown_HubPidPresentQueuesStop` — plan accuracy in both directions.
  - `TestRunDown_RemovesEmptyStubWhenBonesCreated` — full up→down flow; settings.json and `.claude/` both gone.
  - `TestRunDown_PreservesUserKeysWhenBonesCreated` — non-clobber half: a user key added after up survives down.

Closes #307