### PR TITLE
fix(status --all): orphan-hub classifier reads correct pid's cwd (#350)

### DIFF
--- a/internal/registry/processes.go
+++ b/internal/registry/processes.go
@@ -216,15 +216,28 @@ func readProcCwd(pid int) string {
 	return target
 }
 
-// lsofCwd shells `lsof -p <pid> -d cwd -Fn` and parses the cwd line.
-// Returns "" on any failure. Only the FD type "cwd" is requested so
-// the output is a fixed two-line block per pid:
+// lsofCwd shells `lsof -p <pid> -d cwd -Fpn` and parses the cwd line
+// for the requested pid. Returns "" on any failure or when the parsed
+// path is not absolute (e.g. lsof reports `n/` for a process whose
+// working directory has been deleted).
+//
+// `-Fpn` produces blocks shaped like:
 //
 //	p<pid>
+//	fcwd
 //	n<absolute-path>
+//
+// On macOS `lsof -p <pid>` does NOT filter the output to that pid in
+// `-Fn` mode — the filter is non-strict and other processes' fcwd
+// entries appear in the dump. Parsing the first `n/<path>` line
+// without the `p<pid>` block context returned a wrong (foreign-pid)
+// path roughly half the time, which surfaced as misattributed orphan
+// hubs in `bones status --all` (#350). The fix is to find the block
+// that begins with `p<requested-pid>` and read the `n` line within.
 func lsofCwd(pid int) string {
+	want := "p" + strconv.Itoa(pid)
 	out, err := exec.Command("lsof", "-p", strconv.Itoa(pid),
-		"-d", "cwd", "-Fn").Output()
+		"-d", "cwd", "-Fpn").Output()
 	if err != nil {
 		// lsof exits 1 when the process isn't found; treat as unknown.
 		var exitErr *exec.ExitError
@@ -237,9 +250,39 @@ func lsofCwd(pid int) string {
 		}
 		// For other failures still attempt to parse partial output.
 	}
-	for _, line := range strings.Split(string(out), "\n") {
+	return parseLsofCwdBlock(string(out), want)
+}
+
+// parseLsofCwdBlock walks an `lsof -Fpn` dump and returns the cwd
+// (n-line) for the block whose pid header is wantPHeader (e.g.
+// "p21151"). Bare `n/` (deleted/empty cwd) is returned as "" so the
+// caller treats it as undiscoverable rather than the literal root.
+//
+// Pulled out of lsofCwd so unit tests can exercise the parser without
+// depending on a live lsof binary or live host processes (#350).
+func parseLsofCwdBlock(out, wantPHeader string) string {
+	inBlock := false
+	for _, line := range strings.Split(out, "\n") {
+		if strings.HasPrefix(line, "p") {
+			inBlock = (line == wantPHeader)
+			continue
+		}
+		if !inBlock {
+			continue
+		}
 		if strings.HasPrefix(line, "n/") {
-			return strings.TrimPrefix(line, "n")
+			path := strings.TrimPrefix(line, "n")
+			// `n/` (the literal single slash) is lsof's marker for a
+			// process whose cwd has been deleted (the kernel keeps a
+			// reference but the path is gone). Treat as undiscoverable
+			// — falsely returning "/" misled status --all into thinking
+			// the process had a real cwd that didn't match any
+			// workspace, then attributing the orphan to the wrong
+			// workspace via the registry-pid fallback (#350).
+			if path == "/" {
+				return ""
+			}
+			return path
 		}
 	}
 	return ""

--- a/internal/registry/processes_test.go
+++ b/internal/registry/processes_test.go
@@ -110,6 +110,78 @@ func TestLiveHubProcesses_RunsOnHost(t *testing.T) {
 	}
 }
 
+// TestParseLsofCwdBlock_FiltersToRequestedPID pins the load-bearing
+// fix for #350. macOS `lsof -p <pid> -d cwd -Fn` does NOT actually
+// filter the output to the requested pid — other processes' cwd
+// entries appear in the dump. Pre-#350 lsofCwd returned the FIRST
+// `n/<path>` line, which on a busy host was almost never the
+// requested pid's cwd. Now lsofCwd uses `-Fpn` and parses pid blocks.
+func TestParseLsofCwdBlock_FiltersToRequestedPID(t *testing.T) {
+	// Real-world macOS output shape: `lsof -p 21151 -d cwd -Fpn` dumps
+	// blocks for many pids despite the -p filter. We want the cwd from
+	// the p21151 block, not from p401 or p582.
+	out := `p401
+fcwd
+n/
+p582
+fcwd
+n/Users/dmestas/Library/Containers/com.apple.notificationcenterui/Data
+p21151
+fcwd
+n/private/var/folders/_x/abc/T/TestCLI_Ready/002
+p26530
+fcwd
+n/Users/dmestas/projects/agent-harness
+`
+	got := parseLsofCwdBlock(out, "p21151")
+	want := "/private/var/folders/_x/abc/T/TestCLI_Ready/002"
+	if got != want {
+		t.Errorf("parseLsofCwdBlock returned %q, want %q", got, want)
+	}
+}
+
+// TestParseLsofCwdBlock_DeletedCwdReturnsEmpty pins that an `n/`
+// (single slash) entry — lsof's marker for a process whose cwd has
+// been deleted — is treated as undiscoverable. Pre-#350, this would
+// be returned as the literal "/" and then the orphan classifier
+// would Stat("/") (succeeds), miss the registry, and attribute the
+// orphan to whichever workspace happened to share the registry pid
+// fallback path.
+func TestParseLsofCwdBlock_DeletedCwdReturnsEmpty(t *testing.T) {
+	out := `p21151
+fcwd
+n/
+`
+	if got := parseLsofCwdBlock(out, "p21151"); got != "" {
+		t.Errorf("parseLsofCwdBlock with n/ marker returned %q, want \"\"", got)
+	}
+}
+
+// TestParseLsofCwdBlock_MissingPidReturnsEmpty handles the case where
+// lsof's output doesn't contain a block for the requested pid (e.g.
+// the process exited between ps and lsof, or lsof was sandboxed and
+// returned partial output).
+func TestParseLsofCwdBlock_MissingPidReturnsEmpty(t *testing.T) {
+	out := `p582
+fcwd
+n/Users/dmestas/projects/agent-harness
+`
+	if got := parseLsofCwdBlock(out, "p21151"); got != "" {
+		t.Errorf("parseLsofCwdBlock for missing pid returned %q, want \"\"", got)
+	}
+}
+
+// TestParseLsofCwdBlock_HandlesEmpty pins the trivial inputs:
+// nothing in, nothing out.
+func TestParseLsofCwdBlock_HandlesEmpty(t *testing.T) {
+	if got := parseLsofCwdBlock("", "p21151"); got != "" {
+		t.Errorf("parseLsofCwdBlock(\"\") returned %q, want \"\"", got)
+	}
+	if got := parseLsofCwdBlock("\n\n\n", "p21151"); got != "" {
+		t.Errorf("parseLsofCwdBlock(blanks) returned %q, want \"\"", got)
+	}
+}
+
 // TestIndexAfterField verifies the column-reconstruction helper used
 // when ps's command column contains its own whitespace runs.
 func TestIndexAfterField(t *testing.T) {


### PR DESCRIPTION
## Summary

\`bones status --all\` orphan-hub section showed misattributed CWDs because macOS \`lsof -p <pid> -d cwd -Fn\` doesn't actually filter its output to the requested pid. The parser returned the first \`n/<path>\` line it saw, which was almost never the requested pid's cwd.

Closes #350

## Root cause

On macOS, \`-p\` is a non-strict filter in \`-Fn\` mode. Verified by manually running \`lsof -p 6839 -d cwd -Fn\`: dump contained cwd entries for pids 401, 582, 588, ..., 6839 (deep in the list), 25785, 26203, etc. The pre-fix parser took the first \`n/<path>\` line, ignoring pid context entirely.

## Fix

\`lsofCwd\` now uses \`-Fpn\` (include pid headers in output) and parses pid blocks via the new \`parseLsofCwdBlock\` helper. A bare \`n/\` entry (lsof's marker for a deleted-cwd process) is treated as undiscoverable rather than the literal root.

## Test plan

- [x] 4 new unit tests in \`internal/registry/processes_test.go\` covering the parser
  - TestParseLsofCwdBlock_FiltersToRequestedPID (load-bearing — uses real-world lsof output shape)
  - TestParseLsofCwdBlock_DeletedCwdReturnsEmpty
  - TestParseLsofCwdBlock_MissingPidReturnsEmpty
  - TestParseLsofCwdBlock_HandlesEmpty
- [x] \`make check\` — fmt/vet/lint/race/todo all pass
- [x] \`go test -tags=otel -short ./...\` — 1210 tests pass across 35 packages
- [ ] Manual verify: \`bones status --all\` on a host with leaked test-suite hubs shows correct cwds (or empty for deleted tempdirs)