### PR TITLE
feat(doctor): orphan-skill detection + adopt-into-manifest

### DIFF
--- a/cli/doctor.go
+++ b/cli/doctor.go
@@ -488,6 +488,10 @@ func reportHookEntries(w io.Writer, hooks map[string]any) {
 // Per ADR 0051 the hook-presence check is also where doctor's
 // auto-rewrite of the Claude Code hook protocol entries lives;
 // noFix=true switches it to report-only.
+//
+// Per issue #315 the orphan-skills check also lives here, sharing
+// the same noFix flag plumbing — default mode adopts orphans into
+// the manifest, --no-fix surfaces them as WARNs.
 func checkScaffoldGates(w io.Writer, cwd string, noFix bool) int {
 	var warns int
 	if checkBonesScaffoldedHooksWith(w, cwd, noFix) {
@@ -496,7 +500,90 @@ func checkScaffoldGates(w io.Writer, cwd string, noFix bool) int {
 	if checkSessionStartSentinel(w, cwd) {
 		warns++
 	}
+	warns += checkSkillsManifestDrift(w, cwd, noFix)
 	return warns
+}
+
+// checkSkillsManifestDrift reports skills present in
+// `.claude/skills/` that are not bones-owned (per bonesOwnedSkills)
+// and not already adopted into the manifest. Per issue #315 the
+// default behavior adopts each orphan into the manifest with an
+// `adopted_at` / `source: "orphan-migration"` marker; with noFix=true
+// orphans surface as WARN lines and the manifest is left untouched.
+//
+// Adoption is the safe default: orphan skills are operator content
+// (pre-existing skills, manual additions, mid-PR upgrade artifacts)
+// and bones must not delete them. Adoption pulls them into the
+// manifest's accounting so future doctor runs report them as OK
+// rather than re-warning forever.
+//
+// Each emitted line is one of:
+//
+//	OK     .claude/skills/foo  (manifest)
+//	OK     .claude/skills/foo  (adopted)
+//	WARN   .claude/skills/foo  (orphaned — not in manifest)
+//	FIX    adopted .claude/skills/foo
+//
+// Returns the count of WARN-class findings emitted (FIX lines are
+// healing, not findings, and don't increment the counter).
+func checkSkillsManifestDrift(w io.Writer, cwd string, noFix bool) int {
+	skillsDir := filepath.Join(cwd, ".claude", "skills")
+	if info, err := os.Stat(skillsDir); err != nil || !info.IsDir() {
+		return 0
+	}
+	entries, err := os.ReadDir(skillsDir)
+	if err != nil {
+		_, _ = fmt.Fprintf(w, "  WARN  read .claude/skills/: %v\n", err)
+		return 1
+	}
+	manifest, _ := readManifest(cwd)
+	owned := map[string]struct{}{}
+	for _, name := range bonesOwnedSkills {
+		owned[name] = struct{}{}
+	}
+	adopted := map[string]struct{}{}
+	if manifest != nil {
+		for _, a := range manifest.Adopted {
+			adopted[filepath.Base(a.Path)] = struct{}{}
+		}
+	}
+	_, _ = fmt.Fprintln(w, "  skills:")
+	var warns int
+	for _, e := range entries {
+		name := e.Name()
+		if strings.HasPrefix(name, ".") {
+			continue
+		}
+		if !e.IsDir() {
+			continue
+		}
+		switch {
+		case existsIn(owned, name):
+			_, _ = fmt.Fprintf(w, "    OK    .claude/skills/%s  (manifest)\n", name)
+		case existsIn(adopted, name):
+			_, _ = fmt.Fprintf(w, "    OK    .claude/skills/%s  (adopted)\n", name)
+		case noFix:
+			_, _ = fmt.Fprintf(w,
+				"    WARN  .claude/skills/%s  (orphaned — not in manifest)\n", name)
+			warns++
+		default:
+			if err := adoptIntoManifest(cwd, name); err != nil {
+				_, _ = fmt.Fprintf(w,
+					"    WARN  .claude/skills/%s  adopt failed: %v\n", name, err)
+				warns++
+				continue
+			}
+			_, _ = fmt.Fprintf(w, "    FIX   adopted .claude/skills/%s\n", name)
+		}
+	}
+	return warns
+}
+
+// existsIn is a tiny helper so the orphan classifier reads as a flat
+// switch instead of nested map lookups.
+func existsIn(set map[string]struct{}, key string) bool {
+	_, ok := set[key]
+	return ok
 }
 
 // checkSessionStartSentinel surfaces whether bones SessionStart hooks

--- a/cli/doctor_test.go
+++ b/cli/doctor_test.go
@@ -520,6 +520,190 @@ func TestDoctorCmd_AcceptsNoFixFlag(t *testing.T) {
 	}
 }
 
+// TestCheckSkillsManifestDrift_NoOrphans pins issue #315 happy path:
+// a workspace whose only skills are bones-owned (per bonesOwnedSkills)
+// emits OK lines and no WARN/FIX classes. The check is silent on
+// non-skill clutter at the .claude/skills/ root (dotfiles).
+func TestCheckSkillsManifestDrift_NoOrphans(t *testing.T) {
+	root := t.TempDir()
+	skillsDir := filepath.Join(root, ".claude", "skills")
+	if err := os.MkdirAll(skillsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Drop a bones-owned skill on disk so the OK branch fires.
+	owned := filepath.Join(skillsDir, "orchestrator")
+	if err := os.MkdirAll(owned, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(owned, "SKILL.md"),
+		[]byte("# orchestrator\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	warns := checkSkillsManifestDrift(&buf, root, false)
+	if warns != 0 {
+		t.Errorf("no-orphan workspace produced %d WARNs:\n%s", warns, buf.String())
+	}
+	out := buf.String()
+	if !strings.Contains(out, "OK    .claude/skills/orchestrator") {
+		t.Errorf("expected OK line for bones-owned skill, got:\n%s", out)
+	}
+	if strings.Contains(out, "WARN") || strings.Contains(out, "FIX") {
+		t.Errorf("happy path emitted WARN/FIX:\n%s", out)
+	}
+}
+
+// TestCheckSkillsManifestDrift_NoFixReportsOrphan pins issue #315:
+// `--no-fix` mode surfaces orphans as WARN lines but does not modify
+// the manifest. Manifest contents (including absence) are preserved.
+func TestCheckSkillsManifestDrift_NoFixReportsOrphan(t *testing.T) {
+	root := t.TempDir()
+	skillsDir := filepath.Join(root, ".claude", "skills")
+	orphanDir := filepath.Join(skillsDir, "legacy-thing")
+	if err := os.MkdirAll(orphanDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(orphanDir, "SKILL.md"),
+		[]byte("# legacy operator skill\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	manifestPath := filepath.Join(root, ".claude", "skills", ".bones-manifest.json")
+
+	var buf bytes.Buffer
+	warns := checkSkillsManifestDrift(&buf, root, true /* noFix */)
+	if warns != 1 {
+		t.Errorf("expected 1 WARN for orphan in --no-fix mode, got %d:\n%s",
+			warns, buf.String())
+	}
+	out := buf.String()
+	if !strings.Contains(out, "WARN") {
+		t.Errorf("--no-fix orphan did not WARN:\n%s", out)
+	}
+	if !strings.Contains(out, "legacy-thing") {
+		t.Errorf("WARN line missing orphan name:\n%s", out)
+	}
+	if strings.Contains(out, "FIX") {
+		t.Errorf("--no-fix mode emitted FIX line:\n%s", out)
+	}
+	// Manifest must NOT have been written (no manifest existed before;
+	// none should exist after).
+	if _, err := os.Stat(manifestPath); err == nil {
+		t.Errorf("--no-fix mode wrote manifest at %s; it must report only",
+			manifestPath)
+	}
+}
+
+// TestCheckSkillsManifestDrift_DefaultAdoptsOrphan pins issue #315
+// auto-fix: default mode (noFix=false) writes an Adopted entry for
+// the orphan into the manifest, with adopted_at + source markers,
+// and emits a FIX line.
+func TestCheckSkillsManifestDrift_DefaultAdoptsOrphan(t *testing.T) {
+	root := t.TempDir()
+	skillsDir := filepath.Join(root, ".claude", "skills")
+	orphanDir := filepath.Join(skillsDir, "legacy-thing")
+	if err := os.MkdirAll(orphanDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(orphanDir, "SKILL.md"),
+		[]byte("# operator content\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	warns := checkSkillsManifestDrift(&buf, root, false /* default fix */)
+	if warns != 0 {
+		t.Errorf("expected 0 WARN after auto-adoption, got %d:\n%s",
+			warns, buf.String())
+	}
+	out := buf.String()
+	if !strings.Contains(out, "FIX") {
+		t.Errorf("default mode did not FIX orphan:\n%s", out)
+	}
+	if !strings.Contains(out, "adopted .claude/skills/legacy-thing") {
+		t.Errorf("FIX line missing adoption phrasing:\n%s", out)
+	}
+
+	// Manifest must now contain an Adopted entry with the markers.
+	m, err := readManifest(root)
+	if err != nil {
+		t.Fatalf("readManifest: %v", err)
+	}
+	if m == nil {
+		t.Fatal("manifest absent after adoption; expected file written")
+	}
+	if len(m.Adopted) != 1 {
+		t.Fatalf("expected 1 Adopted entry, got %d", len(m.Adopted))
+	}
+	a := m.Adopted[0]
+	if a.Path != ".claude/skills/legacy-thing" {
+		t.Errorf("Adopted.Path = %q, want .claude/skills/legacy-thing", a.Path)
+	}
+	if a.Source != "orphan-migration" {
+		t.Errorf("Adopted.Source = %q, want orphan-migration", a.Source)
+	}
+	if a.AdoptedAt == "" {
+		t.Errorf("Adopted.AdoptedAt empty; markers must be stamped")
+	}
+	if a.SHA256 == "" {
+		t.Errorf("Adopted.SHA256 empty; content hash must be stamped")
+	}
+}
+
+// TestCheckSkillsManifestDrift_Idempotent pins issue #315 idempotency:
+// a second doctor run on the same orphan reports OK (already adopted)
+// and does not append a duplicate Adopted entry.
+func TestCheckSkillsManifestDrift_Idempotent(t *testing.T) {
+	root := t.TempDir()
+	skillsDir := filepath.Join(root, ".claude", "skills")
+	orphanDir := filepath.Join(skillsDir, "legacy-thing")
+	if err := os.MkdirAll(orphanDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(orphanDir, "SKILL.md"),
+		[]byte("# operator content\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// First run: adopts.
+	var buf1 bytes.Buffer
+	if w := checkSkillsManifestDrift(&buf1, root, false); w != 0 {
+		t.Fatalf("first run produced %d WARNs:\n%s", w, buf1.String())
+	}
+	if !strings.Contains(buf1.String(), "FIX") {
+		t.Errorf("first run did not adopt:\n%s", buf1.String())
+	}
+
+	// Second run: must report OK (adopted) and not WARN/FIX.
+	var buf2 bytes.Buffer
+	if w := checkSkillsManifestDrift(&buf2, root, false); w != 0 {
+		t.Fatalf("second run produced %d WARNs:\n%s", w, buf2.String())
+	}
+	out := buf2.String()
+	if strings.Contains(out, "FIX") {
+		t.Errorf("second run re-FIXed an already-adopted orphan:\n%s", out)
+	}
+	if strings.Contains(out, "WARN") {
+		t.Errorf("second run WARNed on already-adopted orphan:\n%s", out)
+	}
+	if !strings.Contains(out, "OK    .claude/skills/legacy-thing  (adopted)") {
+		t.Errorf("second run missing OK (adopted) line:\n%s", out)
+	}
+
+	// Manifest must still have exactly one Adopted entry.
+	m, err := readManifest(root)
+	if err != nil {
+		t.Fatalf("readManifest: %v", err)
+	}
+	if m == nil || len(m.Adopted) != 1 {
+		got := 0
+		if m != nil {
+			got = len(m.Adopted)
+		}
+		t.Errorf("expected exactly 1 Adopted entry after two runs, got %d", got)
+	}
+}
+
 // TestPreCommitHookLabel_Disambiguated pins #231: bones substrate
 // pre-commit hook check must use a label distinct from EdgeSync's
 // "pre-commit hook" label. Without disambiguation, `bones doctor`

--- a/cli/skills.go
+++ b/cli/skills.go
@@ -529,65 +529,6 @@ var nowUTC = func() string {
 	return timefmt.Logged(time.Now())
 }
 
-// orphanSkillEntries lists workspace-relative skill directory names
-// (under .claude/skills/) that exist on disk but are not bones-owned
-// (not in bonesOwnedSkills) and not already adopted in the manifest.
-// Returns slash-separated relative names sorted lexicographically so
-// callers get deterministic output.
-//
-// Pure read; never modifies the manifest. The "orphan" classification
-// is intentionally lexical: a directory is an orphan if its name is
-// not in bonesOwnedSkills AND its name is not in any Adopted entry.
-// We don't recurse into the directory's files — adoption operates at
-// skill granularity to mirror how bones writes them (one dir per
-// skill, treated as an opaque unit).
-func orphanSkillEntries(root string) ([]string, error) {
-	skillsDir := filepath.Join(root, ".claude", "skills")
-	entries, err := os.ReadDir(skillsDir)
-	if errors.Is(err, fs.ErrNotExist) {
-		return nil, nil
-	}
-	if err != nil {
-		return nil, fmt.Errorf("read skills dir: %w", err)
-	}
-	owned := map[string]struct{}{}
-	for _, name := range bonesOwnedSkills {
-		owned[name] = struct{}{}
-	}
-	manifest, err := readManifest(root)
-	if err != nil {
-		return nil, err
-	}
-	adopted := map[string]struct{}{}
-	if manifest != nil {
-		for _, a := range manifest.Adopted {
-			// Adopted.Path is workspace-relative
-			// (".claude/skills/foo"); we compare on the leaf so the
-			// caller's directory walk lines up.
-			leaf := filepath.Base(a.Path)
-			adopted[leaf] = struct{}{}
-		}
-	}
-	var orphans []string
-	for _, e := range entries {
-		name := e.Name()
-		// Hidden dotfiles in the skills root (.bones-manifest.json,
-		// .gitignore, .gitkeep) are skipped.
-		if strings.HasPrefix(name, ".") {
-			continue
-		}
-		if _, ok := owned[name]; ok {
-			continue
-		}
-		if _, ok := adopted[name]; ok {
-			continue
-		}
-		orphans = append(orphans, name)
-	}
-	sort.Strings(orphans)
-	return orphans, nil
-}
-
 // adoptIntoManifest records orphan as a post-hoc adoption in the
 // workspace's skill manifest. Idempotent: a second call with the same
 // orphan is a no-op (the existing Adopted entry is preserved).

--- a/cli/skills.go
+++ b/cli/skills.go
@@ -12,7 +12,9 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 
+	"github.com/danmestas/bones/internal/timefmt"
 	"github.com/danmestas/bones/internal/version"
 	"github.com/danmestas/bones/internal/workspace"
 )
@@ -124,6 +126,29 @@ type skillManifest struct {
 	// legacy manifests; absent / false → preserve-stub semantics
 	// (#256) wins, matching the conservative default for upgraders.
 	SettingsCreatedByUp bool `json:"settings_created_by_up,omitempty"`
+
+	// Adopted records skills that existed in `.claude/skills/` before
+	// bones tracked them and were folded into the manifest by
+	// `bones doctor` (issue #315). These entries are NOT bones-managed
+	// content — bones up will not refresh them, bones down will not
+	// remove them. Each entry records the adoption timestamp and a
+	// source tag so post-hoc audits can distinguish adopted skills
+	// from skills bones wrote during a normal install.
+	Adopted []adoptedSkill `json:"adopted,omitempty"`
+}
+
+// adoptedSkill records one skill directory adopted into the manifest
+// post-hoc by `bones doctor`. Path is the workspace-relative
+// slash-separated path (e.g. ".claude/skills/legacy-thing"); SHA256
+// is the hex of the directory's canonical content hash at adoption
+// time; AdoptedAt is the RFC 3339 UTC timestamp of the adoption;
+// Source tags the migration that produced the entry (currently
+// always "orphan-migration"; reserved for future adoption sources).
+type adoptedSkill struct {
+	Path      string `json:"path"`
+	SHA256    string `json:"sha256"`
+	AdoptedAt string `json:"adopted_at"`
+	Source    string `json:"source"`
 }
 
 // bonesOwnedHookCommands lists the (event, command) pairs bones
@@ -493,6 +518,179 @@ func readManifest(root string) (*skillManifest, error) {
 // override the value without monkey-patching internal/version.
 var bonesVersion = func() string {
 	return version.Get()
+}
+
+// nowUTC returns the adoption timestamp in RFC 3339 UTC. Routes
+// through timefmt.Logged to honor the project-wide #324 policy that
+// every persisted timestamp uses the same shape. Indirected so tests
+// can pin the value (post-hoc adoption rows include this in the
+// manifest, so a stable test value gives stable golden output).
+var nowUTC = func() string {
+	return timefmt.Logged(time.Now())
+}
+
+// orphanSkillEntries lists workspace-relative skill directory names
+// (under .claude/skills/) that exist on disk but are not bones-owned
+// (not in bonesOwnedSkills) and not already adopted in the manifest.
+// Returns slash-separated relative names sorted lexicographically so
+// callers get deterministic output.
+//
+// Pure read; never modifies the manifest. The "orphan" classification
+// is intentionally lexical: a directory is an orphan if its name is
+// not in bonesOwnedSkills AND its name is not in any Adopted entry.
+// We don't recurse into the directory's files — adoption operates at
+// skill granularity to mirror how bones writes them (one dir per
+// skill, treated as an opaque unit).
+func orphanSkillEntries(root string) ([]string, error) {
+	skillsDir := filepath.Join(root, ".claude", "skills")
+	entries, err := os.ReadDir(skillsDir)
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read skills dir: %w", err)
+	}
+	owned := map[string]struct{}{}
+	for _, name := range bonesOwnedSkills {
+		owned[name] = struct{}{}
+	}
+	manifest, err := readManifest(root)
+	if err != nil {
+		return nil, err
+	}
+	adopted := map[string]struct{}{}
+	if manifest != nil {
+		for _, a := range manifest.Adopted {
+			// Adopted.Path is workspace-relative
+			// (".claude/skills/foo"); we compare on the leaf so the
+			// caller's directory walk lines up.
+			leaf := filepath.Base(a.Path)
+			adopted[leaf] = struct{}{}
+		}
+	}
+	var orphans []string
+	for _, e := range entries {
+		name := e.Name()
+		// Hidden dotfiles in the skills root (.bones-manifest.json,
+		// .gitignore, .gitkeep) are skipped.
+		if strings.HasPrefix(name, ".") {
+			continue
+		}
+		if _, ok := owned[name]; ok {
+			continue
+		}
+		if _, ok := adopted[name]; ok {
+			continue
+		}
+		orphans = append(orphans, name)
+	}
+	sort.Strings(orphans)
+	return orphans, nil
+}
+
+// adoptIntoManifest records orphan as a post-hoc adoption in the
+// workspace's skill manifest. Idempotent: a second call with the same
+// orphan is a no-op (the existing Adopted entry is preserved).
+//
+// When the manifest does not yet exist, this function creates one
+// with the adoption row alone — Files/Scaffolded are left empty
+// because adoption happens against workspaces that bones does not
+// fully own (the adopted skill is operator content). The caller
+// (doctor) treats a missing manifest as "no skills tracked yet" and
+// adoption is the first track event.
+//
+// orphan is a leaf name (e.g. "legacy-thing"); the recorded Path is
+// ".claude/skills/<orphan>". The recorded SHA256 is computed from
+// the directory's canonical content hash (sorted relative paths +
+// per-file bytes) so adoption captures a reproducible witness of
+// what was on disk at adoption time.
+func adoptIntoManifest(root, orphan string) error {
+	manifest, err := readManifest(root)
+	if err != nil {
+		return err
+	}
+	if manifest == nil {
+		manifest = &skillManifest{
+			Version: bonesVersion(),
+			Files:   map[string]string{},
+		}
+	}
+	rel := ".claude/skills/" + orphan
+	for _, a := range manifest.Adopted {
+		if a.Path == rel {
+			return nil // idempotent: already adopted
+		}
+	}
+	hash, err := hashSkillDir(filepath.Join(root, ".claude", "skills", orphan))
+	if err != nil {
+		return fmt.Errorf("hash adopted skill %s: %w", orphan, err)
+	}
+	manifest.Adopted = append(manifest.Adopted, adoptedSkill{
+		Path:      rel,
+		SHA256:    hash,
+		AdoptedAt: nowUTC(),
+		Source:    "orphan-migration",
+	})
+	sort.Slice(manifest.Adopted, func(i, j int) bool {
+		return manifest.Adopted[i].Path < manifest.Adopted[j].Path
+	})
+	return writeManifestStruct(root, manifest)
+}
+
+// hashSkillDir returns the SHA-256 hex of a stable canonical
+// rendering of a skill directory's contents: per-file rows of
+// "<relpath>\t<sha256>\n" with relpaths sorted lexicographically.
+// The encoding is path-relative-to-dir, slash-separated, so the
+// resulting hash is portable across hosts.
+func hashSkillDir(dir string) (string, error) {
+	type row struct{ rel, sum string }
+	var rows []row
+	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		rel, rerr := filepath.Rel(dir, path)
+		if rerr != nil {
+			return fmt.Errorf("rel %s: %w", path, rerr)
+		}
+		data, rerr := os.ReadFile(path)
+		if rerr != nil {
+			return fmt.Errorf("read %s: %w", path, rerr)
+		}
+		rows = append(rows, row{rel: filepath.ToSlash(rel), sum: hashHex(data)})
+		return nil
+	})
+	if err != nil {
+		return "", err
+	}
+	sort.Slice(rows, func(i, j int) bool { return rows[i].rel < rows[j].rel })
+	h := sha256.New()
+	for _, r := range rows {
+		_, _ = h.Write([]byte(r.rel))
+		_, _ = h.Write([]byte("\t"))
+		_, _ = h.Write([]byte(r.sum))
+		_, _ = h.Write([]byte("\n"))
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// writeManifestStruct serializes m and writes it to manifestRel
+// under root. The on-disk layout matches writeManifest's output
+// (indented JSON + trailing newline) so a manifest written by
+// `bones up` and one written by adoption are byte-comparable.
+func writeManifestStruct(root string, m *skillManifest) error {
+	out, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal manifest: %w", err)
+	}
+	path := filepath.Join(root, filepath.FromSlash(manifestRel))
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("mkdir manifest dir: %w", err)
+	}
+	return os.WriteFile(path, append(out, '\n'), 0o644)
 }
 
 // materializeSkillFile writes one embedded skill file to dst, honoring


### PR DESCRIPTION
## Summary

- Adds a `bones doctor` check that walks `.claude/skills/` and reports each skill as `OK` (manifest), `OK` (adopted), `WARN` (orphan), or `FIX` (just adopted). Orphans are skills present on disk but absent from `.bones-manifest.json`.
- Default behavior adopts orphans into the manifest with `adopted_at` + `source: "orphan-migration"` markers; `bones doctor --no-fix` surfaces them as WARNs without touching the manifest. Reuses the existing `--no-fix` flag plumbing from #320 (no parallel flag).
- New `Adopted []adoptedSkill` field on the manifest carries post-hoc provenance. `bones up` and `bones down` continue to key off the hardcoded `bonesOwnedSkills` list — adopted entries are accounting only, so adopted skills are neither refreshed nor removed across teardowns.

## Why adopt rather than delete

Orphan skills are operator content (pre-existing skills installed before bones tracked them, manual additions, mid-PR upgrade artifacts). Deleting them would be a foot-cannon. Adoption pulls them into the manifest's accounting so future doctor runs report them as OK rather than re-warning forever.

## Test plan

- [x] `go test -run TestCheckSkillsManifestDrift ./cli/` (4 new tests: no-orphans, `--no-fix`, default-adopts, idempotent)
- [x] `go test -tags=otel -short ./...` — only pre-existing `TestStatusAllEmptyRegistry` flake remains
- [x] `golangci-lint run ./cli/...` — clean
- [x] `go vet ./...` — clean
- [x] `gofmt -l cli/` — no drift

Closes #315