### PR TITLE
feat(manifest): per-hook hashing + doctor drift detection

### DIFF
--- a/cli/doctor.go
+++ b/cli/doctor.go
@@ -806,19 +806,18 @@ func resetDriftedHooks(w io.Writer, cwd string, driftedKeys []string) (int, erro
 		hooks = map[string]any{}
 		root["hooks"] = hooks
 	}
-	// Rewrite every drifted key back to canonical. We don't try to
-	// be surgical at the entry level: the canonical re-install
-	// helpers (pruneCommandFromEvent + addHookWithMatcher) are
-	// idempotent per-command, so reseating every bones-owned
-	// command produces the same byte output as `bones up` did.
-	fixed := 0
+	// Reseat every bones-owned command back to canonical in a
+	// SINGLE pass. rewriteCanonicalHookEntry prunes-and-re-adds the
+	// whole bones-owned set internally, so calling it once heals
+	// every drifted entry — looping per-key would re-prune entries
+	// that the previous iteration just installed and emit duplicate
+	// FIX lines for entries that share the same rewrite cycle.
+	rewriteCanonicalHookEntry(hooks)
 	for _, key := range driftedKeys {
-		if rewriteCanonicalHookEntry(hooks) {
-			_, _ = fmt.Fprintf(w,
-				"  FIX   hooks: %-22s rewritten to canonical (--reset)\n", key)
-		}
-		fixed++
+		_, _ = fmt.Fprintf(w,
+			"  FIX   hooks: %-22s rewritten to canonical (--reset)\n", key)
 	}
+	fixed := len(driftedKeys)
 	root["hooks"] = hooks
 	out, err := json.MarshalIndent(root, "", "  ")
 	if err != nil {

--- a/cli/doctor.go
+++ b/cli/doctor.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -50,6 +51,13 @@ type DoctorCmd struct {
 	// stale .claude/settings.json hook entries; --no-fix surfaces
 	// drift as WARN lines without rewriting the file.
 	NoFix bool `name:"no-fix" help:"report-only: do not auto-rewrite stale hook entries"`
+	// Reset opts in to rewriting drifted bones-owned hook entries
+	// back to their canonical form (issue #318). Default is
+	// report-only because drift here means "operator hand-edited
+	// the entry"; rewriting without consent destroys their change.
+	// Different posture from --no-fix's auto-rewrite of stale v0.12
+	// command forms (where drift = stale shape bones itself created).
+	Reset bool `name:"reset" help:"rewrite drifted hook entries to canonical (overwrites edits)"`
 }
 
 // Run invokes the EdgeSync doctor first; on completion (regardless
@@ -147,14 +155,16 @@ func (c *DoctorCmd) runTelemetryReport() {
 // single-workspace mode (the per-line WARN prefix is the signal).
 //
 // Threads c.NoFix into the bypass report so ADR 0051's hook-protocol
-// auto-rewrite is opt-out via `bones doctor --no-fix`.
+// auto-rewrite is opt-out via `bones doctor --no-fix`. Threads
+// c.Reset so issue #318's per-entry drift check can opt-in to
+// rewriting drifted bones-owned hook entries.
 func (c *DoctorCmd) runBypassReport() {
 	cwd, err := os.Getwd()
 	if err != nil {
 		fmt.Printf("  WARN  cwd: %v\n", err)
 		return
 	}
-	_, _ = runBypassReportToWith(os.Stdout, cwd, c.NoFix)
+	_, _ = runBypassReportToWith(os.Stdout, cwd, c.NoFix, c.Reset)
 }
 
 // runBypassReportTo is the writer-injection variant of runBypassReport.
@@ -166,16 +176,17 @@ func (c *DoctorCmd) runBypassReport() {
 // The warn count is the source of truth — callers must not scrape it from
 // the output buffer (display format is not a stable interface).
 //
-// Default is auto-rewrite mode (noFix=false). Tests and report-only
-// callers should use runBypassReportToWith directly.
+// Default is auto-rewrite mode (noFix=false), no per-entry reset
+// (reset=false). Tests and report-only callers should use
+// runBypassReportToWith directly.
 func runBypassReportTo(w io.Writer, cwd string) (warns int, err error) {
-	return runBypassReportToWith(w, cwd, false)
+	return runBypassReportToWith(w, cwd, false, false)
 }
 
-// runBypassReportToWith is the noFix-aware variant. ADR 0051's
-// auto-rewrite respects the noFix flag; everything else stays
-// unchanged.
-func runBypassReportToWith(w io.Writer, cwd string, noFix bool) (warns int, err error) {
+// runBypassReportToWith is the noFix+reset-aware variant. ADR 0051's
+// auto-rewrite respects noFix; issue #318's per-entry drift rewrite
+// is opt-in via reset. Everything else stays unchanged.
+func runBypassReportToWith(w io.Writer, cwd string, noFix, reset bool) (warns int, err error) {
 	_, _ = fmt.Fprintln(w)
 	_, _ = fmt.Fprintln(w, "=== bones substrate gates (ADR 0034) ===")
 
@@ -225,7 +236,7 @@ func runBypassReportToWith(w io.Writer, cwd string, noFix bool) (warns int, err 
 	}
 
 	warns += checkScaffoldGates(w, cwd, noFix)
-	warns += checkManifestIntegrity(w, cwd)
+	warns += checkManifestIntegrity(w, cwd, reset)
 	warns += checkOrphanHubs(w)
 	warns += checkStaleSlotDirs(w, cwd)
 
@@ -318,6 +329,16 @@ func checkBonesScaffoldedHooksWith(w io.Writer, cwd string, noFix bool) bool {
 		if err := os.WriteFile(settingsPath, append(out, '\n'), 0o644); err != nil {
 			_, _ = fmt.Fprintf(w, "  WARN  rewrite settings.json: %v\n", err)
 			return true
+		}
+		// Coordinate with issue #318: the rewrite changed settings.json
+		// content, so the manifest's per-entry hash map is now stale.
+		// Re-stamp it so the next checkBonesHooksDrift run reports OK
+		// instead of false-positive on the rewrite we just performed.
+		// Silent on workspaces without a manifest (the file is a
+		// post-`bones up` artifact; doctor predates `bones up` here).
+		if mErr := refreshManifestHooksIfPresent(cwd); mErr != nil {
+			_, _ = fmt.Fprintf(w,
+				"  WARN  re-stamp manifest after rewrite: %v\n", mErr)
 		}
 	}
 
@@ -582,18 +603,19 @@ func checkOrphanHubs(w io.Writer) int {
 //   - partial: a file in Scaffolded is missing on disk entirely
 //   - mid-version drift: manifest.Version != current binary version
 //
-// The bones-owned hook subset of .claude/settings.json is also
-// hashed (manifest.SettingsHooksSHA256) and compared against the
-// current on-disk hash. Divergence here means somebody has hand-
-// edited or deleted bones's hook entries since `bones up`; doctor
-// surfaces it as a WARN so the operator can re-run `bones up` to
-// restore the canonical set.
+// Per-entry drift detection for the bones-owned hook subset of
+// .claude/settings.json lives in checkBonesHooksDrift (issue #318);
+// callers walk both helpers together to get the full manifest
+// picture.
 //
 // Read-only and silent on workspaces without a manifest (legacy
 // pre-issue-#262 installs and pre-`bones up` directories).
 //
-// Returns the count of WARN-class findings emitted.
-func checkManifestIntegrity(w io.Writer, cwd string) int {
+// Returns the count of WARN-class findings emitted. Threads reset
+// through to checkBonesHooksDrift so `bones doctor --reset`
+// (issue #318) can opt into rewriting drifted bones-owned hook
+// entries to canonical.
+func checkManifestIntegrity(w io.Writer, cwd string, reset bool) int {
 	manifest, err := readManifest(cwd)
 	if err != nil {
 		_, _ = fmt.Fprintf(w, "  WARN  read bones manifest: %v\n", err)
@@ -649,28 +671,255 @@ func checkManifestIntegrity(w io.Writer, cwd string) int {
 		}
 	}
 
-	// Bones-owned hook subset of .claude/settings.json. Empty
-	// recorded value means a legacy manifest from a pre-#262
-	// binary — skip silently rather than false-positive.
-	if manifest.SettingsHooksSHA256 != "" {
-		got, herr := bonesOwnedHooksHashFromDisk(cwd)
-		if herr != nil {
-			_, _ = fmt.Fprintf(w,
-				"  WARN  read bones-owned hooks: %v\n", herr)
-			warns++
-		} else if got != manifest.SettingsHooksSHA256 {
-			_, _ = fmt.Fprintf(w,
-				"  WARN  bones manifest tamper: .claude/settings.json bones-owned hooks "+
-					"sha256 drift (manifest=%s on-disk=%s) — run `bones up` to restore\n",
-				short(manifest.SettingsHooksSHA256), short(got))
-			warns++
-		}
-	}
+	warns += checkBonesHooksDrift(w, cwd, manifest, reset)
 
 	if warns == 0 && len(manifest.Scaffolded) > 0 {
 		_, _ = fmt.Fprintln(w, "  OK    bones manifest matches on-disk scaffold")
 	}
 	return warns
+}
+
+// checkBonesHooksDrift compares the per-entry hashes recorded in
+// manifest.SettingsHooks against the live state of every bones-owned
+// hook entry in .claude/settings.json. Per issue #318 the drift
+// surface is per-entry (so doctor can name SessionStart[0]/1 instead
+// of saying "something changed") and report-only by default — drift
+// here means "operator hand-edited the entry," and rewriting would
+// clobber their change. Pass --reset to opt into a rewrite.
+//
+// Migration: a legacy v1 manifest carries SettingsHooksSHA256 (the
+// pre-#318 single-roll-up hash) and an empty SettingsHooks map. Doctor
+// reports a one-line INFO so the operator knows their next `bones up`
+// will rewrite to v2; it does NOT compare the legacy hash because
+// the per-entry surface supersedes it.
+//
+// Returns the count of WARN-class findings emitted (zero on a clean
+// workspace). When reset is true, drifted entries are rewritten to
+// their canonical form (re-installed via mergeSettings's helpers)
+// and the manifest's per-entry hash is re-stamped — emitting a FIX
+// line per rewritten entry instead of a WARN.
+func checkBonesHooksDrift(w io.Writer, cwd string, manifest *skillManifest, reset bool) int {
+	if manifest == nil {
+		return 0
+	}
+	// Legacy v1 manifest (pre-#318): single rolled-up hash, no
+	// per-entry map. Don't false-positive against the per-entry
+	// surface — surface a one-line INFO and let `bones up` migrate.
+	if manifest.SchemaVersion < manifestSchemaVersion &&
+		manifest.SettingsHooksSHA256 != "" &&
+		len(manifest.SettingsHooks) == 0 {
+		_, _ = fmt.Fprintln(w,
+			"  INFO  bones manifest uses legacy v1 hook hash — "+
+				"next `bones up` migrates to per-entry hashing (#318)")
+		return 0
+	}
+	if len(manifest.SettingsHooks) == 0 {
+		// Manifest exists but never recorded any hook entries
+		// (workspace where mergeSettings hasn't run). Nothing to
+		// compare against.
+		return 0
+	}
+	live, err := bonesOwnedHookEntryHashesFromDisk(cwd)
+	if err != nil {
+		_, _ = fmt.Fprintf(w, "  WARN  read bones-owned hooks: %v\n", err)
+		return 1
+	}
+	keys := manifestHookKeysSorted(manifest.SettingsHooks, live)
+	driftedKeys, warns := reportHookDriftPerEntry(w, manifest.SettingsHooks, live, keys)
+	if reset && len(driftedKeys) > 0 {
+		fixed, ferr := resetDriftedHooks(w, cwd, driftedKeys)
+		if ferr != nil {
+			_, _ = fmt.Fprintf(w, "  WARN  reset bones-owned hooks: %v\n", ferr)
+			return warns + 1
+		}
+		// FIX lines were already emitted by resetDriftedHooks; the
+		// drift is healed, so do NOT count the original divergence
+		// as a WARN — auto-rewrite of bones-owned shape is a
+		// healing action, not a finding (mirrors ADR 0051's policy
+		// for checkBonesScaffoldedHooks).
+		return warns - fixed
+	}
+	return warns
+}
+
+// reportHookDriftPerEntry emits one WARN/INFO line per entry whose
+// state diverges from the manifest. Returns the entry keys that need
+// canonical rewriting (hash mismatch only — missing entries are
+// re-installed by `bones up` rather than the per-entry rewrite path)
+// and the WARN count.
+func reportHookDriftPerEntry(
+	w io.Writer, manifest, live map[string]string, keys []string,
+) (drifted []string, warns int) {
+	for _, key := range keys {
+		want, hadWant := manifest[key]
+		got, hadGot := live[key]
+		switch {
+		case hadWant && !hadGot:
+			_, _ = fmt.Fprintf(w,
+				"  WARN  hooks: %-22s missing — manifest claims this entry "+
+					"but it is absent on disk; run `bones up` to restore\n",
+				key)
+			warns++
+		case !hadWant && hadGot:
+			// Live entry without a manifest record — likely a
+			// migration window before #318's first `bones up`.
+			// Report as INFO; rewrite happens at next up.
+			_, _ = fmt.Fprintf(w,
+				"  INFO  hooks: %-22s present on disk but not in manifest "+
+					"— next `bones up` will record it\n", key)
+		case want != got:
+			_, _ = fmt.Fprintf(w,
+				"  WARN  hooks: %-22s edited since `bones up` "+
+					"(manifest=%s on-disk=%s) — `bones doctor --reset` "+
+					"rewrites to canonical\n",
+				key, short(want), short(got))
+			warns++
+			drifted = append(drifted, key)
+		}
+	}
+	return drifted, warns
+}
+
+// resetDriftedHooks rewrites every entry in driftedKeys back to its
+// canonical bones-installed shape. The rewrite path uses the same
+// helpers mergeSettings uses (pruneCommandFromEvent +
+// addHookWithMatcher) so the resulting settings.json is byte-
+// identical to a fresh `bones up`. After the rewrite, the manifest
+// is re-stamped with fresh per-entry hashes so a subsequent doctor
+// run reports OK.
+//
+// Emits one FIX line per rewritten entry naming the key. Returns
+// the number of entries successfully rewritten (so the caller can
+// decrement its WARN count — a healed entry is not a finding).
+func resetDriftedHooks(w io.Writer, cwd string, driftedKeys []string) (int, error) {
+	settingsPath := filepath.Join(cwd, ".claude", "settings.json")
+	data, err := os.ReadFile(settingsPath)
+	if err != nil {
+		return 0, fmt.Errorf("read settings.json: %w", err)
+	}
+	var root map[string]any
+	if err := json.Unmarshal(data, &root); err != nil {
+		return 0, fmt.Errorf("parse settings.json: %w", err)
+	}
+	hooks, _ := root["hooks"].(map[string]any)
+	if hooks == nil {
+		hooks = map[string]any{}
+		root["hooks"] = hooks
+	}
+	// Rewrite every drifted key back to canonical. We don't try to
+	// be surgical at the entry level: the canonical re-install
+	// helpers (pruneCommandFromEvent + addHookWithMatcher) are
+	// idempotent per-command, so reseating every bones-owned
+	// command produces the same byte output as `bones up` did.
+	fixed := 0
+	for _, key := range driftedKeys {
+		if rewriteCanonicalHookEntry(hooks) {
+			_, _ = fmt.Fprintf(w,
+				"  FIX   hooks: %-22s rewritten to canonical (--reset)\n", key)
+		}
+		fixed++
+	}
+	root["hooks"] = hooks
+	out, err := json.MarshalIndent(root, "", "  ")
+	if err != nil {
+		return fixed, fmt.Errorf("serialize settings.json: %w", err)
+	}
+	if err := os.WriteFile(settingsPath, append(out, '\n'), 0o644); err != nil {
+		return fixed, fmt.Errorf("write settings.json: %w", err)
+	}
+	// Re-stamp the manifest's per-entry hashes so doctor reports
+	// OK on the next run. nil footprint: the rewrite path is not
+	// part of scaffoldOrchestrator's flow, so #338's
+	// SettingsCreatedByUp signal is unavailable here. The sticky-
+	// provenance logic in writeManifest inherits the previous
+	// manifest's value when fp is nil, which preserves whatever
+	// `bones up` originally recorded.
+	if err := writeManifest(cwd, nil); err != nil {
+		return fixed, fmt.Errorf("re-stamp manifest: %w", err)
+	}
+	return fixed, nil
+}
+
+// refreshManifestHooksIfPresent re-stamps the manifest's per-entry
+// hook hashes from the current on-disk state of .claude/settings.json.
+// No-ops silently when no manifest is present (workspace predates
+// `bones up`). Used by checkBonesScaffoldedHooksWith after an ADR
+// 0051 auto-rewrite to keep #318's per-entry hashes aligned with
+// the file the rewrite just produced.
+func refreshManifestHooksIfPresent(cwd string) error {
+	manifest, err := readManifest(cwd)
+	if err != nil {
+		return err
+	}
+	if manifest == nil {
+		return nil
+	}
+	live, err := bonesOwnedHookEntryHashesFromDisk(cwd)
+	if err != nil {
+		return err
+	}
+	manifest.SettingsHooks = live
+	manifest.SchemaVersion = manifestSchemaVersion
+	// v1 legacy field is intentionally cleared on rewrite — once
+	// the per-entry map is populated, the rolled-up hash is dead
+	// weight and would mislead operators reading the manifest.
+	manifest.SettingsHooksSHA256 = ""
+	out, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal manifest: %w", err)
+	}
+	path := filepath.Join(cwd, filepath.FromSlash(manifestRel))
+	return os.WriteFile(path, append(out, '\n'), 0o644)
+}
+
+// rewriteCanonicalHookEntry re-applies every bones-owned hook
+// command to hooks. Idempotent: re-adding a command bones already
+// installed is a no-op. The matcher placement follows ADR 0051
+// (SessionStart prime under "startup|compact"; everything else
+// under the default "" matcher). Returns true when at least one
+// add operation took effect (the command was missing entirely
+// rather than just edited).
+func rewriteCanonicalHookEntry(hooks map[string]any) bool {
+	primeCmd := clauderhooks.PrimeCommandFor(clauderhooks.EventSessionStart)
+	added := false
+	// First, prune any drifted entry that still exists with the
+	// canonical command — addHookWithMatcher is no-op when the
+	// command is already present at the right matcher, but a
+	// drifted entry might be at a different matcher or have
+	// modified fields. Pruning resets the slate.
+	for _, h := range bonesOwnedHookCommands {
+		pruneCommandFromEvent(hooks, h.Event, h.Command)
+	}
+	// Re-install canonically. Prime gets the matcher; hub start is
+	// at default matcher.
+	if addHookWithMatcher(hooks, "SessionStart",
+		clauderhooks.SessionStartMatcher, primeCmd) {
+		added = true
+	}
+	if addHook(hooks, "SessionStart", "bones hub start") {
+		added = true
+	}
+	return added
+}
+
+// manifestHookKeysSorted returns the union of entry keys from the
+// manifest map and the on-disk map, sorted lexically. Used by
+// checkBonesHooksDrift so output is deterministic regardless of map
+// iteration order.
+func manifestHookKeysSorted(manifest, live map[string]string) []string {
+	seen := map[string]bool{}
+	for k := range manifest {
+		seen[k] = true
+	}
+	for k := range live {
+		seen[k] = true
+	}
+	out := make([]string, 0, len(seen))
+	for k := range seen {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
 }
 
 // checkStaleSlotDirs reports per-slot directories under

--- a/cli/doctor_all.go
+++ b/cli/doctor_all.go
@@ -127,8 +127,12 @@ func runDoctorOne(e registry.Entry) workspaceResult {
 		printFix(&buf, FixForHubDown())
 		r.Issues++
 	}
-	// noFix=true: --all is report-only. See function doc above.
-	bypassWarns, _ := runBypassReportToWith(&buf, e.Cwd, true)
+	// noFix=true, reset=false: --all is report-only across the
+	// board. See function doc above for why; the same blast-radius
+	// logic that gates ADR 0051 auto-rewrite also gates issue
+	// #318's per-entry hook reset (operator may not be in any of
+	// these workspaces' shells).
+	bypassWarns, _ := runBypassReportToWith(&buf, e.Cwd, true, false)
 	r.Issues += bypassWarns
 	r.Detail = buf.String()
 	return r

--- a/cli/manifest_test.go
+++ b/cli/manifest_test.go
@@ -668,6 +668,82 @@ func TestCheckBonesHooksDrift_V1MigratesOnNextWriteManifest(t *testing.T) {
 	}
 }
 
+// TestCheckBonesHooksDrift_ResetMultipleEntriesOneFIXEach pins
+// the regression for the per-key FIX-line bug: with N drifted
+// entries, the rewrite must emit exactly N FIX lines (one per
+// named key), NOT N×K where K is the count of bones-owned
+// commands. The reseat helper handles all entries in one pass —
+// looping over the helper would emit duplicate FIX lines for
+// later iterations.
+func TestCheckBonesHooksDrift_ResetMultipleEntriesOneFIXEach(t *testing.T) {
+	dir := setupCleanScaffold(t)
+	// Edit BOTH bones-owned hook entries (prime + hub start) so
+	// both keys appear in driftedKeys.
+	settingsPath := filepath.Join(dir, ".claude", "settings.json")
+	data, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var settings map[string]any
+	if err := json.Unmarshal(data, &settings); err != nil {
+		t.Fatal(err)
+	}
+	hooks := settings["hooks"].(map[string]any)
+	editPrimeEntry(t, hooks)
+	editHubStartEntry(t, hooks)
+	out, _ := json.MarshalIndent(settings, "", "  ")
+	if err := os.WriteFile(settingsPath, append(out, '\n'), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	manifest, err := readManifest(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	warns := checkBonesHooksDrift(&buf, dir, manifest, true /* reset */)
+	output := buf.String()
+	if warns != 0 {
+		t.Errorf("--reset still WARNed (%d):\n%s", warns, output)
+	}
+	// Exactly N FIX lines for N drifted keys. The pre-fix bug
+	// produced N×K lines (K = count of bones-owned commands).
+	fixLines := strings.Count(output, "FIX")
+	if fixLines != 2 {
+		t.Errorf("expected exactly 2 FIX lines (one per drifted key), got %d:\n%s",
+			fixLines, output)
+	}
+	for _, key := range []string{"SessionStart[0]/0", "SessionStart[1]/0"} {
+		if !strings.Contains(output, key) {
+			t.Errorf("FIX output missing key %s:\n%s", key, output)
+		}
+	}
+}
+
+// editHubStartEntry mutates the `bones hub start` entry
+// (SessionStart[1]/0) so its canonical hash diverges from the
+// manifest record. Mirrors editPrimeEntry's approach.
+func editHubStartEntry(t *testing.T, hooks map[string]any) {
+	t.Helper()
+	groups, _ := hooks["SessionStart"].([]any)
+	if len(groups) < 2 {
+		t.Fatal("SessionStart group 1 missing")
+	}
+	gm, ok := groups[1].(map[string]any)
+	if !ok {
+		t.Fatal("SessionStart[1] not a map")
+	}
+	entries, _ := gm["hooks"].([]any)
+	if len(entries) == 0 {
+		t.Fatal("SessionStart[1].hooks empty")
+	}
+	em, ok := entries[0].(map[string]any)
+	if !ok {
+		t.Fatal("SessionStart[1]/0 not a map")
+	}
+	em["timeout"] = float64(77)
+}
+
 // TestCheckBonesHooksDrift_ResetRewritesEditedEntry pins #318's
 // --reset opt-in: drifted entries are rewritten to canonical and
 // the manifest is re-stamped. The next doctor run reports clean.
@@ -745,5 +821,91 @@ func TestDoctorCmd_AcceptsResetFlag(t *testing.T) {
 	}
 	if !c.Reset {
 		t.Fatalf("Reset flag not set after --reset parse")
+	}
+}
+
+// TestRunBypassReportTo_HookProtocolRewriteRefreshesManifest pins
+// the #320 + #318 coordination contract: when checkBonesScaffoldedHooks
+// rewrites a v0.12 stale prime entry to the envelope-emitting form,
+// refreshManifestHooksIfPresent must re-stamp the per-entry hashes
+// so the immediate next checkBonesHooksDrift run reports zero
+// findings. Without this coordination doctor would false-positive
+// on its own auto-rewrite — the rewrite changes settings.json
+// content, drift check sees new bytes vs. stale manifest, WARNs
+// the operator about an entry doctor itself just edited.
+func TestRunBypassReportTo_HookProtocolRewriteRefreshesManifest(t *testing.T) {
+	dir := setupCleanScaffold(t)
+
+	// Plant a v0.12-style stale entry: rewrite settings.json so the
+	// SessionStart prime command is the legacy `--json` form. The
+	// existing manifest still records hashes for the canonical
+	// entry; #320's auto-rewrite will heal settings.json, and the
+	// coordination path must heal the manifest too.
+	settingsPath := filepath.Join(dir, ".claude", "settings.json")
+	stale := `{
+  "hooks": {
+    "SessionStart": [
+      {"matcher": "", "hooks": [
+        {"command": "bones tasks prime --json", "type": "command", "timeout": 10},
+        {"command": "bones hub start", "type": "command", "timeout": 10}
+      ]}
+    ]
+  }
+}`
+	if err := os.WriteFile(settingsPath, []byte(stale), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Run the full bypass report (default mode: noFix=false,
+	// reset=false). The pre-existing #320 path rewrites the stale
+	// prime entry; the new coordination call refreshes the
+	// manifest's per-entry hashes against the rewritten file.
+	var buf bytes.Buffer
+	if _, err := runBypassReportTo(&buf, dir); err != nil {
+		t.Fatalf("runBypassReportTo: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "FIX") {
+		t.Errorf("expected #320 FIX line for v0.12 prime rewrite:\n%s", out)
+	}
+
+	// Settings.json must now carry the canonical envelope-emitting form.
+	got, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(got), "bones tasks prime --hook=session-start") {
+		t.Errorf("v0.12 prime not rewritten by #320 path:\n%s", got)
+	}
+
+	// Manifest must reflect the rewritten file. Pull the per-entry
+	// hashes both from manifest and from disk; every key the
+	// manifest records must match its on-disk hash.
+	manifest, err := readManifest(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	live, err := bonesOwnedHookEntryHashesFromDisk(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(manifest.SettingsHooks) == 0 {
+		t.Fatalf("manifest SettingsHooks empty after rewrite — refresh did not run")
+	}
+	for k, want := range manifest.SettingsHooks {
+		if g := live[k]; g != want {
+			t.Errorf("post-rewrite drift on %s: manifest=%s on-disk=%s "+
+				"— refreshManifestHooksIfPresent did not re-stamp",
+				k, want, g)
+		}
+	}
+
+	// Drift check on the post-rewrite state must be silent. This is
+	// the load-bearing assertion: doctor should NOT false-positive
+	// on its own auto-rewrite.
+	var buf2 bytes.Buffer
+	if w := checkBonesHooksDrift(&buf2, dir, manifest, false); w != 0 {
+		t.Errorf("drift check after #320 rewrite reported %d WARNs "+
+			"(coordination broken):\n%s", w, buf2.String())
 	}
 }

--- a/cli/manifest_test.go
+++ b/cli/manifest_test.go
@@ -5,17 +5,21 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 
+	"github.com/alecthomas/kong"
 	"github.com/danmestas/bones/internal/version"
 )
 
 // TestWriteManifest_StampsScaffoldedEntries pins issue #262: after a
 // fresh scaffoldOrchestrator pass, the manifest's Scaffolded field
 // records .bones/agent.id and .bones/scaffold_version with sha256 +
-// size, and SettingsHooksSHA256 is non-empty (covering the
-// bones-owned hook subset of .claude/settings.json).
+// size. Per issue #318 it also pins that SettingsHooks (the per-
+// entry hash map) is populated for every bones-owned hook entry,
+// SchemaVersion stamps as v2 (current shape), and the legacy v1
+// SettingsHooksSHA256 field is NOT written.
 func TestWriteManifest_StampsScaffoldedEntries(t *testing.T) {
 	dir := t.TempDir()
 	// Write agent.id so writeManifest has something to stamp for it.
@@ -78,10 +82,40 @@ func TestWriteManifest_StampsScaffoldedEntries(t *testing.T) {
 		}
 	}
 
-	// Settings.json bones-owned hook subset: hash present.
-	if m.SettingsHooksSHA256 == "" {
-		t.Errorf("SettingsHooksSHA256 empty after fresh scaffold")
+	// Settings.json bones-owned hook subset (#318): per-entry map
+	// populated, schema version stamped, legacy v1 hash absent.
+	if m.SchemaVersion != manifestSchemaVersion {
+		t.Errorf("SchemaVersion=%d, want %d (current)",
+			m.SchemaVersion, manifestSchemaVersion)
 	}
+	if len(m.SettingsHooks) == 0 {
+		t.Errorf("SettingsHooks empty after fresh scaffold")
+	}
+	if m.SettingsHooksSHA256 != "" {
+		t.Errorf("SettingsHooksSHA256 written by current binary "+
+			"(want empty; legacy v1 field): %q", m.SettingsHooksSHA256)
+	}
+	// scaffoldOrchestrator places the prime entry under matcher
+	// "startup|compact" (group 0) and `bones hub start` under
+	// the default matcher "" (group 1). The keys reflect that
+	// layout — pin them so a future reordering is caught.
+	for _, want := range []string{"SessionStart[0]/0", "SessionStart[1]/0"} {
+		if _, ok := m.SettingsHooks[want]; !ok {
+			t.Errorf("SettingsHooks missing key %q; got keys=%v",
+				want, sortedKeys(m.SettingsHooks))
+		}
+	}
+}
+
+// sortedKeys returns m's keys in lexical order. Helper for assertion
+// failure messages so the test output is deterministic.
+func sortedKeys(m map[string]string) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
 }
 
 // TestWriteManifest_OmitsRollingFiles pins the scope decision in
@@ -263,7 +297,7 @@ func TestCheckManifestIntegrity_Clean(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	got := checkManifestIntegrity(&buf, dir)
+	got := checkManifestIntegrity(&buf, dir, false)
 	if got != 0 {
 		t.Errorf("warns=%d on clean workspace; output:\n%s", got, buf.String())
 	}
@@ -286,7 +320,7 @@ func TestCheckManifestIntegrity_TamperedScaffoldedFile(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	warns := checkManifestIntegrity(&buf, dir)
+	warns := checkManifestIntegrity(&buf, dir, false)
 	out := buf.String()
 	if warns < 1 {
 		t.Errorf("expected at least 1 WARN, got %d; output:\n%s", warns, out)
@@ -309,7 +343,7 @@ func TestCheckManifestIntegrity_PartialScaffold(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	warns := checkManifestIntegrity(&buf, dir)
+	warns := checkManifestIntegrity(&buf, dir, false)
 	out := buf.String()
 	if warns < 1 {
 		t.Errorf("expected at least 1 WARN, got %d; output:\n%s", warns, out)
@@ -333,7 +367,7 @@ func TestCheckManifestIntegrity_VersionDrift(t *testing.T) {
 	bumpManifestVersion(t, dir, "0.0.1-stale", "9.9.9-current")
 
 	var buf bytes.Buffer
-	warns := checkManifestIntegrity(&buf, dir)
+	warns := checkManifestIntegrity(&buf, dir, false)
 	out := buf.String()
 	if warns < 1 {
 		t.Errorf("expected at least 1 WARN, got %d; output:\n%s", warns, out)
@@ -343,10 +377,13 @@ func TestCheckManifestIntegrity_VersionDrift(t *testing.T) {
 	}
 }
 
-// TestCheckManifestIntegrity_TamperedSettingsHooks detects a hand-
+// TestCheckManifestIntegrity_MissingSettingsHook detects a hand-
 // edit that removes a bones-owned hook from .claude/settings.json
-// after `bones up` stamped the manifest.
-func TestCheckManifestIntegrity_TamperedSettingsHooks(t *testing.T) {
+// after `bones up` stamped the manifest. Per issue #318 the surface
+// is per-entry: doctor names the missing entry's key
+// (`SessionStart[N]/M`) rather than emitting a generic "settings
+// hooks drifted" message.
+func TestCheckManifestIntegrity_MissingSettingsHook(t *testing.T) {
 	dir := setupCleanScaffold(t)
 	// Hand-edit settings.json to drop the `bones hub start` entry.
 	settingsPath := filepath.Join(dir, ".claude", "settings.json")
@@ -366,16 +403,19 @@ func TestCheckManifestIntegrity_TamperedSettingsHooks(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	warns := checkManifestIntegrity(&buf, dir)
+	warns := checkManifestIntegrity(&buf, dir, false)
 	output := buf.String()
 	if warns < 1 {
 		t.Errorf("expected at least 1 WARN, got %d; output:\n%s", warns, output)
 	}
-	if !strings.Contains(output, "settings.json") {
-		t.Errorf("expected settings.json finding:\n%s", output)
+	if !strings.Contains(output, "hooks:") {
+		t.Errorf("expected per-entry hooks finding (#318):\n%s", output)
 	}
-	if !strings.Contains(output, "tamper") {
-		t.Errorf("expected tamper label in output:\n%s", output)
+	if !strings.Contains(output, "SessionStart") {
+		t.Errorf("expected per-entry key naming the event:\n%s", output)
+	}
+	if !strings.Contains(output, "missing") {
+		t.Errorf("expected missing-entry label (#318):\n%s", output)
 	}
 }
 
@@ -385,7 +425,7 @@ func TestCheckManifestIntegrity_TamperedSettingsHooks(t *testing.T) {
 func TestCheckManifestIntegrity_NoManifest(t *testing.T) {
 	dir := t.TempDir()
 	var buf bytes.Buffer
-	warns := checkManifestIntegrity(&buf, dir)
+	warns := checkManifestIntegrity(&buf, dir, false)
 	if warns != 0 {
 		t.Errorf("warns=%d on workspace without manifest; output:\n%s",
 			warns, buf.String())
@@ -440,4 +480,270 @@ func bumpManifestVersion(t *testing.T, dir, stale, current string) {
 	prev := version.Get()
 	version.Set(current)
 	t.Cleanup(func() { version.Set(prev) })
+}
+
+// TestCheckBonesHooksDrift_CleanWorkspaceOK pins issue #318: every
+// per-entry hash matches after a fresh `bones up`, so doctor emits
+// zero hooks-drift findings. This is the hot-path no-op.
+func TestCheckBonesHooksDrift_CleanWorkspaceOK(t *testing.T) {
+	dir := setupCleanScaffold(t)
+	manifest, err := readManifest(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	warns := checkBonesHooksDrift(&buf, dir, manifest, false)
+	if warns != 0 {
+		t.Errorf("clean workspace: warns=%d, want 0; output:\n%s",
+			warns, buf.String())
+	}
+	if strings.Contains(buf.String(), "hooks:") {
+		t.Errorf("clean workspace emitted per-entry findings:\n%s", buf.String())
+	}
+}
+
+// TestCheckBonesHooksDrift_EditedEntryWARN pins #318's per-entry
+// drift surface: editing one bones-owned entry surfaces a WARN that
+// names the specific entry key (`SessionStart[N]/M`) and tells the
+// operator about `bones doctor --reset`.
+func TestCheckBonesHooksDrift_EditedEntryWARN(t *testing.T) {
+	dir := setupCleanScaffold(t)
+	// Edit the prime entry's command in place — different content
+	// at the same slot is the signature of an operator hand-edit.
+	settingsPath := filepath.Join(dir, ".claude", "settings.json")
+	data, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var settings map[string]any
+	if err := json.Unmarshal(data, &settings); err != nil {
+		t.Fatal(err)
+	}
+	hooks := settings["hooks"].(map[string]any)
+	editPrimeEntry(t, hooks)
+	out, _ := json.MarshalIndent(settings, "", "  ")
+	if err := os.WriteFile(settingsPath, append(out, '\n'), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	manifest, err := readManifest(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	warns := checkBonesHooksDrift(&buf, dir, manifest, false)
+	output := buf.String()
+	if warns < 1 {
+		t.Errorf("expected at least 1 WARN on edited entry, got %d:\n%s",
+			warns, output)
+	}
+	if !strings.Contains(output, "SessionStart[0]/0") {
+		t.Errorf("expected entry key SessionStart[0]/0 in output:\n%s", output)
+	}
+	if !strings.Contains(output, "edited since `bones up`") {
+		t.Errorf("expected drift label in output:\n%s", output)
+	}
+	if !strings.Contains(output, "--reset") {
+		t.Errorf("expected --reset hint in WARN output:\n%s", output)
+	}
+}
+
+// editPrimeEntry mutates the prime hook entry (SessionStart[0]/0)
+// to simulate an operator hand-edit. Bumps the timeout so the
+// canonical hash diverges from what the manifest recorded; the
+// command stays bones-owned so the entry remains in the per-entry
+// scan's surface.
+func editPrimeEntry(t *testing.T, hooks map[string]any) {
+	t.Helper()
+	groups, _ := hooks["SessionStart"].([]any)
+	if len(groups) == 0 {
+		t.Fatal("SessionStart group missing")
+	}
+	gm, ok := groups[0].(map[string]any)
+	if !ok {
+		t.Fatal("SessionStart[0] not a map")
+	}
+	entries, _ := gm["hooks"].([]any)
+	if len(entries) == 0 {
+		t.Fatal("SessionStart[0].hooks empty")
+	}
+	em, ok := entries[0].(map[string]any)
+	if !ok {
+		t.Fatal("SessionStart[0]/0 not a map")
+	}
+	em["timeout"] = float64(99)
+}
+
+// TestCheckBonesHooksDrift_LegacyV1ManifestINFOOnly pins the
+// migration-window behavior: a v1 manifest (single hash, no
+// per-entry map) does NOT false-positive against the per-entry
+// scan. doctor surfaces a one-line INFO and waits for `bones up`
+// to migrate.
+func TestCheckBonesHooksDrift_LegacyV1ManifestINFOOnly(t *testing.T) {
+	dir := setupCleanScaffold(t)
+	// Downgrade the manifest to v1 shape: clear the per-entry map,
+	// populate the legacy single-hash field, drop SchemaVersion.
+	mPath := filepath.Join(dir, filepath.FromSlash(manifestRel))
+	data, err := os.ReadFile(mPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var m skillManifest
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatal(err)
+	}
+	m.SchemaVersion = 0
+	m.SettingsHooksSHA256 = "deadbeefcafef00d"
+	m.SettingsHooks = nil
+	out, _ := json.MarshalIndent(m, "", "  ")
+	if err := os.WriteFile(mPath, append(out, '\n'), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	manifest, err := readManifest(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	warns := checkBonesHooksDrift(&buf, dir, manifest, false)
+	output := buf.String()
+	if warns != 0 {
+		t.Errorf("legacy v1 manifest produced WARN, want 0; output:\n%s",
+			output)
+	}
+	if !strings.Contains(output, "INFO") {
+		t.Errorf("expected INFO line for legacy v1 manifest:\n%s", output)
+	}
+	if !strings.Contains(output, "legacy v1 hook hash") {
+		t.Errorf("expected legacy v1 message:\n%s", output)
+	}
+}
+
+// TestCheckBonesHooksDrift_V1MigratesOnNextWriteManifest pins the
+// migration: writing a fresh manifest (the next `bones up` after
+// the v1 install) drops the legacy field, populates the per-entry
+// map, and stamps the current schema version.
+func TestCheckBonesHooksDrift_V1MigratesOnNextWriteManifest(t *testing.T) {
+	dir := setupCleanScaffold(t)
+	// Force the on-disk manifest into the v1 shape.
+	mPath := filepath.Join(dir, filepath.FromSlash(manifestRel))
+	data, err := os.ReadFile(mPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var m skillManifest
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatal(err)
+	}
+	m.SchemaVersion = 0
+	m.SettingsHooksSHA256 = "deadbeefcafef00d"
+	m.SettingsHooks = nil
+	out, _ := json.MarshalIndent(m, "", "  ")
+	if err := os.WriteFile(mPath, append(out, '\n'), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Re-run writeManifest to simulate the next `bones up`. nil
+	// footprint: this is a synthetic re-stamp, not a real
+	// scaffoldOrchestrator pass, so #338's SettingsCreatedByUp
+	// signal is unavailable.
+	if err := writeManifest(dir, nil); err != nil {
+		t.Fatalf("writeManifest after v1 downgrade: %v", err)
+	}
+
+	got, err := readManifest(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.SchemaVersion != manifestSchemaVersion {
+		t.Errorf("SchemaVersion=%d, want %d after migration",
+			got.SchemaVersion, manifestSchemaVersion)
+	}
+	if got.SettingsHooksSHA256 != "" {
+		t.Errorf("legacy SettingsHooksSHA256 not cleared on migration: %q",
+			got.SettingsHooksSHA256)
+	}
+	if len(got.SettingsHooks) == 0 {
+		t.Errorf("SettingsHooks not populated by migration")
+	}
+}
+
+// TestCheckBonesHooksDrift_ResetRewritesEditedEntry pins #318's
+// --reset opt-in: drifted entries are rewritten to canonical and
+// the manifest is re-stamped. The next doctor run reports clean.
+func TestCheckBonesHooksDrift_ResetRewritesEditedEntry(t *testing.T) {
+	dir := setupCleanScaffold(t)
+	// Simulate an operator hand-edit of the prime entry.
+	settingsPath := filepath.Join(dir, ".claude", "settings.json")
+	data, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var settings map[string]any
+	if err := json.Unmarshal(data, &settings); err != nil {
+		t.Fatal(err)
+	}
+	hooks := settings["hooks"].(map[string]any)
+	editPrimeEntry(t, hooks)
+	out, _ := json.MarshalIndent(settings, "", "  ")
+	if err := os.WriteFile(settingsPath, append(out, '\n'), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	manifest, err := readManifest(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	warns := checkBonesHooksDrift(&buf, dir, manifest, true /* reset */)
+	output := buf.String()
+	if !strings.Contains(output, "FIX") {
+		t.Errorf("expected FIX line on --reset rewrite:\n%s", output)
+	}
+	if warns != 0 {
+		t.Errorf("--reset rewrite still surfaced WARN, got %d:\n%s",
+			warns, output)
+	}
+
+	// Verify the canonical state is restored: the entry's timeout
+	// is back to 10 and the manifest hashes match the live state.
+	rerun, err := readManifest(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	live, err := bonesOwnedHookEntryHashesFromDisk(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for k, want := range rerun.SettingsHooks {
+		if got := live[k]; got != want {
+			t.Errorf("post-reset drift on %s: manifest=%s on-disk=%s",
+				k, want, got)
+		}
+	}
+
+	// Idempotency: running the drift check again with reset=false
+	// must report zero findings.
+	var buf2 bytes.Buffer
+	if w := checkBonesHooksDrift(&buf2, dir, rerun, false); w != 0 {
+		t.Errorf("post-reset drift check still WARNed (%d):\n%s",
+			w, buf2.String())
+	}
+}
+
+// TestDoctorCmd_AcceptsResetFlag verifies Kong wires up the new
+// `--reset` flag. Existence of the flag is the contract — the
+// rewrite behavior is tested via TestCheckBonesHooksDrift_Reset*.
+func TestDoctorCmd_AcceptsResetFlag(t *testing.T) {
+	var c DoctorCmd
+	parser, err := kong.New(&c)
+	if err != nil {
+		t.Fatalf("kong.New: %v", err)
+	}
+	if _, err := parser.Parse([]string{"--reset"}); err != nil {
+		t.Fatalf("parse --reset: %v", err)
+	}
+	if !c.Reset {
+		t.Fatalf("Reset flag not set after --reset parse")
+	}
 }

--- a/cli/skills.go
+++ b/cli/skills.go
@@ -86,10 +86,26 @@ type scaffoldFile struct {
 // outside the skills tree (.bones/agent.id, .bones/scaffold_version)
 // and the bones-owned hook subset of .claude/settings.json. The
 // non-skill entries live in Scaffolded (with size + sha256) and
-// SettingsHooksSHA256 — sibling fields rather than crammed into
+// SettingsHooks — sibling fields rather than crammed into
 // Files because removeBonesSkills's per-file remove logic keys off
 // Files entries existing iff they were skill files.
+//
+// Issue #318 replaced the original single-roll-up SettingsHooksSHA256
+// hash with the per-entry SettingsHooks map so doctor can pinpoint
+// which hook entry drifted (e.g. SessionStart[0]/1) instead of
+// reporting an opaque "something changed". A SchemaVersion field was
+// added at the same time so future migrations have a tag to read; v1
+// is the legacy single-hash shape, v2 (current) is the per-entry map.
 type skillManifest struct {
+	// SchemaVersion tags the on-disk shape so manifest-format
+	// migrations can be detected on read. Absent/zero is treated as
+	// v1 (the pre-#318 single-hash shape) and triggers a one-time
+	// rewrite to v2 on the next `bones up`. Bumped whenever the
+	// manifest's structural shape changes in a way that needs a
+	// migration; pure additive fields (e.g. Scaffolded in #262) did
+	// not bump because absent fields are forward-compatible.
+	SchemaVersion int `json:"schema_version,omitempty"`
+
 	// Version is the bones binary version that wrote the manifest.
 	// Diagnostic only — not used in the remove decision.
 	Version string `json:"version"`
@@ -107,12 +123,22 @@ type skillManifest struct {
 	// written by pre-#262 binaries.
 	Scaffolded []scaffoldFile `json:"scaffolded,omitempty"`
 
-	// SettingsHooksSHA256 is the SHA-256 hex of the canonical-JSON
-	// rendering of the bones-owned hook subset of
-	// .claude/settings.json — only the hook entries bones installs
-	// (per bonesOwnedHookCommands). User-added hooks alongside
-	// bones's are NOT tamper-detected (they aren't bones's to claim).
-	// Empty on legacy manifests.
+	// SettingsHooks records a per-entry SHA-256 hex of the canonical
+	// rendering of every bones-owned hook entry in
+	// .claude/settings.json. Keys follow `<event>[<group_index>]/
+	// <hook_index>` (e.g. `SessionStart[0]/1`) so doctor can name the
+	// drifted entry exactly. The hash is over the entry's command,
+	// type, timeout and parent group's matcher — JSON-canonicalized
+	// so semantically equivalent entries produce identical hashes
+	// regardless of map iteration order. Empty on legacy v1 manifests
+	// (pre-#318), which also have a populated SettingsHooksSHA256
+	// field; the next `bones up` migrates to the per-entry map.
+	SettingsHooks map[string]string `json:"settings_hooks,omitempty"`
+
+	// SettingsHooksSHA256 is the legacy v1 single-hash field
+	// (pre-#318). Read for migration detection only; new manifests
+	// never write it. Doctor never compares against it once the v2
+	// map is present.
 	SettingsHooksSHA256 string `json:"settings_hooks_sha256,omitempty"`
 
 	// SettingsCreatedByUp records whether `bones up` created
@@ -125,6 +151,12 @@ type skillManifest struct {
 	// (#256) wins, matching the conservative default for upgraders.
 	SettingsCreatedByUp bool `json:"settings_created_by_up,omitempty"`
 }
+
+// manifestSchemaVersion is the on-disk shape tag the current binary
+// writes. v1 was the implicit single-hash shape; v2 (current) carries
+// the per-entry SettingsHooks map. Bump when structural changes
+// require a one-time rewrite on the next `bones up`.
+const manifestSchemaVersion = 2
 
 // bonesOwnedHookCommands lists the (event, command) pairs bones
 // installs into .claude/settings.json. The integrity hash recorded in
@@ -228,7 +260,7 @@ func writeManifest(root string, fp *scaffoldFootprint) error {
 	if err != nil {
 		return err
 	}
-	hooksHash, err := bonesOwnedHooksHashFromDisk(root)
+	hookEntries, err := bonesOwnedHookEntryHashesFromDisk(root)
 	if err != nil {
 		return err
 	}
@@ -246,10 +278,11 @@ func writeManifest(root string, fp *scaffoldFootprint) error {
 		createdByUp = true
 	}
 	m := skillManifest{
+		SchemaVersion:       manifestSchemaVersion,
 		Version:             bonesVersion(),
 		Files:               files,
 		Scaffolded:          scaff,
-		SettingsHooksSHA256: hooksHash,
+		SettingsHooks:       hookEntries,
 		SettingsCreatedByUp: createdByUp,
 	}
 
@@ -379,28 +412,125 @@ func buildScaffoldedEntries(root string) ([]scaffoldFile, error) {
 	return out, nil
 }
 
-// bonesOwnedHooksHashFromDisk reads .claude/settings.json, extracts
-// the bones-owned hook subset (per bonesOwnedHookCommands), and
-// returns the SHA-256 hex of its canonical rendering. Returns an
-// empty string + nil error when settings.json is absent — that
-// matches a workspace where mergeSettings has not yet run.
-func bonesOwnedHooksHashFromDisk(root string) (string, error) {
+// bonesOwnedHookEntry identifies one bones-owned entry in
+// .claude/settings.json by its position. Key is the doctor-facing
+// `<event>[<group_index>]/<hook_index>` string; Hash is the canonical
+// SHA-256 hex of the entry contents (matcher + command + type +
+// timeout). Used for the per-entry drift detection introduced in
+// issue #318.
+type bonesOwnedHookEntry struct {
+	Key  string
+	Hash string
+}
+
+// bonesOwnedHookEntryHashesFromDisk reads .claude/settings.json,
+// walks every bones-owned hook entry (per bonesOwnedHookCommands),
+// and returns a map of entry key → canonical hash. Returns an empty
+// map + nil error when settings.json is absent — that matches a
+// workspace where mergeSettings has not yet run.
+func bonesOwnedHookEntryHashesFromDisk(root string) (map[string]string, error) {
 	path := filepath.Join(root, ".claude", "settings.json")
 	data, err := os.ReadFile(path)
 	if errors.Is(err, fs.ErrNotExist) {
-		return "", nil
+		return map[string]string{}, nil
 	}
 	if err != nil {
-		return "", fmt.Errorf("read settings.json: %w", err)
+		return nil, fmt.Errorf("read settings.json: %w", err)
 	}
 	var settings map[string]any
 	if len(data) > 0 {
 		if err := json.Unmarshal(data, &settings); err != nil {
-			return "", fmt.Errorf("parse settings.json: %w", err)
+			return nil, fmt.Errorf("parse settings.json: %w", err)
 		}
 	}
 	hooks, _ := settings["hooks"].(map[string]any)
-	return hashBonesOwnedHooks(hooks), nil
+	entries := bonesOwnedHookEntriesIn(hooks)
+	out := map[string]string{}
+	for _, e := range entries {
+		out[e.Key] = e.Hash
+	}
+	return out, nil
+}
+
+// bonesOwnedHookEntriesIn walks hooks and returns one
+// bonesOwnedHookEntry per bones-owned hook entry it finds. The
+// position-keyed identifier (`<event>[<group_index>]/<hook_index>`)
+// matches doctor's report format and lets the manifest pin "this
+// specific slot in settings.json" rather than naming entries by
+// content. Order is deterministic: events sorted alphabetically, then
+// by group index, then hook index.
+//
+// Membership in bonesOwnedHookCommands is what makes an entry
+// "bones-owned" — entries with commands the user installed alongside
+// bones's are not surfaced (they aren't bones's to claim).
+func bonesOwnedHookEntriesIn(hooks map[string]any) []bonesOwnedHookEntry {
+	if hooks == nil {
+		return nil
+	}
+	owned := map[string]map[string]bool{}
+	for _, h := range bonesOwnedHookCommands {
+		if owned[h.Event] == nil {
+			owned[h.Event] = map[string]bool{}
+		}
+		owned[h.Event][h.Command] = true
+	}
+	events := make([]string, 0, len(owned))
+	for ev := range owned {
+		events = append(events, ev)
+	}
+	sort.Strings(events)
+	var out []bonesOwnedHookEntry
+	for _, event := range events {
+		groups, _ := hooks[event].([]any)
+		for gi, g := range groups {
+			gm, ok := g.(map[string]any)
+			if !ok {
+				continue
+			}
+			matcher, _ := gm["matcher"].(string)
+			entries, _ := gm["hooks"].([]any)
+			for hi, e := range entries {
+				em, ok := e.(map[string]any)
+				if !ok {
+					continue
+				}
+				cmd, _ := em["command"].(string)
+				if !owned[event][cmd] {
+					continue
+				}
+				out = append(out, bonesOwnedHookEntry{
+					Key:  fmt.Sprintf("%s[%d]/%d", event, gi, hi),
+					Hash: hashHookEntry(matcher, em),
+				})
+			}
+		}
+	}
+	return out
+}
+
+// hashHookEntry returns the canonical SHA-256 hex of a single hook
+// entry. The hashed shape is JSON of {matcher, command, type,
+// timeout} — exactly the fields bones cares about for drift
+// detection. Whitespace and key ordering don't influence the hash
+// because Marshal sorts keys deterministically and the input is a
+// fixed-shape struct.
+func hashHookEntry(matcher string, entry map[string]any) string {
+	type canonical struct {
+		Matcher string `json:"matcher"`
+		Command string `json:"command"`
+		Type    string `json:"type"`
+		Timeout any    `json:"timeout,omitempty"`
+	}
+	cmd, _ := entry["command"].(string)
+	typ, _ := entry["type"].(string)
+	c := canonical{
+		Matcher: matcher,
+		Command: cmd,
+		Type:    typ,
+		Timeout: entry["timeout"],
+	}
+	out, _ := json.Marshal(c)
+	return hashHex(out)
 }
 
 // hashBonesOwnedHooks computes the canonical SHA-256 hex of the
@@ -414,6 +544,11 @@ func bonesOwnedHooksHashFromDisk(root string) (string, error) {
 // hook commands are present on disk (e.g. user hand-pruned them).
 // In that case doctor compares "" against the manifest's recorded
 // hash and surfaces the divergence as a tamper finding.
+//
+// Retained post-#318 for the legacy v1 single-hash shape; the
+// current binary writes the per-entry SettingsHooks map instead.
+// Tests still exercise this helper to pin the legacy hashing
+// contract since v1 manifests on disk carry the value.
 func hashBonesOwnedHooks(hooks map[string]any) string {
 	type entry struct {
 		Event   string `json:"event"`


### PR DESCRIPTION
## Summary

- Replace `bones-manifest.json`'s single `settings_hooks_sha256` rolled-up hash with a per-entry `settings_hooks` map keyed by `<event>[<group_index>]/<hook_index>` (e.g. `SessionStart[0]/0`). Doctor names the specific drifted entry instead of saying "something changed."
- Bump manifest schema to v2. Legacy v1 manifests carrying `settings_hooks_sha256` migrate to the per-entry map on the next `bones up`; doctor surfaces a one-line INFO during the migration window rather than false-positive against the per-entry surface.
- Default behavior is report-only WARN — drift here means "operator hand-edited the entry"; rewriting clobbers their change. Adds `bones doctor --reset` to opt into rewriting drifted entries back to canonical and re-stamping the manifest.

## Coordination notes

- **#320**: After `migrateHookProtocolEntries` rewrites `.claude/settings.json`, the new `refreshManifestHooksIfPresent` re-stamps the manifest's per-entry hashes so the next doctor run reports OK instead of false-positive on the auto-rewrite.
- **#315 / #314**: changes are surgical — `cli/skills.go` only adds new helpers and the schema field; `cli/doctor.go` extracts `checkBonesHooksDrift` as a new function so it composes cleanly with whatever those branches land.

## Test plan

- [x] `TestWriteManifest_StampsScaffoldedEntries` — pins v2 schema, per-entry map populated, legacy field empty.
- [x] `TestCheckBonesHooksDrift_CleanWorkspaceOK` — clean workspace post `bones up` reports zero findings.
- [x] `TestCheckBonesHooksDrift_EditedEntryWARN` — edited entry surfaces WARN naming `SessionStart[0]/0` and the `--reset` hint.
- [x] `TestCheckBonesHooksDrift_LegacyV1ManifestINFOOnly` — v1 manifest does not false-positive; INFO line only.
- [x] `TestCheckBonesHooksDrift_V1MigratesOnNextWriteManifest` — `writeManifest` drops the legacy field, populates the per-entry map, stamps schema v2.
- [x] `TestCheckBonesHooksDrift_ResetRewritesEditedEntry` — `--reset` rewrites drifted entry, emits FIX, re-stamps manifest, idempotent on next run.
- [x] `TestDoctorCmd_AcceptsResetFlag` — Kong wires up `--reset`.
- [x] `TestCheckManifestIntegrity_MissingSettingsHook` — replaces the legacy "tamper" assertion with the per-entry "missing" assertion.
- [x] `make check` passes (lint, vet, race, todo-check).
- [x] `go test -tags=otel -short ./...` passes (1 pre-existing unrelated `TestStatusAllEmptyRegistry` failure on main).

Closes #318