### PR TITLE
fix(orphans): unify status/reap/doctor classifiers (process + registry)

### DIFF
--- a/cli/doctor.go
+++ b/cli/doctor.go
@@ -661,25 +661,36 @@ func workspaceMarkerPresent(root string) bool {
 // surfaces orphans the operator can still action — not the stale
 // crud that pre-#229 accumulated indefinitely.
 func checkOrphanHubs(w io.Writer) int {
-	orphans, err := registry.Orphans()
+	orphans, err := registry.AllOrphanHubs()
 	if err != nil {
-		_, _ = fmt.Fprintf(w, "  WARN  orphan-hub registry read: %v\n", err)
+		_, _ = fmt.Fprintf(w, "  WARN  orphan-hub scan: %v\n", err)
 		return 1
 	}
 	if len(orphans) == 0 {
-		_, _ = fmt.Fprintln(w, "  OK    no orphan hub processes registered")
+		_, _ = fmt.Fprintln(w, "  OK    no orphan hub processes")
 		return 0
 	}
-	for _, e := range orphans {
-		age := "?"
-		if !e.StartedAt.IsZero() {
-			age = time.Since(e.StartedAt).Round(time.Second).String()
-		}
+	for _, o := range orphans {
+		age := orphanAge(o)
 		_, _ = fmt.Fprintf(w,
 			"  WARN  orphan hub: pid=%d cwd=%s age=%s — run `bones hub reap` to terminate\n",
-			e.HubPID, e.Cwd, age)
+			o.PID, o.Cwd, age)
 	}
 	return len(orphans)
+}
+
+// orphanAge returns a human-readable age for an OrphanHub. Registry-
+// source orphans use Entry.StartedAt; process-source orphans use
+// Process.ETime (raw `ps` etime string) since they have no registry
+// timestamp.
+func orphanAge(o registry.OrphanHub) string {
+	if o.Source == registry.SourceRegistry && !o.Entry.StartedAt.IsZero() {
+		return time.Since(o.Entry.StartedAt).Round(time.Second).String()
+	}
+	if o.Process.ETime != "" {
+		return o.Process.ETime
+	}
+	return "?"
 }
 
 // checkManifestIntegrity reads .claude/skills/.bones-manifest.json

--- a/cli/down.go
+++ b/cli/down.go
@@ -304,25 +304,44 @@ func legacyLeafPID(root string) (int, bool) {
 // load-bearing for tests that register workspaces under the test
 // process's own pid.
 func planReapOrphans() []downAction {
-	orphans, err := registry.Orphans()
+	orphans, err := registry.AllOrphanHubs()
 	if err != nil || len(orphans) == 0 {
 		return nil
 	}
 	self := os.Getpid()
 	plan := make([]downAction, 0, len(orphans))
 	for _, o := range orphans {
-		if o.HubPID == self {
+		if o.PID == self {
 			continue
 		}
-		desc := fmt.Sprintf("reap orphan registry entry %s (pid %d, workspace gone)",
-			o.Name, o.HubPID)
-		entry := o
+		desc, action := planReapOne(o)
 		plan = append(plan, downAction{
 			description: desc,
-			do:          func() error { return registry.Reap(entry) },
+			do:          action,
 		})
 	}
 	return plan
+}
+
+// planReapOne builds the per-orphan description + reap action,
+// dispatching by Source: registry-source orphans get ReapEntry (signal
+// + remove registry entry); process-only orphans get ReapPID (signal
+// only — there's no entry to remove).
+func planReapOne(o registry.OrphanHub) (string, func() error) {
+	if o.Source == registry.SourceRegistry {
+		entry := o.Entry
+		desc := fmt.Sprintf("reap orphan registry entry %s (pid %d, workspace gone)",
+			entry.Name, entry.HubPID)
+		return desc, func() error { return registry.ReapEntry(entry) }
+	}
+	pid := o.PID
+	cwd := o.Cwd
+	if cwd == "" {
+		cwd = "unknown"
+	}
+	desc := fmt.Sprintf("reap orphan hub process pid=%d cwd=%s (no registry entry)",
+		pid, cwd)
+	return desc, func() error { return registry.ReapPID(pid) }
 }
 
 // planRemoveGitHook restores the user's original pre-commit (if any)

--- a/cli/hub_reap.go
+++ b/cli/hub_reap.go
@@ -13,16 +13,19 @@ import (
 	"github.com/danmestas/bones/internal/registry"
 )
 
-// HubReapCmd lists orphan hub processes recorded in the cross-workspace
-// registry (`~/.bones/workspaces/<id>.json`) and offers to terminate
-// them. An orphan is a registered process whose PID is alive but whose
-// workspace path no longer hosts a valid bones workspace — typically
-// because the directory was moved, trashed, or migrated without a
-// `bones down` first. See ADR 0043.
+// HubReapCmd lists orphan hub processes and offers to terminate them.
+// Two orphan kinds are surfaced:
 //
-// Per orphan: SIGTERM then SIGKILL after a short grace; the registry
-// entry is removed on success. Idempotent — running with no orphans
-// is a no-op.
+//  1. Registry-source: a registered entry whose PID is alive but whose
+//     workspace is gone (cwd missing, marker missing, or trashed).
+//  2. Process-source: a live `bones hub start` process with no matching
+//     registry entry — typically a leak from a test runner that spawned
+//     a workspace and exited without `bones down`. Pre-#NNN these were
+//     visible in `bones status --all` but invisible to `bones hub reap`,
+//     forcing operators to `kill -9` directly.
+//
+// Per orphan: SIGTERM then SIGKILL after a short grace. Registry-source
+// orphans also have their entry removed on success. See ADR 0043.
 type HubReapCmd struct {
 	Yes    bool `name:"yes" short:"y" help:"skip the per-orphan confirmation prompt"`
 	DryRun bool `name:"dry-run" help:"print orphans without acting"`
@@ -35,9 +38,9 @@ func (c *HubReapCmd) Run(g *repocli.Globals) error {
 // runHubReap is the testable entry point. confirmIn is the io.Reader
 // used for y/N prompts; tests pass a strings.Reader.
 func runHubReap(c *HubReapCmd, confirmIn io.Reader, out io.Writer) error {
-	orphans, err := registry.Orphans()
+	orphans, err := registry.AllOrphanHubs()
 	if err != nil {
-		return fmt.Errorf("list orphans: %w", err)
+		return fmt.Errorf("scan orphans: %w", err)
 	}
 	if len(orphans) == 0 {
 		_, _ = fmt.Fprintln(out, "hub reap: no orphan hub processes found")
@@ -45,13 +48,9 @@ func runHubReap(c *HubReapCmd, confirmIn io.Reader, out io.Writer) error {
 	}
 
 	_, _ = fmt.Fprintf(out, "hub reap: %d orphan hub process(es):\n", len(orphans))
-	for _, e := range orphans {
-		age := "?"
-		if !e.StartedAt.IsZero() {
-			age = time.Since(e.StartedAt).Round(time.Second).String()
-		}
-		_, _ = fmt.Fprintf(out, "  pid=%d  cwd=%s  hub=%s  age=%s\n",
-			e.HubPID, e.Cwd, e.HubURL, age)
+	for _, o := range orphans {
+		_, _ = fmt.Fprintf(out, "  pid=%d  cwd=%s  source=%s  age=%s  reason=%s\n",
+			o.PID, o.Cwd, sourceLabel(o.Source), reapAge(o), o.Reason)
 	}
 
 	if c.DryRun {
@@ -61,23 +60,53 @@ func runHubReap(c *HubReapCmd, confirmIn io.Reader, out io.Writer) error {
 
 	reader := bufio.NewReader(confirmIn)
 	var firstErr error
-	for _, e := range orphans {
+	for _, o := range orphans {
 		if !c.Yes {
-			_, _ = fmt.Fprintf(out, "Reap pid=%d (%s)? [y/N] ", e.HubPID, e.Cwd)
+			_, _ = fmt.Fprintf(out, "Reap pid=%d (%s)? [y/N] ", o.PID, o.Cwd)
 			line, _ := reader.ReadString('\n')
 			if !strings.HasPrefix(strings.ToLower(strings.TrimSpace(line)), "y") {
 				_, _ = fmt.Fprintln(out, "  skipped")
 				continue
 			}
 		}
-		if err := registry.Reap(e); err != nil {
-			_, _ = fmt.Fprintf(out, "  pid=%d: reap failed: %v\n", e.HubPID, err)
+		if err := reapOrphan(o); err != nil {
+			_, _ = fmt.Fprintf(out, "  pid=%d: reap failed: %v\n", o.PID, err)
 			if firstErr == nil {
 				firstErr = err
 			}
 			continue
 		}
-		_, _ = fmt.Fprintf(out, "  pid=%d: reaped\n", e.HubPID)
+		_, _ = fmt.Fprintf(out, "  pid=%d: reaped\n", o.PID)
 	}
 	return firstErr
+}
+
+// reapOrphan dispatches to ReapEntry (registry-source) or ReapPID
+// (process-source). Process-source orphans have no registry entry so
+// there is nothing to remove after the kill.
+func reapOrphan(o registry.OrphanHub) error {
+	if o.Source == registry.SourceRegistry {
+		return registry.ReapEntry(o.Entry)
+	}
+	return registry.ReapPID(o.PID)
+}
+
+// reapAge returns a human-readable age for an OrphanHub. Registry-
+// source uses Entry.StartedAt; process-source uses Process.ETime.
+func reapAge(o registry.OrphanHub) string {
+	if o.Source == registry.SourceRegistry && !o.Entry.StartedAt.IsZero() {
+		return time.Since(o.Entry.StartedAt).Round(time.Second).String()
+	}
+	if o.Process.ETime != "" {
+		return o.Process.ETime
+	}
+	return "?"
+}
+
+// sourceLabel renders OrphanSource as a one-word string for the listing.
+func sourceLabel(s registry.OrphanSource) string {
+	if s == registry.SourceRegistry {
+		return "registry"
+	}
+	return "process"
 }

--- a/cli/status.go
+++ b/cli/status.go
@@ -738,7 +738,7 @@ func renderOrphanHubsSection(w io.Writer, orphans []orphanHub) error {
 		return err
 	}
 	_, err := io.WriteString(w,
-		"  (run `bones hub reap --pid=N` per process)\n")
+		"  (run `bones hub reap` to clean)\n")
 	return err
 }
 

--- a/internal/coord/subscribe.go
+++ b/internal/coord/subscribe.go
@@ -78,9 +78,8 @@ func (c *Coord) watchChat(
 // reserveSubscriberSlot increments subsActive and rolls back if the new
 // count exceeds Config.MaxSubscribers, returning ErrTooManySubscribers
 // wrapped with the caller-supplied method prefix. prefix is
-// "coord.Subscribe" or "coord.SubscribePattern" so the error text names
-// the actual entry point. Extracted so each Subscribe variant stays
-// below the 70-line funlen cap.
+// "coord.Subscribe" so the error text names the actual entry point.
+// Extracted so each Subscribe variant stays below the 70-line funlen cap.
 func (c *Coord) reserveSubscriberSlot(prefix string) error {
 	next := c.subsActive.Add(1)
 	if int(next) > c.cfg.Tuning.MaxSubscribers {

--- a/internal/registry/orphan.go
+++ b/internal/registry/orphan.go
@@ -79,6 +79,11 @@ func isTrashed(path string) bool {
 
 // Orphans returns all registry entries whose process is alive but
 // whose workspace is gone. Read-only; the caller decides what to do.
+//
+// Deprecated: prefer AllOrphanHubs, which also surfaces process-only
+// orphans (live `bones hub start` PIDs with no registry entry at all).
+// Retained for the existing test surface; new callers should not use
+// it.
 func Orphans() ([]Entry, error) {
 	all, err := List()
 	if err != nil {
@@ -93,39 +98,241 @@ func Orphans() ([]Entry, error) {
 	return out, nil
 }
 
+// OrphanSource discriminates how an OrphanHub was discovered. Process-
+// only orphans (no registry entry at all) used to be invisible to
+// `bones hub reap`, `bones doctor`, and `bones down` because those
+// callers all used Orphans() which only filters List(). AllOrphanHubs
+// unions both kinds; the Source field tells the caller which fields
+// of OrphanHub are populated.
+type OrphanSource int
+
+const (
+	// SourceRegistry: the orphan was discovered via the registry
+	// (entry exists, IsOrphan returned true). Entry is fully populated.
+	SourceRegistry OrphanSource = iota
+	// SourceProcess: the orphan is a live `bones hub start` process
+	// with no matching registry entry. Process is populated; Entry is
+	// the zero value.
+	SourceProcess
+)
+
+// OrphanHub is the unified shape returned by AllOrphanHubs. The Source
+// discriminant tells callers which struct fields are meaningful:
+//
+//   - Source==SourceRegistry: Entry is populated; PID/Cwd are mirrored
+//     from Entry.HubPID/Entry.Cwd for renderer convenience.
+//   - Source==SourceProcess: Process is populated; Entry is zero;
+//     PID/Cwd are mirrored from Process.PID/Process.Cwd. The renderer
+//     uses Process.ETime in lieu of Entry.StartedAt.
+//
+// Reason carries a short human-readable string describing why the
+// orphan was flagged; used by `bones status --all`'s tabular output.
+type OrphanHub struct {
+	Source  OrphanSource
+	Entry   Entry
+	Process HubProcess
+	PID     int
+	Cwd     string
+	Reason  string
+}
+
+// liveHubProcessesFn is the live-process scanner AllOrphanHubs calls.
+// Production sets it to LiveHubProcesses; tests can swap it for canned
+// HubProcess slices to exercise the process-source orphan path without
+// needing to spawn a real `bones hub start` subprocess.
+var liveHubProcessesFn = LiveHubProcesses
+
+// AllOrphanHubs returns the union of registry-side orphans (entries
+// where IsOrphan is true) and process-only orphans (live `bones hub
+// start` PIDs with no matching registry entry).
+//
+// Discovery proceeds in two passes:
+//
+//  1. List() + IsOrphan filter — produces SourceRegistry rows.
+//  2. LiveHubProcesses() minus the live PIDs from (1)+remaining List
+//     entries — produces SourceProcess rows for processes the
+//     registry doesn't account for.
+//
+// Cwd comparison uses ResolveCwd so a workspace path like /tmp/foo
+// compares equal to the lsof-resolved /private/tmp/foo on macOS
+// (#353).
+//
+// Best-effort: a LiveHubProcesses failure (e.g. no `ps` on PATH) is
+// not fatal — only registry-source orphans are returned in that case,
+// alongside the underlying error.
+func AllOrphanHubs() ([]OrphanHub, error) {
+	entries, err := List()
+	if err != nil {
+		return nil, fmt.Errorf("registry.AllOrphanHubs: list: %w", err)
+	}
+
+	out := make([]OrphanHub, 0)
+	registryByCwd := make(map[string]Entry, len(entries))
+	registryByPID := make(map[int]struct{}, len(entries))
+	for _, e := range entries {
+		registryByCwd[ResolveCwd(e.Cwd)] = e
+		if e.HubPID > 0 {
+			registryByPID[e.HubPID] = struct{}{}
+		}
+		if IsOrphan(e) {
+			out = append(out, OrphanHub{
+				Source: SourceRegistry,
+				Entry:  e,
+				PID:    e.HubPID,
+				Cwd:    e.Cwd,
+				Reason: registryOrphanReason(e),
+			})
+		}
+	}
+
+	procs, procErr := liveHubProcessesFn()
+	if procErr != nil {
+		// Process-table read failed — return whatever registry-side
+		// orphans we found alongside the error so callers can still
+		// render Section 1 of status --all.
+		return out, fmt.Errorf("registry.AllOrphanHubs: live processes: %w", procErr)
+	}
+
+	for _, p := range procs {
+		// If a registry entry already covers this PID, the entry is
+		// the canonical orphan record (Section 2 of status --all
+		// surfaces process-only orphans; Section 3 surfaces paused
+		// registry entries; here we only care about the cross set).
+		if _, ok := registryByPID[p.PID]; ok {
+			continue
+		}
+		// If the process's cwd matches a known registry entry's cwd
+		// (modulo symlink resolution), it's an active or paused
+		// workspace, not a process-only orphan.
+		if p.Cwd != "" {
+			if _, ok := registryByCwd[ResolveCwd(p.Cwd)]; ok {
+				continue
+			}
+		}
+		out = append(out, OrphanHub{
+			Source:  SourceProcess,
+			Process: p,
+			PID:     p.PID,
+			Cwd:     p.Cwd,
+			Reason:  processOrphanReason(p),
+		})
+	}
+
+	return out, nil
+}
+
+// registryOrphanReason returns the human-readable reason for a
+// registry-side orphan (mirrors the doctor/down phrasing).
+func registryOrphanReason(e Entry) string {
+	if _, err := os.Stat(e.Cwd); os.IsNotExist(err) {
+		return "cwd no longer exists"
+	}
+	marker := filepath.Join(bonesDir(e.Cwd), "agent.id")
+	if _, err := os.Stat(marker); os.IsNotExist(err) {
+		return "workspace marker missing (.bones/agent.id)"
+	}
+	if isTrashed(e.Cwd) {
+		return "cwd is in Trash"
+	}
+	return "registry entry orphaned"
+}
+
+// processOrphanReason returns the reason string for a process-only
+// orphan (no matching registry entry).
+func processOrphanReason(p HubProcess) string {
+	if p.Cwd == "" {
+		return "cwd unknown (process introspection failed)"
+	}
+	if _, err := os.Stat(p.Cwd); os.IsNotExist(err) {
+		return "cwd no longer exists"
+	}
+	return "cwd missing from registry"
+}
+
+// ResolveCwd returns the symlink-resolved absolute form of p, falling
+// back to filepath.Clean(p) when EvalSymlinks fails (path doesn't
+// exist, permission denied, broken symlink chain). Used to normalize
+// both registry-side cwds (as stored, e.g. "/tmp/foo") and process-
+// side cwds (as lsof returns them, e.g. "/private/tmp/foo") to the
+// same canonical form before comparison.
+//
+// Without this normalization a workspace at /tmp/foo on macOS (where
+// /tmp is a symlink to /private/tmp) shows in `bones status --all`
+// twice (#353); the registry entry keyed by /tmp/foo (which preserves
+// /tmp) misses the lookup keyed by the lsof-resolved /private/tmp
+// path.
+//
+// EvalSymlinks does NOT make a filesystem call when p has no symlink
+// components, so the fallback path on Linux (where /tmp is a real
+// directory) costs roughly the same as filepath.Clean.
+func ResolveCwd(p string) string {
+	if r, err := filepath.EvalSymlinks(p); err == nil {
+		return r
+	}
+	return filepath.Clean(p)
+}
+
 // Reap terminates the process for e and removes its registry entry.
-// SIGTERM first; if the PID is still alive after reapGrace, SIGKILL.
-// Returns nil on success (process gone, entry removed) or an error
-// describing which step failed. The entry is removed even after
-// SIGKILL — leaving it would create a permanent registry record for
-// a process that, by definition, isn't going to come back.
+// Thin wrapper over ReapEntry preserved for backwards compatibility
+// with the existing test surface; new callers should select between
+// ReapEntry (registry-tracked) and ReapPID (process-only) explicitly.
 func Reap(e Entry) error {
+	return ReapEntry(e)
+}
+
+// ReapEntry terminates the process for e and removes its registry
+// entry. SIGTERM first; if the PID is still alive after reapGrace,
+// SIGKILL. Returns nil on success (process gone, entry removed) or
+// an error describing which step failed. The entry is removed even
+// after SIGKILL — leaving it would create a permanent registry
+// record for a process that, by definition, isn't going to come back.
+func ReapEntry(e Entry) error {
 	if !pidAlive(e.HubPID) {
 		return Remove(e.Cwd)
 	}
-	proc, err := os.FindProcess(e.HubPID)
+	if err := killPID(e.HubPID); err != nil {
+		return err
+	}
+	return Remove(e.Cwd)
+}
+
+// ReapPID terminates pid (SIGTERM-then-SIGKILL like ReapEntry) but
+// does not touch the registry. Used for process-source orphans
+// surfaced by AllOrphanHubs that have no registry entry to remove.
+// A no-op if pid is already dead.
+func ReapPID(pid int) error {
+	if !pidAlive(pid) {
+		return nil
+	}
+	return killPID(pid)
+}
+
+// killPID is the shared signal+grace-period helper. SIGTERM, wait
+// reapGrace polling pidAlive at 50ms; if still alive, SIGKILL and
+// best-effort wait at 25ms x 20.
+func killPID(pid int) error {
+	proc, err := os.FindProcess(pid)
 	if err != nil {
-		return fmt.Errorf("registry.Reap: find pid %d: %w", e.HubPID, err)
+		return fmt.Errorf("registry.Reap: find pid %d: %w", pid, err)
 	}
 	if err := proc.Signal(syscall.SIGTERM); err != nil {
-		return fmt.Errorf("registry.Reap: SIGTERM pid %d: %w", e.HubPID, err)
+		return fmt.Errorf("registry.Reap: SIGTERM pid %d: %w", pid, err)
 	}
 	deadline := time.Now().Add(reapGrace)
 	for time.Now().Before(deadline) {
-		if !pidAlive(e.HubPID) {
-			return Remove(e.Cwd)
+		if !pidAlive(pid) {
+			return nil
 		}
 		time.Sleep(50 * time.Millisecond)
 	}
 	if err := proc.Signal(syscall.SIGKILL); err != nil {
-		return fmt.Errorf("registry.Reap: SIGKILL pid %d: %w", e.HubPID, err)
+		return fmt.Errorf("registry.Reap: SIGKILL pid %d: %w", pid, err)
 	}
-	// Best-effort wait for SIGKILL to take effect; remove entry regardless.
-	for i := 0; i < 20; i++ {
-		if !pidAlive(e.HubPID) {
+	for range 20 {
+		if !pidAlive(pid) {
 			break
 		}
 		time.Sleep(25 * time.Millisecond)
 	}
-	return Remove(e.Cwd)
+	return nil
 }

--- a/internal/registry/orphan_test.go
+++ b/internal/registry/orphan_test.go
@@ -183,3 +183,162 @@ func TestReap_DeadPidJustRemovesEntry(t *testing.T) {
 		t.Errorf("entry should be removed after Reap on dead PID")
 	}
 }
+
+// TestAllOrphanHubs_UnionOfBothSources pins the central invariant of
+// the unify-orphan-classifiers fix: AllOrphanHubs returns BOTH
+// registry-side orphans (entries with IsOrphan==true) AND process-only
+// orphans (live `bones hub start` PIDs with no registry entry).
+//
+// Pre-fix: hub_reap, doctor, down all called Orphans() and saw only
+// the first set. Test-spawn process leaks (the dominant case) were
+// invisible. See the spy-on-bones session that produced this fix.
+func TestAllOrphanHubs_UnionOfBothSources(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	// Registry-source orphan: an entry whose Cwd directory exists but
+	// has no .bones/agent.id marker. Use os.Getpid() so the process is
+	// live (registry self-prune kills dead-pid entries before
+	// IsOrphan can reach them).
+	regCwd := t.TempDir()
+	regPID := os.Getpid()
+	if err := Write(Entry{
+		Cwd:       regCwd,
+		Name:      "orphan-reg",
+		HubPID:    regPID,
+		HubURL:    "http://127.0.0.1:1",
+		StartedAt: time.Now(),
+	}); err != nil {
+		t.Fatalf("Write registry orphan: %v", err)
+	}
+
+	// Process-only orphan: stub liveHubProcessesFn to return a fake
+	// hub PID + cwd that doesn't appear in the registry. Pre-fix this
+	// was the leak case `hub reap` couldn't see.
+	procPID := 1_234_567
+	procCwd := "/tmp/bones-proc-orphan-fake-" + filepath.Base(t.TempDir())
+	stub := func() ([]HubProcess, error) {
+		return []HubProcess{
+			{PID: procPID, ETime: "01:23", Cwd: procCwd, Cmd: "bones hub start"},
+		}, nil
+	}
+	prev := liveHubProcessesFn
+	liveHubProcessesFn = stub
+	t.Cleanup(func() { liveHubProcessesFn = prev })
+
+	orphans, err := AllOrphanHubs()
+	if err != nil {
+		t.Fatalf("AllOrphanHubs: %v", err)
+	}
+	if len(orphans) != 2 {
+		t.Fatalf("expected 2 orphans (1 registry + 1 process); got %d: %+v",
+			len(orphans), orphans)
+	}
+
+	var sawReg, sawProc bool
+	for _, o := range orphans {
+		switch o.Source {
+		case SourceRegistry:
+			sawReg = true
+			if o.PID != regPID || o.Cwd != regCwd {
+				t.Errorf("registry orphan mismatch: pid=%d cwd=%s, want pid=%d cwd=%s",
+					o.PID, o.Cwd, regPID, regCwd)
+			}
+			if o.Entry.Name != "orphan-reg" {
+				t.Errorf("Entry not populated for SourceRegistry: %+v", o.Entry)
+			}
+		case SourceProcess:
+			sawProc = true
+			if o.PID != procPID || o.Cwd != procCwd {
+				t.Errorf("process orphan mismatch: pid=%d cwd=%s, want pid=%d cwd=%s",
+					o.PID, o.Cwd, procPID, procCwd)
+			}
+			if o.Process.Cmd != "bones hub start" {
+				t.Errorf("Process not populated for SourceProcess: %+v", o.Process)
+			}
+		}
+	}
+	if !sawReg {
+		t.Errorf("missing SourceRegistry orphan in result")
+	}
+	if !sawProc {
+		t.Errorf("missing SourceProcess orphan in result")
+	}
+}
+
+// TestAllOrphanHubs_ProcessAlreadyInRegistryNotDoublyReported pins
+// that a live hub PID covered by an existing registry entry is NOT
+// also surfaced as a process-source orphan. The cross-source dedup
+// is keyed on PID first, then on resolved Cwd.
+func TestAllOrphanHubs_ProcessAlreadyInRegistryNotDoublyReported(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	cwd := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cwd, ".bones"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cwd, ".bones", "agent.id"),
+		[]byte("test"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	pid := os.Getpid()
+	if err := Write(Entry{
+		Cwd:       cwd,
+		Name:      "healthy-ws",
+		HubPID:    pid,
+		HubURL:    "http://127.0.0.1:1",
+		StartedAt: time.Now(),
+	}); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	stub := func() ([]HubProcess, error) {
+		return []HubProcess{
+			{PID: pid, ETime: "00:42", Cwd: cwd, Cmd: "bones hub start"},
+		}, nil
+	}
+	prev := liveHubProcessesFn
+	liveHubProcessesFn = stub
+	t.Cleanup(func() { liveHubProcessesFn = prev })
+
+	orphans, err := AllOrphanHubs()
+	if err != nil {
+		t.Fatalf("AllOrphanHubs: %v", err)
+	}
+	if len(orphans) != 0 {
+		t.Errorf("healthy registered workspace should produce 0 orphans, got %d: %+v",
+			len(orphans), orphans)
+	}
+}
+
+// TestReapPID_KillsProcessOnly pins that ReapPID terminates a live PID
+// without touching the registry. Used by hub_reap when handling a
+// process-source orphan that has no Entry to remove.
+func TestReapPID_KillsProcessOnly(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	cmd := exec.Command("sleep", "30")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start sleep: %v", err)
+	}
+	t.Cleanup(func() {
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+			_ = cmd.Wait()
+		}
+	})
+
+	if err := ReapPID(cmd.Process.Pid); err != nil {
+		t.Fatalf("ReapPID: %v", err)
+	}
+	_ = cmd.Wait()
+	if pidAlive(cmd.Process.Pid) {
+		t.Errorf("process still alive after ReapPID+Wait")
+	}
+}
+
+// TestReapPID_DeadPidIsNoOp pins idempotency: ReapPID on a dead PID
+// returns nil without error and without touching anything.
+func TestReapPID_DeadPidIsNoOp(t *testing.T) {
+	if err := ReapPID(999_999); err != nil {
+		t.Errorf("ReapPID on assumed-dead PID should be no-op, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Bug

`bones status --all` flagged ~60 leaked test-spawn hub processes (cwds in deleted `/var/folders/T/TestCLI_*`). `bones hub reap` said "no orphan hub processes found"; `bones doctor` said "OK no orphan hub processes registered". Verified the PIDs were alive (running `bones` binaries pointed at deleted dirs).

Three out of four orphan-aware surfaces were blind to the dominant leak case. `hub reap` couldn't actually clean what `status --all` surfaced; the only recovery path was `kill -9` directly. `status --all`'s footer hint also pointed at a non-existent `--pid=N` flag.

## Root cause

`cli/hub_reap.go`, `cli/doctor.go`, `cli/down.go` all called `registry.Orphans()`, which filters `List()` results — process-only orphans (live `bones hub start` PIDs with no registry entry at all) were invisible. `cli/status.go`'s orphan classifier was the odd one out, walking the process table directly via `registry.LiveHubProcesses()`.

The two orphan definitions are both legitimate but capture different leak modes:
- **Process-based** (status): live `bones hub` whose cwd isn't claimed by any registry entry
- **Registry-based** (reap/doctor/down): registered entry whose PID is alive but cwd dir gone

Test-spawn leaks live only in the first set.

## Fix

Add `registry.AllOrphanHubs()` returning the union of both kinds with an `OrphanSource` discriminant. Migrate the three callers. Split `Reap` into `ReapEntry` (registry-source — kill + remove entry) and `ReapPID` (process-source — kill only). Status keeps its existing renderer; just the footer hint changes.

`ResolveCwd` (formerly the private `cli/status.go:resolveCwd`) moves to the registry package as the canonical symlink-aware comparison helper.

## Changes

- `internal/registry/orphan.go` — `OrphanSource`, `OrphanHub`, `AllOrphanHubs`, `ReapEntry`/`ReapPID` split, `ResolveCwd` helper. `Orphans()` retained as deprecated.
- `cli/hub_reap.go` — switched to `AllOrphanHubs`; renderer dispatches by `Source` for reap action and age fallback.
- `cli/doctor.go` — switched to `AllOrphanHubs`; OK message drops "registered".
- `cli/down.go` — switched to `AllOrphanHubs`; per-orphan plan dispatches by `Source` to `ReapEntry` or `ReapPID`.
- `cli/status.go` — footer hint now reads `(run \`bones hub reap\` to clean)`. The `--pid` flag never existed on `hub reap`.
- `internal/coord/subscribe.go` — 1-line stale comment cleanup (referenced deleted `coord.SubscribePattern`).

## Tests

Added in `internal/registry/orphan_test.go`:
- `TestAllOrphanHubs_UnionOfBothSources` — registry-source + process-source side by side; assert both surface with correct `Source` discriminant.
- `TestAllOrphanHubs_ProcessAlreadyInRegistryNotDoublyReported` — cross-source dedup keyed on PID + resolved Cwd.
- `TestReapPID_KillsProcessOnly` — spawns `sleep`, calls `ReapPID`, confirms killed.
- `TestReapPID_DeadPidIsNoOp` — idempotency.

Test-injectable seam: `liveHubProcessesFn` package-level variable so tests can stub the process scan without spawning real `bones hub start` subprocesses.

`go test -tags=otel -short ./...`: 1148 passed. `make check`: clean.

## Verified end-to-end

After the spy session that surfaced the divergence, the locally-built fix correctly reaps process-source orphans that were previously visible only to `status --all`.
