### PR TITLE
feat(tasks watch): switch live tail to event log per ADR 0052

### DIFF
--- a/cli/schemas_test.go
+++ b/cli/schemas_test.go
@@ -271,6 +271,11 @@ func TestEvery_JSONFlag_HasRegistryEntry(t *testing.T) {
 	}
 	exempt := map[string]bool{
 		"logs.go": true, // ADR 0053 / ADR 0052 carve-out
+		// tasks_watch.go --json emits streaming NDJSON
+		// (one EventEnvelope per line) per ADR 0052; the
+		// registry holds one-shot envelope verbs only. Same
+		// carve-out shape as logs.go.
+		"tasks_watch.go": true,
 	}
 
 	registered := make(map[string]struct{}, len(schemas.Verbs))

--- a/cli/tasks_watch.go
+++ b/cli/tasks_watch.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -15,15 +16,23 @@ import (
 	"github.com/danmestas/bones/internal/timefmt"
 )
 
-// TasksWatchCmd subscribes to the task event log and streams human-
-// readable lifecycle events to stdout until Ctrl-C or context
-// cancellation. Default is live-only per ADR 0052; --from and --since
-// opt into a one-shot backfill before tailing.
+// migrationMarkerTaskID is the synthetic ID recovery uses to record
+// that a v0.12 → v0.13 KV→event-log migration ran. The marker emits as
+// a Created event but is internal bookkeeping; user-facing surfaces
+// (watch, both human and JSON) filter it out.
+const migrationMarkerTaskID = "__bones_tasks_events_migrated"
+
+// TasksWatchCmd subscribes to the task event log and streams lifecycle
+// events to stdout until Ctrl-C or context cancellation. Default is
+// live-only per ADR 0052; --from and --since opt into a one-shot
+// backfill before tailing. --json switches the output to one
+// EventEnvelope JSON object per line for downstream automation.
 type TasksWatchCmd struct {
 	From uint64 `name:"from" help:"start at stream sequence (excl with --since)"`
 	// Since takes a Go time.Duration (e.g. "24h"). Mutually exclusive
 	// with --from. Default zero means live-only consumption.
 	Since time.Duration `name:"since" help:"start at wall-clock offset (excl with --from)"`
+	JSON  bool          `name:"json" help:"emit one EventEnvelope JSON object per line"`
 }
 
 func (c *TasksWatchCmd) Run(g *repocli.Globals) error {
@@ -55,13 +64,17 @@ func (c *TasksWatchCmd) Run(g *repocli.Globals) error {
 	}
 	defer func() { _ = m.Close() }()
 
+	emit := watchEmitter(c.JSON)
+
 	// One-shot backfill if --from or --since is set; happens before the
-	// live KV-watch tail so operators see history then live updates.
-	if err := watchBackfill(ctx, m, c.From, c.Since); err != nil {
+	// live tail so operators see history then live updates. Backfill
+	// uses Replay (one-shot drain), live uses the new event-log
+	// subscription primitive (ADR 0052 follow-on, #343).
+	if err := watchBackfill(ctx, m, c.From, c.Since, emit); err != nil {
 		return err
 	}
 
-	ch, err := m.Watch(ctx)
+	ch, err := m.Live(ctx)
 	if err != nil {
 		return fmt.Errorf("watch: subscribe: %w", err)
 	}
@@ -72,23 +85,43 @@ func (c *TasksWatchCmd) Run(g *repocli.Globals) error {
 		select {
 		case <-ctx.Done():
 			return nil
-		case ev, ok := <-ch:
+		case env, ok := <-ch:
 			if !ok {
 				return nil
 			}
-			printTaskEvent(ev)
+			if env.TaskID == migrationMarkerTaskID {
+				continue
+			}
+			emit(env)
 		}
 	}
 }
 
-// watchBackfill runs Replay with --from / --since options and renders
-// each event before the live tail starts. Default behavior (both flags
-// zero) is live-only; nothing prints until the first live event.
+// watchEmitter returns the formatter used for both backfill and live
+// output. Two shapes: human (printEventEnvelope) or JSONL (one encoded
+// EventEnvelope per line). The switch happens once at the top of Run
+// so the loop body stays branch-free.
+func watchEmitter(asJSON bool) func(tasks.EventEnvelope) {
+	if asJSON {
+		enc := json.NewEncoder(os.Stdout)
+		return func(env tasks.EventEnvelope) {
+			_ = enc.Encode(env)
+		}
+	}
+	return printEventEnvelope
+}
+
+// watchBackfill runs Replay with --from / --since options and emits
+// each event through the provided emitter before the live tail starts.
+// Default behavior (both flags zero) is live-only; nothing prints
+// until the first live event. The migration marker is filtered here
+// too so backfill output mirrors live behavior.
 func watchBackfill(
 	ctx context.Context,
 	m *tasks.Manager,
 	from uint64,
 	since time.Duration,
+	emit func(tasks.EventEnvelope),
 ) error {
 	if from == 0 && since == 0 {
 		return nil
@@ -101,42 +134,22 @@ func watchBackfill(
 		return fmt.Errorf("watch: backfill: %w", err)
 	}
 	for _, env := range envs {
-		printEventEnvelope(env)
+		if env.TaskID == migrationMarkerTaskID {
+			continue
+		}
+		emit(env)
 	}
 	return nil
 }
 
-// printEventEnvelope renders a single event-log envelope in the same
-// shape as printTaskEvent so live and backfill output align. The
-// bracket prefix is timefmt.Display per #324 — live operator surface,
-// local time + zone abbreviation.
+// printEventEnvelope renders a single event-log envelope in human-
+// readable form. The bracket prefix is timefmt.Display per #324 —
+// operator surface, local time + zone abbreviation. Both backfill and
+// live paths route through this helper after the event-log migration
+// (#343); the prior printTaskEvent (KV-watch shape, time.Now()
+// timestamps) is removed.
 func printEventEnvelope(env tasks.EventEnvelope) {
 	ts := timefmt.Display(env.Timestamp.Time)
 	fmt.Printf("[%s] %-12s id=%s seq=%d\n",
 		ts, env.Type.String(), env.TaskID, env.StreamSeq)
-}
-
-// printTaskEvent formats a single tasks.Event as a timestamped line.
-// Retained for the live KV-watch path; the event-log path uses
-// printEventEnvelope above.
-func printTaskEvent(ev tasks.Event) {
-	ts := timefmt.Display(time.Now())
-	switch ev.Kind {
-	case tasks.EventCreated:
-		fmt.Printf("[%s] created  task=%q id=%s\n", ts, ev.Task.Title, ev.ID)
-	case tasks.EventUpdated:
-		switch ev.Task.Status {
-		case tasks.StatusClaimed:
-			fmt.Printf("[%s] claimed  task=%q by=%s id=%s\n",
-				ts, ev.Task.Title, ev.Task.ClaimedBy, ev.ID)
-		case tasks.StatusClosed:
-			fmt.Printf("[%s] closed   task=%q id=%s\n",
-				ts, ev.Task.Title, ev.ID)
-		default:
-			fmt.Printf("[%s] updated  task=%q status=%s id=%s\n",
-				ts, ev.Task.Title, ev.Task.Status, ev.ID)
-		}
-	case tasks.EventDeleted:
-		fmt.Printf("[%s] deleted  id=%s\n", ts, ev.ID)
-	}
 }

--- a/internal/tasks/live_reader_test.go
+++ b/internal/tasks/live_reader_test.go
@@ -1,0 +1,157 @@
+package tasks_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/danmestas/bones/internal/tasks"
+)
+
+// TestLive_DeliversNewEvents asserts that an event published *after* a
+// Live subscription opens lands on the channel within a short window.
+// Pins the basic happy path: subscribe, mutate, receive.
+func TestLive_DeliversNewEvents(t *testing.T) {
+	m, _, cleanup := openEventLogManager(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ch, err := m.Live(ctx)
+	if err != nil {
+		t.Fatalf("Live: %v", err)
+	}
+
+	rec := txNewTask("bones-live-1")
+	if err := m.Tx(ctx, rec.ID, func(tx *tasks.Tx) error {
+		return tx.Create(rec)
+	}); err != nil {
+		t.Fatalf("Tx.Create: %v", err)
+	}
+
+	select {
+	case env, ok := <-ch:
+		if !ok {
+			t.Fatal("channel closed before event arrived")
+		}
+		if env.TaskID != rec.ID {
+			t.Errorf("got TaskID %q, want %q", env.TaskID, rec.ID)
+		}
+		if env.Type != tasks.EventTypeCreated {
+			t.Errorf("got Type %s, want EventTypeCreated", env.Type)
+		}
+		if env.Timestamp.IsZero() {
+			t.Error("envelope Timestamp is zero — Live must preserve the original event time")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for live event delivery")
+	}
+}
+
+// TestLive_PreSubscribeEventsNotDelivered pins the DeliverNewPolicy
+// semantic: events published *before* Live subscribes are NOT delivered
+// to that subscriber. Replay covers backfill; Live is for new events
+// only.
+func TestLive_PreSubscribeEventsNotDelivered(t *testing.T) {
+	m, _, cleanup := openEventLogManager(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Mutate before subscribing.
+	pre := txNewTask("bones-live-pre")
+	if err := m.Tx(ctx, pre.ID, func(tx *tasks.Tx) error {
+		return tx.Create(pre)
+	}); err != nil {
+		t.Fatalf("Tx.Create pre: %v", err)
+	}
+
+	ch, err := m.Live(ctx)
+	if err != nil {
+		t.Fatalf("Live: %v", err)
+	}
+
+	// Mutate after subscribing.
+	post := txNewTask("bones-live-post")
+	if err := m.Tx(ctx, post.ID, func(tx *tasks.Tx) error {
+		return tx.Create(post)
+	}); err != nil {
+		t.Fatalf("Tx.Create post: %v", err)
+	}
+
+	// Drain for a short window. Only the post-subscribe event is allowed.
+	deadline := time.After(1500 * time.Millisecond)
+	seen := make(map[string]bool)
+loop:
+	for {
+		select {
+		case env, ok := <-ch:
+			if !ok {
+				break loop
+			}
+			seen[env.TaskID] = true
+		case <-deadline:
+			break loop
+		}
+	}
+
+	if seen[pre.ID] {
+		t.Errorf("Live delivered pre-subscribe event for %q (DeliverNewPolicy violated)", pre.ID)
+	}
+	if !seen[post.ID] {
+		t.Errorf("Live did not deliver post-subscribe event for %q", post.ID)
+	}
+}
+
+// TestLive_StopsOnCtxCancel pins that canceling ctx closes the channel
+// promptly so callers see an end-of-stream signal rather than blocking.
+func TestLive_StopsOnCtxCancel(t *testing.T) {
+	m, _, cleanup := openEventLogManager(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ch, err := m.Live(ctx)
+	if err != nil {
+		t.Fatalf("Live: %v", err)
+	}
+
+	cancel()
+
+	select {
+	case _, ok := <-ch:
+		if ok {
+			// A late event arriving before cleanup is fine; just keep
+			// draining until the channel closes.
+			select {
+			case _, ok2 := <-ch:
+				if ok2 {
+					t.Error("channel still open after multiple drain attempts post-cancel")
+				}
+			case <-time.After(2 * time.Second):
+				t.Error("timed out waiting for channel close after ctx cancel")
+			}
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for channel close after ctx cancel")
+	}
+}
+
+// TestLive_ErrorWhenEventLogDisabled pins the contract that Live
+// returns an error rather than a nil channel when the manager wasn't
+// opened with EnableEventLog. openTestManager (in subscribe_test.go)
+// opens the KV-only mode used by tests that don't need the log.
+func TestLive_ErrorWhenEventLogDisabled(t *testing.T) {
+	m, _, cleanup := openTestManager(t)
+	defer cleanup()
+
+	_, err := m.Live(context.Background())
+	if err == nil {
+		t.Fatal("Live with event log disabled should return error")
+	}
+	if !strings.Contains(err.Error(), "event log disabled") {
+		t.Errorf("error %q should mention event log disabled", err.Error())
+	}
+}

--- a/internal/tasks/log_reader.go
+++ b/internal/tasks/log_reader.go
@@ -131,6 +131,77 @@ func drainReplay(
 	}
 }
 
+// Live opens a live subscription to the task event log. The returned
+// channel emits envelopes published *after* the call (DeliverNewPolicy)
+// until ctx is canceled, the manager is closed, or the underlying
+// consumer stops. Symmetric to Replay (one-shot drain) but for the
+// continuous tail used by `bones tasks watch`.
+//
+// Per ADR 0052 the event log is the source of truth for task state;
+// Live consumers see the full envelope (Type, TaskID, Timestamp,
+// Payload) on every event — no projection lookup required. Field-level
+// changes for EventTypeUpdated land in the payload, so context-only
+// updates surface here even though they don't mutate the KV projection
+// shape consumers can distinguish.
+//
+// Callers must drain the channel promptly; a blocked reader stalls the
+// forwarder. Buffer is sized for typical interactive use (64). Decode
+// errors are dropped silently — one malformed record does not poison
+// the stream.
+func (m *Manager) Live(ctx context.Context) (<-chan EventEnvelope, error) {
+	assert.NotNil(ctx, "tasks.Live: ctx is nil")
+	if m.stream == nil {
+		return nil, errors.New("tasks.Live: event log disabled")
+	}
+
+	cons, err := m.stream.OrderedConsumer(ctx, jetstream.OrderedConsumerConfig{
+		FilterSubjects: []string{AllEventsSubject},
+		DeliverPolicy:  jetstream.DeliverNewPolicy,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("tasks.Live: consumer: %w", err)
+	}
+
+	out := make(chan EventEnvelope, 64)
+	go forwardLive(ctx, cons, out)
+	return out, nil
+}
+
+// forwardLive bridges a JetStream consumer to the EventEnvelope channel.
+// Callbacks fired by Consume marshal-and-send each envelope; the loop
+// blocks on ctx.Done so the goroutine has a single exit path. cc.Stop
+// flushes in-flight callbacks before close(out) so a late callback
+// never writes to a closed channel.
+func forwardLive(
+	ctx context.Context,
+	cons jetstream.Consumer,
+	out chan EventEnvelope,
+) {
+	cc, err := cons.Consume(func(msg jetstream.Msg) {
+		env, perr := UnmarshalEnvelope(msg.Data())
+		_ = msg.Ack()
+		if perr != nil {
+			return
+		}
+		meta, _ := msg.Metadata()
+		if meta != nil {
+			env.StreamSeq = meta.Sequence.Stream
+		}
+		select {
+		case out <- env:
+		case <-ctx.Done():
+		}
+	})
+	if err != nil {
+		close(out)
+		return
+	}
+
+	<-ctx.Done()
+	cc.Stop()
+	close(out)
+}
+
 // Recent returns the most recent n events from the log in stream
 // order (oldest of the slice first, newest last). Used by
 // `bones status` for the Recent Activity surface.

--- a/internal/tasks/tx_test.go
+++ b/internal/tasks/tx_test.go
@@ -90,6 +90,7 @@ func TestTx_OnlyMutationPath(t *testing.T) {
 		"Get":       true,
 		"KVForTest": true, // exposed for in-package test seeding only
 		"List":      true,
+		"Live":      true,
 		"Purge":     true,
 		"Recent":    true,
 		"Replay":    true,


### PR DESCRIPTION
## Summary

- Adds `Manager.Live(ctx)` event-log streaming primitive symmetric to `Replay`
- Switches `bones tasks watch` live tail from KV `Watch` to event-log `Live` so replay events carry original timestamps and `--context` updates surface field-change info
- Adds `bones tasks watch --json` (streaming NDJSON, one `EventEnvelope` per line)
- Filters the `__bones_tasks_events_migrated` recovery marker from the user-facing stream
- Removes the now-dead `printTaskEvent` KV-watch formatter

Closes #343

## Test plan

- [x] `go test ./internal/tasks/...` — 4 new Live tests + the Manager method whitelist update
- [x] `make check` — all gates pass (fmt, vet, lint, race, todo)
- [x] `go test -tags=otel -short ./...` — 1201 tests pass across 35 packages
- [ ] Manual smoke: `bones tasks watch --json` in a workspace, write events, verify NDJSON output