### PR TITLE
docs(adr): 0048 coord narrows to its used chat surface

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -139,6 +139,17 @@ chat}`. Domain may import substrate; substrate may not import
 domain (enforced by `depguard` in `.golangci.yml`). See ADR 0025
 for the layering rule and its known exceptions.
 
+**Substrate API discipline.** A substrate verb ships only when a
+non-test caller ships in the same change. Speculative APIs —
+verbs that "the substrate could support" but no caller exercises —
+are rejected at ADR review. An ADR that proposes adding a verb
+names the caller, the failure semantics, and the wire shape; if
+the caller is hypothetical, the ADR is rejected. Applies to every
+substrate package (`internal/coord/`, `internal/coord/thread/`,
+`internal/swarm/`, `internal/holds/`, `internal/tasks/`, future
+ones). ADR 0048 is the first enforcement of this rule and the
+worked example.
+
 ## Process
 
 **Orchestrator.** The role that drives bootstrap (`bones up`),

--- a/docs/adr/0023-hub-leaf-orchestrator.md
+++ b/docs/adr/0023-hub-leaf-orchestrator.md
@@ -1,6 +1,7 @@
 # ADR 0023 — Hub-leaf orchestrator
 
 **Status:** Accepted (2026-04-26, deployment merge 2026-04-29)
+**Amended by:** ADR 0048 — the orchestrator's task-thread messaging surface is `Post` / `Subscribe` / `Who` on `internal/coord/thread`, not the wider chat surface this ADR was written against. The hub-leaf substrate, autosync, trunk linearization, and slot-disjointness properties below are unchanged.
 
 ## Context
 
@@ -96,8 +97,8 @@ caller-driven.
 5. Slot disjointness — plan validator enforces it; coord trusts it.
    Amended by ADR 0050: applies to plan-anchored slots only. Synthetic
    agent slots (issue #266) target overlapping files by design and rely
-   on fossil auto-fork (ADR 0010 §4) plus chat-on-conflict (§5) as the
-   recovery path.
+   on fossil auto-fork (ADR 0010 §4) plus thread-post-on-conflict (per
+   ADR 0048's narrowed messaging surface) as the recovery path.
 
 ## Tradeoffs
 

--- a/docs/adr/0048-coord-narrows-chat-surface.md
+++ b/docs/adr/0048-coord-narrows-chat-surface.md
@@ -1,0 +1,100 @@
+# ADR 0048 — Coord narrows to its used chat surface
+
+**Status:** Accepted
+**Supersedes:** ADR 0008 (chat substrate definition), ADR 0047 (chat-on-JetStream — the JetStream backing is kept; the API surface narrows)
+**Amends:** ADR 0023 (the orchestrator's messaging surface is `Post` / `Subscribe` / `Who`, not chat)
+
+## Context
+
+ADR 0008 introduced a chat substrate over raw NATS request/reply. ADR 0047 migrated the chat substrate to a JetStream stream owned by `internal/chat.Manager` and routed `coord.Subscribe` over `js.OrderedConsumer`. The two together left `internal/coord` exposing a wide chat-flavored surface:
+
+```go
+// internal/coord/coord.go (selected)
+func (c *Coord) Post(ctx, taskID, body) error
+func (c *Coord) Subscribe(ctx, thread) (<-chan Event, func(), error)
+func (c *Coord) SubscribePattern(ctx, pattern) (<-chan Event, func(), error)
+func (c *Coord) Who(ctx) ([]Presence, error)
+func (c *Coord) WatchPresence(ctx) (<-chan PresenceEvent, func(), error)
+func (c *Coord) Ask(ctx, recipient, body) ([]byte, error)
+func (c *Coord) AskAdmin(ctx, body) ([]byte, error)
+func (c *Coord) Answer(ctx, recipient, handler) (func(), error)
+func (c *Coord) React(ctx, taskID, target, glyph) error
+func (c *Coord) Threads(ctx, agent) ([]Thread, error)
+func (c *Coord) Heartbeat(ctx) error
+```
+
+The orchestrator and dispatch paths exercise three of those verbs: `Post` (event emission for tasks and reaped sessions), `Subscribe` (task-thread tail in `tasks_dispatch.go`), and `Who` (peer enumeration in `tasks_list.go`). The remaining verbs (`Ask`, `AskAdmin`, `React`, `SubscribePattern`, `WatchPresence`, `Threads`, `Heartbeat`) have no production callers — only tests reach them. The unused surface comes with maintenance load: per-verb wire-format tests, `OrderedConsumer` lifecycle, presence schema, raw-NATS request/reply plumbing, and an `AskAdmin` pre-flight handshake.
+
+Two related shapes fall out of the same accumulation:
+
+**`internal/coord` is a wide-surface package, not a deep module.** `coord.go` alone is 829 lines exposing ~25 methods; production callers hand-pick from that menu. Per Ousterhout, depth is the ratio of hidden complexity to interface size. A package with 25 exported methods of which 9 are reached is not deep — it is a grab-bag held together by package boundary alone.
+
+**The chat surface and the task-substrate surface live in the same import path.** `Open`, `Close`, `Claim`, `Release`, `Reclaim`, `Handoff`, `OpenTask`, `CloseTask`, `Compact`, `Link`, `Block`, `Ready`, the leaf/hub primitives, and `Prime` are the substrate the orchestrator depends on for correctness. `Post` / `Subscribe` / `Who` ride the same package because chat originally lived there, not because callers need them adjacent. Every reader of `coord` carries the chat APIs in their working memory regardless of whether they touch them.
+
+## Decision
+
+The coord package retains exactly the chat surface its callers exercise. The unused chat verbs are deleted. The retained chat surface moves to a sub-package so the task substrate stops carrying it.
+
+### Retained
+
+```go
+// internal/coord/thread (new sub-package)
+type Message struct {
+    From      string
+    Body      []byte
+    Timestamp time.Time
+}
+
+type Peer struct {
+    AgentID string
+    Slot    string
+}
+
+func (t *Thread) Post(ctx context.Context, threadID string, body []byte) error
+func (t *Thread) Subscribe(ctx context.Context, threadID string) (<-chan Message, func(), error)
+func (t *Thread) Who(ctx context.Context) ([]Peer, error)
+```
+
+`internal/coord/thread` hides its transport. The JetStream backing from ADR 0047 — stream name, subject tree, ordered-consumer lifecycle, presence KV, wire envelope, deterministic-thread-hash convergence — is an implementation detail of the sub-package, not part of its interface. Callers see only the three-verb surface above and the two value types it returns. `Event`, `Envelope`, and the union variants for reactions and media are no longer exported from any coord package; they were the type-level surface of the deleted verbs and have no callers.
+
+`internal/coord` (the parent package) keeps the task substrate: `Open`, `Close`, `Claim`, `Release`, `Reclaim`, `Handoff`, `OpenTask`, `CloseTask`, `Compact`, `Link`, `Block`, `Ready`, leaf/hub/media primitives, `Prime`, and the `bones-swarm-sessions` provisioning. This is the substrate the orchestrator depends on for correctness.
+
+### Removed
+
+The verbs `Ask`, `AskAdmin`, `Answer`, `React`, `SubscribePattern`, `WatchPresence`, `Threads`, and `Heartbeat` are removed from the coord surface, along with their wire types (`Envelope`, `Event`, the reaction and media variants), the raw-NATS request/reply plumbing they relied on, and their tests.
+
+The deletion is not a deferral — these verbs are removed from the public surface, not hidden. If a future caller needs an `Ask`-shaped RPC, a reaction stream, or a thread-pattern subscription, the architectural work begins fresh: a new ADR identifies the concrete caller, the wire format, and the failure semantics.
+
+### Acquisition
+
+The substrate constructor returns the task-substrate handle and the thread handle as separate values from a single call:
+
+```go
+sub, thread, err := coord.Open(ctx, cfg)
+```
+
+A single combined handle would re-introduce the wide-surface anti-pattern this ADR exists to retire — callers would see thread methods alongside claim and lease methods on the same receiver. Two handles concentrate the import-site change to one location per caller and keep the surfaces distinct. Callers that touch only the task substrate ignore the thread handle; callers that touch only thread messaging acquire the substrate handle but use only its lifecycle.
+
+## Depth invariant
+
+After this change, `internal/coord`'s public surface is exactly the set of operations the orchestrator and dispatch paths exercise to maintain task-substrate correctness. `internal/coord/thread`'s public surface is exactly the set of operations the orchestrator and dispatch paths exercise to emit and observe task-thread messages. Neither surface exposes its transport.
+
+## Non-goal: addressed delivery
+
+`thread.Post` is broadcast emission to a thread, not addressed delivery. It has no recipient field, no correlation ID, and no reply channel — by design. `thread.Subscribe` returns the broadcast as it arrives; consumers select what concerns them. An RPC-shaped substrate (request/reply, addressed messages, awaited responses) is a separate ADR with its own concrete caller. A future change that adds a `ReplyTo`, `Recipient`, or `CorrelationID` field to `Message` is the architectural shape this ADR exists to prevent.
+
+## Rule for future ADRs
+
+This is the local enforcement of the project-wide substrate-API discipline stated in CONTEXT.md: **a coord verb ships only when a non-test caller ships in the same change.** Speculative substrate APIs — verbs that "the substrate could support" but no caller exercises — do not belong in `internal/coord` or `internal/coord/thread`. A future ADR that proposes adding a verb names the caller, the failure semantics, and the wire shape. If the caller is hypothetical, the ADR is rejected.
+
+This rule is what supersedes ADRs 0008 and 0047. Their architectural intent — chat is a first-class substrate, JetStream is its transport — is preserved in `internal/coord/thread`. Their accumulated API surface, built ahead of callers, is not.
+
+## Consequences
+
+**For the orchestrator role:** boot is unchanged. The three retained chat verbs migrate to the new import path; no CLI verb name changes.
+
+**For substrate readers:** `internal/coord` becomes a deeper module. The methods on `*Coord` are the ones the orchestrator and dispatch paths rely on for correctness, with no chat APIs sharing namespace with claim and lease semantics.
+
+**For ADR 0023 (hub-leaf orchestrator):** the orchestrator's messaging surface is exactly `thread.Post` / `thread.Subscribe` / `thread.Who`. References to "chat" in 0023 narrow accordingly. The hub-leaf substrate, autosync, and trunk linearization properties are unchanged.
+
+**For tests:** smoke tests for the deleted verbs are deleted along with the verbs — they had no other callers. Per-verb tests for the retained surface live in `internal/coord/thread` and run against an embedded NATS server (the substrate-test rule from CONTEXT.md applies — no mocks for substrate behavior).

--- a/docs/audits/2026-05-09-cut-sequence.md
+++ b/docs/audits/2026-05-09-cut-sequence.md
@@ -1,0 +1,256 @@
+# Cut Sequence — Ousterhout Deletion Pass
+
+Sequenced PR plan to absorb the deletions agreed in the 2026-05-09 grilling
+session. Total: ~9K LOC removed across 8 PRs in 5 waves. End state: doctor
+distributed into substrate `Healthy()` checks, coord narrowed to its used
+surface (chat verbs deleted, kept verbs in `coord/thread/`), telemetry
+reduced to the OTEL core ADR 0040 mandates, three pass-through verbs gone,
+two pure-UX packages gone.
+
+## Wave 1 — Isolated cleanups (parallelizable)
+
+Three independent PRs touching disjoint files. Land any order, any time. No
+dependencies on the rest of the plan. Build review-confidence cheaply.
+
+### PR 1 — Remove `internal/banner`
+
+- Delete `internal/banner/`.
+- Strip banner calls from `cli/up.go`, `cli/apply.go`, anywhere else `grep`
+  finds them.
+- ~?? LOC removed (need final `wc -l`); orchestrator boot path unchanged.
+
+### PR 2 — Remove `internal/updatecheck`
+
+- Delete `internal/updatecheck/`.
+- Strip background-goroutine launch from main.go / root command bootstrap.
+- ~230 LOC.
+
+### PR 3 — Remove `cli/peek.go` + `cli/rename.go`
+
+- Delete both files and their tests.
+- Remove command registration from `cli/root.go` (or wherever subcommands
+  register).
+- ~250 LOC. No substrate or coordination impact.
+
+## Wave 2 — Documentation (gates Wave 3)
+
+### PR 4 — ADR 0048 + CONTEXT.md + ADR 0023 narrowing
+
+- `docs/adr/0048-coord-narrows-chat-surface.md` (already drafted,
+  MERGE-ready).
+- `CONTEXT.md` Layering section gains "Substrate API discipline" rule
+  (already applied locally — needs to ship in this PR).
+- `docs/adr/0023-hub-leaf-orchestrator.md` — narrow the "messaging
+  surface" reference per ADR 0048's amends. One-line edit; lands in
+  this PR, not deferred.
+- Docs only. No code changes. Establishes the architectural cover for
+  Wave 3.
+
+## Wave 3 — Chat verb deletion + coord/thread split (gated by PR 4)
+
+Two PRs because bundling them produces a single ~3K-LOC review. Splitting
+makes each digestible.
+
+### PR 5 — Delete the unused chat verb files
+
+Narrow scope: verb-file deletion only. Type changes (unexporting
+`Envelope`/`Event`, retyping `Subscribe`'s return) defer to PR 6 — doing
+both in PR 5 produces a transient broken state where `Subscribe` returns
+a type that's no longer exported.
+
+- Delete `internal/coord/{ask,ask_admin,react,subscribe_pattern}.go` and
+  their tests.
+- Delete `WatchPresence` method body + the half of `presence_test.go` that
+  exercises it.
+- Delete `Threads` and `Heartbeat` methods from `coord.go`.
+- Delete `Answer` method (the receive half of Ask).
+- Delete `chat_smoke_test.go`.
+- Delete the raw-NATS request/reply plumbing in `coord.go` (subjects under
+  `<proj>.ask.<recipient>`).
+- **Keep** `Envelope`, `Event`, and the reaction/media variants exported
+  for now — `Subscribe` still returns `<-chan Event` until PR 6 retypes
+  it. They lose their reaction/media producer code in PR 5 but remain
+  reachable types.
+- ~2.4K LOC removed. Coord stays in one package; `Post`/`Subscribe`/`Who`
+  signatures unchanged.
+- Real-substrate tests for Post/Subscribe/Who continue to pass against the
+  trimmed surface.
+
+### PR 6 — Split `internal/coord/thread/` sub-package
+
+- Create `internal/coord/thread/` with the 3-verb interface:
+  ```go
+  type Thread struct { /* unexported */ }
+  type Message struct { From string; Body []byte; Timestamp time.Time }
+  type Peer struct { AgentID string; Slot string }
+  func (t *Thread) Post(ctx, threadID, body) error
+  func (t *Thread) Subscribe(ctx, threadID) (<-chan Message, func(), error)
+  func (t *Thread) Who(ctx) ([]Peer, error)
+  ```
+- Move JetStream stream wiring + presence KV from coord into thread.
+- `coord.Open` returns `(*Coord, *Thread, error)` (two handles, one call).
+- Update callers:
+  - `cli/swarm_close.go`              → `thread.Post`
+  - `cli/swarm_reap.go`               → `thread.Post`
+  - `cli/tasks_autoclaim.go`          → `thread.Post`
+  - `cli/tasks_dispatch.go`           → `thread.Post`, `thread.Subscribe`
+  - `cli/tasks_list.go`               → `thread.Who`
+  - `examples/hub-leaf-e2e/main.go`   → updated `coord.Open` signature
+  - `examples/herd-hub-leaf/harness.go` → updated `coord.Open` signature
+  - test helpers in `internal/testutil/` (any that wrap `coord.Open`)
+- Unexport `Envelope` (wire format) and the previously-public `Event`
+  reaction/media union. `Subscribe` retypes to `<-chan Message`. This is
+  the type-change PR 5 deferred.
+- Real-substrate tests for the three verbs land in
+  `internal/coord/thread/`. No mocks (CONTEXT.md rule).
+- ~500 LOC moved + ~300 LOC of new tests. Net ~+200 LOC short-term, but
+  unlocks the depth invariant from ADR 0048.
+
+## Wave 4 — Telemetry shim cleanup (independent)
+
+Lands any time after Wave 1. No dependencies. Split on the
+ADR-0040-mandate axis: mechanical deletion separates from judgment-heavy
+audit so each gets the review attention it warrants.
+
+### PR 7a — Delete the four shallow shims (mechanical)
+
+- Delete `cli/installid.go`, `cli/notice.go`, `cli/scrub.go`,
+  `cli/telemetry_default.go` and their tests.
+- ~2K LOC removed. Pure deletion. No ADR 0040 contract surface affected.
+
+### PR 7b — Trim `telemetry.go` and `telemetry_otel.go` against ADR 0040
+
+- Audit `cli/telemetry.go` and `cli/telemetry_otel.go` against the
+  contract ADR 0040 mandates: default-on Axiom export, opt-out semantics,
+  install-id provenance.
+- Delete what isn't required by that contract.
+- Confirm `cli/init_otel.go` (the OTEL SDK setup) is untouched.
+- Confirm `cli/optout.go` (consent semantics) is untouched.
+- ~1.9K LOC removed.
+- Re-run telemetry integration tests against the trimmed surface.
+
+7a lands first; 7b is the judgment call that benefits from a smaller
+prior PR establishing the cut shape.
+
+## Wave 5 — Doctor distribution (independent, biggest architectural)
+
+Lands after Wave 3 so the new substrate shape (coord + coord/thread) is
+stable. Splits into three sequential PRs to keep review burden bounded.
+
+### PR 8a — Define `Healthy()` interface + add to one substrate
+
+- Define a minimal interface in `internal/coord/`:
+  ```go
+  type Healther interface {
+      Healthy(ctx context.Context) error
+  }
+  ```
+- Implement on `swarm.Manager` first as proof: existing `bones-swarm-sessions`
+  bucket reachability + lease invariants.
+- Add a thin runner in `cli/doctor.go` that iterates known Healthers.
+- One existing `checkX` aggregator in doctor.go calls swarm's `Healthy()`
+  instead of inlining its check.
+- ~150 LOC added, ~60 LOC removed from doctor. Net small.
+
+### PR 8b — Migrate remaining checks into substrate managers
+
+- Each `checkX` aggregator in `cli/doctor.go` (9 of them) moves to the
+  substrate manager that owns the invariant:
+  - hooks-drift → `internal/skills/`
+  - manifest integrity → `internal/skills/`
+  - orphan hubs → `internal/coord/hub/`
+  - telemetry status → `cli/telemetry.go` (or fold into report verb)
+  - scaffold gates → `internal/skills/`
+  - bypass detection → wherever the bypass invariant lives
+  - sentinel → `internal/coord/`
+  - holds → `internal/holds/`
+  - tasks → `internal/tasks/`
+- Each gains `Healthy(ctx) error`.
+- Doctor runner now just iterates and prints.
+- ~1.5K LOC moved (not removed yet — concentrated in deeper modules).
+
+**Regression guard:** each per-check migration ships with a
+golden-output test comparing the old `checkX` output against the new
+`Healthy()` output for one known-good and one known-bad fixture.
+Operators see the same diagnostic before and after. No feature flag
+(flags add change amplification and never get removed); revert per-PR
+if a regression escapes the goldens.
+
+### PR 8c — Delete the doctor aggregator
+
+- Delete the 9 `checkX` functions from `cli/doctor.go`.
+- `cli/doctor.go` becomes ≤100 LOC: a runner over `[]Healther` with
+  formatting.
+- ~600 LOC net removed.
+- ADR 0017 (managerBase scaffold, if it lands) composes naturally —
+  `Healthy()` can be an embeddable default that managers override.
+
+## Dependency graph
+
+```
+Wave 1 (PR 1, 2, 3) — independent, parallelizable
+                    ↓
+Wave 2 (PR 4 — ADR + CONTEXT.md) — docs only, gates Wave 3
+                    ↓
+Wave 3 (PR 5 → PR 6) — chat verbs deleted, then thread split
+                    ↓
+Wave 4 (PR 7 — telemetry shims) — independent of Wave 3
+                    ↓
+Wave 5 (PR 8a → 8b → 8c) — doctor distribution, sequenced
+```
+
+PRs that can land in parallel batches:
+- Wave 1's three PRs
+- PR 7 (telemetry shims) parallel with anything in Waves 1–3
+- Within Wave 5, 8a→8b→8c is strictly sequential
+
+## Per-PR checklist
+
+Each PR follows the project's session-completion contract from CLAUDE.md:
+
+1. Feature branch + PR (never direct push to main).
+2. `make check` locally before push.
+3. Replicate CI commands locally (especially
+   `go test -tags=otel -short ./...` per memory).
+4. Wait for human review and merge — no auto-merge.
+5. After merge: delete local + remote branch, prune refs, clean worktrees.
+
+## LOC summary
+
+| Wave | PR | Removed | Net |
+|---|---|---|---|
+| 1 | PR 1 banner | ~?? | -?? |
+| 1 | PR 2 updatecheck | ~230 | -230 |
+| 1 | PR 3 peek + rename | ~250 | -250 |
+| 2 | PR 4 ADR 0048 + CONTEXT.md + ADR 0023 narrowing | docs | 0 |
+| 3 | PR 5 chat verb files | ~2,400 | -2,400 |
+| 3 | PR 6 thread split + type changes + examples | ~500 moved + ~300 tests | +200 |
+| 4 | PR 7a telemetry shims | ~2,000 | -2,000 |
+| 4 | PR 7b telemetry audit-trim | ~1,900 | -1,900 |
+| 5 | PR 8a Healthy() proof | net small | ~+90 |
+| 5 | PR 8b migrate checks (with goldens) | net concentration | 0 |
+| 5 | PR 8c delete aggregator | ~600 | -600 |
+
+**Total: ~9K LOC removed; substrate managers deepened with `Healthy()`;
+coord narrowed to its used surface.**
+
+## What this plan does not do
+
+- Does not touch `cli/swarm_reap.go` (kept — operator-facing post-reap
+  announcement TTL eviction can't provide).
+- Does not touch `internal/slotgc/` (kept — orphan-process registry per
+  ADR 0043, distinct state from swarm sessions).
+- Does not touch `cli/skills.go` (kept — load-bearing for `bones up`
+  scaffolding).
+- Does not touch `internal/clauderhooks/` (kept — orchestrator/Claude
+  contract).
+- Does not rewrite ADR 0023 — only narrows its messaging surface
+  reference per ADR 0048's amends.
+
+## Out of scope for this pass
+
+The architecture-backlog items from the 2026-04-29 Ousterhout audit
+(Lease type-split, autosync seam, dispatch decoupling, substrate
+managerBase) are independent. They land on their own plan. PR 8b's
+migration of checks composes naturally with managerBase if both are
+in flight, but neither blocks the other.


### PR DESCRIPTION
## Summary

- Adds **ADR 0048** establishing that `internal/coord` retains exactly the chat surface its callers exercise (`Post` / `Subscribe` / `Who`); the unused verbs (`Ask`, `AskAdmin`, `Answer`, `React`, `SubscribePattern`, `WatchPresence`, `Threads`, `Heartbeat`) are deleted, and the kept three move to `internal/coord/thread/`. Supersedes ADR 0008 and ADR 0047 (the JetStream backing 0047 introduced is preserved; only the API surface narrows).
- Promotes the **substrate-API-discipline rule** project-wide in `CONTEXT.md`: a substrate verb ships only when a non-test caller ships in the same change. Speculative APIs are rejected at ADR review.
- Amends **ADR 0023** to point at the narrowed messaging surface.
- Adds the **cut sequence** under `docs/audits/2026-05-09-cut-sequence.md` — 11 PRs across 5 waves, ~9K LOC removed. PR 4 is this one (docs gate); subsequent PRs follow the plan.

## Why

`internal/coord` had grown into a wide-surface package with ~25 exported methods, of which production callers exercised 9. The chat verbs were built ahead of demand and never cashed in. The rule this ADR establishes prevents the next accumulation cycle.

## Test plan

- [x] `make check` — fmt-check, vet, lint, race, todo-check, schemas-check pass
- [x] `go test -tags=otel -short ./...` — 1201 tests passed in 35 packages
- [x] No code changes — docs and `CONTEXT.md` only