### PR TITLE
fix(status --all): resolve symlinks before cwd dedup (#353)

### DIFF
--- a/cli/status.go
+++ b/cli/status.go
@@ -655,7 +655,7 @@ func liveOrphanHubs(active []registry.Entry) ([]orphanHub, error) {
 func reconcileOrphanHubs(procs []registry.HubProcess, active []registry.Entry) []orphanHub {
 	byCwd := make(map[string]registry.Entry, len(active))
 	for _, e := range active {
-		byCwd[filepath.Clean(e.Cwd)] = e
+		byCwd[resolveCwd(e.Cwd)] = e
 	}
 	var out []orphanHub
 	for _, p := range procs {
@@ -670,7 +670,7 @@ func reconcileOrphanHubs(procs []registry.HubProcess, active []registry.Entry) [
 			out = append(out, o)
 			continue
 		}
-		entry, ok := byCwd[filepath.Clean(p.Cwd)]
+		entry, ok := byCwd[resolveCwd(p.Cwd)]
 		if !ok {
 			o.Reason = "cwd missing from registry"
 			out = append(out, o)
@@ -683,6 +683,30 @@ func reconcileOrphanHubs(procs []registry.HubProcess, active []registry.Entry) [
 		}
 	}
 	return out
+}
+
+// resolveCwd returns the symlink-resolved absolute form of p, falling
+// back to filepath.Clean(p) when EvalSymlinks fails (path doesn't
+// exist, permission denied, broken symlink chain). Used to normalize
+// both registry-side cwds (as stored, e.g. "/tmp/foo") and process-
+// side cwds (as lsof returns them, e.g. "/private/tmp/foo") to the
+// same canonical form before comparison.
+//
+// Without this normalization a workspace at /tmp/foo on macOS (where
+// /tmp is a symlink to /private/tmp) shows in `bones status --all`
+// twice — once correctly under Active workspaces, and once falsely
+// under Orphan hubs because the byCwd map keyed by filepath.Clean
+// (which preserves /tmp) misses the lookup keyed by the lsof-
+// resolved /private/tmp path (#353).
+//
+// EvalSymlinks does NOT make a filesystem call when p has no symlink
+// components, so the fallback path on Linux (where /tmp is a real
+// directory) costs roughly the same as filepath.Clean.
+func resolveCwd(p string) string {
+	if r, err := filepath.EvalSymlinks(p); err == nil {
+		return r
+	}
+	return filepath.Clean(p)
 }
 
 // renderOrphanHubsSection emits Section 2 of status --all: the live

--- a/cli/status_test.go
+++ b/cli/status_test.go
@@ -682,6 +682,82 @@ func TestReconcileOrphanHubs_AllSignals(t *testing.T) {
 	}
 }
 
+// TestReconcileOrphanHubs_ResolvesSymlinkedCwds pins the load-bearing
+// fix for #353. On macOS /tmp is a symlink to /private/tmp; the
+// registry stores user-typed paths (e.g. "/tmp/foo") while lsof
+// returns symlink-resolved paths (e.g. "/private/tmp/foo"). Pre-#353
+// the byCwd map keyed by filepath.Clean preserved /tmp and missed
+// the lookup keyed by /private/tmp, so a live healthy workspace
+// appeared as both Active and Orphan in `bones status --all`.
+//
+// We construct a real symlink in t.TempDir() and verify that an
+// entry stored under the symlinked path matches a process whose
+// reported cwd is the resolved path.
+func TestReconcileOrphanHubs_ResolvesSymlinkedCwds(t *testing.T) {
+	tmp := t.TempDir()
+	// real/    <- the actual workspace dir
+	// link/    <- symlink to real/
+	realDir := filepath.Join(tmp, "real")
+	if err := os.Mkdir(realDir, 0o755); err != nil {
+		t.Fatalf("mkdir real: %v", err)
+	}
+	linkDir := filepath.Join(tmp, "link")
+	if err := os.Symlink(realDir, linkDir); err != nil {
+		// Symlinks may not be supported (e.g. some sandboxed CI). Skip
+		// rather than fail the rest of the suite.
+		t.Skipf("symlink unsupported: %v", err)
+	}
+
+	// Registry entry stored under the symlink-side path (mirrors what
+	// `bones up` does when the operator runs it from /tmp/foo).
+	active := []registry.Entry{
+		{Cwd: linkDir, HubPID: 100},
+	}
+	// Process reports the resolved-side path (mirrors macOS lsof).
+	procs := []registry.HubProcess{
+		{PID: 100, ETime: "1:00", Cwd: realDir},
+	}
+
+	got := reconcileOrphanHubs(procs, active)
+	if len(got) != 0 {
+		t.Errorf("symlinked-vs-resolved cwds should match, got %d orphan(s): %+v",
+			len(got), got)
+	}
+}
+
+// TestResolveCwd_FallsBackOnMissingPath pins that resolveCwd returns
+// filepath.Clean(p) when EvalSymlinks fails (e.g. path doesn't exist
+// or symlink chain is broken). This preserves the existing "cwd no
+// longer exists" classification path — without the fallback,
+// resolveCwd would return "" for a deleted tempdir, and that empty
+// string would key the byCwd map confusingly.
+func TestResolveCwd_FallsBackOnMissingPath(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "does-not-exist")
+	got := resolveCwd(missing)
+	want := filepath.Clean(missing)
+	if got != want {
+		t.Errorf("resolveCwd(missing) = %q, want %q (filepath.Clean fallback)", got, want)
+	}
+}
+
+// TestResolveCwd_IsIdempotent pins the load-bearing property: passing
+// resolveCwd's output back into itself yields the same path. That's
+// what makes the byCwd lookup work — both sides of the comparison
+// canonicalize to the same string regardless of which form (typed,
+// symlinked, fully-resolved) the caller starts with.
+func TestResolveCwd_IsIdempotent(t *testing.T) {
+	// t.TempDir() returns a path that on macOS still has the
+	// /var -> /private/var symlink unfollowed; on Linux it's
+	// already fully resolved. Either way, applying resolveCwd
+	// twice must converge.
+	dir := t.TempDir()
+	once := resolveCwd(dir)
+	twice := resolveCwd(once)
+	if once != twice {
+		t.Errorf("resolveCwd not idempotent: once=%q twice=%q", once, twice)
+	}
+}
+
 // TestRenderOrphanHubsSection pins the renderer column shape: PID,
 // ETIME, CWD, REASON, plus the trailing reap hint pointing at #263.
 func TestRenderOrphanHubsSection(t *testing.T) {


### PR DESCRIPTION
## Summary

A live healthy workspace at a symlinked path (e.g. \`/tmp/foo\` on macOS where \`/tmp\` -> \`/private/tmp\`) showed in BOTH \`bones status --all\` Active workspaces AND Orphan hubs. Same hub, two non-matching map keys: registry stored \`/tmp/foo\`, lsof returned \`/private/tmp/foo\`, \`filepath.Clean\` doesn't resolve symlinks.

Closes #353

## Fix

New \`resolveCwd\` helper in \`cli/status.go\` applies \`filepath.EvalSymlinks\` before keying / lookup. Falls back to \`filepath.Clean\` when EvalSymlinks errors (preserves the existing \"cwd no longer exists\" path). EvalSymlinks is a no-op for paths with no symlink components, so Linux pays roughly the same cost as before.

## Test plan

- [x] 3 new unit tests in \`cli/status_test.go\` (one builds a real symlink in \`t.TempDir()\` and verifies dedup)
- [x] Existing \`TestReconcileOrphanHubs_AllSignals\` still passes (no regression on the four classification paths)
- [x] \`make check\` — fmt/vet/lint/race/todo all pass
- [x] \`go test -tags=otel -short ./...\` — 1213 tests pass across 35 packages
- [ ] Manual verify: \`cp -R real-project /tmp/foo && cd /tmp/foo && bones up && bones tasks list && bones status --all\` shows /tmp/foo only in Active, not in Orphans

## Audit note

Other \`filepath.Clean\` cwd-handling sites grepped:
- \`internal/registry/registry.go:18\` — derives a SHA from \`filepath.Clean(cwd)\` for the registry filename. Intentionally NOT changing this here: it would orphan existing on-disk registry entries. The lookup-side fix in this PR is sufficient because resolveCwd canonicalizes both sides at comparison time.