### PR TITLE
fix(apply): trunkRev parser + fan-in nudge

### DIFF
--- a/cli/apply.go
+++ b/cli/apply.go
@@ -386,7 +386,23 @@ func branchRev(hubFossil, fossilBin, branch string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("fossil info %s: %w", branch, err)
 	}
-	for _, line := range strings.Split(string(out), "\n") {
+	rev, ok := parseFossilInfoRev(string(out))
+	if !ok {
+		return "", fmt.Errorf("could not parse rev for branch %q from `fossil info`", branch)
+	}
+	return rev, nil
+}
+
+// parseFossilInfoRev extracts the hex UUID from `fossil info` output.
+// The `hash:` (current) and `uuid:` (legacy) lines have the form
+// `hash:    <40-hex> <timestamp> UTC`. Earlier code paths returned the
+// whole trailing portion (timestamp included), which then poisoned
+// `.bones/last-applied` and made every subsequent `manifestAtRev`
+// lookup fail. Splitting at the first whitespace token isolates the
+// hex UUID. Shared between branchRev and trunkRev so the two paths
+// can't drift again.
+func parseFossilInfoRev(out string) (string, bool) {
+	for _, line := range strings.Split(out, "\n") {
 		line = strings.TrimSpace(line)
 		for _, prefix := range []string{"uuid:", "hash:"} {
 			if !strings.HasPrefix(line, prefix) {
@@ -396,10 +412,13 @@ func branchRev(hubFossil, fossilBin, branch string) (string, error) {
 			if i := strings.IndexAny(rest, " \t"); i >= 0 {
 				rest = rest[:i]
 			}
-			return rest, nil
+			if rest == "" {
+				return "", false
+			}
+			return rest, true
 		}
 	}
-	return "", fmt.Errorf("could not parse rev for branch %q from `fossil info`", branch)
+	return "", false
 }
 
 // latestSlotRecoveryDir scans `.bones/recovery/` for entries matching
@@ -543,6 +562,7 @@ func (c *ApplyCmd) applyFromCheckout(
 	if total == 0 {
 		outcome.AlreadyUpToDate = true
 		fmt.Printf("bones apply: already up to date at %s\n", shortRev(rev))
+		printFanInNudgeIfNeeded(pre.HubFossil, pre.FossilBin)
 		return writeLastAppliedMarker(pre.WorkspaceDir, rev)
 	}
 	if c.DryRun {
@@ -619,12 +639,27 @@ func refuseIfDirty(workspaceDir string, manifest []string) error {
 // manifest at that rev. A missing marker returns (nil, nil) — first
 // apply is additive-only. A marker pointing at an unknown rev logs a
 // warning and returns (nil, nil) so deletions are suppressed.
+//
+// Self-healing: if the marker is malformed (not a 40-char fossil hex
+// UUID), it is treated as a write-side bug from a prior apply that
+// emitted polluted output. The marker is rewritten to empty so
+// subsequent runs aren't trapped, and the call returns (nil, nil)
+// (additive-only). A legitimately-missing rev (history rewrite, repo
+// swap, valid hex but garbage-collected) keeps the marker so the
+// operator sees the signal across runs.
 func loadPrevManifest(pre *applyPreflight) ([]string, error) {
 	prevRev, err := readLastAppliedMarker(pre.WorkspaceDir)
 	if err != nil {
 		return nil, fmt.Errorf("read last-applied marker: %w", err)
 	}
 	if prevRev == "" {
+		return nil, nil
+	}
+	if !isFossilHexRev(prevRev) {
+		fmt.Fprintf(os.Stderr,
+			"bones apply: discarding malformed last-applied marker %q "+
+				"(not a fossil hex UUID); treating as fresh apply\n", prevRev)
+		_ = writeLastAppliedMarker(pre.WorkspaceDir, "")
 		return nil, nil
 	}
 	prevManifest, err := manifestAtRev(pre.HubFossil, pre.FossilBin, prevRev)
@@ -635,6 +670,26 @@ func loadPrevManifest(pre *applyPreflight) ([]string, error) {
 		return nil, nil
 	}
 	return prevManifest, nil
+}
+
+// isFossilHexRev reports whether s is a syntactically-valid fossil
+// commit hash: exactly 40 lowercase hex characters. Used as the
+// load-side gate that catches polluted markers from pre-fix code paths
+// (where trunkRev returned `<hex> <ts> UTC`).
+func isFossilHexRev(s string) bool {
+	const fossilHexLen = 40
+	if len(s) != fossilHexLen {
+		return false
+	}
+	for _, r := range s {
+		switch {
+		case r >= '0' && r <= '9':
+		case r >= 'a' && r <= 'f':
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 // shortRev abbreviates a fossil hex UUID to 12 characters — fossil's
@@ -910,20 +965,87 @@ func manifestAtRev(hubFossil, fossilBin, rev string) ([]string, error) {
 	return paths, nil
 }
 
+// printFanInNudgeIfNeeded surfaces the agent-branch-with-unmerged-work
+// situation that pre-fix #NNN looked indistinguishable from "nothing
+// to do" to operators.
+//
+// When `bones apply` finds total==0 changes against trunk, the
+// natural read is "everything is already in git". But after a swarm
+// dispatch where slots commit to `agent/<id>` branches and the
+// operator hasn't run `bones swarm fan-in` yet, trunk is still at
+// the seed and the slot work is sitting on agent branches awaiting
+// merge. The operator sees nothing happen and concludes the work
+// was lost.
+//
+// Detection is cheap: `fossil branch list` enumerates all branches;
+// any matching the `agent/*` pattern from ADR 0050 indicates pending
+// slot work the operator can fan-in or apply per-slot. If the helper
+// can't enumerate (fossil-CLI failure, missing binary), it stays
+// silent — the apply already succeeded; the nudge is purely advisory.
+func printFanInNudgeIfNeeded(hubFossil, fossilBin string) {
+	branches, err := fossilAgentBranches(hubFossil, fossilBin)
+	if err != nil || len(branches) == 0 {
+		return
+	}
+	fmt.Fprintf(os.Stderr,
+		"bones apply: trunk is up to date but %d agent branch%s ha%s unmerged work:\n",
+		len(branches), pluralizeBranches(len(branches)), pluralizeHaveHas(len(branches)))
+	for _, b := range branches {
+		fmt.Fprintf(os.Stderr, "  - %s\n", b)
+	}
+	fmt.Fprintln(os.Stderr,
+		"  run `bones swarm fan-in` to land them in trunk, then re-run `bones apply`,")
+	fmt.Fprintln(os.Stderr,
+		"  or `bones apply --slot=<branch> --to=<dir>` to materialize one (ADR 0050).")
+}
+
+// fossilAgentBranches lists branches in the hub fossil whose name
+// matches the agent-branch pattern from ADR 0050 (`agent/<id>`). Used
+// by printFanInNudgeIfNeeded as the "is there pending slot work?"
+// signal.
+func fossilAgentBranches(hubFossil, fossilBin string) ([]string, error) {
+	out, err := exec.Command(fossilBin, "branch", "list", "-R", hubFossil).Output()
+	if err != nil {
+		return nil, err
+	}
+	var agents []string
+	for _, line := range strings.Split(string(out), "\n") {
+		line = strings.TrimSpace(line)
+		// Fossil prefixes the current branch with `* `.
+		line = strings.TrimPrefix(line, "* ")
+		if strings.HasPrefix(line, "agent/") {
+			agents = append(agents, line)
+		}
+	}
+	return agents, nil
+}
+
+func pluralizeBranches(n int) string {
+	if n == 1 {
+		return ""
+	}
+	return "es"
+}
+
+func pluralizeHaveHas(n int) string {
+	if n == 1 {
+		return "s"
+	}
+	return "ve"
+}
+
 // trunkRev returns the trunk tip's hex UUID via `fossil info`.
 // Accepts both legacy (`uuid:`) and current (`hash:`) labels.
+// Routes through parseFossilInfoRev so the trailing-timestamp pollution
+// fixed for branchRev (#NNN) cannot recur here.
 func trunkRev(hubFossil, fossilBin string) (string, error) {
 	out, err := exec.Command(fossilBin, "info", "-R", hubFossil, "trunk").Output()
 	if err != nil {
 		return "", fmt.Errorf("fossil info trunk: %w", err)
 	}
-	for _, line := range strings.Split(string(out), "\n") {
-		line = strings.TrimSpace(line)
-		for _, prefix := range []string{"uuid:", "hash:"} {
-			if strings.HasPrefix(line, prefix) {
-				return strings.TrimSpace(strings.TrimPrefix(line, prefix)), nil
-			}
-		}
+	rev, ok := parseFossilInfoRev(string(out))
+	if !ok {
+		return "", errors.New("could not parse trunk rev from `fossil info`")
 	}
-	return "", errors.New("could not parse trunk rev from `fossil info`")
+	return rev, nil
 }

--- a/cli/apply_test.go
+++ b/cli/apply_test.go
@@ -170,6 +170,236 @@ func TestApplyPreflight_HappyPath(t *testing.T) {
 	}
 }
 
+// TestParseFossilInfoRev pins the rev-extraction contract that
+// branchRev and trunkRev both depend on. Pre-fix, trunkRev returned
+// the entire trailing portion of the `hash:` line (including
+// timestamp and "UTC"), which then poisoned .bones/last-applied and
+// made every subsequent manifestAtRev lookup fail (#NNN). The shared
+// parser splits at the first whitespace token to isolate the hex.
+func TestParseFossilInfoRev(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+		ok   bool
+	}{
+		{
+			name: "current_hash_with_timestamp",
+			in: "hash:    deadbeefcafebabedeadbeefcafebabedeadbeef 2026-05-10 19:05:28 UTC\n" +
+				"tags:    trunk\n",
+			want: "deadbeefcafebabedeadbeefcafebabedeadbeef",
+			ok:   true,
+		},
+		{
+			name: "legacy_uuid_with_timestamp",
+			in:   "uuid:    abcdef0123456789abcdef0123456789abcdef01 2025-01-01 00:00:00 UTC\n",
+			want: "abcdef0123456789abcdef0123456789abcdef01",
+			ok:   true,
+		},
+		{
+			name: "hash_no_trailing",
+			in:   "hash: 1234567890abcdef1234567890abcdef12345678",
+			want: "1234567890abcdef1234567890abcdef12345678",
+			ok:   true,
+		},
+		{
+			name: "tab_separator",
+			in:   "hash:\t1234567890abcdef1234567890abcdef12345678\t2026-01-01",
+			want: "1234567890abcdef1234567890abcdef12345678",
+			ok:   true,
+		},
+		{
+			name: "no_hash_line",
+			in:   "comment: foo\ntags: trunk\n",
+			want: "",
+			ok:   false,
+		},
+		{
+			name: "empty",
+			in:   "",
+			want: "",
+			ok:   false,
+		},
+		{
+			name: "hash_label_no_value",
+			in:   "hash:\n",
+			want: "",
+			ok:   false,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, ok := parseFossilInfoRev(c.in)
+			if got != c.want || ok != c.ok {
+				t.Errorf("parseFossilInfoRev(%q) = (%q, %v), want (%q, %v)",
+					c.in, got, ok, c.want, c.ok)
+			}
+		})
+	}
+}
+
+// TestIsFossilHexRev pins the marker-validity gate used by
+// loadPrevManifest to detect markers polluted by the pre-fix trunkRev
+// (which returned `<hex> <timestamp> UTC` strings).
+func TestIsFossilHexRev(t *testing.T) {
+	cases := map[string]bool{
+		"deadbeefcafebabedeadbeefcafebabedeadbeef":  true,
+		"DEADBEEFCAFEBABEDEADBEEFCAFEBABEDEADBEEF":  false, // uppercase rejected
+		"deadbeefcafebabedeadbeefcafebabedeadbee":   false, // 39 chars
+		"deadbeefcafebabedeadbeefcafebabedeadbeefa": false, // 41 chars
+		"": false,
+		"deadbeef cafebabe deadbeef cafebabe deadb":               false, // contains spaces
+		"65e730745b52867d021a915c4b40f0e3c62f99ea 2026-05-10 UTC": false, // pre-fix marker shape
+	}
+	for in, want := range cases {
+		t.Run(in, func(t *testing.T) {
+			if got := isFossilHexRev(in); got != want {
+				t.Errorf("isFossilHexRev(%q) = %v, want %v", in, got, want)
+			}
+		})
+	}
+}
+
+// TestLoadPrevManifest_HealsMalformedMarker pins the self-healing
+// fallback: if .bones/last-applied was written by pre-fix code that
+// returned `<hex> <ts> UTC`, the gate detects the malformed value,
+// rewrites the marker to empty, and returns (nil, nil) so apply
+// proceeds in additive-only mode. Without the heal, every subsequent
+// run would log "previous rev not found" forever.
+func TestLoadPrevManifest_HealsMalformedMarker(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".bones"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	bad := "65e730745b52867d021a915c4b40f0e3c62f99ea 2026-05-10 19:05:28 UTC"
+	if err := os.WriteFile(filepath.Join(dir, ".bones", "last-applied"),
+		[]byte(bad+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	pre := &applyPreflight{WorkspaceDir: dir}
+	got, err := loadPrevManifest(pre)
+	if err != nil {
+		t.Fatalf("loadPrevManifest: %v", err)
+	}
+	if got != nil {
+		t.Errorf("malformed marker should produce nil manifest, got %v", got)
+	}
+	rev, err := readLastAppliedMarker(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rev != "" {
+		t.Errorf("malformed marker should be cleared, still got %q", rev)
+	}
+}
+
+// TestLoadPrevManifest_ValidHexUnknownRev pins the deletion-suppression
+// path: a marker with a syntactically-valid hex that fossil can't find
+// (history rewrite, repo swap) keeps the marker so the operator sees
+// the signal across runs, and returns (nil, nil) so deletes are
+// suppressed for that apply.
+func TestLoadPrevManifest_ValidHexUnknownRev(t *testing.T) {
+	if _, err := exec.LookPath("fossil"); err != nil {
+		t.Skip("fossil not on PATH")
+	}
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".bones"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Valid hex shape, but no fossil exists at all so any lookup fails.
+	hex := "deadbeefcafebabedeadbeefcafebabedeadbeef"
+	if err := os.WriteFile(filepath.Join(dir, ".bones", "last-applied"),
+		[]byte(hex+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	pre := &applyPreflight{
+		WorkspaceDir: dir,
+		HubFossil:    filepath.Join(dir, "no-such.fossil"),
+		FossilBin:    "fossil",
+	}
+	got, err := loadPrevManifest(pre)
+	if err != nil {
+		t.Fatalf("loadPrevManifest: %v", err)
+	}
+	if got != nil {
+		t.Errorf("missing-rev should suppress deletes (nil manifest), got %v", got)
+	}
+	// Marker preserved across the unknown-rev case (operator-visible signal).
+	rev, err := readLastAppliedMarker(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rev != hex {
+		t.Errorf("valid-hex unknown-rev marker should be preserved, got %q", rev)
+	}
+}
+
+// TestFossilAgentBranches_RealRepo pins the agent-branch detection
+// used by printFanInNudgeIfNeeded. Creates a fossil with one trunk
+// branch + two `agent/<id>` branches and verifies only the agents
+// surface. Stand-in for the operator workflow where slots commit on
+// per-agent branches and the operator forgot to fan-in.
+func TestFossilAgentBranches_RealRepo(t *testing.T) {
+	if _, err := exec.LookPath("fossil"); err != nil {
+		t.Skip("fossil not on PATH")
+	}
+	dir := t.TempDir()
+	hubFossil := filepath.Join(dir, "hub.fossil")
+	wt := filepath.Join(dir, "wt")
+
+	mustRun(t, "fossil", "new", "--admin-user", "u", hubFossil)
+	mustRun(t, "fossil", "open", "--force", hubFossil, "--workdir", wt)
+	defer mustRunIn(t, wt, "fossil", "close", "--force")
+
+	// Seed: single commit on trunk so the repo isn't empty.
+	if err := os.WriteFile(filepath.Join(wt, "seed.txt"), []byte("seed\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mustRunIn(t, wt, "fossil", "add", "seed.txt")
+	mustRunIn(t, wt, "fossil", "commit", "--no-warnings", "--user-override", "u", "-m", "init")
+
+	// Two agent branches via `branch new` from trunk.
+	mustRunIn(t, wt, "fossil", "branch", "new", "agent/writer-abc", "trunk")
+	mustRunIn(t, wt, "fossil", "branch", "new", "agent/tester-xyz", "trunk")
+
+	got, err := fossilAgentBranches(hubFossil, "fossil")
+	if err != nil {
+		t.Fatalf("fossilAgentBranches: %v", err)
+	}
+	if !equalStringSets(got, []string{"agent/tester-xyz", "agent/writer-abc"}) {
+		t.Errorf("agent branches = %v, want [agent/tester-xyz agent/writer-abc]", got)
+	}
+}
+
+// TestFossilAgentBranches_NoAgents pins the negative case: a fossil
+// with only trunk + a feature branch returns an empty slice (the
+// nudge stays silent for non-swarm workspaces).
+func TestFossilAgentBranches_NoAgents(t *testing.T) {
+	if _, err := exec.LookPath("fossil"); err != nil {
+		t.Skip("fossil not on PATH")
+	}
+	dir := t.TempDir()
+	hubFossil := filepath.Join(dir, "hub.fossil")
+	wt := filepath.Join(dir, "wt")
+	mustRun(t, "fossil", "new", "--admin-user", "u", hubFossil)
+	mustRun(t, "fossil", "open", "--force", hubFossil, "--workdir", wt)
+	defer mustRunIn(t, wt, "fossil", "close", "--force")
+	if err := os.WriteFile(filepath.Join(wt, "seed.txt"), []byte("seed\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mustRunIn(t, wt, "fossil", "add", "seed.txt")
+	mustRunIn(t, wt, "fossil", "commit", "--no-warnings", "--user-override", "u", "-m", "init")
+	mustRunIn(t, wt, "fossil", "branch", "new", "feature/foo", "trunk")
+
+	got, err := fossilAgentBranches(hubFossil, "fossil")
+	if err != nil {
+		t.Fatalf("fossilAgentBranches: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("non-agent branches should not surface, got %v", got)
+	}
+}
+
 func TestTrunkManifest_RealFossilRepo(t *testing.T) {
 	if _, err := exec.LookPath("fossil"); err != nil {
 		t.Skip("fossil not on PATH")


### PR DESCRIPTION
## Bug surfaced by spy on v0.15.3

After `bones swarm dispatch plan.md` + slot commits + `swarm dispatch --advance` ("all waves complete"), running `bones apply` printed:

```
bones apply: previous rev 65e730745b52867d021a915c4b40f0e3c62f99ea 2026-05-10 19:05:28 UTC not found in hub fossil; suppressing deletions
bones apply: already up to date at 65e730745b52
```

…with zero new files in `git status`. The slot work appeared lost.

## Two real defects, one architectural clarity

A Plan-agent dive established that the work was **not lost** — slot commits land on per-agent branches (`agent/<id>`) per ADR 0023/0050, awaiting an explicit `swarm fan-in` to reach trunk. But two real bugs amplified the operator confusion:

### 1. `trunkRev` returned a polluted rev string

`fossil info trunk` prints `hash:    <40-hex> <timestamp> UTC` on one line. `branchRev` (`cli/apply.go:384`) handles this via `IndexAny(rest, " \t")` whitespace-split. `trunkRev` (`cli/apply.go:915`) was missed in that fix and returned the entire trailing portion. The polluted string was then written to `.bones/last-applied` by every successful apply, and every subsequent `manifestAtRev(prevRev)` lookup failed because fossil's CLI doesn't accept hex-with-trailing-text.

**Self-perpetuating bug**: each successful apply re-wrote the poisoned marker.

### 2. UX gap: trunk apply says "up to date" when slot work sits unmerged

After a swarm dispatch, slot commits live on `agent/*` branches. `bones apply` (no flags) materializes trunk. If the operator hasn't run `swarm fan-in`, trunk is still at the seed and apply finds zero changes. The output `"already up to date"` reads as "everything's good" — but the slot work is sitting on agent branches the operator hasn't touched.

## Fix

### Fix 1 — Shared rev parser (anti-drift)

Extracted a single `parseFossilInfoRev(out string) (string, bool)` helper that both `branchRev` and `trunkRev` now route through. Splits at the first whitespace token, returns the bare hex. The two paths can no longer drift.

### Fix 2 — Marker self-healing

`loadPrevManifest` gained an `isFossilHexRev` gate (lowercase 40-hex check). When the marker is malformed, the gate logs `"discarding malformed last-applied marker"`, rewrites the marker to empty, and returns `(nil, nil)` — additive-only apply. A legitimate "rev not in fossil" (history rewrite, repo swap with valid hex) keeps the marker so the operator sees the signal across runs.

### Fix 3 — Operator nudge in the up-to-date branch

When `bones apply` finds total==0 changes, it now consults `fossil branch list` and surfaces any `agent/*` branches as pending slot work:

```
bones apply: trunk is up to date but 2 agent branches have unmerged work:
  - agent/tester-xyz
  - agent/writer-abc
  run `bones swarm fan-in` to land them in trunk, then re-run `bones apply`,
  or `bones apply --slot=<branch> --to=<dir>` to materialize one (ADR 0050).
```

Best-effort: if `fossil branch list` fails (binary missing, permission), the helper stays silent. Apply already succeeded; the nudge is purely advisory.

### Architectural choice (P1, ADR-faithful)

The Plan agent surfaced three options for closing the UX gap:
- **P1** keep `swarm fan-in` manual; add the nudge in apply
- **P2** auto-fan-in inside apply when no `--slot` flag
- **P3** auto-fan-in at end of `swarm dispatch --advance`

Picked **P1**. CONTEXT.md's substrate-API discipline (explicit verbs over implicit side effects, recently restated in ADR 0048) favors operator-gated fan-in. The nudge fully closes the operator-confusion path without making `apply` or `advance` mutate state implicitly.

## Tests

- `TestParseFossilInfoRev` — table-test of the shared parser across `hash:`/`uuid:`, with/without trailing timestamp, tab vs space, label-only, empty.
- `TestIsFossilHexRev` — boundary cases for the marker-validity gate.
- `TestLoadPrevManifest_HealsMalformedMarker` — pre-fix marker shape gets cleared.
- `TestLoadPrevManifest_ValidHexUnknownRev` — valid hex with missing rev is preserved (history-rewrite signal).
- `TestFossilAgentBranches_RealRepo` — real fossil with two `agent/*` branches surfaces them.
- `TestFossilAgentBranches_NoAgents` — `feature/*` branches don't surface (nudge stays silent for non-swarm workspaces).

`go test -tags=otel -short ./...`: passing. `make check`: clean.

## Verified manually

Pre-fix: dispatch → 2 slots commit → advance → apply showed "previous rev not found" + zero new files, no recovery hint.

Post-fix: same sequence shows the nudge listing the 2 agent branches and the recovery commands. Marker is no longer polluted on subsequent applies.
