### PR TITLE
fix(up): skip SessionStart hooks in non-git workspaces

### DIFF
--- a/cli/orchestrator.go
+++ b/cli/orchestrator.go
@@ -31,6 +31,16 @@ type scaffoldOpts struct {
 	// skills bundle, scaffold-version stamp, and manifest still write
 	// — only the cross-territory hook merge is skipped.
 	Stealth bool
+
+	// OmitHooks skips the .claude/settings.json hook merge for a
+	// different reason than Stealth: the workspace has no .git, so the
+	// SessionStart hooks bones would install (`bones tasks prime`,
+	// `bones hub start`) require git-tracked files to seed fossil and
+	// would fail every time Claude opens the workspace. Set by runUp
+	// when githook.FindGitDir returns empty. The skills bundle, stamp,
+	// and manifest still write so a later `git init && bones up`
+	// converges to a complete scaffold.
+	OmitHooks bool
 }
 
 // scaffoldFootprint captures what scaffoldOrchestrator did during a
@@ -121,7 +131,7 @@ func scaffoldOrchestrator(root string, opts scaffoldOpts) (scaffoldFootprint, er
 	if err := writeBonesSkills(root, &fp); err != nil {
 		return fp, fmt.Errorf("skills bundle: %w", err)
 	}
-	if !opts.Stealth {
+	if !opts.Stealth && !opts.OmitHooks {
 		if err := mergeSettings(filepath.Join(root, ".claude", "settings.json"), &fp); err != nil {
 			return fp, fmt.Errorf("settings: %w", err)
 		}

--- a/cli/up.go
+++ b/cli/up.go
@@ -109,7 +109,25 @@ func runUp(cwd string, opts upOpts) (err error) {
 		logger.Warnf("bones: scaffold incomplete from prior run — re-running scaffold")
 	}
 
-	fp, scaffErr := scaffoldOrchestrator(wsDir, scaffoldOpts{Stealth: opts.Stealth})
+	// Detect git presence once and route both hook-install paths
+	// uniformly. Without .git, the pre-commit hook can't install (no
+	// hooks dir) AND the SessionStart hooks bones would write into
+	// .claude/settings.json all call commands that require git-tracked
+	// files to seed fossil — so they'd fail every time Claude opens
+	// the workspace. See #NNN: scaffolding hooks that will fail is
+	// strictly worse than refusing to scaffold them.
+	noGit := githook.FindGitDir(wsDir) == ""
+	if noGit && !opts.JSON {
+		logger.Infof(
+			"up: no .git found — skipping pre-commit and SessionStart hook install. " +
+				"Run `git init && git add . && git commit -m init` then re-run " +
+				"`bones up` to bootstrap the substrate.")
+	}
+
+	fp, scaffErr := scaffoldOrchestrator(wsDir, scaffoldOpts{
+		Stealth:   opts.Stealth,
+		OmitHooks: noGit,
+	})
 	if scaffErr != nil {
 		err = fmt.Errorf("orchestrator scaffold: %w", scaffErr)
 		return err
@@ -381,13 +399,13 @@ func initOrJoinWorkspace(ctx context.Context, cwd string) (workspace.Info, error
 // enforcement seam that prevents agents from silently bypassing the
 // shadow trunk.
 //
-// The "no .git found" line prints regardless of verbose because it
-// signals a missing enforcement gate the operator should know about.
-// The success line is verbose-only.
+// runUp emits the unified no-.git skip message before calling this and
+// scaffoldOrchestrator, so the no-git branch here is silent — the
+// operator already knows hooks were skipped. Success line is verbose-
+// only.
 func installGitHook(wsDir string, verbose bool, logger *upLogger) error {
 	gitDir := githook.FindGitDir(wsDir)
 	if gitDir == "" {
-		logger.Infof("up: no .git found — skipping pre-commit hook install")
 		return nil
 	}
 	if err := githook.Install(gitDir); err != nil {

--- a/cli/up_migration_test.go
+++ b/cli/up_migration_test.go
@@ -63,3 +63,45 @@ func TestSwarmUp_AcceptsCleanWorkspace_NoMigrationFailure(t *testing.T) {
 		t.Errorf("clean workspace tripped migration check: %v", err)
 	}
 }
+
+// TestUp_NonGitWorkspace_SkipsSessionStartHooks pins the Plan B fix:
+// `bones up` in a workspace without a .git directory must NOT install
+// SessionStart hooks. Pre-fix: hooks were installed, and the
+// `bones tasks prime --hook=session-start` and `bones hub start`
+// commands they invoke require git-tracked files to seed fossil,
+// so they would fail every time Claude opened the workspace. The
+// new behavior is dual-skip: pre-commit hook AND SessionStart hooks
+// are both gated on git presence.
+func TestUp_NonGitWorkspace_SkipsSessionStartHooks(t *testing.T) {
+	dir := t.TempDir() // no `git init` — not a git repo
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("BONES_DIR", t.TempDir())
+
+	// runUp may still emit other downstream errors (e.g. an unrelated
+	// scaffold step), but the migration check is irrelevant here and
+	// .claude/settings.json must not gain SessionStart hooks.
+	_ = runUp(dir, upOpts{Quiet: true})
+
+	settingsPath := filepath.Join(dir, ".claude", "settings.json")
+	data, err := os.ReadFile(settingsPath)
+	if errors.Is(err, os.ErrNotExist) {
+		// Best outcome: no settings.json at all (no hooks merged).
+		return
+	}
+	if err != nil {
+		t.Fatalf("read settings.json: %v", err)
+	}
+	body := string(data)
+	if strings.Contains(body, "SessionStart") {
+		t.Errorf("non-git workspace should not have SessionStart hooks; settings.json:\n%s",
+			body)
+	}
+	if strings.Contains(body, "bones tasks prime") {
+		t.Errorf("non-git workspace should not have `bones tasks prime` hook; settings.json:\n%s",
+			body)
+	}
+	if strings.Contains(body, "bones hub start") {
+		t.Errorf("non-git workspace should not have `bones hub start` hook; settings.json:\n%s",
+			body)
+	}
+}

--- a/internal/hub/hub.go
+++ b/internal/hub/hub.go
@@ -1025,13 +1025,28 @@ var ErrSeedPrecondition = errors.New(
 // the hub is spawned. Today the only precondition is that the
 // workspace has at least one git-tracked file; future preconditions
 // (e.g., libfossil version compatibility) belong here too.
+//
+// Three failure modes share a single user-visible shape:
+//
+//  1. Git binary not on PATH — distinct error naming the missing tool.
+//  2. Workspace is not a git repo (`git ls-files` exit 128) — surfaced
+//     as ErrSeedPrecondition. The actionable message ("commit at least
+//     one file") names the same recovery path that works post-`git
+//     init`, just preceded by `git init`. Pre-fix this case leaked
+//     `git ls-files: exit status 128` to operators (#NNN).
+//  3. Workspace is a git repo with zero tracked files — also
+//     ErrSeedPrecondition.
 func checkSeedPrecondition(root string) error {
 	files, err := gitTrackedFiles(root)
 	if err != nil {
-		// Not a git repo, or git unavailable. Pass through with a
-		// hub: prefix; the underlying error message already names
-		// `git ls-files` which is enough for the user to act on.
-		return fmt.Errorf("hub: seed precondition: %w", err)
+		if errors.Is(err, exec.ErrNotFound) {
+			return errors.New(
+				"hub: git binary not found on PATH; install git to use bones")
+		}
+		// Not a git repo (exit 128) — same actionable recovery as
+		// "no tracked files": the user runs `git init && git add . &&
+		// git commit -m init`. Single friendly error covers both.
+		return ErrSeedPrecondition
 	}
 	if len(files) == 0 {
 		return ErrSeedPrecondition

--- a/internal/hub/precondition_test.go
+++ b/internal/hub/precondition_test.go
@@ -5,9 +5,39 @@ import (
 	"errors"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
+
+// TestCheckSeedPrecondition_NoGitRepo_ReturnsFriendlyError pins that
+// running checkSeedPrecondition in a directory that is NOT a git repo
+// surfaces ErrSeedPrecondition (the friendly "no git-tracked files...
+// commit at least one" message) rather than leaking
+// `git ls-files: exit status 128` to the operator. Spy on v0.15.0
+// surfaced the unfriendly leak.
+func TestCheckSeedPrecondition_NoGitRepo_ReturnsFriendlyError(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	root := t.TempDir() // no `git init` — not a git repo
+	err := checkSeedPrecondition(root)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, ErrSeedPrecondition) {
+		t.Errorf("expected ErrSeedPrecondition, got: %v", err)
+	}
+	// Negative: must NOT contain the cryptic underlying command name.
+	// If a future regression rewires this to fmt.Errorf("...%w", ...)
+	// over the raw exec error again, this guard fires.
+	if strings.Contains(err.Error(), "git ls-files") {
+		t.Errorf("error leaks underlying command; should be friendly: %v", err)
+	}
+	if strings.Contains(err.Error(), "exit status") {
+		t.Errorf("error leaks exit status; should be friendly: %v", err)
+	}
+}
 
 // TestStart_FailsFastOnEmptyGitRepo pins the #138 item 9 fix: when the
 // workspace has no git-tracked files, `bones hub start` must return the


### PR DESCRIPTION
## Bug

`bones up` in a non-git workspace warned `up: no .git found — skipping pre-commit hook install` and proceeded. **But it still installed the SessionStart hooks** that call `bones tasks prime --hook=session-start` and `bones hub start`. Both commands require git-tracked files to seed the fossil — so the hooks would fail every time Claude opened the workspace.

Plus, the underlying error message leaked the cryptic `auto-start hub: hub: seed precondition: git ls-files: exit status 128` to operators in the no-git case (the post-`git init` case already had a friendly message).

## Fix

Two related changes:

### 1. Refuse SessionStart hooks in non-git workspaces

`runUp` now detects git absence once via `githook.FindGitDir(wsDir)` and:
- Emits a unified skip message: `up: no .git found — skipping pre-commit and SessionStart hook install. Run \`git init && git add . && git commit -m init\` then re-run \`bones up\` to bootstrap the substrate.`
- Passes `OmitHooks: true` to `scaffoldOrchestrator`, which gates the `mergeSettings` step on `!Stealth && !OmitHooks`.
- `installGitHook`'s no-git branch becomes silent (the unified message in `runUp` already covered the user).

### 2. Friendly error in the no-git seed-precondition case

`internal/hub/hub.go:checkSeedPrecondition` previously wrapped the `git ls-files: exit status 128` exec error with a `hub: seed precondition:` prefix. It now:
- Detects `errors.Is(err, exec.ErrNotFound)` and surfaces a distinct error naming the missing `git` binary.
- Treats other errors (the dominant case: not-a-repo exit 128) as `ErrSeedPrecondition` — same friendly message that already covered the empty-tracked-files case. The recovery path is identical: `git init && git add . && git commit -m init`.

## Changes

- `cli/up.go` — single git-presence check at the top of `runUp`; unified skip message; pass `OmitHooks` to scaffold; `installGitHook` no-git branch silent.
- `cli/orchestrator.go` — `scaffoldOpts.OmitHooks` field; gate `mergeSettings` on it.
- `internal/hub/hub.go` — `checkSeedPrecondition` distinguishes git-missing from not-a-repo; both surface friendly errors.

## Tests

- `cli/up_migration_test.go::TestUp_NonGitWorkspace_SkipsSessionStartHooks` — runUp on a no-`.git` dir; assert `.claude/settings.json` either doesn't exist or lacks `SessionStart`/`bones tasks prime`/`bones hub start` entries.
- `internal/hub/precondition_test.go::TestCheckSeedPrecondition_NoGitRepo_ReturnsFriendlyError` — non-git dir; assert `errors.Is(err, ErrSeedPrecondition)` and the error string contains neither `git ls-files` nor `exit status` (regression guards).

`go test -tags=otel -short ./...`: passing. `make check`: clean.

## Why "refuse" rather than "make tasks prime tolerate missing fossil"

The substrate-API discipline rule from CONTEXT.md (recently added in PR #345 / ADR 0048): a substrate verb's preconditions are part of its contract. Making `tasks prime` fall back gracefully when fossil can't seed would push complexity into the substrate to paper over a hook that should never have been wired. Refusing to install the hook keeps the substrate strict and the user-visible failure mode near the install step (where the operator can act) rather than at every Claude session-start (where they'd just see hook-rot).
