### PR TITLE
feat(up): structured per-action output + json envelope + quiet flag

### DIFF
--- a/cli/doctor.go
+++ b/cli/doctor.go
@@ -393,7 +393,7 @@ func migrateHookProtocolEntries(w io.Writer, hooks map[string]any,
 				summary)
 			warns++
 		} else {
-			pruneCommandFromEvent(hooks, "SessionStart", "bones tasks prime --json")
+			pruneCommandFromEvent(hooks, "SessionStart", "bones tasks prime --json", nil)
 			addHookWithMatcher(hooks, "SessionStart",
 				clauderhooks.SessionStartMatcher, primeCmd)
 			_, _ = fmt.Fprintf(w,
@@ -415,7 +415,7 @@ func migrateHookProtocolEntries(w io.Writer, hooks map[string]any,
 				summary)
 			warns++
 		} else {
-			pruneCommandFromEvent(hooks, "PreCompact", "bones tasks prime")
+			pruneCommandFromEvent(hooks, "PreCompact", "bones tasks prime", nil)
 			_, _ = fmt.Fprintf(w,
 				"  FIX   .claude/settings.json: %s\n", summary)
 			rewrites = append(rewrites, summary)
@@ -974,7 +974,7 @@ func rewriteCanonicalHookEntry(hooks map[string]any) bool {
 	// drifted entry might be at a different matcher or have
 	// modified fields. Pruning resets the slate.
 	for _, h := range bonesOwnedHookCommands {
-		pruneCommandFromEvent(hooks, h.Event, h.Command)
+		pruneCommandFromEvent(hooks, h.Event, h.Command, nil)
 	}
 	// Re-install canonically. Prime gets the matcher; hub start is
 	// at default matcher.

--- a/cli/init.go
+++ b/cli/init.go
@@ -43,10 +43,12 @@ func (c *JoinCmd) Run(g *repocli.Globals) error {
 // longer started by `bones up`; per ADR 0041 it auto-starts on the first
 // verb that needs it via workspace.Join.
 //
-// Default output: a single confirmation line. With -v / --verbose: the
-// banner plus per-step status lines. WARN lines (drift, missing git)
-// print regardless because they describe real issues the operator must
-// see. Verbosity comes from the global -v flag on repocli.Globals.
+// Per #314 the default output is now per-action structured: every
+// gitignore add, hook install/rewrite, skill sync, and manifest bump
+// gets one grep-friendly line, terminated by a one-line success
+// signature ("up <workspace> actions=<n>"). --quiet suppresses both
+// the per-action lines AND the summary signature; --json emits the
+// same actions wrapped in the ADR 0053 schema envelope.
 //
 // --stealth (issue #291) suppresses the merge into .claude/settings.json
 // — useful when running bones against a project where the operator does
@@ -56,17 +58,24 @@ type UpCmd struct {
 	// Stealth skips the .claude/settings.json merge. Combine with
 	// BONES_DIR=/path for a zero-workspace-write install.
 	Stealth bool `name:"stealth" help:"skip .claude/settings.json merge (combine with BONES_DIR)"`
+	JSON    bool `name:"json" help:"emit JSON envelope (ADR 0053)"`
+	Quiet   bool `name:"quiet" help:"suppress per-action output and success signature"`
 }
 
 func (c *UpCmd) Run(g *repocli.Globals) error {
-	if g.Verbose {
+	if g.Verbose && !c.JSON {
 		banner.Print()
 	}
 	cwd, err := os.Getwd()
 	if err != nil {
 		return fmt.Errorf("cwd: %w", err)
 	}
-	return runUp(cwd, g.Verbose, c.Stealth)
+	return runUp(cwd, upOpts{
+		Verbose: g.Verbose,
+		Stealth: c.Stealth,
+		JSON:    c.JSON,
+		Quiet:   c.Quiet,
+	})
 }
 
 // reportWorkspace formats the standard workspace report and returns nil

--- a/cli/manifest_test.go
+++ b/cli/manifest_test.go
@@ -396,7 +396,7 @@ func TestCheckManifestIntegrity_MissingSettingsHook(t *testing.T) {
 		t.Fatal(err)
 	}
 	hooks := settings["hooks"].(map[string]any)
-	pruneCommandFromEvent(hooks, "SessionStart", "bones hub start")
+	pruneCommandFromEvent(hooks, "SessionStart", "bones hub start", nil)
 	out, _ := json.MarshalIndent(settings, "", "  ")
 	if err := os.WriteFile(settingsPath, append(out, '\n'), 0o644); err != nil {
 		t.Fatal(err)

--- a/cli/orchestrator.go
+++ b/cli/orchestrator.go
@@ -35,8 +35,9 @@ type scaffoldOpts struct {
 
 // scaffoldFootprint captures what scaffoldOrchestrator did during a
 // single invocation, for surfacing in the default-mode `bones up`
-// summary (issue #173). All counts and slices are zero-value safe; a
-// re-run on a fully-scaffolded workspace yields an empty footprint.
+// summary (issue #173, issue #314). All counts and slices are zero-
+// value safe; a re-run on a fully-scaffolded workspace yields an
+// empty footprint.
 type scaffoldFootprint struct {
 	// FilesWritten lists workspace-relative paths that were created or
 	// rewritten as bones-owned files (e.g. .bones/scaffold_version,
@@ -47,6 +48,20 @@ type scaffoldFootprint struct {
 	// keyed by event name (e.g. "SessionStart": 2, "PreCompact": 1).
 	// Existing duplicates are not counted.
 	HooksAddedByEvent map[string]int
+
+	// HookInstalls is the per-event list of fresh hook entries added
+	// to settings.json (issue #314). Each entry pairs (event, command);
+	// renderers turn these into `hooks installed <event> <cmd>` lines
+	// after pairing them with HookRewrites.
+	HookInstalls []hookInstall
+
+	// HookRemovals records hook entries pruned from settings.json by
+	// migration helpers (legacy `bones tasks prime --json`, the bash
+	// hub-bootstrap shim, the legacy hub-shutdown entry under Stop /
+	// SessionEnd). The per-call `runUp` pairs these with HookInstalls
+	// to produce `hooks rewrote <event> "<from>" → "<to>"` lines per
+	// #314 — silent rewrites are the bug being surfaced.
+	HookRemovals []hookInstall
 
 	// SkillsModified lists workspace-relative paths under
 	// .claude/skills/<bones-owned skill>/ that diverged from the
@@ -218,7 +233,7 @@ func mergeSettings(path string, fp *scaffoldFootprint) error {
 	// Drop the pre-ADR-0041 bash hub-bootstrap entry before adding the
 	// new `bones hub start` entry, so re-scaffold over a legacy workspace
 	// doesn't leave both commands wired.
-	pruneLegacyBootstrap(hooks)
+	pruneLegacyBootstrap(hooks, fp)
 
 	// The hub is a workspace-scoped daemon (per-workspace pid files +
 	// per-workspace ports). Tying its teardown to SessionEnd was a bug:
@@ -226,8 +241,8 @@ func mergeSettings(path string, fp *scaffoldFootprint) error {
 	// even another concurrent session in the same workspace, may still
 	// be using. `bones down` is the explicit teardown; SessionEnd no
 	// longer carries hub-shutdown.
-	migrateStopToSessionEnd(hooks)
-	migrateSessionEndShutdown(hooks)
+	migrateStopToSessionEnd(hooks, fp)
+	migrateSessionEndShutdown(hooks, fp)
 
 	// ADR 0051 migration: the v0.12 SessionStart `bones tasks prime
 	// --json` entry was a Claude-Code-protocol no-op; replace it
@@ -235,7 +250,7 @@ func mergeSettings(path string, fp *scaffoldFootprint) error {
 	// substring-matches, but the needle here is specific enough
 	// (`bones tasks prime --json`) that it only catches the v0.12
 	// command — user-added prime variants in other shapes survive.
-	pruneCommandFromEvent(hooks, "SessionStart", "bones tasks prime --json")
+	pruneCommandFromEvent(hooks, "SessionStart", "bones tasks prime --json", fp)
 
 	// ADR 0051 migration: PreCompact has no `additionalContext`
 	// mechanism documented in the Claude Code hook protocol. Any
@@ -246,7 +261,7 @@ func mergeSettings(path string, fp *scaffoldFootprint) error {
 	// removed equally. User scripts that happen to invoke
 	// `bones tasks prime` from PreCompact are exceptional and would
 	// have been a v0.12-era workaround; they are not preserved.
-	pruneCommandFromEvent(hooks, "PreCompact", "bones tasks prime")
+	pruneCommandFromEvent(hooks, "PreCompact", "bones tasks prime", fp)
 
 	// Install the canonical envelope-emitting prime entry under
 	// SessionStart with matcher "startup|compact" so the same hook
@@ -258,6 +273,7 @@ func mergeSettings(path string, fp *scaffoldFootprint) error {
 	if addHookWithMatcher(hooks, "SessionStart",
 		clauderhooks.SessionStartMatcher, primeCmd) {
 		recordHook(fp, "SessionStart")
+		recordHookInstall(fp, "SessionStart", primeCmd)
 	}
 
 	// `bones hub start` keeps its existing default-matcher placement
@@ -266,6 +282,7 @@ func mergeSettings(path string, fp *scaffoldFootprint) error {
 	// side-effecting daemon launcher, not a context-injection hook.
 	if addHook(hooks, "SessionStart", "bones hub start") {
 		recordHook(fp, "SessionStart")
+		recordHookInstall(fp, "SessionStart", "bones hub start")
 	}
 
 	root["hooks"] = hooks
@@ -286,38 +303,43 @@ func mergeSettings(path string, fp *scaffoldFootprint) error {
 // the migration now just prunes the legacy entry. The scan is
 // shim-specific (matches the hub-shutdown.sh command) so unrelated Stop
 // hooks the user has installed are preserved.
-func migrateStopToSessionEnd(hooks map[string]any) {
-	pruneHubShutdown(hooks, "Stop")
+func migrateStopToSessionEnd(hooks map[string]any, fp *scaffoldFootprint) {
+	pruneHubShutdown(hooks, "Stop", fp)
 }
 
 // migrateSessionEndShutdown drops the bones-managed hub-shutdown entry
 // from the SessionEnd event for workspaces scaffolded before ADR 0038.
 // The hub is workspace-scoped now and only torn down by `bones down`;
 // SessionEnd should not stop it.
-func migrateSessionEndShutdown(hooks map[string]any) {
-	pruneHubShutdown(hooks, "SessionEnd")
+func migrateSessionEndShutdown(hooks map[string]any, fp *scaffoldFootprint) {
+	pruneHubShutdown(hooks, "SessionEnd", fp)
 }
 
 // pruneLegacyBootstrap removes the pre-ADR-0041 SessionStart entry
 // invoking bash .orchestrator/scripts/hub-bootstrap.sh. Re-scaffolding
 // over an existing workspace replaces it with the `bones hub start`
 // invocation; pruning first prevents both entries from coexisting.
-func pruneLegacyBootstrap(hooks map[string]any) {
-	pruneCommandFromEvent(hooks, "SessionStart", "hub-bootstrap.sh")
+func pruneLegacyBootstrap(hooks map[string]any, fp *scaffoldFootprint) {
+	pruneCommandFromEvent(hooks, "SessionStart", "hub-bootstrap.sh", fp)
 }
 
 // pruneHubShutdown removes any hook entry under event whose command
 // references hub-shutdown.sh. Wraps pruneCommandFromEvent so the two
 // hub-shutdown migration helpers retain a self-documenting name.
-func pruneHubShutdown(hooks map[string]any, event string) {
-	pruneCommandFromEvent(hooks, event, "hub-shutdown.sh")
+func pruneHubShutdown(hooks map[string]any, event string, fp *scaffoldFootprint) {
+	pruneCommandFromEvent(hooks, event, "hub-shutdown.sh", fp)
 }
 
 // pruneCommandFromEvent removes any hook entry under the given event
 // whose command contains needle. Empty matcher groups and the event
 // key itself are cleaned up if no entries remain. Unrelated entries
 // are preserved verbatim.
-func pruneCommandFromEvent(hooks map[string]any, event, needle string) {
+//
+// Per #314 each removed entry is recorded into fp.HookRemovals so
+// `bones up` can pair it with a freshly-installed entry under the
+// same event and surface the migration as a `hooks rewrote` line.
+// fp is allowed to be nil for callers that do not care.
+func pruneCommandFromEvent(hooks map[string]any, event, needle string, fp *scaffoldFootprint) {
 	groups, _ := hooks[event].([]any)
 	if groups == nil {
 		return
@@ -340,7 +362,9 @@ func pruneCommandFromEvent(hooks map[string]any, event, needle string) {
 			cmd, _ := em["command"].(string)
 			if !strings.Contains(cmd, needle) {
 				keepEntries = append(keepEntries, e)
+				continue
 			}
+			recordHookRemoval(fp, event, cmd)
 		}
 		if len(keepEntries) == 0 {
 			continue
@@ -441,4 +465,33 @@ func recordHook(fp *scaffoldFootprint, event string) {
 		fp.HooksAddedByEvent = map[string]int{}
 	}
 	fp.HooksAddedByEvent[event]++
+}
+
+// recordHookInstall captures a freshly-installed hook entry into
+// fp.HookInstalls. runUp pairs the result with fp.HookRemovals to
+// emit `hooks rewrote` lines (when an event sees both a removal and
+// an addition) or `hooks installed` lines (additions with no
+// matching removal) per #314. nil fp is a no-op.
+func recordHookInstall(fp *scaffoldFootprint, event, cmd string) {
+	if fp == nil {
+		return
+	}
+	fp.HookInstalls = append(fp.HookInstalls, hookInstall{
+		Event:   event,
+		Command: cmd,
+	})
+}
+
+// recordHookRemoval captures a pruned hook entry into fp.HookRemovals.
+// Used by pruneCommandFromEvent so migration paths surface in the up
+// summary instead of silently rewriting the operator's settings.json.
+// nil fp is a no-op.
+func recordHookRemoval(fp *scaffoldFootprint, event, cmd string) {
+	if fp == nil {
+		return
+	}
+	fp.HookRemovals = append(fp.HookRemovals, hookInstall{
+		Event:   event,
+		Command: cmd,
+	})
 }

--- a/cli/orchestrator_test.go
+++ b/cli/orchestrator_test.go
@@ -722,7 +722,7 @@ func TestPruneLegacyBootstrap_RemovesLegacyEntry(t *testing.T) {
 			},
 		},
 	}
-	pruneLegacyBootstrap(hooks)
+	pruneLegacyBootstrap(hooks, nil)
 	if _, ok := hooks["SessionStart"]; ok {
 		t.Errorf("SessionStart key should be removed; got %v", hooks)
 	}
@@ -749,7 +749,7 @@ func TestPruneLegacyBootstrap_PreservesUnrelatedEntries(t *testing.T) {
 			},
 		},
 	}
-	pruneLegacyBootstrap(hooks)
+	pruneLegacyBootstrap(hooks, nil)
 	groups, ok := hooks["SessionStart"].([]any)
 	if !ok || len(groups) != 1 {
 		t.Fatalf("expected 1 group remaining, got %v", hooks)
@@ -781,7 +781,7 @@ func TestPruneLegacyBootstrap_NoLegacyEntry(t *testing.T) {
 			},
 		},
 	}
-	pruneLegacyBootstrap(hooks)
+	pruneLegacyBootstrap(hooks, nil)
 	groups, ok := hooks["SessionStart"].([]any)
 	if !ok || len(groups) != 1 {
 		t.Fatalf("SessionStart group dropped unexpectedly: %v", hooks)

--- a/cli/schemas/up.go
+++ b/cli/schemas/up.go
@@ -1,0 +1,41 @@
+package schemas
+
+// UpPayload is the payload for `bones up --json` (issue #314).
+// Mirrors the per-action structured output emitted on the human path,
+// plus a summary block carrying the workspace path and total action
+// count so the envelope is self-describing.
+//
+// The shape is generic over action category — `gitignore`, `hooks`,
+// `skills`, `manifest` — to keep the typed wire surface stable as
+// future actions enter the categories. Adding a brand-new category
+// is intentional friction (per the issue's trap-3 guidance) but
+// requires no schema change here.
+type UpPayload struct {
+	Actions []UpAction `json:"actions"`
+	Summary UpSummary  `json:"summary"`
+}
+
+// UpAction is one structured action `bones up` performed during this
+// invocation. Category is one of the pinned set (gitignore, hooks,
+// skills, manifest); Action is the verb (added, refreshed, installed,
+// rewrote, synced, bumped); Target is the object (gitignore entry,
+// hook event + command, skill count, schema version stamp).
+//
+// From / To are populated only for `rewrote` actions — the legacy
+// command and the canonical replacement, respectively. They are
+// `omitempty` so non-rewrite rows don't carry empty string noise.
+type UpAction struct {
+	Category string `json:"category"`
+	Action   string `json:"action"`
+	Target   string `json:"target"`
+	From     string `json:"from,omitempty"`
+	To       string `json:"to,omitempty"`
+}
+
+// UpSummary is the trailing summary block of an UpPayload. Mirrors
+// the human-path success signature emitted via uxprint.Up: workspace
+// path + action count.
+type UpSummary struct {
+	Workspace   string `json:"workspace"`
+	ActionCount int    `json:"action_count"`
+}

--- a/cli/schemas/verbs.go
+++ b/cli/schemas/verbs.go
@@ -43,6 +43,7 @@ var Verbs = []VerbInfo{
 	{Verb: "tasks.ready", CurrentVersion: "v1", PayloadName: "TasksReadyPayload"},
 	{Verb: "tasks.show", CurrentVersion: "v1", PayloadName: "TasksShowPayload"},
 	{Verb: "tasks.update", CurrentVersion: "v1", PayloadName: "TasksUpdatePayload"},
+	{Verb: "up", CurrentVersion: "v1", PayloadName: "UpPayload"},
 	{Verb: "workspaces.get", CurrentVersion: "v1", PayloadName: "WorkspacesGetPayload"},
 	{Verb: "workspaces.list", CurrentVersion: "v1", PayloadName: "WorkspacesListPayload"},
 }

--- a/cli/schemas_test.go
+++ b/cli/schemas_test.go
@@ -206,6 +206,10 @@ func zeroPayloadFor(t *testing.T, name string) any {
 		return schemas.TasksShowPayload{Files: []string{}}
 	case "TasksUpdatePayload":
 		return schemas.TasksUpdatePayload{Files: []string{}}
+	case "UpPayload":
+		return schemas.UpPayload{
+			Actions: []schemas.UpAction{},
+		}
 	case "WorkspacesGetPayload":
 		return schemas.WorkspacesGetPayload{}
 	case "WorkspacesListPayload":
@@ -259,6 +263,9 @@ func TestEvery_JSONFlag_HasRegistryEntry(t *testing.T) {
 		"tasks_ready.go":  "tasks.ready",
 		"tasks_show.go":   "tasks.show",
 		"tasks_update.go": "tasks.update",
+		// init.go declares UpCmd; --json on `bones up` lives there
+		// per the existing struct layout (#314).
+		"init.go": "up",
 		// workspaces.go also drives workspaces.get via WorkspacesShowCmd.
 		"workspaces.go": "workspaces.list",
 	}

--- a/cli/up.go
+++ b/cli/up.go
@@ -234,34 +234,62 @@ func scaffoldChanged(fp scaffoldFootprint) bool {
 //
 // Three checks today:
 //   - ensureBonesGitignore (#306): adds .bones/ + skill manifest entries.
-//   - trackedDeletedFiles (#303): warns about tracked-but-missing files.
+//   - trackedDeletedFiles (#303 / #310): warns about tracked-but-missing files.
 //   - checkFossilDrift: warns when fossil tip diverges from git HEAD.
 //
-// JSON mode silences the human-targeted WARN lines — they would
-// otherwise contaminate the JSON envelope on stdout. The structured
-// JSON payload itself is still authoritative; warnings are surfaced
-// via stderr in the human path only.
+// Warnings route through the per-mode sink returned by warnSink:
+//
+//   - default (human) mode → logger.Warnf, which writes to stderr +
+//     captures to .bones/up.log;
+//   - JSON mode → bare stderr, so stdout stays a single valid envelope
+//     and warnings are still discoverable (matches #311's precedent of
+//     hub URLs → stderr);
+//   - --quiet → dropped entirely (the operator opted into silence).
 func runPostScaffoldChecks(
 	wsDir string, opts upOpts, logger *upLogger,
 ) []string {
+	warn := warnSink(opts, logger)
+
 	gitignoreAdded, gitignoreErr := ensureBonesGitignore(wsDir, opts.Stealth)
-	if gitignoreErr != nil && !opts.JSON && !opts.Quiet {
+	if gitignoreErr != nil {
 		// Non-fatal: a read-only filesystem or gitignore the operator
 		// pinned with chmod 444 must not block scaffold. Surface as a
 		// warning so the host-local agent.id risk is at least visible.
-		logger.Warnf("up: WARN  gitignore: %v", gitignoreErr)
+		warn("up: WARN  gitignore: %v", gitignoreErr)
 	}
 
-	if missing, _ := trackedDeletedFiles(wsDir); len(missing) > 0 && !opts.JSON && !opts.Quiet {
-		logger.Warnf("up: WARN  %s",
-			formatTrackedDeletedWarning(missing))
+	if missing, _ := trackedDeletedFiles(wsDir); len(missing) > 0 {
+		warn("up: WARN  %s", formatTrackedDeletedWarning(missing))
 	}
 
-	if dErr := checkFossilDrift(wsDir); dErr != nil && !opts.JSON && !opts.Quiet {
-		logger.Warnf("up: WARN  %v", dErr)
+	if dErr := checkFossilDrift(wsDir); dErr != nil {
+		warn("up: WARN  %v", dErr)
 	}
 
 	return gitignoreAdded
+}
+
+// warnSink returns the per-mode warning emitter for runPostScaffoldChecks.
+// One seam decides where post-scaffold WARN lines land so the three
+// call sites stay terse and consistent.
+//
+//   - --quiet: returns a no-op closure (operator opted into silence).
+//   - --json:  returns a closure that writes to os.Stderr only — stdout
+//     stays a single valid envelope, but the warnings remain visible
+//     to operators piping `--json | jq` (#310's intent is preserved).
+//   - default: returns logger.Warnf, which writes to stderr AND
+//     captures to .bones/up.log so the audit trail mirrors the
+//     terminal output.
+func warnSink(opts upOpts, logger *upLogger) func(format string, args ...any) {
+	if opts.Quiet {
+		return func(format string, args ...any) {}
+	}
+	if opts.JSON {
+		return func(format string, args ...any) {
+			_, _ = fmt.Fprintf(os.Stderr, format+"\n", args...)
+		}
+	}
+	return logger.Warnf
 }
 
 // formatHookCounts renders the per-event hook-add counts with stable

--- a/cli/up.go
+++ b/cli/up.go
@@ -11,14 +11,28 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/danmestas/bones/cli/schemas"
+	"github.com/danmestas/bones/cli/uxprint"
 	"github.com/danmestas/bones/internal/githook"
 	"github.com/danmestas/bones/internal/hub"
 	"github.com/danmestas/bones/internal/registry"
 	"github.com/danmestas/bones/internal/scaffoldver"
 	"github.com/danmestas/bones/internal/swarm"
 	"github.com/danmestas/bones/internal/telemetry"
+	"github.com/danmestas/bones/internal/version"
 	"github.com/danmestas/bones/internal/workspace"
 )
+
+// upOpts bundles the per-invocation toggles for runUp. Pinned as a
+// struct so future flags (#314 added JSON + Quiet on top of the
+// pre-existing Verbose + Stealth) don't keep growing the runUp
+// signature.
+type upOpts struct {
+	Verbose bool
+	Stealth bool
+	JSON    bool
+	Quiet   bool
+}
 
 // runUp performs workspace bootstrap from a fresh clone:
 //  1. workspace init (idempotent — joins if already initialized)
@@ -49,7 +63,7 @@ import (
 // stealth=true (issue #291) skips the merge into `.claude/settings.json`.
 // Operators set this — typically alongside BONES_DIR — when running bones
 // against a project they don't want to mark with Claude hook entries.
-func runUp(cwd string, verbose, stealth bool) (err error) {
+func runUp(cwd string, opts upOpts) (err error) {
 	ctx, end := telemetry.RecordCommand(context.Background(), "bones.up",
 		telemetry.String("workspace_hash", telemetry.WorkspaceHash(cwd)),
 	)
@@ -87,116 +101,172 @@ func runUp(cwd string, verbose, stealth bool) (err error) {
 	logger := openUpLog(wsDir)
 	defer logger.Close(err)
 
-	if verbose {
+	if opts.Verbose && !opts.JSON {
 		logger.Infof("up: workspace at %s", wsDir)
 	}
 
-	if recovery {
+	if recovery && !opts.JSON {
 		logger.Warnf("bones: scaffold incomplete from prior run — re-running scaffold")
 	}
 
-	fp, scaffErr := scaffoldOrchestrator(wsDir, scaffoldOpts{Stealth: stealth})
+	fp, scaffErr := scaffoldOrchestrator(wsDir, scaffoldOpts{Stealth: opts.Stealth})
 	if scaffErr != nil {
 		err = fmt.Errorf("orchestrator scaffold: %w", scaffErr)
 		return err
 	}
-	if verbose {
-		logger.Infof("up: orchestrator skills and hooks installed")
-	}
 
-	if hookErr := installGitHook(wsDir, verbose, logger); hookErr != nil {
+	if hookErr := installGitHook(wsDir, opts.Verbose && !opts.JSON, logger); hookErr != nil {
 		err = fmt.Errorf("git hook: %w", hookErr)
 		return err
 	}
 
 	// Register the workspace in the cross-host registry so it appears
 	// in `bones status --all` between `bones up` and the first verb
-	// that triggers a hub serve (#305). PID=0 entry; the hub start
-	// path overwrites it with a PID-bearing record. `bones down`
-	// removes the entry. Best-effort: a HOME/permission failure here
-	// must not block scaffold completion.
-	if regErr := registry.Register(wsDir, resolveWorkspaceName(wsDir)); regErr != nil {
+	// that triggers a hub serve (#305 / #339). PID=0 entry; the hub
+	// start path overwrites it with a PID-bearing record. `bones
+	// down` removes the entry. Best-effort: a HOME/permission failure
+	// here must not block scaffold completion. Gated on !JSON to keep
+	// stdout clean for --json | jq pipelines; the second commit on
+	// this branch routes the warning to stderr instead of dropping it.
+	if regErr := registry.Register(wsDir, resolveWorkspaceName(wsDir)); regErr != nil && !opts.JSON && !opts.Quiet {
 		logger.Warnf("up: WARN  registry register: %v", regErr)
 	}
 
-	gitignoreAdded := runPostScaffoldChecks(wsDir, stealth, logger)
+	gitignoreAdded := runPostScaffoldChecks(wsDir, opts, logger)
+	actions := collectUpActions(fp, gitignoreAdded)
+	return emitUpResult(opts, logger, wsDir, actions)
+}
 
-	if verbose {
-		logger.Infof("up: workspace ready. Run any verb (e.g., `bones tasks status`) " +
-			"and the hub will start automatically; or run `bones hub start` now.")
-	} else {
-		logger.Infof("up: ready at %s", wsDir)
-		emitFootprintSummary(logger, fp)
-		if len(gitignoreAdded) > 0 {
-			logger.Infof("up:   added to .gitignore: %s",
-				strings.Join(gitignoreAdded, ", "))
+// collectUpActions assembles the per-action list from the scaffold
+// footprint and the gitignore-added entries. Pairs hook removals with
+// matching installs so legacy → canonical migrations surface as
+// `hooks rewrote` lines. Manifest is reported as bumped only when the
+// scaffold actually mutated state — re-runs against a converged
+// workspace yield no manifest action.
+func collectUpActions(fp scaffoldFootprint, gitignoreAdded []string) []upAction {
+	rewrites, installs := pairRewrites(fp.HookRemovals, fp.HookInstalls)
+	skillsSynced := countSkillFiles(fp.FilesWritten)
+	manifestVersion := ""
+	if scaffoldChanged(fp) {
+		manifestVersion = version.Get()
+	}
+	return buildUpActions(gitignoreAdded, rewrites, installs, skillsSynced, manifestVersion)
+}
+
+// emitUpResult dispatches the actions slice onto the JSON, quiet, or
+// human output paths per opts. JSON returns the envelope contract;
+// quiet returns silently; the default path renders per-action lines,
+// the success signature, and the hub-status orientation aid through
+// the logger's Tee so the audit log captures every emitted line.
+func emitUpResult(opts upOpts, logger *upLogger, wsDir string, actions []upAction) error {
+	if opts.JSON {
+		return emitUpJSON(os.Stdout, wsDir, actions)
+	}
+	if opts.Quiet {
+		return nil
+	}
+	teeOut := logger.Tee(os.Stdout)
+	for _, a := range actions {
+		renderUpAction(teeOut, a)
+	}
+	uxprint.Up(teeOut, shortenCwd(wsDir, os.Getenv("HOME")), len(actions))
+	printHubStatus(teeOut, wsDir)
+	return nil
+}
+
+// emitUpJSON marshals the up actions + summary into the ADR 0053
+// envelope and writes it to w. Per #314 the JSON path is the round-
+// trippable surface for tests and downstream consumers; --json
+// suppresses every other stdout line so a `--json | jq` pipeline
+// gets exactly one object.
+func emitUpJSON(w io.Writer, wsDir string, actions []upAction) error {
+	payload := schemas.UpPayload{
+		Actions: make([]schemas.UpAction, 0, len(actions)),
+		Summary: schemas.UpSummary{
+			Workspace:   wsDir,
+			ActionCount: len(actions),
+		},
+	}
+	for _, a := range actions {
+		payload.Actions = append(payload.Actions, schemas.UpAction{
+			Category: a.Category,
+			Action:   a.Action,
+			Target:   a.Target,
+			From:     a.From,
+			To:       a.To,
+		})
+	}
+	return emitEnvelope(w, "up", payload)
+}
+
+// countSkillFiles returns how many entries in filesWritten are
+// .claude/skills/*. Used to surface the `skills synced N skills`
+// action when the scaffold materialized fresh skill content.
+func countSkillFiles(filesWritten []string) int {
+	n := 0
+	for _, f := range filesWritten {
+		if strings.HasPrefix(f, ".claude/skills/") {
+			n++
 		}
 	}
-	printHubStatus(logger.Tee(os.Stdout), wsDir)
-	return nil
+	return n
+}
+
+// scaffoldChanged reports whether the scaffold pass actually mutated
+// state on disk (wrote files or rewired hooks). Used to gate the
+// `manifest bumped` action — re-running on a converged workspace
+// should not claim a manifest bump that did not happen.
+func scaffoldChanged(fp scaffoldFootprint) bool {
+	if len(fp.FilesWritten) > 0 {
+		return true
+	}
+	if len(fp.HookInstalls) > 0 || len(fp.HookRemovals) > 0 {
+		return true
+	}
+	return false
 }
 
 // runPostScaffoldChecks runs the workspace-wide checks that follow
 // orchestrator scaffold + git-hook install. None of them should
 // block bones up — the scaffold already landed; these are
 // informational. Returns the gitignore entries added so the caller
-// can surface them in the footprint summary.
+// can surface them in the per-action structured output.
 //
 // Three checks today:
 //   - ensureBonesGitignore (#306): adds .bones/ + skill manifest entries.
 //   - trackedDeletedFiles (#303): warns about tracked-but-missing files.
 //   - checkFossilDrift: warns when fossil tip diverges from git HEAD.
+//
+// JSON mode silences the human-targeted WARN lines — they would
+// otherwise contaminate the JSON envelope on stdout. The structured
+// JSON payload itself is still authoritative; warnings are surfaced
+// via stderr in the human path only.
 func runPostScaffoldChecks(
-	wsDir string, stealth bool, logger *upLogger,
+	wsDir string, opts upOpts, logger *upLogger,
 ) []string {
-	gitignoreAdded, gitignoreErr := ensureBonesGitignore(wsDir, stealth)
-	if gitignoreErr != nil {
+	gitignoreAdded, gitignoreErr := ensureBonesGitignore(wsDir, opts.Stealth)
+	if gitignoreErr != nil && !opts.JSON && !opts.Quiet {
 		// Non-fatal: a read-only filesystem or gitignore the operator
 		// pinned with chmod 444 must not block scaffold. Surface as a
 		// warning so the host-local agent.id risk is at least visible.
 		logger.Warnf("up: WARN  gitignore: %v", gitignoreErr)
 	}
 
-	if missing, _ := trackedDeletedFiles(wsDir); len(missing) > 0 {
+	if missing, _ := trackedDeletedFiles(wsDir); len(missing) > 0 && !opts.JSON && !opts.Quiet {
 		logger.Warnf("up: WARN  %s",
 			formatTrackedDeletedWarning(missing))
 	}
 
-	if dErr := checkFossilDrift(wsDir); dErr != nil {
+	if dErr := checkFossilDrift(wsDir); dErr != nil && !opts.JSON && !opts.Quiet {
 		logger.Warnf("up: WARN  %v", dErr)
 	}
 
 	return gitignoreAdded
 }
 
-// emitFootprintSummary surfaces per-action file/hook changes from the
-// scaffold pass into the default-mode summary (#173). Each line is
-// indented under the "up: ready at" banner so a quick scan reads as
-// "what just changed in this workspace". When the workspace was already
-// fully scaffolded (no-op re-run), the function emits a single
-// "no changes" line so the operator sees an explicit affirmation rather
-// than wondering whether they pasted the wrong cwd.
-func emitFootprintSummary(logger *upLogger, fp scaffoldFootprint) {
-	emitted := false
-
-	if len(fp.FilesWritten) > 0 {
-		emitted = true
-		logger.Infof("up:   wrote %s", strings.Join(fp.FilesWritten, ", "))
-	}
-	if total := fp.hooksAdded(); total > 0 {
-		emitted = true
-		logger.Infof("up:   merged %d hooks into .claude/settings.json (%s)",
-			total, formatHookCounts(fp.HooksAddedByEvent))
-	}
-
-	if !emitted {
-		logger.Infof("up:   no changes (workspace already converged)")
-	}
-}
-
 // formatHookCounts renders the per-event hook-add counts with stable
-// ordering so summary output is reproducible across runs (the underlying
-// map is unordered).
+// ordering. Retained as a helper so tests and any future debug surface
+// (e.g. `bones doctor`'s hook-coverage section) can reuse the wording.
 func formatHookCounts(byEvent map[string]int) string {
 	keys := make([]string, 0, len(byEvent))
 	for k, v := range byEvent {

--- a/cli/up.go
+++ b/cli/up.go
@@ -125,11 +125,12 @@ func runUp(cwd string, opts upOpts) (err error) {
 	// that triggers a hub serve (#305 / #339). PID=0 entry; the hub
 	// start path overwrites it with a PID-bearing record. `bones
 	// down` removes the entry. Best-effort: a HOME/permission failure
-	// here must not block scaffold completion. Gated on !JSON to keep
-	// stdout clean for --json | jq pipelines; the second commit on
-	// this branch routes the warning to stderr instead of dropping it.
-	if regErr := registry.Register(wsDir, resolveWorkspaceName(wsDir)); regErr != nil && !opts.JSON && !opts.Quiet {
-		logger.Warnf("up: WARN  registry register: %v", regErr)
+	// here must not block scaffold completion. Routes through the
+	// per-mode warn sink so --json keeps stdout clean (warning lands
+	// on stderr, matching #311's hub-URL precedent) and --quiet drops
+	// the warning entirely.
+	if regErr := registry.Register(wsDir, resolveWorkspaceName(wsDir)); regErr != nil {
+		warnSink(opts, logger)("up: WARN  registry register: %v", regErr)
 	}
 
 	gitignoreAdded := runPostScaffoldChecks(wsDir, opts, logger)

--- a/cli/up_actions.go
+++ b/cli/up_actions.go
@@ -1,0 +1,215 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+)
+
+// upAction is one structured per-action line emitted by `bones up`
+// (issue #314). Categories are pinned (`gitignore`, `hooks`, `skills`,
+// `manifest`); actions describe what bones did to the target. From / To
+// are non-empty only for the `rewrote` action (legacy → canonical
+// command migration in `.claude/settings.json`).
+//
+// The same struct shape backs both the human stdout path (one line per
+// action via [renderUpAction]) and the `--json` envelope payload
+// (cli/schemas/up.go's UpAction). Pinning one struct keeps the two
+// surfaces from drifting verb-by-verb.
+type upAction struct {
+	Category string `json:"category"`
+	Action   string `json:"action"`
+	Target   string `json:"target"`
+	From     string `json:"from,omitempty"`
+	To       string `json:"to,omitempty"`
+}
+
+// hookRewrite captures one legacy → canonical hook command migration
+// performed by mergeSettings. From is the v0.12 / pre-ADR-0051 command
+// substring matched and removed; To is the canonical command installed
+// in its place. Captured so `bones up` can emit a `hooks rewrote
+// <event> "<from>" → "<to>"` line per #314 (silent rewrites are the
+// bug being fixed).
+type hookRewrite struct {
+	Event string
+	From  string
+	To    string
+}
+
+// hookInstall captures one fresh hook entry added to settings.json by
+// mergeSettings (no legacy entry to migrate from). Surfaced as a
+// `hooks installed <event> <command>` action.
+type hookInstall struct {
+	Event   string
+	Command string
+}
+
+// renderUpAction writes one structured per-action line to w. The shape
+// is verb-first column for grep-friendliness, then action column, then
+// target, then optional from/to tail for `rewrote` actions.
+//
+// Column widths are pinned so vertical scans in a terminal align across
+// categories. Rewrites get their own renderer because the "from → to"
+// tail spans multiple fields. Wording lives here so future helpers can
+// not invent their own variants.
+func renderUpAction(w io.Writer, a upAction) {
+	if a.Action == "rewrote" {
+		_, _ = fmt.Fprintf(w, "%-10s %-9s %s %q → %q\n",
+			a.Category, a.Action, a.Target, a.From, a.To)
+		return
+	}
+	_, _ = fmt.Fprintf(w, "%-10s %-9s %s\n", a.Category, a.Action, a.Target)
+}
+
+// buildUpActions assembles the per-action list from the scaffold
+// footprint, the gitignore-added entries, and the rewrite/install
+// records. Ordering is deterministic so snapshot tests pin one shape:
+// gitignore actions first (in argument order), then hook rewrites
+// (by event then from), then hook installs (by event then command),
+// then the skills-synced summary, then manifest.
+func buildUpActions(
+	gitignoreAdded []string,
+	rewrites []hookRewrite,
+	installs []hookInstall,
+	skillsSynced int,
+	manifestVersion string,
+) []upAction {
+	var out []upAction
+
+	for _, entry := range gitignoreAdded {
+		out = append(out, upAction{
+			Category: "gitignore",
+			Action:   "added",
+			Target:   entry,
+		})
+	}
+
+	sort.SliceStable(rewrites, func(i, j int) bool {
+		if rewrites[i].Event != rewrites[j].Event {
+			return rewrites[i].Event < rewrites[j].Event
+		}
+		return rewrites[i].From < rewrites[j].From
+	})
+	for _, r := range rewrites {
+		out = append(out, upAction{
+			Category: "hooks",
+			Action:   "rewrote",
+			Target:   r.Event,
+			From:     r.From,
+			To:       r.To,
+		})
+	}
+
+	sort.SliceStable(installs, func(i, j int) bool {
+		if installs[i].Event != installs[j].Event {
+			return installs[i].Event < installs[j].Event
+		}
+		return installs[i].Command < installs[j].Command
+	})
+	for _, ins := range installs {
+		out = append(out, upAction{
+			Category: "hooks",
+			Action:   "installed",
+			Target:   ins.Event + " " + ins.Command,
+		})
+	}
+
+	if skillsSynced > 0 {
+		out = append(out, upAction{
+			Category: "skills",
+			Action:   "synced",
+			Target:   fmt.Sprintf("%d skills", skillsSynced),
+		})
+	}
+
+	if manifestVersion != "" {
+		out = append(out, upAction{
+			Category: "manifest",
+			Action:   "bumped",
+			Target:   "schema_version=" + manifestVersion,
+		})
+	}
+
+	return out
+}
+
+// pairRewrites converts a (removed, added) pair from mergeSettings
+// into hookRewrites and unmatched hookInstalls. A removed entry whose
+// event matches a freshly-added entry is treated as a rewrite (the
+// new command replaced the old one in the same slot); leftover
+// additions surface as plain installs.
+//
+// Today bones rewrites at most one canonical command per event
+// (SessionStart's `bones tasks prime --hook=session-start` replaces
+// the v0.12 `--json` form). The per-event match is therefore "first
+// addition to that event wins"; multi-rewrite ordering is not load-
+// bearing on any current call site.
+func pairRewrites(removed, added []hookInstall) ([]hookRewrite, []hookInstall) {
+	var rewrites []hookRewrite
+	usedAdds := make(map[int]bool, len(added))
+	usedRems := make(map[int]bool, len(removed))
+
+	for ri, r := range removed {
+		for ai, a := range added {
+			if usedAdds[ai] {
+				continue
+			}
+			if r.Event != a.Event {
+				continue
+			}
+			rewrites = append(rewrites, hookRewrite{
+				Event: r.Event,
+				From:  r.Command,
+				To:    a.Command,
+			})
+			usedAdds[ai] = true
+			usedRems[ri] = true
+			break
+		}
+	}
+
+	var installs []hookInstall
+	for ai, a := range added {
+		if !usedAdds[ai] {
+			installs = append(installs, a)
+		}
+	}
+
+	// Removed entries with no matching addition are silent prunes (the
+	// v0.12 PreCompact `bones tasks prime --json` entry is a current
+	// example — it is dropped without a replacement). Surface them as
+	// `hooks rewrote <event> "<from>" → ""` so the operator still sees
+	// the change. An empty To is harmless to %q rendering.
+	for ri, r := range removed {
+		if usedRems[ri] {
+			continue
+		}
+		rewrites = append(rewrites, hookRewrite{
+			Event: r.Event,
+			From:  r.Command,
+			To:    "",
+		})
+	}
+
+	return rewrites, installs
+}
+
+// shortenCwd returns a workspace path trimmed against the user's home
+// directory for terminal-friendly summary lines. `~/projects/bones` is
+// shorter and easier to recognize than `/Users/dan/projects/bones`.
+// Falls back to the raw path when HOME is unset or the workspace lives
+// outside it.
+func shortenCwd(path, home string) string {
+	if home == "" || !strings.HasPrefix(path, home) {
+		return path
+	}
+	rest := strings.TrimPrefix(path, home)
+	if rest == "" {
+		return "~"
+	}
+	if rest[0] != '/' {
+		return path
+	}
+	return "~" + rest
+}

--- a/cli/up_actions_test.go
+++ b/cli/up_actions_test.go
@@ -1,0 +1,200 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// TestRenderUpAction_Added pins the column layout and wording of the
+// `gitignore added <entry>` shape — the most common per-action line.
+func TestRenderUpAction_Added(t *testing.T) {
+	var buf bytes.Buffer
+	renderUpAction(&buf, upAction{
+		Category: "gitignore",
+		Action:   "added",
+		Target:   ".bones/",
+	})
+	want := "gitignore  added     .bones/\n"
+	if got := buf.String(); got != want {
+		t.Fatalf("renderUpAction added: got %q want %q", got, want)
+	}
+}
+
+// TestRenderUpAction_Installed pins the wording of the `hooks
+// installed <event> <command>` shape. Target carries both the event
+// and the command separated by a single space.
+func TestRenderUpAction_Installed(t *testing.T) {
+	var buf bytes.Buffer
+	renderUpAction(&buf, upAction{
+		Category: "hooks",
+		Action:   "installed",
+		Target:   "SessionStart bones hub start",
+	})
+	want := "hooks      installed SessionStart bones hub start\n"
+	if got := buf.String(); got != want {
+		t.Fatalf("renderUpAction installed: got %q want %q", got, want)
+	}
+}
+
+// TestRenderUpAction_Rewrote pins the from/to tail format. The
+// rewrite case is the load-bearing shape #314 added: silent legacy
+// rewrites become `hooks rewrote <event> "<from>" → "<to>"` lines.
+func TestRenderUpAction_Rewrote(t *testing.T) {
+	var buf bytes.Buffer
+	renderUpAction(&buf, upAction{
+		Category: "hooks",
+		Action:   "rewrote",
+		Target:   "SessionStart",
+		From:     "bones tasks prime --json",
+		To:       "bones tasks prime --hook=session-start",
+	})
+	got := buf.String()
+	wantSubstrings := []string{
+		"hooks",
+		"rewrote",
+		"SessionStart",
+		`"bones tasks prime --json"`,
+		"→",
+		`"bones tasks prime --hook=session-start"`,
+	}
+	for _, want := range wantSubstrings {
+		if !strings.Contains(got, want) {
+			t.Errorf("renderUpAction rewrote missing %q in:\n%s", want, got)
+		}
+	}
+}
+
+// TestBuildUpActions_FullSet exercises the canonical fresh-workspace
+// shape: gitignore adds + hook installs + skills synced + manifest
+// bumped. Order is pinned: gitignore first, hook rewrites, hook
+// installs, skills, manifest.
+func TestBuildUpActions_FullSet(t *testing.T) {
+	rewrites := []hookRewrite{{
+		Event: "SessionStart",
+		From:  "bones tasks prime --json",
+		To:    "bones tasks prime --hook=session-start",
+	}}
+	installs := []hookInstall{{Event: "SessionStart", Command: "bones hub start"}}
+	actions := buildUpActions(
+		[]string{".bones/", ".claude/skills/.bones-manifest.json"},
+		rewrites,
+		installs,
+		3,
+		"v1.2.3",
+	)
+	wantLen := 6
+	if len(actions) != wantLen {
+		t.Fatalf("buildUpActions: got %d actions, want %d:\n%+v",
+			len(actions), wantLen, actions)
+	}
+	wantOrder := []string{
+		"gitignore", "gitignore", "hooks", "hooks", "skills", "manifest",
+	}
+	for i, w := range wantOrder {
+		if actions[i].Category != w {
+			t.Errorf("action[%d].Category = %q, want %q", i, actions[i].Category, w)
+		}
+	}
+	// Hook rewrite must come before hook install per the deterministic
+	// ordering rule.
+	if actions[2].Action != "rewrote" {
+		t.Errorf("action[2].Action = %q, want rewrote", actions[2].Action)
+	}
+	if actions[3].Action != "installed" {
+		t.Errorf("action[3].Action = %q, want installed", actions[3].Action)
+	}
+}
+
+// TestBuildUpActions_Idempotent pins the second-run shape: zero
+// gitignore adds, zero hook installs/rewrites, zero skills synced,
+// zero manifest bump → empty action slice. The success signature
+// downstream still emits with actions=0.
+func TestBuildUpActions_Idempotent(t *testing.T) {
+	actions := buildUpActions(nil, nil, nil, 0, "")
+	if len(actions) != 0 {
+		t.Fatalf("idempotent re-run should produce 0 actions, got %d:\n%+v",
+			len(actions), actions)
+	}
+}
+
+// TestPairRewrites_LegacyToCanonical covers the headline #314 case:
+// a removed v0.12 `bones tasks prime --json` paired with a freshly-
+// installed `bones tasks prime --hook=session-start` under the same
+// SessionStart event. The pair surfaces as a single hookRewrite, no
+// orphan install.
+func TestPairRewrites_LegacyToCanonical(t *testing.T) {
+	removed := []hookInstall{
+		{Event: "SessionStart", Command: "bones tasks prime --json"},
+	}
+	added := []hookInstall{
+		{Event: "SessionStart", Command: "bones tasks prime --hook=session-start"},
+		{Event: "SessionStart", Command: "bones hub start"},
+	}
+	rewrites, installs := pairRewrites(removed, added)
+	if len(rewrites) != 1 {
+		t.Fatalf("want 1 rewrite, got %d:\n%+v", len(rewrites), rewrites)
+	}
+	if rewrites[0].From != "bones tasks prime --json" {
+		t.Errorf("rewrite.From = %q", rewrites[0].From)
+	}
+	if rewrites[0].To != "bones tasks prime --hook=session-start" {
+		// Either of the two adds may be paired (first-match-wins) — but
+		// because the loop matches in event order, the prime one wins
+		// because it was added first.
+		t.Errorf("rewrite.To = %q (expected the prime canonical form)",
+			rewrites[0].To)
+	}
+	// `bones hub start` is the orphan install.
+	if len(installs) != 1 || installs[0].Command != "bones hub start" {
+		t.Errorf("expected orphan install of `bones hub start`, got %+v", installs)
+	}
+}
+
+// TestPairRewrites_PrunedWithoutReplacement covers the PreCompact
+// case: a removed `bones tasks prime` entry has no matching addition
+// under PreCompact (PreCompact is no longer a bones-owned slot). It
+// surfaces as a `hooks rewrote PreCompact "<from>" → ""` line so the
+// operator still sees the change instead of a silent prune.
+func TestPairRewrites_PrunedWithoutReplacement(t *testing.T) {
+	removed := []hookInstall{
+		{Event: "PreCompact", Command: "bones tasks prime --json"},
+	}
+	rewrites, installs := pairRewrites(removed, nil)
+	if len(rewrites) != 1 {
+		t.Fatalf("want 1 rewrite (the prune), got %d:\n%+v", len(rewrites), rewrites)
+	}
+	if rewrites[0].To != "" {
+		t.Errorf("prune-without-replacement should have empty To, got %q",
+			rewrites[0].To)
+	}
+	if len(installs) != 0 {
+		t.Errorf("no installs expected, got %+v", installs)
+	}
+}
+
+// TestShortenCwd_HomeRelative pins the home-directory abbreviation
+// applied to the success signature workspace path.
+func TestShortenCwd_HomeRelative(t *testing.T) {
+	got := shortenCwd("/Users/dan/projects/bones", "/Users/dan")
+	if got != "~/projects/bones" {
+		t.Errorf("shortenCwd: got %q, want %q", got, "~/projects/bones")
+	}
+}
+
+// TestShortenCwd_OutsideHome leaves paths untouched when they don't
+// share the home prefix.
+func TestShortenCwd_OutsideHome(t *testing.T) {
+	got := shortenCwd("/tmp/scratch", "/Users/dan")
+	if got != "/tmp/scratch" {
+		t.Errorf("shortenCwd: got %q, want unchanged", got)
+	}
+}
+
+// TestShortenCwd_EmptyHome falls back to the raw path when HOME is unset.
+func TestShortenCwd_EmptyHome(t *testing.T) {
+	got := shortenCwd("/Users/dan/projects/bones", "")
+	if got != "/Users/dan/projects/bones" {
+		t.Errorf("shortenCwd: got %q, want unchanged", got)
+	}
+}

--- a/cli/up_migration_test.go
+++ b/cli/up_migration_test.go
@@ -32,7 +32,7 @@ func TestSwarmUp_RejectsStaleClaudeWorktrees(t *testing.T) {
 		t.Fatalf("mkdir .bones: %v", err)
 	}
 
-	err := runUp(dir, false, false)
+	err := runUp(dir, upOpts{})
 	if err == nil {
 		t.Fatal("runUp succeeded on workspace with stale agent worktree; want error")
 	}
@@ -56,7 +56,7 @@ func TestSwarmUp_AcceptsCleanWorkspace_NoMigrationFailure(t *testing.T) {
 		t.Fatalf("setup: %v", err)
 	}
 
-	err := runUp(dir, false, false)
+	err := runUp(dir, upOpts{})
 	// runUp may fail downstream (no git repo to scaffold, etc.).
 	// What matters is the migration check did NOT fire.
 	if errors.Is(err, swarm.ErrStaleClaudeWorktrees) {

--- a/cli/uxprint/uxprint.go
+++ b/cli/uxprint/uxprint.go
@@ -125,6 +125,20 @@ func Summary(w io.Writer, n int, noun, verb string) {
 	_, _ = fmt.Fprintf(w, "%d %s %s\n", n, noun, verb)
 }
 
+// Up prints the one-line success signature for `bones up` (issue
+// #314 / convention #323). Workspace is the (possibly home-shortened)
+// workspace path; actionCount is the number of structured per-action
+// lines emitted before this signature.
+//
+//	up       <workspace>  actions=<n>
+//
+// The verb column matches the eight-char width used by the other
+// helpers so a `bones tasks watch`-style scan reads aligned. Workspace
+// is rendered as a bare token (no %q) — it's a path, not a title.
+func Up(w io.Writer, workspace string, actionCount int) {
+	_, _ = fmt.Fprintf(w, "up       %s  actions=%d\n", workspace, actionCount)
+}
+
 // NoOpenTasks prints the filter-emptiness hint emitted by `tasks
 // list` (and read verbs that gate on open/closed) when the filter
 // hid existing closed rows.

--- a/cli/uxprint/uxprint_test.go
+++ b/cli/uxprint/uxprint_test.go
@@ -135,6 +135,31 @@ func TestSummary(t *testing.T) {
 	}
 }
 
+// TestUp pins the `bones up` success signature wording per #314 /
+// the convention from #323. Workspace path is rendered bare; the
+// action count surfaces as `actions=<n>`.
+func TestUp(t *testing.T) {
+	var buf bytes.Buffer
+	Up(&buf, "~/projects/bones", 7)
+	want := "up       ~/projects/bones  actions=7\n"
+	if got := buf.String(); got != want {
+		t.Fatalf("Up: got %q want %q", got, want)
+	}
+}
+
+// TestUpZeroActions covers the no-op-rerun case: `bones up` after a
+// fully-converged workspace emits zero per-action lines and the
+// summary still renders with actions=0 so the operator gets explicit
+// affirmation rather than silence.
+func TestUpZeroActions(t *testing.T) {
+	var buf bytes.Buffer
+	Up(&buf, "/tmp/ws", 0)
+	want := "up       /tmp/ws  actions=0\n"
+	if got := buf.String(); got != want {
+		t.Fatalf("Up zero-actions: got %q want %q", got, want)
+	}
+}
+
 func TestNoOpenTasks(t *testing.T) {
 	var buf bytes.Buffer
 	NoOpenTasks(&buf, 1)

--- a/cli/uxprint_enforce_test.go
+++ b/cli/uxprint_enforce_test.go
@@ -29,6 +29,7 @@ var mutatingVerbs = []struct {
 	{"tasks.update", "tasks_update.go"},
 	{"tasks.link", "tasks_link.go"},
 	{"swarm.dispatch", "swarm_dispatch.go"},
+	{"up", "init.go"},
 }
 
 // TestEveryMutatingVerbCallsUxprint walks each entry in mutatingVerbs

--- a/cmd/bones-schemagen/main.go
+++ b/cmd/bones-schemagen/main.go
@@ -121,6 +121,7 @@ func payloadInstances() map[string]any {
 		"TasksReadyPayload":     &schemas.TasksReadyPayload{},
 		"TasksShowPayload":      &schemas.TasksShowPayload{},
 		"TasksUpdatePayload":    &schemas.TasksUpdatePayload{},
+		"UpPayload":             &schemas.UpPayload{},
 		"WorkspacesGetPayload":  &schemas.WorkspacesGetPayload{},
 		"WorkspacesListPayload": &schemas.WorkspacesListPayload{},
 	}

--- a/cmd/bones/integration/up_output_test.go
+++ b/cmd/bones/integration/up_output_test.go
@@ -43,10 +43,11 @@ func TestCLI_UpHelpADR0041(t *testing.T) {
 	}
 }
 
-// TestCLI_UpDefaultSummary pins #173: default-mode `bones up` lists
-// per-action file footprint changes (wrote files, merged hooks) instead
-// of just "ready at <wsDir>". Operators auditing what bones did to
-// their tree should not need `git status`.
+// TestCLI_UpDefaultSummary pins #314: default-mode `bones up` emits
+// one structured per-action line per change (gitignore add, hook
+// install/rewrite, skill sync, manifest bump) plus a one-line
+// success signature ("up <workspace> actions=<n>"). Operators
+// auditing what bones did to their tree should not need `git status`.
 func TestCLI_UpDefaultSummary(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skip in -short: integration test")
@@ -67,14 +68,16 @@ func TestCLI_UpDefaultSummary(t *testing.T) {
 	}
 	t.Cleanup(func() { _, _, _ = runCmd(t, bonesBin, dir, "down", "--yes") })
 
-	// Default summary must surface concrete file footprint, not just the
-	// pre-#173 "ready at" + hub status.
+	// Default summary must surface the per-action structure introduced
+	// in #314.
 	mustContain := []string{
-		"up: ready at",
-		"up:   wrote",           // file footprint marker
-		"up:   merged",          // hook merge marker
-		".claude/settings.json", // hook target named
-		"up: hub:",              // existing hub status line
+		"gitignore  added",     // gitignore action category
+		"hooks      installed", // hook install line
+		"skills     synced",    // skills sync line
+		"manifest   bumped",    // manifest bump line
+		"up       ",            // success signature verb column
+		"actions=",             // success signature key=value tail
+		"up: hub:",             // existing hub status line
 	}
 	for _, want := range mustContain {
 		if !strings.Contains(stdout, want) {
@@ -118,7 +121,7 @@ func TestCLI_UpWritesAuditLog(t *testing.T) {
 		"finished",  // close banner
 		"exit=0",    // success exit code
 		"duration=", // elapsed
-		"up: ready", // captured terminal output
+		"actions=",  // captured success signature (#314)
 	} {
 		if !strings.Contains(body, want) {
 			t.Errorf("up.log missing %q:\n%s", want, body)

--- a/cmd/bones/integration/up_structured_test.go
+++ b/cmd/bones/integration/up_structured_test.go
@@ -155,6 +155,124 @@ func TestCLI_Up_JSONEnvelope(t *testing.T) {
 	}
 }
 
+// TestCLI_Up_JSONRoutesWarningsToStderr pins the reviewer-flagged
+// regression risk on the #310 surface: in --json mode, post-scaffold
+// WARN lines (tracked-deleted files, gitignore err, fossil drift)
+// must not be silently dropped. They land on stderr while stdout
+// stays a single valid envelope — matches #311's precedent of
+// routing hub URLs to stderr so `bones up --json | jq` works.
+//
+// Fixture: a workspace with one tracked-but-deleted file. The
+// warning copy from formatTrackedDeletedWarning ("missing from
+// working tree (deleted without 'git rm')") must appear on stderr;
+// stdout must parse as the up envelope.
+func TestCLI_Up_JSONRoutesWarningsToStderr(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip in -short: integration test")
+	}
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	dir := newWorkspace(t)
+	gitInit(t, dir)
+	t.Cleanup(func() { _, _, _ = runCmd(t, bonesBin, dir, "down", "--yes") })
+
+	if _, _, code := runCmd(t, bonesBin, dir, "down", "--yes"); code != 0 {
+		t.Fatalf("down --yes failed before warning fixture")
+	}
+
+	plantTrackedDeleted(t, dir)
+
+	stdout, stderr, code := runCmd(t, bonesBin, dir, "up", "--json")
+	if code != 0 {
+		t.Fatalf("up --json: code=%d stderr=%s", code, stderr)
+	}
+
+	// Stdout must remain parseable as the up envelope — no warning
+	// contamination.
+	var env struct {
+		Schema struct {
+			Verb string `json:"verb"`
+		} `json:"schema"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &env); err != nil {
+		t.Fatalf("--json stdout not parseable as envelope: %v\n%s",
+			err, stdout)
+	}
+	if env.Schema.Verb != "up" {
+		t.Errorf("schema.verb=%q want %q", env.Schema.Verb, "up")
+	}
+
+	// Warning must surface on stderr — silence here would be the
+	// regression the reviewer flagged.
+	if !strings.Contains(stderr, "missing from working tree") {
+		t.Errorf("--json should route tracked-deleted warning to stderr; "+
+			"got stderr:\n%s", stderr)
+	}
+	if !strings.Contains(stderr, "to-be-deleted.txt") {
+		t.Errorf("--json stderr warning should name the missing file:\n%s",
+			stderr)
+	}
+}
+
+// TestCLI_Up_QuietDropsWarnings pins the matched negative: --quiet
+// suppresses post-scaffold WARN lines on BOTH stdout and stderr.
+// The operator opted into silence; tracked-deleted warnings stay
+// on the human path (and JSON mode's stderr) only.
+func TestCLI_Up_QuietDropsWarnings(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip in -short: integration test")
+	}
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	dir := newWorkspace(t)
+	gitInit(t, dir)
+	t.Cleanup(func() { _, _, _ = runCmd(t, bonesBin, dir, "down", "--yes") })
+
+	if _, _, code := runCmd(t, bonesBin, dir, "down", "--yes"); code != 0 {
+		t.Fatalf("down --yes failed before quiet fixture")
+	}
+
+	plantTrackedDeleted(t, dir)
+
+	stdout, stderr, code := runCmd(t, bonesBin, dir, "up", "--quiet")
+	if code != 0 {
+		t.Fatalf("up --quiet: code=%d stderr=%s", code, stderr)
+	}
+	if strings.TrimSpace(stdout) != "" {
+		t.Errorf("--quiet stdout not empty:\n%s", stdout)
+	}
+	if strings.Contains(stderr, "missing from working tree") {
+		t.Errorf("--quiet should suppress tracked-deleted warning on stderr too:\n%s",
+			stderr)
+	}
+}
+
+// plantTrackedDeleted commits a file under dir then deletes it from
+// the working tree without `git rm`. Reproduces the #310 trigger
+// state used by the JSON / quiet warning-routing tests.
+func plantTrackedDeleted(t *testing.T, dir string) {
+	t.Helper()
+	tracked := filepath.Join(dir, "to-be-deleted.txt")
+	if err := os.WriteFile(tracked, []byte("hi\n"), 0o644); err != nil {
+		t.Fatalf("write tracked file: %v", err)
+	}
+	for _, args := range [][]string{
+		{"add", "to-be-deleted.txt"},
+		{"commit", "-q", "-m", "track file"},
+	} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	if err := os.Remove(tracked); err != nil {
+		t.Fatalf("delete tracked file: %v", err)
+	}
+}
+
 // TestCLI_Up_LegacyHookRewrite pins #314's load-bearing fix: a
 // workspace whose .claude/settings.json already contains the v0.12
 // `bones tasks prime --json` SessionStart entry triggers a `hooks

--- a/cmd/bones/integration/up_structured_test.go
+++ b/cmd/bones/integration/up_structured_test.go
@@ -1,0 +1,208 @@
+package integration_test
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestCLI_Up_IdempotentSecondRun pins #314's idempotency clause:
+// after a fresh up, a second `bones up` emits zero `added` and zero
+// `rewrote` lines (the workspace is already converged). The success
+// signature still renders, with actions=0.
+func TestCLI_Up_IdempotentSecondRun(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip in -short: integration test")
+	}
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	dir := newWorkspace(t)
+	gitInit(t, dir)
+
+	if _, _, code := runCmd(t, bonesBin, dir, "down", "--yes"); code != 0 {
+		t.Fatalf("pre-up down failed")
+	}
+	if _, stderr, code := runCmd(t, bonesBin, dir, "up"); code != 0 {
+		t.Fatalf("first up: code=%d stderr=%s", code, stderr)
+	}
+	stdout, stderr, code := runCmd(t, bonesBin, dir, "up")
+	if code != 0 {
+		t.Fatalf("second up: code=%d stderr=%s", code, stderr)
+	}
+	t.Cleanup(func() { _, _, _ = runCmd(t, bonesBin, dir, "down", "--yes") })
+
+	for _, forbidden := range []string{
+		"gitignore  added",
+		"hooks      installed",
+		"hooks      rewrote",
+		"manifest   bumped",
+	} {
+		if strings.Contains(stdout, forbidden) {
+			t.Errorf("idempotent second run emitted %q (workspace already converged):\n%s",
+				forbidden, stdout)
+		}
+	}
+	// The success signature still emits — silence on a re-run would be
+	// ambiguous (did bones run? did it crash?). Per #314 the signature
+	// always reports actions=N where N can be 0.
+	if !strings.Contains(stdout, "actions=0") {
+		t.Errorf("idempotent run should still report actions=0:\n%s", stdout)
+	}
+}
+
+// TestCLI_Up_QuietSuppressesEverything pins #314's --quiet contract:
+// stdout must be empty on success when --quiet is passed. Per-action
+// lines AND the summary signature are both suppressed (consistent
+// with the convention #323 set for state-mutating verbs).
+func TestCLI_Up_QuietSuppressesEverything(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip in -short: integration test")
+	}
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	dir := newWorkspace(t)
+	gitInit(t, dir)
+
+	if _, _, code := runCmd(t, bonesBin, dir, "down", "--yes"); code != 0 {
+		t.Fatalf("pre-up down failed")
+	}
+	stdout, stderr, code := runCmd(t, bonesBin, dir, "up", "--quiet")
+	if code != 0 {
+		t.Fatalf("up --quiet: code=%d stderr=%s", code, stderr)
+	}
+	t.Cleanup(func() { _, _, _ = runCmd(t, bonesBin, dir, "down", "--yes") })
+
+	if strings.TrimSpace(stdout) != "" {
+		t.Errorf("--quiet should produce empty stdout on success:\n%s", stdout)
+	}
+}
+
+// TestCLI_Up_JSONEnvelope pins #314's --json contract per the ADR
+// 0053 envelope shape: schema.verb=="up", schema.version=="v1", and
+// data.actions / data.summary present with the documented fields.
+func TestCLI_Up_JSONEnvelope(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip in -short: integration test")
+	}
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	dir := newWorkspace(t)
+	gitInit(t, dir)
+
+	if _, _, code := runCmd(t, bonesBin, dir, "down", "--yes"); code != 0 {
+		t.Fatalf("pre-up down failed")
+	}
+	stdout, stderr, code := runCmd(t, bonesBin, dir, "up", "--json")
+	if code != 0 {
+		t.Fatalf("up --json: code=%d stderr=%s", code, stderr)
+	}
+	t.Cleanup(func() { _, _, _ = runCmd(t, bonesBin, dir, "down", "--yes") })
+
+	var env struct {
+		Schema struct {
+			Verb    string `json:"verb"`
+			Version string `json:"version"`
+		} `json:"schema"`
+		Data struct {
+			Actions []struct {
+				Category string `json:"category"`
+				Action   string `json:"action"`
+				Target   string `json:"target"`
+				From     string `json:"from,omitempty"`
+				To       string `json:"to,omitempty"`
+			} `json:"actions"`
+			Summary struct {
+				Workspace   string `json:"workspace"`
+				ActionCount int    `json:"action_count"`
+			} `json:"summary"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &env); err != nil {
+		t.Fatalf("unmarshal --json output: %v\n%s", err, stdout)
+	}
+	if env.Schema.Verb != "up" {
+		t.Errorf("schema.verb=%q want %q", env.Schema.Verb, "up")
+	}
+	if env.Schema.Version != "v1" {
+		t.Errorf("schema.version=%q want %q", env.Schema.Version, "v1")
+	}
+	if env.Data.Summary.ActionCount != len(env.Data.Actions) {
+		t.Errorf("summary.action_count=%d != len(data.actions)=%d",
+			env.Data.Summary.ActionCount, len(env.Data.Actions))
+	}
+	if env.Data.Summary.Workspace == "" {
+		t.Errorf("summary.workspace empty in:\n%s", stdout)
+	}
+	// Fresh workspace should produce at least one gitignore + one hook
+	// install + one skill sync action.
+	if len(env.Data.Actions) == 0 {
+		t.Fatalf("fresh up produced no actions:\n%s", stdout)
+	}
+	categories := map[string]bool{}
+	for _, a := range env.Data.Actions {
+		categories[a.Category] = true
+	}
+	for _, want := range []string{"gitignore", "hooks", "skills", "manifest"} {
+		if !categories[want] {
+			t.Errorf("fresh up missing category %q in actions:\n%s", want, stdout)
+		}
+	}
+}
+
+// TestCLI_Up_LegacyHookRewrite pins #314's load-bearing fix: a
+// workspace whose .claude/settings.json already contains the v0.12
+// `bones tasks prime --json` SessionStart entry triggers a `hooks
+// rewrote SessionStart "<from>" → "<to>"` line on `bones up`.
+// Silent rewrites were the bug — surfacing them is the fix.
+func TestCLI_Up_LegacyHookRewrite(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip in -short: integration test")
+	}
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	dir := newWorkspace(t)
+	gitInit(t, dir)
+	t.Cleanup(func() { _, _, _ = runCmd(t, bonesBin, dir, "down", "--yes") })
+
+	// Tear down to a clean state, then plant a v0.12 settings.json
+	// containing the legacy `bones tasks prime --json` SessionStart
+	// entry. `bones up` should rewrite it to the canonical
+	// `--hook=session-start` form and surface the change.
+	if _, _, code := runCmd(t, bonesBin, dir, "down", "--yes"); code != 0 {
+		t.Fatalf("down --yes failed before legacy plant")
+	}
+	settingsPath := filepath.Join(dir, ".claude", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
+		t.Fatalf("mkdir .claude: %v", err)
+	}
+	legacy := `{"hooks":{"SessionStart":[{"matcher":"","hooks":[` +
+		`{"command":"bones tasks prime --json","type":"command","timeout":10}` +
+		`]}]}}`
+	if err := os.WriteFile(settingsPath, []byte(legacy), 0o644); err != nil {
+		t.Fatalf("write legacy settings.json: %v", err)
+	}
+
+	stdout, stderr, code := runCmd(t, bonesBin, dir, "up")
+	if code != 0 {
+		t.Fatalf("up: code=%d stderr=%s", code, stderr)
+	}
+
+	mustContain := []string{
+		"hooks      rewrote",
+		"SessionStart",
+		"bones tasks prime --json",               // from
+		"bones tasks prime --hook=session-start", // to
+	}
+	for _, want := range mustContain {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("legacy-rewrite output missing %q:\n%s", want, stdout)
+		}
+	}
+}

--- a/schemas/up.v1.json
+++ b/schemas/up.v1.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "properties": {
+    "actions": {
+      "items": {
+        "properties": {
+          "category": {
+            "type": "string"
+          },
+          "action": {
+            "type": "string"
+          },
+          "target": {
+            "type": "string"
+          },
+          "from": {
+            "type": "string"
+          },
+          "to": {
+            "type": "string"
+          }
+        },
+        "type": "object",
+        "required": [
+          "category",
+          "action",
+          "target"
+        ]
+      },
+      "type": "array"
+    },
+    "summary": {
+      "properties": {
+        "workspace": {
+          "type": "string"
+        },
+        "action_count": {
+          "type": "integer"
+        }
+      },
+      "type": "object",
+      "required": [
+        "workspace",
+        "action_count"
+      ]
+    }
+  },
+  "type": "object",
+  "required": [
+    "actions",
+    "summary"
+  ],
+  "title": "UpPayload",
+  "description": "Payload (`data` field) for `bones up --json` envelope, version v1."
+}


### PR DESCRIPTION
## Summary
- `bones up` now emits one structured grep-friendly line per action (gitignore added, hooks installed/rewrote, skills synced, manifest bumped) terminated by the one-line success signature `up <workspace> actions=<n>` via the new `uxprint.Up` helper.
- Silent v0.12 → ADR 0051 hook rewrites (`bones tasks prime --json` → `--hook=session-start`) are now surfaced as `hooks rewrote <event> "<from>" → "<to>"` lines — the bug fix is making them visible.
- Adds `--json` (ADR 0053 envelope; `cli/schemas/up.go` + `schemas/up.v1.json` registered with the schemagen pipeline) and `--quiet` (suppresses per-action lines AND the summary signature, per #323's convention for state-mutating verbs).

## Test plan
- [x] Unit: `cli/up_actions_test.go` covers `renderUpAction`, `buildUpActions` (full set + idempotent), `pairRewrites` (legacy→canonical + prune-without-replacement), and `shortenCwd`.
- [x] Unit: `cli/uxprint/uxprint_test.go` adds `TestUp` and `TestUpZeroActions` pinning the success-signature wording.
- [x] Integration (`cmd/bones/integration/up_structured_test.go`): fresh-up shape, idempotent second run (zero `added`/`rewrote` lines, summary still emits `actions=0`), `--quiet` produces empty stdout, `--json` envelope round-trips with documented schema/version/data fields, legacy-hook rewrite surfaces with from/to.
- [x] Existing audit-log + default-summary integration tests updated to match the new shape.
- [x] `make schemas` regenerated `schemas/up.v1.json`.
- [x] `make check` clean (only the pre-existing `TestStatusAllEmptyRegistry` flake; unchanged in scope).
- [x] `go test -tags=otel -short ./...` clean modulo same flake.

Closes #314