### PR TITLE
fix(status): registered vs active workspaces + stale-lock recovery

### DIFF
--- a/cli/schemas/verbs.go
+++ b/cli/schemas/verbs.go
@@ -83,10 +83,16 @@ type StatusAllPayload struct {
 }
 
 // StatusWorkspaceRow is one row of the status --all view.
+//
+// State (#305) is one of "active" (live hub, PID alive + HTTP probe
+// ok), "idle" (PID=0, registered by `bones up` but no hub serving),
+// or "paused" (PID > 0 but probe failed). Scripts branching on the
+// row should match this field rather than reading HubPID directly.
 type StatusWorkspaceRow struct {
 	Cwd       string             `json:"cwd"`
 	Name      string             `json:"name"`
 	HubURL    string             `json:"hub_url"`
+	State     string             `json:"state"`
 	Sessions  int                `json:"sessions"`
 	StartedAt timefmt.LoggedTime `json:"started_at"`
 }

--- a/cli/status.go
+++ b/cli/status.go
@@ -460,9 +460,9 @@ func truncateTitle(s string, n int) string {
 }
 
 // renderStatusAll iterates the workspace registry and prints up to
-// three sections (#264):
+// four sections (#264, #305):
 //
-//  1. Active workspaces with running hubs — the existing live-table.
+//  1. Active workspaces with running hubs — the live-table.
 //  2. Orphan hubs — `bones hub start` processes alive on this host but
 //     either with no registry entry, a registry entry pointing at a
 //     different PID, or whose cwd no longer exists. Surfaces hubs that
@@ -472,8 +472,13 @@ func truncateTitle(s string, n int) string {
 //     self-prune (#229) but whose hub HTTP probe failed (PID alive,
 //     port not bound). Useful for "bookmarked workspace where the hub
 //     stopped" without quietly deleting the registry entry on view.
+//  4. Idle workspaces — registered via `bones up` but no hub serving
+//     yet (PID=0 entries from #305). Lets operators see workspaces
+//     that exist on disk before any verb has triggered a hub start;
+//     pre-#305 a fresh `bones up` showed an empty registry with the
+//     misleading "use 'bones up' in a project" hint.
 //
-// Sections 2 and 3 are skipped entirely (header + body) when empty.
+// Sections 2-4 are skipped entirely (header + body) when empty.
 //
 // Headers use double-equal markers (`== Active workspaces ==`) so a
 // terminal-savvy operator can split sections visually without column
@@ -483,13 +488,32 @@ func renderStatusAll(w io.Writer) error {
 	if err != nil {
 		return err
 	}
-	var active, paused []registry.Entry
+	var active, paused, idle []registry.Entry
 	for _, e := range entries {
-		if registry.IsAlive(e) {
+		switch {
+		case e.HubPID == 0:
+			idle = append(idle, e)
+		case registry.IsAlive(e):
 			active = append(active, e)
-		} else {
+		default:
 			paused = append(paused, e)
 		}
+	}
+
+	// Empty-registry short-circuit (#305): if the registry holds no
+	// entries, emit the friendly hint and skip the orphan walk
+	// entirely. Pre-#305 the orphan walk ran first and the "No
+	// workspaces" message was suppressed when ANY orphan `bones hub
+	// start` process existed on the host — making
+	// TestStatusAllEmptyRegistry flake on dev machines that happened
+	// to have a hub running for an unrelated workspace. The orphan
+	// section's value is "you have a registered workspace whose hub
+	// drifted from the registry"; with no registry entries at all,
+	// there's nothing to drift FROM, so suppressing the section is
+	// the right call.
+	if len(entries) == 0 {
+		_, err := io.WriteString(w, "No workspaces running. Use 'bones up' in a project.\n")
+		return err
 	}
 
 	// Orphans: walk the host process table for `bones hub start` and
@@ -497,11 +521,6 @@ func renderStatusAll(w io.Writer) error {
 	// PID. ps/lsof failures degrade the orphan section to empty rather
 	// than failing the whole command (#264 edge case).
 	orphans, _ := liveOrphanHubs(active)
-
-	if len(active) == 0 && len(orphans) == 0 && len(paused) == 0 {
-		_, err := io.WriteString(w, "No workspaces running. Use 'bones up' in a project.\n")
-		return err
-	}
 
 	if err := renderActiveWorkspacesSection(w, active); err != nil {
 		return err
@@ -522,6 +541,14 @@ func renderStatusAll(w io.Writer) error {
 			return err
 		}
 	}
+	if len(idle) > 0 {
+		if _, err := io.WriteString(w, "\n"); err != nil {
+			return err
+		}
+		if err := renderIdleWorkspacesSection(w, idle); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -529,6 +556,11 @@ func renderStatusAll(w io.Writer) error {
 // the active set is empty but other sections exist, we still print the
 // header + a "(none)" body so the operator can see "no live hubs but
 // here are orphans/paused" without ambiguity.
+//
+// STATE column carries the literal "active" so scripts that grep
+// across the active + idle (#305) tables can branch on a single
+// column. Section header is the human-facing signal; STATE is the
+// scripted one.
 func renderActiveWorkspacesSection(w io.Writer, active []registry.Entry) error {
 	if _, err := io.WriteString(w, "== Active workspaces ==\n"); err != nil {
 		return err
@@ -538,16 +570,45 @@ func renderActiveWorkspacesSection(w io.Writer, active []registry.Entry) error {
 		return err
 	}
 	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
-	if _, err := fmt.Fprintln(tw, "WORKSPACE\tPATH\tHUB\tSESSIONS\tUPTIME"); err != nil {
+	if _, err := fmt.Fprintln(tw, "WORKSPACE\tPATH\tSTATE\tHUB\tSESSIONS\tUPTIME"); err != nil {
 		return err
 	}
 	for _, e := range active {
-		_, err := fmt.Fprintf(tw, "%s\t%s\t%s\t%d\t%s\n",
+		_, err := fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%d\t%s\n",
 			e.Name,
 			shortenHome(e.Cwd),
+			"active",
 			extractPort(e.HubURL),
 			sessions.CountByWorkspace(e.Cwd),
 			humanDuration(time.Since(e.StartedAt)),
+		)
+		if err != nil {
+			return err
+		}
+	}
+	return tw.Flush()
+}
+
+// renderIdleWorkspacesSection emits Section 4 of status --all (#305):
+// workspaces registered by `bones up` for which no hub is currently
+// serving (HubPID == 0). The row reports the same identity columns as
+// the active table plus the registration timestamp so operators can
+// see "I've up'd this workspace, no agent has touched it yet". STATE
+// holds the literal "idle" for scripted parity with the active table.
+func renderIdleWorkspacesSection(w io.Writer, idle []registry.Entry) error {
+	if _, err := io.WriteString(w, "== Idle workspaces ==\n"); err != nil {
+		return err
+	}
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	if _, err := fmt.Fprintln(tw, "WORKSPACE\tPATH\tSTATE\tREGISTERED"); err != nil {
+		return err
+	}
+	for _, e := range idle {
+		_, err := fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n",
+			e.Name,
+			shortenHome(e.Cwd),
+			"idle",
+			humanAge(time.Since(e.StartedAt)),
 		)
 		if err != nil {
 			return err
@@ -684,30 +745,39 @@ func renderPausedWorkspacesSection(w io.Writer, paused []registry.Entry) error {
 }
 
 // renderStatusAllJSON emits a JSON object with a "workspaces" array
-// covering every live registry entry. Wrapped in the ADR 0053
+// covering every registered workspace. Wrapped in the ADR 0053
 // envelope under verb "status".
+//
+// Per #305 the payload carries every entry the registry still holds
+// (including PID=0 idle entries from `bones up`) with a per-row
+// `state` field: `active` (live hub, PID alive + HTTP probe ok),
+// `idle` (PID=0, no hub serving), or `paused` (PID > 0 but probe
+// failed). Pre-#305 only `active` rows appeared and PID=0 entries
+// were silently dropped.
 func renderStatusAllJSON(w io.Writer) error {
 	entries, err := registry.List()
 	if err != nil {
 		return err
 	}
-	live := entries[:0]
+	rows := make([]schemas.StatusWorkspaceRow, 0, len(entries))
 	for _, e := range entries {
-		if registry.IsAlive(e) {
-			live = append(live, e)
-		} else {
-			_ = registry.Remove(e.Cwd)
+		state := "idle"
+		switch {
+		case e.HubPID == 0:
+			state = "idle"
+		case registry.IsAlive(e):
+			state = "active"
+		default:
+			state = "paused"
 		}
-	}
-	rows := make([]schemas.StatusWorkspaceRow, len(live))
-	for i, e := range live {
-		rows[i] = schemas.StatusWorkspaceRow{
+		rows = append(rows, schemas.StatusWorkspaceRow{
 			Cwd:       e.Cwd,
 			Name:      e.Name,
 			HubURL:    e.HubURL,
+			State:     state,
 			Sessions:  sessions.CountByWorkspace(e.Cwd),
 			StartedAt: timefmt.NewLoggedTime(e.StartedAt),
-		}
+		})
 	}
 	return emitEnvelope(w, "status", schemas.StatusAllPayload{Workspaces: rows})
 }

--- a/cli/status_test.go
+++ b/cli/status_test.go
@@ -260,6 +260,158 @@ func TestStatusAllEmptyRegistry(t *testing.T) {
 	}
 }
 
+// TestStatusAllShowsIdleAfterRegister pins #305 acceptance criterion 1:
+// after `bones up` (modeled here as registry.Register, the underlying
+// call), `bones status --all` shows the workspace under the Idle
+// section with state=idle. Pre-#305 the workspace was invisible to
+// --all because only hub-write paths populated the registry.
+func TestStatusAllShowsIdleAfterRegister(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	cwd := t.TempDir()
+
+	if err := registry.Register(cwd, "freshly-up"); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	var buf bytes.Buffer
+	if err := renderStatusAll(&buf); err != nil {
+		t.Fatalf("renderStatusAll: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{"== Idle workspaces ==", "freshly-up", "idle"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output missing %q:\n%s", want, out)
+		}
+	}
+	// "No workspaces running" must NOT appear when the registry has an
+	// idle entry — that hint is the bug #305 fixes.
+	if strings.Contains(out, "No workspaces running") {
+		t.Fatalf("idle workspace must suppress empty-registry hint:\n%s", out)
+	}
+}
+
+// TestStatusAllPromotesIdleToActiveOnHubWrite pins #305 acceptance
+// criterion 2: a workspace that was idle gets surfaced as active once
+// the hub start path overwrites the PID=0 entry with a PID-bearing
+// row. We model the hub-write by Register-then-Write, matching the
+// real bones up → bones hub start sequence.
+func TestStatusAllPromotesIdleToActiveOnHubWrite(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	cwd := t.TempDir()
+
+	if err := registry.Register(cwd, "served"); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(200)
+	}))
+	defer srv.Close()
+	if err := registry.Write(registry.Entry{
+		Cwd: cwd, Name: "served", HubURL: srv.URL,
+		HubPID: os.Getpid(), StartedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	var buf bytes.Buffer
+	if err := renderStatusAll(&buf); err != nil {
+		t.Fatalf("renderStatusAll: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{"== Active workspaces ==", "served", "active"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output missing %q:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "== Idle workspaces ==") {
+		t.Fatalf("active entry must not appear in idle section:\n%s", out)
+	}
+}
+
+// TestStatusAllJSONIncludesStateField pins #305 acceptance criterion 3:
+// the --json envelope's per-workspace row carries a `state` field set
+// to "active", "idle", or "paused". Scripts branching on workspace
+// state should match this field rather than re-deriving it from
+// HubPID.
+func TestStatusAllJSONIncludesStateField(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	cwdIdle := t.TempDir()
+	cwdActive := t.TempDir()
+
+	if err := registry.Register(cwdIdle, "idle-ws"); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(200)
+	}))
+	defer srv.Close()
+	if err := registry.Write(registry.Entry{
+		Cwd: cwdActive, Name: "active-ws", HubURL: srv.URL,
+		HubPID: os.Getpid(), StartedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	var buf bytes.Buffer
+	if err := renderStatusAllJSON(&buf); err != nil {
+		t.Fatalf("renderStatusAllJSON: %v", err)
+	}
+
+	// Envelope shape: { "verb": "status", "version": "v1", "data": { "workspaces": [...] } }.
+	var env struct {
+		Data struct {
+			Workspaces []struct {
+				Name  string `json:"name"`
+				State string `json:"state"`
+			} `json:"workspaces"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &env); err != nil {
+		t.Fatalf("unmarshal: %v\n%s", err, buf.String())
+	}
+	if len(env.Data.Workspaces) != 2 {
+		t.Fatalf("expected 2 rows, got %d:\n%s", len(env.Data.Workspaces), buf.String())
+	}
+	got := map[string]string{}
+	for _, r := range env.Data.Workspaces {
+		got[r.Name] = r.State
+	}
+	if got["idle-ws"] != "idle" {
+		t.Errorf("idle-ws state = %q, want %q", got["idle-ws"], "idle")
+	}
+	if got["active-ws"] != "active" {
+		t.Errorf("active-ws state = %q, want %q", got["active-ws"], "active")
+	}
+}
+
+// TestStatusAllRemovedAfterRegistryRemove pins #305 acceptance
+// criterion 4: after `bones down` (modeled by registry.Remove), the
+// workspace disappears from --all output entirely.
+func TestStatusAllRemovedAfterRegistryRemove(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	cwd := t.TempDir()
+
+	if err := registry.Register(cwd, "transient"); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	if err := registry.Remove(cwd); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+
+	var buf bytes.Buffer
+	if err := renderStatusAll(&buf); err != nil {
+		t.Fatalf("renderStatusAll: %v", err)
+	}
+	out := buf.String()
+	if strings.Contains(out, "transient") {
+		t.Fatalf("removed workspace must not appear in output:\n%s", out)
+	}
+	if !strings.Contains(out, "No workspaces running") {
+		t.Fatalf("empty registry should produce friendly hint:\n%s", out)
+	}
+}
+
 // TestResolveStatusRoot_DoesNotAutoStartHub mirrors the #138 item 7
 // fix for `bones down` (TestResolveDownRoot_DoesNotAutoStartHub) for
 // `bones status` (#207). Pre-fix, every CLI verb resolved the

--- a/cli/up.go
+++ b/cli/up.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/danmestas/bones/internal/githook"
 	"github.com/danmestas/bones/internal/hub"
+	"github.com/danmestas/bones/internal/registry"
 	"github.com/danmestas/bones/internal/scaffoldver"
 	"github.com/danmestas/bones/internal/swarm"
 	"github.com/danmestas/bones/internal/telemetry"
@@ -106,6 +107,16 @@ func runUp(cwd string, verbose, stealth bool) (err error) {
 	if hookErr := installGitHook(wsDir, verbose, logger); hookErr != nil {
 		err = fmt.Errorf("git hook: %w", hookErr)
 		return err
+	}
+
+	// Register the workspace in the cross-host registry so it appears
+	// in `bones status --all` between `bones up` and the first verb
+	// that triggers a hub serve (#305). PID=0 entry; the hub start
+	// path overwrites it with a PID-bearing record. `bones down`
+	// removes the entry. Best-effort: a HOME/permission failure here
+	// must not block scaffold completion.
+	if regErr := registry.Register(wsDir, resolveWorkspaceName(wsDir)); regErr != nil {
+		logger.Warnf("up: WARN  registry register: %v", regErr)
 	}
 
 	gitignoreAdded := runPostScaffoldChecks(wsDir, stealth, logger)

--- a/internal/registry/lock.go
+++ b/internal/registry/lock.go
@@ -2,6 +2,7 @@ package registry
 
 import (
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -76,8 +77,20 @@ func AcquireWorkspaceLock(root string) (func(), error) {
 	// "holder pid in lock.pid is alive" as the contention signal there.
 	// On Unix this is just an early human-readable error: flock will
 	// also fail and we'd still surface the holder pid below.
-	if holder, ok := readLockHolderPID(pidPath); ok && holder != os.Getpid() && pidAlive(holder) {
-		return nil, &ErrLockHeld{PID: holder, Path: path}
+	//
+	// Stale-holder shortcut (#305): if the recorded holder is dead the
+	// pid file is leftover crud from a crashed prior run. Remove it
+	// proactively so the post-flock recovery branch starts from a
+	// clean slate, and emit the recovery log line operators expect.
+	// On Windows this is the ONLY recovery path (no flock to fall
+	// through to).
+	if holder, ok := readLockHolderPID(pidPath); ok && holder != os.Getpid() {
+		if pidAlive(holder) {
+			return nil, &ErrLockHeld{PID: holder, Path: path}
+		}
+		slog.Warn("workspace lock: stale lock recovered",
+			"pid", holder, "lock", path, "reason", "dead")
+		_ = os.Remove(pidPath)
 	}
 
 	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o644)
@@ -90,8 +103,12 @@ func AcquireWorkspaceLock(root string) (func(), error) {
 		// Stale-holder reclamation: if the recorded holder is dead,
 		// delete the pid file and retry once. The flock itself is
 		// already released (the dead process exited), so the retry
-		// succeeds.
+		// succeeds. Log the recovery so operators can correlate a
+		// "hub started but the lock looked held" sequence in
+		// .bones/hub.log (#305 acceptance criterion).
 		if holder > 0 && !pidAlive(holder) {
+			slog.Warn("workspace lock: stale lock recovered",
+				"pid", holder, "lock", path, "reason", "dead")
 			_ = os.Remove(pidPath)
 			f, err = os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o644)
 			if err != nil {

--- a/internal/registry/lock_test.go
+++ b/internal/registry/lock_test.go
@@ -1,7 +1,9 @@
 package registry
 
 import (
+	"bytes"
 	"errors"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -147,6 +149,58 @@ func pidAliveOrSkip(t *testing.T, pid int) bool {
 		t.Skip("dead-pid sentinel is alive on this host")
 	}
 	return false
+}
+
+// TestAcquireWorkspaceLock_DeadHolderEmitsRecoveryLog pins #305: when
+// the lock is reclaimed from a dead holder, the recovery is announced
+// via slog.Warn("workspace lock: stale lock recovered", ...) so
+// operators reading .bones/hub.log can correlate "the hub started but
+// the lock looked held" sequences instead of seeing a silent retake
+// followed by the hub coming up. Pre-#305 the recovery happened but
+// emitted no log line, leaving the hub-log void of any signal that a
+// crashed prior hub had been recovered from.
+func TestAcquireWorkspaceLock_DeadHolderEmitsRecoveryLog(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix-only: dead-PID reclamation uses flock")
+	}
+	root := t.TempDir()
+	bones := filepath.Join(root, ".bones")
+	if err := os.MkdirAll(bones, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	dead := 999_999
+	for !pidAliveOrSkip(t, dead) {
+		break
+	}
+	pidPath := filepath.Join(bones, "hub.lock.pid")
+	if err := os.WriteFile(pidPath, []byte(strconv.Itoa(dead)+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Capture slog output through a JSON handler bound to a buffer for
+	// the duration of this test.
+	var buf bytes.Buffer
+	prev := slog.Default()
+	handler := slog.NewJSONHandler(&buf, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	})
+	slog.SetDefault(slog.New(handler))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	rel, err := AcquireWorkspaceLock(root)
+	if err != nil {
+		t.Fatalf("AcquireWorkspaceLock: %v", err)
+	}
+	t.Cleanup(rel)
+
+	out := buf.String()
+	if !strings.Contains(out, "stale lock recovered") {
+		t.Errorf("expected stale-lock recovery log, got: %s", out)
+	}
+	if !strings.Contains(out, strconv.Itoa(dead)) {
+		t.Errorf("expected dead pid %d in recovery log, got: %s", dead, out)
+	}
 }
 
 // TestHelperHoldsLock is the child helper for the "held by live

--- a/internal/registry/prune.go
+++ b/internal/registry/prune.go
@@ -61,25 +61,36 @@ func pruneStale() ([]string, []Entry, error) {
 }
 
 // isStaleEntry reports whether e is registry crud that the read-path
-// scan should delete. Two signals qualify:
+// scan should delete. Three signals qualify:
 //
-//  1. e.HubPID is not alive on this host (dead PID, never-existed PID,
-//     or recycled-to-other-process PID we don't have permission to
-//     signal). The original hub is gone; nothing this entry points to
-//     still exists.
-//  2. e.Cwd does not exist on disk (ENOENT). The workspace was rm
+//  1. e.Cwd does not exist on disk (ENOENT). The workspace was rm
 //     -rf'd; even if the PID happens to be alive (recycled to an
 //     unrelated process, or a true orphan), the entry has no
 //     reachable workspace to act against.
+//  2. e.HubPID > 0 but is not alive on this host (dead PID, never-
+//     existed PID, or recycled-to-other-process PID we don't have
+//     permission to signal). The original hub is gone; nothing this
+//     entry points to still exists.
+//
+// PID=0 entries are NOT stale: they're "registered but idle"
+// workspaces written by `bones up` (#305). They carry a valid cwd
+// and no claimed hub PID; they exist so a freshly-up'd workspace is
+// visible to `bones status --all` between `bones up` and the first
+// verb that triggers a hub serve. `bones down` deletes these via
+// Remove; a hub start overwrites them with a PID-bearing entry.
 //
 // Live PID + cwd-exists-but-marker-missing-or-trashed entries are
 // left alone — those are doctor-actionable orphans (ADR 0043) that
 // the operator should resolve via `bones hub reap`.
 func isStaleEntry(e Entry) bool {
-	if !pidAlive(e.HubPID) {
+	if _, err := os.Stat(e.Cwd); errors.Is(err, os.ErrNotExist) {
 		return true
 	}
-	if _, err := os.Stat(e.Cwd); errors.Is(err, os.ErrNotExist) {
+	if e.HubPID == 0 {
+		// Registered-but-idle (#305): no claimed hub, valid cwd. Keep.
+		return false
+	}
+	if !pidAlive(e.HubPID) {
 		return true
 	}
 	return false

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -86,6 +86,33 @@ func Write(e Entry) error {
 // ErrNotFound is returned by Read when no entry exists for the given cwd.
 var ErrNotFound = errors.New("registry: entry not found")
 
+// Register persists a PID=0 "registered but idle" entry for cwd
+// (#305). Used by `bones up` so the workspace is visible to
+// `bones status --all` between `bones up` and the first verb that
+// triggers a hub serve.
+//
+// Idempotent: if an entry already exists with HubPID > 0 (a live or
+// recently-live hub), Register is a no-op so the hub-written record
+// is preserved. If the existing entry is a PID=0 register row, it's
+// refreshed with the new name and timestamp.
+//
+// `bones down` removes entries via Remove; a hub start overwrites
+// the idle row with a PID-bearing entry via Write.
+func Register(cwd, name string) error {
+	if existing, err := Read(cwd); err == nil {
+		if existing.HubPID > 0 {
+			return nil
+		}
+	} else if !errors.Is(err, ErrNotFound) {
+		return err
+	}
+	return Write(Entry{
+		Cwd:       cwd,
+		Name:      name,
+		StartedAt: time.Now().UTC(),
+	})
+}
+
 // Read loads the workspace's registry entry. Single-file layout (#250):
 // the canonical path is <id>.json. Legacy per-PID files (`<id>-<pid>.json`)
 // are migrated on read into the canonical name and then deleted —

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -313,3 +313,98 @@ func TestRemove(t *testing.T) {
 		t.Fatalf("Remove nonexistent: want nil, got %v", err)
 	}
 }
+
+// TestRegister_WritesIdleEntry pins #305: Register writes an entry
+// with HubPID=0 and the supplied name, so a freshly-up'd workspace
+// is visible to `bones status --all` before any verb triggers a hub
+// serve.
+func TestRegister_WritesIdleEntry(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	cwd := t.TempDir()
+	writeWorkspaceMarker(t, cwd)
+
+	if err := Register(cwd, "fresh"); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	got, err := Read(cwd)
+	if err != nil {
+		t.Fatalf("Read after Register: %v", err)
+	}
+	if got.HubPID != 0 {
+		t.Errorf("HubPID = %d, want 0 (idle entry)", got.HubPID)
+	}
+	if got.Name != "fresh" {
+		t.Errorf("Name = %q, want %q", got.Name, "fresh")
+	}
+	if got.Cwd != cwd {
+		t.Errorf("Cwd = %q, want %q", got.Cwd, cwd)
+	}
+}
+
+// TestRegister_PreservesLiveEntry pins #305: Register is a no-op when
+// a live (PID > 0) entry already exists, so `bones up` re-runs against
+// a workspace whose hub is currently serving must NOT clobber the
+// HubURL/PID/timestamps the hub wrote. Only the PID=0 idle case gets
+// refreshed.
+func TestRegister_PreservesLiveEntry(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	cwd := t.TempDir()
+	writeWorkspaceMarker(t, cwd)
+
+	live := Entry{
+		Cwd: cwd, Name: "live", HubURL: "http://127.0.0.1:9",
+		HubPID: os.Getpid(), StartedAt: time.Now().UTC().Truncate(time.Second),
+	}
+	if err := Write(live); err != nil {
+		t.Fatalf("Write live: %v", err)
+	}
+
+	if err := Register(cwd, "should-be-ignored"); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	got, err := Read(cwd)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if got.Name != "live" {
+		t.Errorf("Register clobbered live entry name: %q want %q", got.Name, "live")
+	}
+	if got.HubPID != live.HubPID {
+		t.Errorf("Register clobbered live entry HubPID: %d want %d",
+			got.HubPID, live.HubPID)
+	}
+	if got.HubURL != live.HubURL {
+		t.Errorf("Register clobbered live entry HubURL: %q want %q",
+			got.HubURL, live.HubURL)
+	}
+}
+
+// TestRegister_IdleEntrySurvivesPrune pins #305 corollary: a PID=0
+// idle entry written by Register must NOT be pruned by the read-time
+// self-prune. Pre-#305 isStaleEntry treated PID=0 as dead and dropped
+// the row on the next List/Read, making the registered-but-idle state
+// unobservable. cwd existence still gates pruning.
+func TestRegister_IdleEntrySurvivesPrune(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	cwd := t.TempDir()
+	writeWorkspaceMarker(t, cwd)
+
+	if err := Register(cwd, "idle"); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	entries, err := List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	var found bool
+	for _, e := range entries {
+		if e.Cwd == cwd {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("idle entry pruned by List(); have %+v", entries)
+	}
+}

--- a/schemas/status.v1.json
+++ b/schemas/status.v1.json
@@ -13,6 +13,9 @@
           "hub_url": {
             "type": "string"
           },
+          "state": {
+            "type": "string"
+          },
           "sessions": {
             "type": "integer"
           },
@@ -26,6 +29,7 @@
           "cwd",
           "name",
           "hub_url",
+          "state",
           "sessions",
           "started_at"
         ]


### PR DESCRIPTION
## Summary

Two related defects in workspace-presence visibility:

1. `bones status --all` returned an empty list immediately after `bones up` succeeded. Per ADR 0041 the hub doesn't start at up-time, so the registry only gained an entry when a verb later triggered a hub serve. `bones up` now writes a PID=0 "registered but idle" entry via `registry.Register`; `bones down` removes it. The read-time self-prune (#229) keeps PID=0 rows whose cwd still exists.
2. `AcquireWorkspaceLock`'s dead-pid reclamation path was silent. Now `slog.Warn("workspace lock: stale lock recovered", pid=N)` fires on both reclamation branches so `.bones/hub.log` records the event.

`status --all` gains a fourth section ("Idle workspaces") and a STATE column on the Active table; the JSON envelope's per-row payload now carries a `state` field (`active` / `idle` / `paused`) so scripts can branch on a single key. `cli/schemas/verbs.go` and the regenerated `schemas/status.v1.json` reflect the new field.

Also fixes the `TestStatusAllEmptyRegistry` flake other PRs have been ignoring: the empty-registry short-circuit now runs before the orphan-hub process walk, so a dev host with an unrelated `bones hub start` running no longer perturbs the test.

## Test plan

- [x] `make check` passes locally
- [x] `go test -tags=otel -short ./...` passes locally (CI parity)
- [x] New tests cover acceptance criteria 1-6 from the brief:
  - `TestStatusAllShowsIdleAfterRegister` — fresh up shows `idle`
  - `TestStatusAllPromotesIdleToActiveOnHubWrite` — hub serve flips to `active`
  - `TestStatusAllJSONIncludesStateField` — `--json` carries `state`
  - `TestStatusAllRemovedAfterRegistryRemove` — down removes the row
  - `TestAcquireWorkspaceLock_DeadHolderEmitsRecoveryLog` — stale-lock recovery logged
  - `TestAcquireWorkspaceLock_HeldByLiveProcess` — live-lock still blocks (pre-existing)
- [x] `TestRegister_*` registry-side tests pin idle-write, live-preserve, prune-survival
- [x] `TestStatusAllEmptyRegistry` no longer flakes when a host hub is running

Closes #305