### PR TITLE
fix(hub): parent waits for child registry write before returning (#358)

### DIFF
--- a/internal/hub/hub.go
+++ b/internal/hub/hub.go
@@ -552,6 +552,36 @@ func spawnDetachedChild(p paths, o opts) error {
 	// real pid (#148).
 	pid := cmd.Process.Pid
 
+	return finalizeDetachedChild(p, cmd, parentLog, pid, o)
+}
+
+// finalizeDetachedChild bridges the gap between "child has bound TCP
+// listeners" and "operator-visible lazy-start succeeded." It blocks
+// until the child's registry entry lands, then releases the child
+// process and announces the hub URL on stderr. Pulled out of
+// spawnDetachedChild so the spawn body stays under the funlen cap;
+// also colocates the registry-wait, the cmd.Process.Release, and the
+// announce — they're a sequence that must run in order or the
+// post-#355 contract breaks.
+func finalizeDetachedChild(
+	p paths, cmd *exec.Cmd, parentLog *hubLogger, pid int, o opts,
+) error {
+	// Wait for the child to publish its registry entry before we
+	// return. The TCP probes above only confirm the listeners are
+	// bound — the child still has to finish runTaskRecovery (can be
+	// 100ms+) and then call registry.Write. Pre-fix, a sequenced
+	// `bones up && bones tasks list && bones status --all` would see
+	// the second workspace's hub as "idle" and its actual running
+	// hub PID classified as orphan, because the registry update
+	// hadn't landed by the time status read it. Now the parent CLI
+	// verb only returns once the registry knows the hub. (#355)
+	if err := waitForRegistry(p.root, pid, readyTimeout); err != nil {
+		_ = cmd.Process.Kill()
+		parentLog.Errorf("hub: child started but registry never updated: %v", err)
+		return fmt.Errorf("hub: registry not ready: %w%s",
+			err, hubLogTail(p))
+	}
+
 	// Release the child so it isn't reaped when we return.
 	if err := cmd.Process.Release(); err != nil {
 		return fmt.Errorf("hub: release child: %w", err)
@@ -562,6 +592,28 @@ func spawnDetachedChild(p paths, o opts) error {
 		"hub: fossil at http://127.0.0.1:%d, nats at nats://127.0.0.1:%d (pid=%d)\n",
 		o.repoPort, o.coordPort, pid)
 	return nil
+}
+
+// waitForRegistry polls registry.Read until it returns an entry whose
+// HubPID matches childPID, or until timeout. Used by the detach-mode
+// parent to bridge the gap between "child has bound TCP listeners"
+// (waitForTCP returns) and "child has finished runTaskRecovery and
+// written its registry entry" (registry.Write completes).
+//
+// A registry.Read error is treated as "not ready yet" rather than a
+// terminal failure — the child may simply not have published yet on
+// a fresh workspace where the registry file doesn't exist.
+func waitForRegistry(root string, childPID int, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		entry, err := registry.Read(root)
+		if err == nil && entry.HubPID == childPID {
+			return nil
+		}
+		time.Sleep(pollInterval)
+	}
+	return fmt.Errorf("timeout waiting for registry to record hub pid %d after %s",
+		childPID, timeout)
 }
 
 // StopOption configures Stop. Passed variadically so existing callers

--- a/internal/hub/wait_registry_test.go
+++ b/internal/hub/wait_registry_test.go
@@ -1,0 +1,144 @@
+package hub
+
+import (
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/danmestas/bones/internal/registry"
+)
+
+// TestWaitForRegistry_ReturnsImmediatelyWhenAlreadyRecorded pins the
+// happy-no-op path: if the registry already has an entry whose
+// HubPID matches childPID at call time, waitForRegistry returns
+// without polling.
+func TestWaitForRegistry_ReturnsImmediatelyWhenAlreadyRecorded(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	root := t.TempDir()
+	// Use the test process's own pid so registry.Read's self-pruning
+	// of dead-pid entries doesn't delete the entry between Write and
+	// the first poll (real production callers always pass a live pid).
+	livePID := os.Getpid()
+	if err := registry.Write(registry.Entry{
+		Cwd:       root,
+		Name:      "test",
+		HubPID:    livePID,
+		StartedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("registry.Write: %v", err)
+	}
+
+	start := time.Now()
+	if err := waitForRegistry(root, livePID, time.Second); err != nil {
+		t.Fatalf("waitForRegistry: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > 100*time.Millisecond {
+		t.Errorf("waitForRegistry took %v on already-recorded entry; "+
+			"should have returned without polling", elapsed)
+	}
+}
+
+// TestWaitForRegistry_TimesOutWhenNotRecorded pins that a registry
+// that never gets the right entry causes waitForRegistry to return
+// a timeout error mentioning the expected pid. Pre-#355 the parent
+// CLI verb didn't wait at all; this test guards against a regression
+// that would silently re-introduce the gap.
+func TestWaitForRegistry_TimesOutWhenNotRecorded(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	root := t.TempDir()
+
+	start := time.Now()
+	err := waitForRegistry(root, 99999, 200*time.Millisecond)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+	if elapsed < 200*time.Millisecond {
+		t.Errorf("waitForRegistry returned in %v; expected at least 200ms timeout",
+			elapsed)
+	}
+	if elapsed > time.Second {
+		t.Errorf("waitForRegistry took %v on missing entry; expected ~200ms timeout",
+			elapsed)
+	}
+	if !strings.Contains(err.Error(), "99999") {
+		t.Errorf("error should mention expected pid 99999: %v", err)
+	}
+	if !strings.Contains(err.Error(), "timeout") {
+		t.Errorf("error should mention timeout: %v", err)
+	}
+}
+
+// TestWaitForRegistry_PollsUntilEntryAppears simulates the actual
+// race the fix is closing: another goroutine writes the registry
+// entry mid-poll. waitForRegistry must observe the write and return
+// without hitting the timeout. This is the integration-shape test —
+// it pins the operator-visible contract that lazy-start blocks until
+// the registry catches up.
+func TestWaitForRegistry_PollsUntilEntryAppears(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	root := t.TempDir()
+
+	// Write the entry from a goroutine after a short delay, simulating
+	// the real-world race: child is still in runTaskRecovery while
+	// the parent waits. Use the test's own pid so the entry survives
+	// registry.Read's dead-pid self-pruning.
+	livePID := os.Getpid()
+	const writeDelay = 100 * time.Millisecond
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		time.Sleep(writeDelay)
+		_ = registry.Write(registry.Entry{
+			Cwd:       root,
+			Name:      "test",
+			HubPID:    livePID,
+			StartedAt: time.Now().UTC(),
+		})
+	}()
+
+	start := time.Now()
+	err := waitForRegistry(root, livePID, 2*time.Second)
+	elapsed := time.Since(start)
+	wg.Wait()
+
+	if err != nil {
+		t.Fatalf("waitForRegistry: %v", err)
+	}
+	if elapsed < writeDelay {
+		t.Errorf("waitForRegistry returned in %v before writeDelay %v — "+
+			"didn't actually wait for the entry", elapsed, writeDelay)
+	}
+	if elapsed > writeDelay+500*time.Millisecond {
+		t.Errorf("waitForRegistry took %v but entry was written at %v — "+
+			"poll loop may not be reacting promptly", elapsed, writeDelay)
+	}
+}
+
+// TestWaitForRegistry_RejectsMismatchedPID pins that a registry
+// entry whose HubPID is a DIFFERENT pid (e.g. a stale one from a
+// crashed prior hub) is treated as "not ready yet" and the loop
+// keeps polling — not a false-positive success.
+func TestWaitForRegistry_RejectsMismatchedPID(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	root := t.TempDir()
+	// Stale entry from some other pid.
+	if err := registry.Write(registry.Entry{
+		Cwd:       root,
+		Name:      "test",
+		HubPID:    11111,
+		StartedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("registry.Write: %v", err)
+	}
+
+	err := waitForRegistry(root, 22222, 200*time.Millisecond)
+	if err == nil {
+		t.Fatal("waitForRegistry returned nil on mismatched pid; " +
+			"should have polled past the stale entry until timeout")
+	}
+}


### PR DESCRIPTION
## Summary

Detached lazy-start had a race: parent CLI returned to user after \`waitForTCP\` (TCP listeners bound), but the forked child still had to finish \`runTaskRecovery\` and \`registry.Write\`. A subsequent \`bones status --all\` saw the workspace as \`idle\` and the running hub PID as orphan.

Closes #358

## Fix

New \`waitForRegistry\` helper polls registry until the child's PID lands or readyTimeout. Called from \`spawnDetachedChild\` right after \`waitForTCP\`, before the announce/release. Operator-visible contract: \"if \`bones tasks list\` returned, the registry knows about the hub.\"

Extracted the post-spawn finalize sequence into \`finalizeDetachedChild\` to stay under the funlen budget.

## Test plan

- [x] 4 new unit tests in \`internal/hub/wait_registry_test.go\` (\`TestWaitForRegistry_*\`)
- [x] \`make check\` — fmt/vet/lint/race/todo pass
- [x] \`go test -tags=otel -short ./...\` — 1217 tests pass across 35 packages
- [x] Manual: locally-built binary with the fix shows both \`smoke-A\` and \`smoke-B\` as \`running\` immediately after sequenced \`bones up && bones tasks list\`; pre-fix v0.14.3 binary showed \`smoke-B\` as \`—\` for ~2s