### PR TITLE
fix(tasks watch): suppress header on stderr under --json

### DIFF
--- a/cli/tasks_watch.go
+++ b/cli/tasks_watch.go
@@ -79,7 +79,9 @@ func (c *TasksWatchCmd) Run(g *repocli.Globals) error {
 		return fmt.Errorf("watch: subscribe: %w", err)
 	}
 
-	fmt.Fprintln(os.Stderr, "watching task events — press Ctrl-C to stop")
+	if !c.JSON {
+		fmt.Fprintln(os.Stderr, "watching task events — press Ctrl-C to stop")
+	}
 
 	for {
 		select {


### PR DESCRIPTION
## Bug

`bones tasks watch --json` emits `watching task events — press Ctrl-C to stop` to stderr alongside the JSONL event stream on stdout. The header is correctly on stderr (so pure stdout-piping consumers like `jq -c .` aren't affected), but consumers that capture both streams (or that pipe stderr into structured-output tooling) see a non-JSON line in their output.

`--json` signals "consumer wants programmatic output". The convention elsewhere in bones (e.g. `bones up --json` from #342) suppresses both human-readable preamble *and* progress lines under `--json`. `tasks watch` was not following that convention.

## Fix

Gate the header `Fprintln` on `!c.JSON`. When the consumer asked for JSON, both streams stay quiet of human-readable framing. The non-`--json` interactive case still prints the header.

## Changes

- `cli/tasks_watch.go` — 3 lines wrapping the existing header emit.

## Tests

`go test -tags=otel -short ./...`: 1148 passed (no regression). `make check`: clean.

The schemas test (`TestEvery_JSONFlag_HasRegistryEntry`) continues to recognize `tasks watch`'s `--json` flag (streaming NDJSON, exempted from envelope-shape contract per #344). No new dedicated test added — exercising the header-gating end-to-end requires a full hub-integration harness, which is scope-disproportionate to a one-condition fix. The behavior change is a single boolean gate; refactoring to make it unit-testable would expand the diff further than the bug warrants.

## Verified

Spy-confirmed against locally-built binary: `bones tasks watch --json 2>&1 | jq -c .` no longer emits the leading non-JSON line.
