### PR TITLE
fix(tasks update): applyContext returns a new map (#347)

### DIFF
--- a/cli/tasks_common.go
+++ b/cli/tasks_common.go
@@ -166,23 +166,29 @@ func parseStatus(s string) (tasks.Status, error) {
 	return "", fmt.Errorf("invalid status %q (want open|claimed|closed)", s)
 }
 
-// applyContext merges key=value pairs into existing (creating it if nil).
-// Later pairs with the same key overwrite earlier ones.
+// applyContext merges key=value pairs into existing and returns a NEW
+// map. Later pairs with the same key overwrite earlier ones. The
+// input map is never mutated — that matters for the update path,
+// where the same map underlies both `before.Context` and the mutator's
+// `t.Context`. In-place mutation there silently corrupts `before` and
+// fools `diffTaskFields` into seeing no change, dropping the write
+// (#347).
 func applyContext(existing map[string]string, pairs []string) map[string]string {
 	if len(pairs) == 0 {
 		return existing
 	}
-	if existing == nil {
-		existing = map[string]string{}
+	out := make(map[string]string, len(existing)+len(pairs))
+	for k, v := range existing {
+		out[k] = v
 	}
 	for _, p := range pairs {
 		idx := strings.IndexRune(p, '=')
 		if idx <= 0 {
 			continue
 		}
-		existing[p[:idx]] = p[idx+1:]
+		out[p[:idx]] = p[idx+1:]
 	}
-	return existing
+	return out
 }
 
 // validateContextPairs returns an error if any pair lacks a non-empty key.

--- a/cli/tasks_common_test.go
+++ b/cli/tasks_common_test.go
@@ -1,0 +1,92 @@
+package cli
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestApplyContext_DoesNotMutateInput pins the load-bearing contract
+// for #347. applyContext is called from buildUpdateMutator with
+// `t.Context` whose underlying map is shared with the pre-image
+// `before.Context`. If applyContext mutated in place, before.Context
+// would change too, fooling diffTaskFields into seeing no change and
+// silently dropping the write.
+//
+// Concretely: this test fails on the pre-#347 implementation and
+// passes on the new copy-on-write one.
+func TestApplyContext_DoesNotMutateInput(t *testing.T) {
+	original := map[string]string{"foo": "bar"}
+	originalCopy := map[string]string{"foo": "bar"}
+
+	got := applyContext(original, []string{"foo=baz"})
+
+	if !reflect.DeepEqual(original, originalCopy) {
+		t.Errorf("applyContext mutated input map: got %v, want %v",
+			original, originalCopy)
+	}
+	if got["foo"] != "baz" {
+		t.Errorf("applyContext returned %v, want context with foo=baz", got)
+	}
+	// Same-pointer check belt-and-braces. A shared backing map would
+	// allow callers to observe mutations even when DeepEqual happens
+	// to coincide.
+	if reflect.ValueOf(original).Pointer() == reflect.ValueOf(got).Pointer() {
+		t.Errorf("applyContext returned the input map; must return a new map")
+	}
+}
+
+// TestApplyContext_PreservesExistingKeys verifies that a NEW pair
+// merges with existing entries rather than replacing the whole map.
+// Distinct from the mutation test: this asserts merge semantics on
+// the returned value.
+func TestApplyContext_PreservesExistingKeys(t *testing.T) {
+	in := map[string]string{"a": "1", "b": "2"}
+	got := applyContext(in, []string{"c=3"})
+
+	want := map[string]string{"a": "1", "b": "2", "c": "3"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+// TestApplyContext_NewKeyOverwritesExisting confirms last-pair-wins
+// for repeated keys. Pre-existing behavior; pinned here so the
+// copy-on-write rewrite doesn't accidentally regress it.
+func TestApplyContext_NewKeyOverwritesExisting(t *testing.T) {
+	in := map[string]string{"k": "old"}
+	got := applyContext(in, []string{"k=new"})
+
+	if got["k"] != "new" {
+		t.Errorf("got k=%q, want k=new", got["k"])
+	}
+	if in["k"] != "old" {
+		t.Errorf("input k mutated to %q, want still old", in["k"])
+	}
+}
+
+// TestApplyContext_NilExistingProducesFreshMap pins the nil-input
+// branch — the case where the FIRST context update on a task with
+// no existing context goes through. This branch worked in the buggy
+// implementation; the test ensures the rewrite preserves it.
+func TestApplyContext_NilExistingProducesFreshMap(t *testing.T) {
+	got := applyContext(nil, []string{"k=v"})
+	want := map[string]string{"k": "v"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+// TestApplyContext_EmptyPairsReturnsInput confirms the early-return
+// branch is unchanged: zero pairs means no-op, return whatever was
+// passed in (including nil).
+func TestApplyContext_EmptyPairsReturnsInput(t *testing.T) {
+	in := map[string]string{"a": "1"}
+	got := applyContext(in, nil)
+	if reflect.ValueOf(got).Pointer() != reflect.ValueOf(in).Pointer() {
+		t.Errorf("with empty pairs, applyContext should return the input map verbatim")
+	}
+
+	if applyContext(nil, nil) != nil {
+		t.Errorf("applyContext(nil, nil) should return nil")
+	}
+}


### PR DESCRIPTION
## Summary

P0 silent-data-loss fix. `applyContext` mutated its input map in place; because the update mutator shared the underlying map with `before.Context`, this fooled `diffTaskFields` into seeing no change, dropped the write entirely, and emitted the corrupted before-state as the would-be after.

Now `applyContext` always returns a fresh map.

Closes #347

## Test plan

- [x] 5 new unit tests in \`cli/tasks_common_test.go\` (input-not-mutated is the load-bearing one)
- [x] \`go test -short ./cli/\` — TestApplyContext_* all pass
- [x] \`make check\` — fmt, vet, lint, race, todo all pass
- [x] \`go test -tags=otel -short ./...\` — 1206 tests pass across 35 packages
- [ ] Manual verify: \`bones tasks create x --context foo=bar\` → \`bones tasks update <id> --context foo=baz\` → \`bones tasks show <id>\` returns \`foo=baz\`