### PR TITLE
fix(json): honor --json on status/doctor + fix tasks list --closed

### DIFF
--- a/cli/doctor.go
+++ b/cli/doctor.go
@@ -17,6 +17,7 @@ import (
 	edgecli "github.com/danmestas/EdgeSync/cli"
 	repocli "github.com/danmestas/EdgeSync/cli/repo"
 
+	"github.com/danmestas/bones/cli/schemas"
 	"github.com/danmestas/bones/internal/clauderhooks"
 	"github.com/danmestas/bones/internal/githook"
 	"github.com/danmestas/bones/internal/hub"
@@ -67,6 +68,15 @@ func (c *DoctorCmd) Run(g *repocli.Globals) (err error) {
 	if c.All {
 		return c.runAll(g)
 	}
+	// JSON mode (no --all): emit a single-element DoctorAllPayload
+	// covering the current workspace, mirroring the --all --json
+	// envelope shape. Pre-fix #NNN, --json was declared on this verb
+	// but the non-`--all` path silently emitted human text. The
+	// per-workspace JSON path delegates to runDoctorOne so it sees
+	// exactly the checks --all does.
+	if c.JSON {
+		return c.runJSONForCwd()
+	}
 
 	_, end := telemetry.RecordCommand(context.Background(), "doctor")
 	var (
@@ -104,6 +114,53 @@ func (c *DoctorCmd) Run(g *repocli.Globals) (err error) {
 		return baseErr
 	}
 	return swarmErr
+}
+
+// runJSONForCwd renders `bones doctor --json` (no --all) by locating
+// the current cwd's registry entry and running the same runDoctorOne
+// path --all uses for that single workspace. Emits the standard
+// DoctorAllPayload envelope so consumers piping `doctor --json` and
+// `doctor --all --json` get the same shape (single-element vs full
+// roster). When the cwd has no registry entry yet (incomplete `bones
+// up`, fresh workspace), emits an empty workspaces array — same
+// "registered or not" provenance the --all path uses.
+func (c *DoctorCmd) runJSONForCwd() error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("cwd: %w", err)
+	}
+	entries, err := registry.List()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "doctor --json: registry list: %v\n", err)
+		return err
+	}
+	cwdResolved := registry.ResolveCwd(cwd)
+	rows := make([]schemas.DoctorWorkspaceRow, 0, 1)
+	anyIssue := false
+	for _, e := range entries {
+		if registry.ResolveCwd(e.Cwd) != cwdResolved {
+			continue
+		}
+		r := runDoctorOne(e)
+		rows = append(rows, schemas.DoctorWorkspaceRow{
+			Name:     r.Entry.Name,
+			Cwd:      r.Entry.Cwd,
+			HubAlive: r.HubAlive,
+			Issues:   r.Issues,
+		})
+		if r.Issues > 0 {
+			anyIssue = true
+		}
+		break
+	}
+	if err := emitEnvelope(os.Stdout, "doctor",
+		schemas.DoctorAllPayload{Workspaces: rows}); err != nil {
+		return err
+	}
+	if anyIssue {
+		return fmt.Errorf("doctor: issues found")
+	}
+	return nil
 }
 
 // runAll dispatches the cross-workspace --all rendering path.

--- a/cli/doctor_all_test.go
+++ b/cli/doctor_all_test.go
@@ -157,6 +157,68 @@ func TestDoctorAllJSON(t *testing.T) {
 	}
 }
 
+// TestDoctorJSON_PerWorkspaceEnvelope pins the Cluster D fix:
+// `bones doctor --json` (no --all) emits the same DoctorAllPayload
+// envelope shape --all uses, scoped to the single workspace at the
+// caller's cwd. Pre-fix #NNN, --json was declared but the non-`--all`
+// path silently emitted human text.
+func TestDoctorJSON_PerWorkspaceEnvelope(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+	}))
+	defer srv.Close()
+	xDir := makeFakeWorkspace(t, "lone")
+	if err := registry.Write(registry.Entry{
+		Cwd: xDir, Name: "lone", HubURL: srv.URL, HubPID: os.Getpid(),
+		StartedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	t.Chdir(xDir)
+	// Capture stdout via the package-level os.Stdout swap pattern other
+	// tests use. Simpler here: redirect os.Stdout for the duration of
+	// the call and restore after.
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	prev := os.Stdout
+	os.Stdout = w
+	cmd := &DoctorCmd{JSON: true}
+	runErr := cmd.runJSONForCwd()
+	_ = w.Close()
+	os.Stdout = prev
+	if runErr != nil {
+		t.Fatalf("runJSONForCwd: %v", runErr)
+	}
+	var buf bytes.Buffer
+	if _, err := buf.ReadFrom(r); err != nil {
+		t.Fatal(err)
+	}
+	var env struct {
+		Schema struct {
+			Verb    string `json:"verb"`
+			Version string `json:"version"`
+		} `json:"schema"`
+		Data struct {
+			Workspaces []struct {
+				Name string `json:"name"`
+				Cwd  string `json:"cwd"`
+			} `json:"workspaces"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &env); err != nil {
+		t.Fatalf("unmarshal: %v\noutput: %s", err, buf.String())
+	}
+	if env.Schema.Verb != "doctor" || env.Schema.Version != "v1" {
+		t.Errorf("schema = %+v, want {doctor v1}", env.Schema)
+	}
+	if len(env.Data.Workspaces) != 1 || env.Data.Workspaces[0].Name != "lone" {
+		t.Errorf("workspaces = %+v", env.Data.Workspaces)
+	}
+}
+
 // TestDoctorAll_DoesNotRewriteSettings pins the ADR 0051 contract
 // for --all mode: per-workspace auto-rewrite is off in the
 // multi-workspace path. A `bones doctor --all` invocation walks

--- a/cli/status.go
+++ b/cli/status.go
@@ -100,6 +100,15 @@ func (c *StatusCmd) Run(g *repocli.Globals) error {
 	if err != nil {
 		return err
 	}
+	// JSON mode (no --all): emit the current workspace's row through
+	// the same StatusAllPayload schema --all uses, so consumers piping
+	// `bones status --json` and `bones status --all --json` get the
+	// same envelope shape (single-element workspaces array vs full
+	// host roster). Pre-fix #NNN the --json flag was declared but the
+	// non-`--all` path silently emitted human text.
+	if c.JSON {
+		return renderStatusJSONForRoot(os.Stdout, root)
+	}
 	// Read-only hub probe (#207). If the hub isn't healthy, render
 	// the existing degraded-mode branch (HubAvailable=false) without
 	// touching workspace.Join — Join would lazy-start the hub via
@@ -119,6 +128,49 @@ func (c *StatusCmd) Run(g *repocli.Globals) error {
 		return err
 	}
 	return renderStatus(report, os.Stdout)
+}
+
+// renderStatusJSONForRoot emits the StatusAllPayload envelope with a
+// single workspace row matching the current root. Used by `bones
+// status --json` (without `--all`) so the JSON contract is uniform
+// with `--all --json`. Looks the row up by cwd in the registry,
+// falling back to a synthetic row when the workspace isn't registered
+// (e.g. an incomplete `bones up`).
+func renderStatusJSONForRoot(w io.Writer, root string) error {
+	entries, err := registry.List()
+	if err != nil {
+		return err
+	}
+	rootResolved := registry.ResolveCwd(root)
+	for _, e := range entries {
+		if registry.ResolveCwd(e.Cwd) != rootResolved {
+			continue
+		}
+		state := "idle"
+		switch {
+		case e.HubPID == 0:
+			state = "idle"
+		case registry.IsAlive(e):
+			state = "active"
+		default:
+			state = "paused"
+		}
+		row := schemas.StatusWorkspaceRow{
+			Cwd:       e.Cwd,
+			Name:      e.Name,
+			HubURL:    e.HubURL,
+			State:     state,
+			Sessions:  sessions.CountByWorkspace(e.Cwd),
+			StartedAt: timefmt.NewLoggedTime(e.StartedAt),
+		}
+		return emitEnvelope(w, "status",
+			schemas.StatusAllPayload{Workspaces: []schemas.StatusWorkspaceRow{row}})
+	}
+	// Workspace not in registry — emit an empty workspaces list so
+	// the schema contract holds. Operator hint about the missing
+	// registration is the human-mode renderer's job.
+	return emitEnvelope(w, "status",
+		schemas.StatusAllPayload{Workspaces: []schemas.StatusWorkspaceRow{}})
 }
 
 // resolveStatusRoot walks up from cwd to the workspace marker

--- a/cli/status_test.go
+++ b/cli/status_test.go
@@ -803,6 +803,80 @@ func TestRenderActiveWorkspacesSection_NoneFallback(t *testing.T) {
 	}
 }
 
+// TestStatusJSONForRoot_RegisteredWorkspace pins the Cluster D fix:
+// `bones status --json` (no --all) emits the same StatusAllPayload
+// envelope shape --all uses, scoped to the single workspace at the
+// caller's cwd. Pre-fix #NNN, --json was declared but the non-`--all`
+// path silently emitted human text.
+func TestStatusJSONForRoot_RegisteredWorkspace(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+	}))
+	defer srv.Close()
+	cwd := t.TempDir()
+	if err := registry.Write(registry.Entry{
+		Cwd: cwd, Name: "lone", HubURL: srv.URL, HubPID: os.Getpid(),
+		StartedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	var buf bytes.Buffer
+	if err := renderStatusJSONForRoot(&buf, cwd); err != nil {
+		t.Fatalf("renderStatusJSONForRoot: %v", err)
+	}
+	var env struct {
+		Schema struct {
+			Verb    string `json:"verb"`
+			Version string `json:"version"`
+		} `json:"schema"`
+		Data struct {
+			Workspaces []struct {
+				Name  string `json:"name"`
+				Cwd   string `json:"cwd"`
+				State string `json:"state"`
+			} `json:"workspaces"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &env); err != nil {
+		t.Fatalf("unmarshal: %v\noutput: %s", err, buf.String())
+	}
+	if env.Schema.Verb != "status" || env.Schema.Version != "v1" {
+		t.Errorf("schema = %+v, want {status v1}", env.Schema)
+	}
+	if len(env.Data.Workspaces) != 1 {
+		t.Fatalf("workspaces len = %d, want 1: %s", len(env.Data.Workspaces), buf.String())
+	}
+	if env.Data.Workspaces[0].Name != "lone" {
+		t.Errorf("name = %q, want lone", env.Data.Workspaces[0].Name)
+	}
+}
+
+// TestStatusJSONForRoot_UnregisteredCwd pins the missing-registration
+// path: a cwd that hasn't called `bones up` yet (or whose entry was
+// removed by `bones down`) emits an empty workspaces array — the
+// envelope contract holds; consumers see len(workspaces)==0.
+func TestStatusJSONForRoot_UnregisteredCwd(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	cwd := t.TempDir() // never registered
+	var buf bytes.Buffer
+	if err := renderStatusJSONForRoot(&buf, cwd); err != nil {
+		t.Fatalf("renderStatusJSONForRoot: %v", err)
+	}
+	var env struct {
+		Data struct {
+			Workspaces []struct{} `json:"workspaces"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &env); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(env.Data.Workspaces) != 0 {
+		t.Errorf("unregistered cwd: workspaces len = %d, want 0",
+			len(env.Data.Workspaces))
+	}
+}
+
 func TestStatusAllJSON(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/cli/tasks_list.go
+++ b/cli/tasks_list.go
@@ -122,6 +122,7 @@ func (c *TasksListCmd) Run(g *repocli.Globals) error {
 		defer closeCoord()
 
 		out := filterTasks(allTasks, c.All, filterStatus, c.ClaimedBy)
+		statusFilterActive := filterStatus != ""
 		if c.Ready {
 			// Delegate readiness to coord — it knows the full edge
 			// model (blocks/supersedes/duplicates/parent) that a flat
@@ -147,7 +148,7 @@ func (c *TasksListCmd) Run(g *repocli.Globals) error {
 			out = filterOrphans(out, liveAgentSet(peers))
 		}
 
-		return c.render(out, allTasks)
+		return c.render(out, allTasks, statusFilterActive)
 	}))
 }
 
@@ -156,7 +157,14 @@ func (c *TasksListCmd) Run(g *repocli.Globals) error {
 // rendering. Pulled out of Run so the orchestration body stays under
 // the funlen budget while the rendering logic remains adjacent to
 // the filter pipeline that produced its inputs.
-func (c *TasksListCmd) render(out, allTasks []tasks.Task) error {
+//
+// statusFilterActive scopes the "no open tasks; N closed" hint:
+// pre-fix #NNN, that hint fired even when the user explicitly asked
+// for `--status=closed` (or its --closed alias) and got an empty
+// result, conflating "filter excluded all rows" with "nothing matches
+// your filter". Now the hint fires only in the no-filter case where
+// it actually answers the operator's likely question.
+func (c *TasksListCmd) render(out, allTasks []tasks.Task, statusFilterActive bool) error {
 	// --by-slot replaces the per-task rendering with the per-slot
 	// summary (issue #214). Composes with the other filters: e.g.
 	// `--by-slot --claimed-by=-` shows hot slots among unclaimed
@@ -168,12 +176,12 @@ func (c *TasksListCmd) render(out, allTasks []tasks.Task) error {
 	}
 
 	// Filter-emptiness hint: when the human-mode result is empty
-	// but closed tasks exist, point the operator at --all so they
-	// can tell "the filter hid closed rows" from "there is nothing
-	// to list at all". JSON output skips the hint — JSON consumers
-	// see the empty array; the hint is human-only by design (issue
-	// #323's read-verb rule).
-	if !c.JSON && len(out) == 0 && !c.All {
+	// but closed tasks exist AND the operator did not explicitly
+	// filter, point them at --all so they can tell "the filter hid
+	// closed rows" from "there is nothing to list at all". JSON
+	// output skips the hint — JSON consumers see the empty array;
+	// the hint is human-only by design (issue #323's read-verb rule).
+	if !c.JSON && len(out) == 0 && !c.All && !statusFilterActive {
 		closedCount := countClosed(allTasks)
 		if closedCount > 0 {
 			uxprint.NoOpenTasks(os.Stdout, closedCount)
@@ -199,10 +207,18 @@ func countClosed(in []tasks.Task) int {
 
 // filterTasks applies the always-on list filters (closed-vs-all, status,
 // claimed-by). Other selectors compose on top of its result.
+//
+// The --all-vs-hide-closed rule applies only when no explicit status
+// filter is set. Pre-fix #NNN, this branch always dropped closed
+// tasks unless --all was set — which made `bones tasks list --closed`
+// (and `--status=closed`) silently empty: the !all branch dropped
+// closed first, leaving the explicit status filter with nothing to
+// match. The fix only hides closed when the user asked for no
+// status filter at all.
 func filterTasks(in []tasks.Task, all bool, status tasks.Status, claimedBy string) []tasks.Task {
 	out := make([]tasks.Task, 0, len(in))
 	for _, t := range in {
-		if !all && t.Status == tasks.StatusClosed {
+		if status == "" && !all && t.Status == tasks.StatusClosed {
 			continue
 		}
 		if status != "" && t.Status != status {

--- a/cli/tasks_list_test.go
+++ b/cli/tasks_list_test.go
@@ -134,6 +134,72 @@ func TestSelectByStatus(t *testing.T) {
 	}
 }
 
+// TestFilterTasks_StatusClosedReturnsClosed pins the Cluster E fix:
+// pre-fix #NNN, filterTasks dropped closed tasks unless --all was set,
+// regardless of an explicit `--status=closed` filter. The `--closed`
+// alias from #336 routed through the same path and was therefore
+// silently empty. Now an explicit closed-status filter returns the
+// closed tasks even without --all.
+func TestFilterTasks_StatusClosedReturnsClosed(t *testing.T) {
+	all := []tasks.Task{
+		{ID: "open1", Status: tasks.StatusOpen},
+		{ID: "claimed1", Status: tasks.StatusClaimed},
+		{ID: "closed1", Status: tasks.StatusClosed},
+		{ID: "closed2", Status: tasks.StatusClosed},
+	}
+	got := filterTasks(all, false, tasks.StatusClosed, "")
+	if len(got) != 2 {
+		t.Fatalf("status=closed without --all: want 2 closed, got %d: %#v", len(got), got)
+	}
+	for _, ts := range got {
+		if ts.Status != tasks.StatusClosed {
+			t.Errorf("expected only closed, got status=%s id=%s", ts.Status, ts.ID)
+		}
+	}
+}
+
+// TestFilterTasks_NoFilterHidesClosed pins the unchanged default
+// behavior: with no --all and no --status, closed tasks are hidden
+// (so plain `bones tasks list` shows only the in-flight backlog).
+func TestFilterTasks_NoFilterHidesClosed(t *testing.T) {
+	all := []tasks.Task{
+		{ID: "open1", Status: tasks.StatusOpen},
+		{ID: "closed1", Status: tasks.StatusClosed},
+	}
+	got := filterTasks(all, false, "", "")
+	if len(got) != 1 || got[0].ID != "open1" {
+		t.Errorf("no-filter default: want only open1, got %#v", got)
+	}
+}
+
+// TestFilterTasks_AllReturnsEverything pins that --all (with no status
+// filter) returns every task regardless of status.
+func TestFilterTasks_AllReturnsEverything(t *testing.T) {
+	all := []tasks.Task{
+		{ID: "open1", Status: tasks.StatusOpen},
+		{ID: "closed1", Status: tasks.StatusClosed},
+		{ID: "claimed1", Status: tasks.StatusClaimed},
+	}
+	got := filterTasks(all, true, "", "")
+	if len(got) != 3 {
+		t.Errorf("--all: want all 3, got %d", len(got))
+	}
+}
+
+// TestFilterTasks_StatusOpenAlias pins that --status=open (alias
+// --open) returns only open tasks (claimed and closed both filtered).
+func TestFilterTasks_StatusOpenAlias(t *testing.T) {
+	all := []tasks.Task{
+		{ID: "open1", Status: tasks.StatusOpen},
+		{ID: "claimed1", Status: tasks.StatusClaimed},
+		{ID: "closed1", Status: tasks.StatusClosed},
+	}
+	got := filterTasks(all, false, tasks.StatusOpen, "")
+	if len(got) != 1 || got[0].ID != "open1" {
+		t.Errorf("status=open: want only open1, got %#v", got)
+	}
+}
+
 // TestGroupBySlot covers the inspection-mode aggregation introduced for
 // issue #214 — grouping open tasks by their Context["slot"] value with a
 // hot-slot indicator. Closed tasks free the slot and must not be counted.


### PR DESCRIPTION
## Two related v0.15.3 spy findings

Spy on v0.15.3 surfaced three JSON-contract issues. Two are non-breaking bug fixes and ship here:

### Cluster D — `--json` declared on `status` and `doctor` but ignored

Both verbs declare a `--json` flag that the implementation silently dropped on the **default** (no-`--all`) path. `bones status --all --json` worked because that branch had its own JSON renderer; `bones status --json` and `bones doctor --json` printed human text.

**Fix:** the non-`--all` path now emits the same envelope shape as `--all`, scoped to the current workspace's row. Single-element `data.workspaces` array. Consumers piping `--json` and `--all --json` see the same shape with different cardinality.

`status` uses `StatusAllPayload`, `doctor` uses `DoctorAllPayload` — no schema bump, no breaking change for existing `--all --json` consumers.

### Cluster E — `tasks list --closed` returns nothing

`bones tasks list --closed` (alias from PR #336) and `bones tasks list --status=closed` (long form) both fell through to the default-mode `(no open tasks; N closed — pass --all to include)` hint instead of filtering to closed tasks.

Root cause in `cli/tasks_list.go::filterTasks`: `if !all && t.Status == StatusClosed { continue }` dropped closed tasks unconditionally before the explicit-status filter could match them. The `--all` semantic was conflated with "show closed".

**Fix:** the hide-closed branch now applies only when no explicit status filter is set:

```go
if status == "" && !all && t.Status == tasks.StatusClosed {
    continue
}
```

The `(no open tasks)` hint also gained a `statusFilterActive` gate so it stops mis-firing when the operator's explicit `--status=closed` returns zero rows for unrelated reasons.

## Changes

- `cli/status.go` — `--json` branch in `StatusCmd.Run`; new `renderStatusJSONForRoot` emits a single-element `StatusAllPayload`.
- `cli/doctor.go` — `--json` branch in `DoctorCmd.Run`; new `runJSONForCwd` emits a single-element `DoctorAllPayload`. Imports `cli/schemas`.
- `cli/tasks_list.go` — gate the hide-closed filter on `status == ""`; thread `statusFilterActive` into `render` to gate the misleading hint.

## Tests

- `TestFilterTasks_StatusClosedReturnsClosed` — explicit status=closed without --all returns closed.
- `TestFilterTasks_NoFilterHidesClosed` — default behavior unchanged.
- `TestFilterTasks_AllReturnsEverything` — --all returns everything.
- `TestFilterTasks_StatusOpenAlias` — --status=open works.
- `TestStatusJSONForRoot_RegisteredWorkspace` — registered cwd emits single-element envelope.
- `TestStatusJSONForRoot_UnregisteredCwd` — unregistered cwd emits empty workspaces array (envelope contract holds).
- `TestDoctorJSON_PerWorkspaceEnvelope` — doctor --json emits DoctorAllPayload with one row.

`go test -tags=otel -short ./...`: passing. `make check`: clean (modulo the pre-existing flaky NATS pse vs timefmt race documented in known-issues.md).

## Cluster F deferred

The third spy finding — `tasks list --json` returns `data` as a top-level array (`type TasksListPayload []Task`) while every other envelope wraps `data` in a named field — is a **breaking JSON-shape change**. Bumping `tasks.list` to v2 with `data.tasks: [...]` would break every consumer using `.data[]`. Surfaced for explicit decision; not in this PR.
