### PR TITLE
fix(apply): plan-slot commits advance trunk + apply walks temp checkout

### DIFF
--- a/cli/apply.go
+++ b/cli/apply.go
@@ -539,7 +539,19 @@ func (o *applyOutcome) attrs() []telemetry.Attr {
 func (c *ApplyCmd) applyFromCheckout(
 	pre *applyPreflight, tempDir string, outcome *applyOutcome,
 ) error {
-	manifest, rev, err := trunkManifest(pre.HubFossil, pre.FossilBin)
+	// Use the on-disk temp checkout as the manifest source rather than
+	// `fossil ls -r trunk` (the prior implementation in trunkManifest).
+	// Per the comment on scanCheckoutManifest, libfossil-written commits
+	// (every slot commit goes through this path) come back as empty
+	// from `fossil ls -R repo -r <rev>` on Fossil 2.28 — the xfer
+	// protocol on the receive side doesn't hydrate the row that ls
+	// queries. The on-disk checkout, once `fossil open` extracts it,
+	// is authoritative. Walking it gives us the actual manifest.
+	manifest, err := scanCheckoutManifest(tempDir)
+	if err != nil {
+		return fmt.Errorf("bones apply: scan trunk checkout: %w", err)
+	}
+	rev, err := trunkRev(pre.HubFossil, pre.FossilBin)
 	if err != nil {
 		return err
 	}

--- a/internal/swarm/lease.go
+++ b/internal/swarm/lease.go
@@ -556,15 +556,23 @@ func (l *ResumedLease) Commit(
 		return CommitResult{}, fmt.Errorf("swarm.ResumedLease.Commit: leaf already stopped")
 	}
 	// #288: synthetic agent slots (slot name `agent-<prefix>`) commit on
-	// the per-agent fossil branch `agent/<full-id>` instead of advancing
-	// trunk. Plan-anchored slots leave Tags nil and continue the
-	// trunk-based-development model. The full agent_id lives on the
-	// session record's AgentID field, which Resume copied into
-	// l.fossilUser; for plan slots that field is `slot-<name>` and
-	// IsSyntheticSlot keeps the tag derivation off it.
+	// the per-agent fossil branch `agent/<full-id>` for parallel-work
+	// isolation per ADR 0050.
+	//
+	// Plan-anchored slots commit on trunk (the trunk-based-development
+	// model). Pre-#NNN they passed Tags=nil expecting parent-branch
+	// inheritance the way `fossil ci` does, but libfossil emits exactly
+	// the tags the caller supplies — no inheritance — so the slot
+	// commits had no branch tag and `fossil info trunk` kept resolving
+	// to the seed. Now plan-anchored slots pass an explicit
+	// `branch=trunk` + `sym-trunk=*` pair, mirroring what fossil's CLI
+	// `ci` would emit, so the resulting checkin advances trunk
+	// correctly and `bones apply` materializes the slot work.
 	var tags []TagSpec
 	if IsSyntheticSlot(l.slot) {
 		tags = AgentBranchTags(l.fossilUser)
+	} else {
+		tags = TrunkBranchTags()
 	}
 	uuid, err := commitViaLeaf(ctx, l.leaf, l.taskID, message, files, tags)
 	if err != nil {

--- a/internal/swarm/synthetic.go
+++ b/internal/swarm/synthetic.go
@@ -112,6 +112,34 @@ func AgentBranchTags(agentID string) []TagSpec {
 	}
 }
 
+// TrunkBranchTags returns the libfossil branch-tag pair that explicitly
+// lands a commit on trunk. Mirrors AgentBranchTags's shape (the same
+// `branch=<name>` + `sym-<name>=*` pair) but with name="trunk".
+//
+// Plan-anchored slots use this (not nil tags) so the resulting checkin
+// carries the propagating `branch=trunk` tag. Pre-#NNN, plan-anchored
+// slots passed Tags=nil to libfossil.Commit, expecting parent-branch
+// inheritance the way `fossil ci` does. libfossil emits exactly the
+// tag cards the caller supplies — when none are supplied, the commit
+// has no branch tag, `fossil info trunk` resolves to the seed (the
+// last commit explicitly tagged), and `bones apply` shows the trunk
+// as un-advanced even though the operator's slot work pushed
+// successfully. Today's spy on v0.16.0 reproduced this end-to-end:
+// after `swarm dispatch --advance` "all waves complete", `bones apply`
+// returned "already up to date" and `git status` showed zero new
+// files even though the commits were in the hub fossil.
+//
+// Same emission path as AgentBranchTags — libfossil's existing tag
+// machinery handles both. The only behavioral asymmetry was the
+// caller passing nil for plan slots while passing AgentBranchTags
+// for synthetic ones.
+func TrunkBranchTags() []TagSpec {
+	return []TagSpec{
+		{Name: "branch", Value: "trunk"},
+		{Name: "sym-trunk", Value: "*"},
+	}
+}
+
 // IsSyntheticSlot reports whether slot is a synthetic agent slot
 // (i.e. begins with AgentSlotPrefix). Used by callers that need to
 // distinguish plan-anchored slots from agent slots — for example,

--- a/internal/swarm/synthetic_test.go
+++ b/internal/swarm/synthetic_test.go
@@ -116,6 +116,31 @@ func TestAgentBranchTags_Pair(t *testing.T) {
 	}
 }
 
+// TestTrunkBranchTags_Pair pins the libfossil branch-tag pair
+// TrunkBranchTags emits. Plan-anchored slots use this to land
+// commits on trunk explicitly. Pre-#NNN they passed nil tags
+// expecting parent-branch inheritance, which libfossil does not do
+// — the result was tag-less commits that `fossil info trunk`
+// didn't recognize, so `bones apply` saw an empty trunk while slot
+// work sat in the hub fossil unreachable to the operator.
+//
+// Same shape as AgentBranchTags but with name="trunk".
+func TestTrunkBranchTags_Pair(t *testing.T) {
+	tags := TrunkBranchTags()
+	if len(tags) != 2 {
+		t.Fatalf("TrunkBranchTags returned %d tags; want exactly 2 (branch + sym pair)",
+			len(tags))
+	}
+	if tags[0].Name != "branch" || tags[0].Value != "trunk" {
+		t.Errorf("tags[0] = {Name:%q Value:%q}, want {Name:%q Value:%q}",
+			tags[0].Name, tags[0].Value, "branch", "trunk")
+	}
+	if tags[1].Name != "sym-trunk" || tags[1].Value != "*" {
+		t.Errorf("tags[1] = {Name:%q Value:%q}, want {Name:%q Value:%q}",
+			tags[1].Name, tags[1].Value, "sym-trunk", "*")
+	}
+}
+
 // TestSwarmJoinAuto_IdempotentReEntry: a second JoinAuto with the
 // same agent.id returns ReEntry=true and the same slot/wt without
 // creating a duplicate session record.


### PR DESCRIPTION
## Bug

After `bones swarm dispatch` → slot commits → `swarm dispatch --advance` "all waves complete" → `bones apply` returned `already up to date` and `git status` showed zero new files. Slot work was reachable in the hub fossil but never landed in the operator's git tree. **B-29 from today's spy on v0.16.0.**

## Two compounding root causes

Systematic-debugging traced the bug through two layers, both required to land slot work on operator's tree.

### 1. `Tags=nil` doesn't propagate `branch=trunk`

`internal/swarm/lease.go::Commit` had two branches: synthetic-slot (ADR 0050) commits emitted `AgentBranchTags(agentID)` so the checkin landed on `agent/<id>`. Plan-anchored slots (the autosync default) emitted `Tags=nil` with the comment "continue the trunk-based-development model" — assuming libfossil would inherit the parent's `branch=trunk` tag the way `fossil ci` does.

Empirically, libfossil emits exactly the tag cards the caller supplies. With `Tags=nil`, the slot commit has zero tag cards, no `branch=trunk` propagating tag, and `fossil info trunk` keeps resolving to the seed (the last commit explicitly tagged trunk).

The fix mirrors the `AgentBranchTags` shape — a new `TrunkBranchTags()` helper emits `[{branch, "trunk"}, {sym-trunk, "*"}]`. Plan-anchored slots use it instead of nil. Same emission path, just stops the asymmetry.

### 2. `fossil ls -R repo -r <rev>` returns empty for libfossil-xfer commits

Even after fix #1, `bones apply` still said "up to date". `cli/apply.go::manifestAtRev` shells to `fossil ls -R hub.fossil -r trunk` to list files at the trunk tip. **This shell-out returns empty for tips written through libfossil's xfer protocol on Fossil 2.28** — a fossil/libfossil interop quirk the bones authors knew about (`apply.go:199` documents it).

The workaround already existed: `scanCheckoutManifest` walks the on-disk temp checkout fossil produces during `openTempCheckout`, which IS authoritative. But the workaround was only used by the synthetic-slot apply path. The default `bones apply` (the path operators actually run) still went through `manifestAtRev` and got empty results.

Fix: route default `applyFromCheckout` through `scanCheckoutManifest` against the temp checkout it already opens. The on-disk checkout is the source of truth for which files trunk's tip carries — `fossil ls -r` is irrelevant.

## Verified end-to-end

```
bones up → bones swarm dispatch plan.md → swarm join + commit + close → bones apply
```

Pre-fix: `bones apply: already up to date`; `git status` shows zero new files; `cat alpha/n.md` → No such file.

Post-fix: `bones apply: applied 1 changes from trunk @ 6b93dff206b7`; `git status` shows `A alpha/n.md`; `cat alpha/n.md` → `B-29 FIXED` (the slot's content materialized into operator git tree).

## Changes

- `internal/swarm/synthetic.go` — new `TrunkBranchTags()` helper alongside `AgentBranchTags()`. Same shape, name="trunk".
- `internal/swarm/lease.go::Commit` — plan-anchored slots now emit `TrunkBranchTags()` instead of nil.
- `cli/apply.go::applyFromCheckout` — switched from `trunkManifest` (which calls `manifestAtRev` → `fossil ls -r`) to `scanCheckoutManifest` against the temp checkout. Trunk rev still queried via `trunkRev` for the apply marker.
- `internal/swarm/synthetic_test.go::TestTrunkBranchTags_Pair` — pins the new helper's tag pair.

## What this doesn't change

- Synthetic-slot mode (ADR 0050) keeps `AgentBranchTags(agentID)` for `agent/<id>` per-agent branches. Multi-session deconfliction via tags is still a documented and supported feature; this PR only fixes the plan-anchored path that was supposed to advance trunk and didn't.
- The `cli/apply.go::manifestAtRev` helper stays for synthetic-slot paths that don't have a temp checkout to walk. The empty-results-for-libfossil-xfer quirk is logged in the existing comment at `apply.go:199`; if EdgeSync/libfossil ever fix the xfer hydration, `manifestAtRev` becomes usable for trunk too.

`go test -tags=otel -short ./...`: passing. End-to-end smoke against locally-built binary: passing.
